### PR TITLE
feat(phase4): event-driven architecture with circuit breaker & health server

### DIFF
--- a/projects/polymarket/polyquantbot/phase4/.env.example
+++ b/projects/polymarket/polyquantbot/phase4/.env.example
@@ -1,0 +1,10 @@
+# Telegram
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+TELEGRAM_CHAT_ID=your_chat_id_here
+
+# Polymarket (for live trading — Phase 3+)
+POLYMARKET_API_KEY=
+POLYMARKET_PRIVATE_KEY=
+
+# Database
+DB_PATH=polyquantbot_phase4.db

--- a/projects/polymarket/polyquantbot/phase4/config.yaml
+++ b/projects/polymarket/polyquantbot/phase4/config.yaml
@@ -1,0 +1,37 @@
+trading:
+  poll_interval_seconds: 20
+  min_ev_threshold: 0.02
+  max_position_pct: 0.10
+  max_concurrent_positions: 3
+  max_trades_per_cycle: 2
+  max_total_exposure_pct: 0.30
+  summary_every_n_cycles: 5
+  market_depth_threshold: 50.0
+  fee_pct: 0.02
+
+paper:
+  enabled: true
+  initial_balance: 1000.0
+  slippage_bps: 50
+
+exit:
+  take_profit_pct: 0.10
+  stop_loss_pct: 0.05
+  timeout_minutes: 30
+
+circuit_breaker:
+  max_consecutive_losses: 3
+  max_api_failures: 5
+  latency_breach_threshold_ms: 1000
+  cooldown_seconds: 120
+
+latency_budgets:
+  signal_ms: 200
+  execution_ms: 500
+  total_ms: 1000
+
+health:
+  port: 8080
+
+telegram:
+  chat_id: "${TELEGRAM_CHAT_ID}"

--- a/projects/polymarket/polyquantbot/phase4/core/__init__.py
+++ b/projects/polymarket/polyquantbot/phase4/core/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4 core package — signal model and risk manager."""

--- a/projects/polymarket/polyquantbot/phase4/core/execution/__init__.py
+++ b/projects/polymarket/polyquantbot/phase4/core/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4 execution package."""

--- a/projects/polymarket/polyquantbot/phase4/core/execution/paper_executor.py
+++ b/projects/polymarket/polyquantbot/phase4/core/execution/paper_executor.py
@@ -1,0 +1,87 @@
+"""Paper order executor with partial fills, dynamic slippage, and fees."""
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger()
+
+
+@dataclass
+class OrderResult:
+    """Result of a paper order execution."""
+
+    success: bool
+    market_id: str
+    fill_price: float
+    filled_size: float
+    requested_size: float
+    latency_ms: int
+    fee: float
+    partial: bool = False
+    error: str | None = None
+
+
+class PaperExecutor:
+    """Simulates order execution for paper trading."""
+
+    def __init__(self, cfg: dict[str, Any]) -> None:
+        """Initialise with config."""
+        paper_cfg = cfg.get("paper", {})
+        trading_cfg = cfg.get("trading", {})
+        self._slippage_bps = paper_cfg.get("slippage_bps", 50)
+        self._fee_pct = trading_cfg.get("fee_pct", 0.02)
+        self._depth_threshold = trading_cfg.get("market_depth_threshold", 50.0)
+
+    async def execute_paper_order(
+        self,
+        market_id: str,
+        price: float,
+        size: float,
+    ) -> OrderResult:
+        """Simulate paper order with latency, slippage, partial fill, and fee."""
+        start = time.time()
+
+        # Simulate execution latency 100-250ms
+        await asyncio.sleep(random.uniform(0.1, 0.25))
+
+        # Partial fill if size exceeds depth threshold
+        partial = size > self._depth_threshold
+        filled_size = size * 0.5 if partial else size
+
+        # Dynamic slippage: increases with size ratio
+        size_ratio = filled_size / self._depth_threshold if self._depth_threshold > 0 else 1.0
+        effective_slippage = self._slippage_bps * (1 + size_ratio * 0.5)
+        fill_price = price * (1 + effective_slippage / 10_000)
+
+        # Fee calculation
+        fee = filled_size * self._fee_pct
+
+        latency_ms = int((time.time() - start) * 1000)
+
+        log.info(
+            "paper_order_executed",
+            market_id=market_id,
+            fill_price=round(fill_price, 6),
+            filled_size=round(filled_size, 4),
+            requested_size=round(size, 4),
+            partial=partial,
+            fee=round(fee, 4),
+            latency_ms=latency_ms,
+        )
+
+        return OrderResult(
+            success=True,
+            market_id=market_id,
+            fill_price=fill_price,
+            filled_size=filled_size,
+            requested_size=size,
+            latency_ms=latency_ms,
+            fee=fee,
+            partial=partial,
+        )

--- a/projects/polymarket/polyquantbot/phase4/core/risk_manager.py
+++ b/projects/polymarket/polyquantbot/phase4/core/risk_manager.py
@@ -1,0 +1,55 @@
+"""Fractional Kelly risk manager — unchanged from Phase 2."""
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger()
+
+KELLY_FRACTION = 0.25  # CLAUDE.md: always alpha = 0.25
+
+
+class RiskManager:
+    """Sizes positions using fractional Kelly criterion."""
+
+    def __init__(self, cfg: dict[str, Any]) -> None:
+        """Initialise with config."""
+        self._max_position_pct = cfg.get("trading", {}).get("max_position_pct", 0.10)
+
+    def get_position_size(
+        self,
+        ev: float,
+        p_model: float,
+        p_market: float,
+        balance: float,
+    ) -> float:
+        """Return position size in dollars using fractional Kelly.
+
+        Returns 0.0 if Kelly fraction is non-positive or size < $1.
+        """
+        if p_market <= 0 or p_market >= 1:
+            return 0.0
+        b = (1.0 / p_market) - 1.0
+        if b <= 0:
+            return 0.0
+        q = 1.0 - p_model
+        kelly_f = (p_model * b - q) / b
+        if kelly_f <= 0:
+            return 0.0
+
+        fractional_f = kelly_f * KELLY_FRACTION
+        capped_f = min(fractional_f, self._max_position_pct)
+        size = balance * capped_f
+
+        if size < 1.0:
+            return 0.0
+
+        log.debug(
+            "position_sized",
+            kelly_f=round(kelly_f, 4),
+            fractional_f=round(fractional_f, 4),
+            capped_f=round(capped_f, 4),
+            size=round(size, 4),
+        )
+        return size

--- a/projects/polymarket/polyquantbot/phase4/core/signal_model.py
+++ b/projects/polymarket/polyquantbot/phase4/core/signal_model.py
@@ -1,0 +1,87 @@
+"""Bayesian signal model — unchanged from Phase 2."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+ALPHA = 0.05  # Bayesian update strength
+
+
+@dataclass
+class TradingSignal:
+    """Output of the signal model for a single market."""
+
+    market_id: str
+    question: str
+    p_model: float
+    p_market: float
+    ev: float
+    kelly_f: float
+    edge_score: float
+
+
+class BayesianSignalModel:
+    """Generates trading signals using Bayesian EV calculation."""
+
+    def __init__(self, cfg: dict[str, Any]) -> None:
+        """Initialise with config."""
+        self._min_ev = cfg.get("trading", {}).get("min_ev_threshold", 0.02)
+
+    def _bayesian_update(self, p_market: float) -> float:
+        """Apply Bayesian update: pull p_market toward 0.5 by ALPHA."""
+        return p_market + ALPHA * (0.5 - p_market)
+
+    def calculate_ev(self, p_model: float, p_market: float) -> tuple[float, float]:
+        """Return (ev, kelly_f) for given model and market probabilities."""
+        b = (1.0 / p_market) - 1.0  # decimal odds
+        q = 1.0 - p_model
+        ev = p_model * b - q
+        kelly_f = (p_model * b - q) / b if b > 0 else 0.0
+        return ev, kelly_f
+
+    def generate_signal(self, market: Any) -> Optional[TradingSignal]:
+        """Generate signal for a single market dict/dataclass.
+
+        Returns None if EV is below threshold.
+        """
+        try:
+            if isinstance(market, dict):
+                market_id = market["market_id"]
+                question = market.get("question", "")
+                p_market = float(market["best_ask"])
+            else:
+                market_id = market.market_id
+                question = market.question
+                p_market = float(market.best_ask)
+
+            if p_market <= 0 or p_market >= 1:
+                return None
+
+            p_model = self._bayesian_update(p_market)
+            ev, kelly_f = self.calculate_ev(p_model, p_market)
+
+            if ev < self._min_ev:
+                return None
+
+            edge_score = ev * p_model
+            return TradingSignal(
+                market_id=market_id,
+                question=question,
+                p_model=p_model,
+                p_market=p_market,
+                ev=ev,
+                kelly_f=kelly_f,
+                edge_score=edge_score,
+            )
+        except Exception as exc:
+            log.warning("signal_generation_error", error=str(exc))
+            return None
+
+    def generate_all(self, markets: list[Any]) -> list[TradingSignal]:
+        """Generate signals for all markets, sorted by edge_score descending."""
+        signals = [s for m in markets if (s := self.generate_signal(m)) is not None]
+        return sorted(signals, key=lambda s: s.edge_score, reverse=True)

--- a/projects/polymarket/polyquantbot/phase4/engine/__init__.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4 engine package — event-driven architecture."""

--- a/projects/polymarket/polyquantbot/phase4/engine/circuit_breaker.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/circuit_breaker.py
@@ -1,0 +1,108 @@
+"""Circuit breaker — trips on loss streaks, API failures, or latency breaches."""
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import structlog
+
+from .event_bus import CIRCUIT_BREAKER_OPEN, EventBus, EventEnvelope
+
+if TYPE_CHECKING:
+    pass
+
+log = structlog.get_logger()
+
+
+class CircuitBreaker:
+    """Monitors trading health and halts the pipeline when thresholds are breached."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        max_consecutive_losses: int = 3,
+        max_api_failures: int = 5,
+        latency_breach_threshold_ms: int = 1000,
+        cooldown_seconds: int = 120,
+    ) -> None:
+        """Initialise circuit breaker with configurable thresholds."""
+        self._bus = bus
+        self._max_consecutive_losses = max_consecutive_losses
+        self._max_api_failures = max_api_failures
+        self._latency_breach_threshold_ms = latency_breach_threshold_ms
+        self._cooldown_seconds = cooldown_seconds
+
+        self._is_open: bool = False
+        self._opened_at: float = 0.0
+        self._consecutive_losses: int = 0
+        self._api_failures: int = 0
+
+    def is_open(self) -> bool:
+        """Return True if circuit is open (trading halted).
+
+        Auto-resets after cooldown period.
+        """
+        if self._is_open:
+            elapsed = time.time() - self._opened_at
+            if elapsed >= self._cooldown_seconds:
+                self._is_open = False
+                self._consecutive_losses = 0
+                self._api_failures = 0
+                log.info(
+                    "circuit_breaker_reset",
+                    elapsed_seconds=round(elapsed, 1),
+                )
+        return self._is_open
+
+    def record_win(self) -> None:
+        """Reset consecutive loss counter on a winning trade."""
+        self._consecutive_losses = 0
+
+    def record_loss(self) -> None:
+        """Increment loss counter; trip if threshold exceeded."""
+        self._consecutive_losses += 1
+        if self._consecutive_losses >= self._max_consecutive_losses:
+            self._trip(
+                reason="consecutive_losses",
+                count=self._consecutive_losses,
+            )
+
+    def record_api_failure(self) -> None:
+        """Increment API failure counter; trip if threshold exceeded."""
+        self._api_failures += 1
+        if self._api_failures >= self._max_api_failures:
+            self._trip(
+                reason="api_failures",
+                count=self._api_failures,
+            )
+
+    def record_latency_breach(self, elapsed_ms: int) -> None:
+        """Trip if a single operation exceeds the latency threshold."""
+        if elapsed_ms >= self._latency_breach_threshold_ms:
+            self._trip(
+                reason="latency_breach",
+                elapsed_ms=elapsed_ms,
+                threshold_ms=self._latency_breach_threshold_ms,
+            )
+
+    def _trip(self, **context) -> None:
+        """Open the circuit and publish CIRCUIT_BREAKER_OPEN event."""
+        if self._is_open:
+            return  # already open
+        self._is_open = True
+        self._opened_at = time.time()
+        log.warning("circuit_breaker_tripped", **context)
+        import asyncio
+        asyncio.create_task(
+            self._bus.publish(
+                EventEnvelope(
+                    event_type=CIRCUIT_BREAKER_OPEN,
+                    source="circuit_breaker",
+                    payload={
+                        "reason": context.get("reason", "unknown"),
+                        "context": context,
+                        "cooldown_seconds": self._cooldown_seconds,
+                    },
+                )
+            )
+        )

--- a/projects/polymarket/polyquantbot/phase4/engine/event_bus.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/event_bus.py
@@ -1,0 +1,97 @@
+"""Async fan-out event bus for Phase 4 event-driven architecture."""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+import structlog
+
+log = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# Event type constants
+# ---------------------------------------------------------------------------
+MARKET_DATA = "MARKET_DATA"
+SIGNAL = "SIGNAL"
+FILTERED_SIGNAL = "FILTERED_SIGNAL"
+POSITION_SIZED = "POSITION_SIZED"
+ORDER_FILLED = "ORDER_FILLED"
+STATE_UPDATED = "STATE_UPDATED"
+TELEGRAM_NOTIFY = "TELEGRAM_NOTIFY"
+SYSTEM_ERROR = "SYSTEM_ERROR"
+CIRCUIT_BREAKER_OPEN = "CIRCUIT_BREAKER_OPEN"
+HEALTH_CHECK = "HEALTH_CHECK"
+
+Handler = Callable[["EventEnvelope"], Coroutine[Any, Any, None]]
+
+
+@dataclass
+class EventEnvelope:
+    """Immutable event container propagated through the pipeline."""
+
+    event_type: str
+    source: str
+    payload: dict[str, Any]
+    correlation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp_ms: int = field(default_factory=lambda: int(time.time() * 1000))
+    market_id: str | None = None
+
+
+class EventBus:
+    """Async pub/sub bus with per-subscriber queues and worker tasks."""
+
+    def __init__(self) -> None:
+        """Initialise empty subscriber registry."""
+        self._subscribers: dict[str, list[asyncio.Queue[EventEnvelope]]] = {}
+        self._tasks: list[asyncio.Task] = []
+
+    def subscribe(self, event_type: str, handler: Handler) -> None:
+        """Register an async handler for event_type.
+
+        Each handler gets its own Queue so a slow handler can't block others.
+        """
+        queue: asyncio.Queue[EventEnvelope] = asyncio.Queue()
+        if event_type not in self._subscribers:
+            self._subscribers[event_type] = []
+        self._subscribers[event_type].append(queue)
+
+        async def _worker() -> None:
+            while True:
+                envelope = await queue.get()
+                try:
+                    await handler(envelope)
+                except Exception as exc:
+                    log.error(
+                        "event_handler_error",
+                        event_type=event_type,
+                        correlation_id=envelope.correlation_id,
+                        error=str(exc),
+                    )
+                finally:
+                    queue.task_done()
+
+        task = asyncio.create_task(_worker())
+        self._tasks.append(task)
+
+    async def publish(self, envelope: EventEnvelope) -> None:
+        """Fan-out envelope to all subscribers of its event_type."""
+        queues = self._subscribers.get(envelope.event_type, [])
+        for q in queues:
+            await q.put(envelope)
+        log.debug(
+            "event_published",
+            event_type=envelope.event_type,
+            correlation_id=envelope.correlation_id,
+            market_id=envelope.market_id,
+            subscribers=len(queues),
+        )
+
+    async def shutdown(self) -> None:
+        """Cancel all worker tasks."""
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        log.info("event_bus_shutdown", tasks_cancelled=len(self._tasks))

--- a/projects/polymarket/polyquantbot/phase4/engine/health_server.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/health_server.py
@@ -1,0 +1,63 @@
+"""HTTP health server on :8080 for liveness and status checks."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import structlog
+from aiohttp import web
+
+from .state_manager import StateManager
+
+log = structlog.get_logger()
+
+_start_time = time.time()
+
+
+def make_health_app(
+    state: StateManager,
+    pipeline_state: dict[str, Any],
+) -> web.Application:
+    """Create aiohttp application with /health endpoint."""
+    app = web.Application()
+
+    async def health_handler(request: web.Request) -> web.Response:
+        """Return system health status as JSON."""
+        try:
+            open_positions = await state.get_open_positions()
+            realized_pnl = await state.get_balance()
+            initial_balance = pipeline_state.get("initial_balance", 1000.0)
+            balance = initial_balance + realized_pnl
+
+            payload = {
+                "status": "ok",
+                "uptime_seconds": round(time.time() - _start_time, 1),
+                "pipeline_state": pipeline_state.get("state", "running"),
+                "cycle": pipeline_state.get("cycle", 0),
+                "balance": round(balance, 4),
+                "open_positions": len(open_positions),
+            }
+            return web.json_response(payload)
+        except Exception as exc:
+            log.error("health_check_error", error=str(exc))
+            return web.json_response(
+                {"status": "error", "error": str(exc)}, status=500
+            )
+
+    app.router.add_get("/health", health_handler)
+    return app
+
+
+async def start_health_server(
+    state: StateManager,
+    pipeline_state: dict[str, Any],
+    port: int = 8080,
+) -> web.AppRunner:
+    """Start the health server and return the runner for cleanup."""
+    app = make_health_app(state, pipeline_state)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+    log.info("health_server_started", port=port)
+    return runner

--- a/projects/polymarket/polyquantbot/phase4/engine/performance_tracker.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/performance_tracker.py
@@ -1,0 +1,41 @@
+"""Performance tracker — unchanged from Phase 2."""
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger()
+
+
+class PerformanceTracker:
+    """Tracks win/loss metrics in memory."""
+
+    def __init__(self) -> None:
+        """Initialise counters."""
+        self._total: int = 0
+        self._wins: int = 0
+        self._total_pnl: float = 0.0
+        self._ev_sum: float = 0.0
+
+    def record(self, pnl: float, ev: float) -> None:
+        """Record a closed trade result."""
+        self._total += 1
+        self._total_pnl += pnl
+        self._ev_sum += ev
+        if pnl > 0:
+            self._wins += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return current performance stats and log them."""
+        win_rate = self._wins / self._total if self._total > 0 else 0.0
+        avg_ev = self._ev_sum / self._total if self._total > 0 else 0.0
+        stats = {
+            "total_trades": self._total,
+            "winning_trades": self._wins,
+            "total_pnl": round(self._total_pnl, 4),
+            "win_rate": round(win_rate, 4),
+            "avg_ev": round(avg_ev, 4),
+        }
+        log.info("performance_snapshot", **stats)
+        return stats

--- a/projects/polymarket/polyquantbot/phase4/engine/pipeline_handlers.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/pipeline_handlers.py
@@ -1,0 +1,276 @@
+"""Event pipeline handlers — one per stage of the trading flow."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import structlog
+
+from ..core.risk_manager import RiskManager
+from ..core.signal_model import BayesianSignalModel
+from ..core.execution.paper_executor import PaperExecutor
+from .circuit_breaker import CircuitBreaker
+from .event_bus import (
+    FILTERED_SIGNAL,
+    MARKET_DATA,
+    ORDER_FILLED,
+    POSITION_SIZED,
+    SIGNAL,
+    STATE_UPDATED,
+    SYSTEM_ERROR,
+    EventBus,
+    EventEnvelope,
+)
+from .state_manager import OpenTrade, StateManager
+
+log = structlog.get_logger()
+
+
+def _check_latency(
+    start_ms: int,
+    budget_ms: int,
+    stage: str,
+    correlation_id: str,
+) -> None:
+    """Log warning if stage exceeded its latency budget."""
+    elapsed = int(time.time() * 1000) - start_ms
+    if elapsed > budget_ms:
+        log.warning(
+            "latency_budget_exceeded",
+            stage=stage,
+            elapsed_ms=elapsed,
+            budget_ms=budget_ms,
+            correlation_id=correlation_id,
+        )
+
+
+async def _publish_system_error(
+    bus: EventBus,
+    envelope: EventEnvelope,
+    error: str,
+    stage: str,
+) -> None:
+    """Publish SYSTEM_ERROR event and log the failure."""
+    log.error("pipeline_stage_error", stage=stage, error=error,
+              correlation_id=envelope.correlation_id)
+    await bus.publish(
+        EventEnvelope(
+            event_type=SYSTEM_ERROR,
+            source=stage,
+            correlation_id=envelope.correlation_id,
+            market_id=envelope.market_id,
+            payload={"error": error, "stage": stage},
+        )
+    )
+
+
+def make_handlers(
+    bus: EventBus,
+    state: StateManager,
+    model: BayesianSignalModel,
+    cb: CircuitBreaker,
+    cfg: dict[str, Any],
+) -> None:
+    """Wire all pipeline stage handlers to the event bus."""
+    executor = PaperExecutor(cfg)
+    risk = RiskManager(cfg)
+    latency = cfg.get("latency_budgets", {})
+    signal_budget = latency.get("signal_ms", 200)
+    exec_budget = latency.get("execution_ms", 500)
+
+    # ------------------------------------------------------------------
+    # Stage 1: MARKET_DATA → SIGNAL
+    # ------------------------------------------------------------------
+    async def handle_market_data(envelope: EventEnvelope) -> None:
+        """Generate trading signal from raw market data."""
+        if cb.is_open():
+            return
+        start = envelope.timestamp_ms
+        try:
+            market = envelope.payload["market"]
+            signal = model.generate_signal(market)
+            if signal is None:
+                return
+            await bus.publish(
+                EventEnvelope(
+                    event_type=SIGNAL,
+                    source="signal_model",
+                    correlation_id=envelope.correlation_id,
+                    market_id=envelope.market_id,
+                    payload={"signal": signal.__dict__},
+                )
+            )
+            _check_latency(start, signal_budget, "handle_market_data",
+                           envelope.correlation_id)
+        except Exception as exc:
+            await _publish_system_error(bus, envelope, str(exc), "handle_market_data")
+            await state.save_failed_event(envelope, str(exc))
+
+    # ------------------------------------------------------------------
+    # Stage 2: SIGNAL → FILTERED_SIGNAL
+    # ------------------------------------------------------------------
+    async def handle_signal(envelope: EventEnvelope) -> None:
+        """Filter signal against open position limits and EV threshold."""
+        if cb.is_open():
+            return
+        try:
+            signal = envelope.payload["signal"]
+            open_positions = await state.get_open_positions()
+            open_ids = {t.market_id for t in open_positions}
+            max_concurrent = cfg.get("trading", {}).get("max_concurrent_positions", 3)
+            min_ev = cfg.get("trading", {}).get("min_ev_threshold", 0.02)
+
+            if signal["market_id"] in open_ids:
+                return
+            if len(open_positions) >= max_concurrent:
+                return
+            if signal["ev"] < min_ev:
+                return
+
+            await bus.publish(
+                EventEnvelope(
+                    event_type=FILTERED_SIGNAL,
+                    source="signal_filter",
+                    correlation_id=envelope.correlation_id,
+                    market_id=envelope.market_id,
+                    payload={"signal": signal},
+                )
+            )
+        except Exception as exc:
+            await _publish_system_error(bus, envelope, str(exc), "handle_signal")
+            await state.save_failed_event(envelope, str(exc))
+
+    # ------------------------------------------------------------------
+    # Stage 3: FILTERED_SIGNAL → POSITION_SIZED
+    # ------------------------------------------------------------------
+    async def handle_filtered_signal(envelope: EventEnvelope) -> None:
+        """Apply Kelly criterion to size the position."""
+        if cb.is_open():
+            return
+        try:
+            signal = envelope.payload["signal"]
+            open_positions = await state.get_open_positions()
+            initial_balance = cfg.get("paper", {}).get("initial_balance", 1000.0)
+            realized_pnl = await state.get_balance()
+            balance = initial_balance + realized_pnl
+
+            size = risk.get_position_size(
+                ev=signal["ev"],
+                p_model=signal["p_model"],
+                p_market=signal["p_market"],
+                balance=balance,
+            )
+            if size <= 0:
+                return
+
+            await bus.publish(
+                EventEnvelope(
+                    event_type=POSITION_SIZED,
+                    source="risk_manager",
+                    correlation_id=envelope.correlation_id,
+                    market_id=envelope.market_id,
+                    payload={
+                        "signal": signal,
+                        "size": size,
+                        "balance": balance,
+                    },
+                )
+            )
+        except Exception as exc:
+            await _publish_system_error(bus, envelope, str(exc), "handle_filtered_signal")
+            await state.save_failed_event(envelope, str(exc))
+
+    # ------------------------------------------------------------------
+    # Stage 4: POSITION_SIZED → ORDER_FILLED
+    # ------------------------------------------------------------------
+    async def handle_position_sized(envelope: EventEnvelope) -> None:
+        """Execute paper order and emit fill result."""
+        if cb.is_open():
+            return
+        start = int(time.time() * 1000)
+        try:
+            signal = envelope.payload["signal"]
+            size = envelope.payload["size"]
+            result = await executor.execute_paper_order(
+                market_id=signal["market_id"],
+                price=signal["p_market"],
+                size=size,
+            )
+            elapsed = int(time.time() * 1000) - start
+            cb.record_latency_breach(elapsed)
+            _check_latency(start, exec_budget, "handle_position_sized",
+                           envelope.correlation_id)
+
+            await bus.publish(
+                EventEnvelope(
+                    event_type=ORDER_FILLED,
+                    source="paper_executor",
+                    correlation_id=envelope.correlation_id,
+                    market_id=envelope.market_id,
+                    payload={
+                        "signal": signal,
+                        "result": result.__dict__,
+                        "balance": envelope.payload["balance"],
+                    },
+                )
+            )
+        except Exception as exc:
+            cb.record_api_failure()
+            await _publish_system_error(bus, envelope, str(exc), "handle_position_sized")
+            await state.save_failed_event(envelope, str(exc))
+
+    # ------------------------------------------------------------------
+    # Stage 5: ORDER_FILLED → STATE_UPDATED
+    # ------------------------------------------------------------------
+    async def handle_order_filled(envelope: EventEnvelope) -> None:
+        """Persist trade to state and emit STATE_UPDATED for Telegram."""
+        try:
+            signal = envelope.payload["signal"]
+            result = envelope.payload["result"]
+            if not result.get("success"):
+                return
+
+            trade = OpenTrade(
+                market_id=signal["market_id"],
+                question=signal.get("question", ""),
+                entry_price=result["fill_price"],
+                size=result["filled_size"],
+                kelly_f=signal.get("kelly_f", 0.0),
+                ev=signal["ev"],
+                fee=result.get("fee", 0.0),
+                entry_time=time.time(),
+                correlation_id=envelope.correlation_id,
+            )
+            await state.save_trade(trade)
+            await state.log_event(envelope)
+
+            await bus.publish(
+                EventEnvelope(
+                    event_type=STATE_UPDATED,
+                    source="order_handler",
+                    correlation_id=envelope.correlation_id,
+                    market_id=envelope.market_id,
+                    payload={
+                        "action": "TRADE_OPENED",
+                        "trade": {
+                            "market_id": trade.market_id,
+                            "question": trade.question,
+                            "entry_price": trade.entry_price,
+                            "size": trade.size,
+                            "ev": trade.ev,
+                            "fee": trade.fee,
+                        },
+                        "balance": envelope.payload["balance"],
+                    },
+                )
+            )
+        except Exception as exc:
+            await _publish_system_error(bus, envelope, str(exc), "handle_order_filled")
+            await state.save_failed_event(envelope, str(exc))
+
+    # Wire all handlers
+    bus.subscribe(MARKET_DATA, handle_market_data)
+    bus.subscribe(SIGNAL, handle_signal)
+    bus.subscribe(FILTERED_SIGNAL, handle_filtered_signal)
+    bus.subscribe(POSITION_SIZED, handle_position_sized)
+    bus.subscribe(ORDER_FILLED, handle_order_filled)

--- a/projects/polymarket/polyquantbot/phase4/engine/runner.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/runner.py
@@ -1,0 +1,251 @@
+"""Phase 4 runner — event-driven main loop."""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from typing import Any
+
+import structlog
+import yaml
+from dotenv import load_dotenv
+
+from ..core.signal_model import BayesianSignalModel
+from ..infra.polymarket_client import PolymarketClient
+from ..infra.telegram_service import TelegramService
+from ..engine.circuit_breaker import CircuitBreaker
+from ..engine.event_bus import (
+    CIRCUIT_BREAKER_OPEN,
+    MARKET_DATA,
+    STATE_UPDATED,
+    EventBus,
+    EventEnvelope,
+)
+from ..engine.health_server import start_health_server
+from ..engine.pipeline_handlers import make_handlers
+from ..engine.state_manager import StateManager
+from ..engine.performance_tracker import PerformanceTracker
+
+log = structlog.get_logger()
+
+
+def _load_config(path: str = "config.yaml") -> dict[str, Any]:
+    """Load YAML config file."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+async def exit_monitor_loop(
+    state: StateManager,
+    bus: EventBus,
+    cb: CircuitBreaker,
+    cfg: dict[str, Any],
+) -> None:
+    """Continuously monitor open positions for exit conditions."""
+    exit_cfg = cfg.get("exit", {})
+    take_profit = exit_cfg.get("take_profit_pct", 0.10)
+    stop_loss = exit_cfg.get("stop_loss_pct", 0.05)
+    timeout_min = exit_cfg.get("timeout_minutes", 30)
+    poll = cfg.get("trading", {}).get("poll_interval_seconds", 20)
+
+    while True:
+        try:
+            positions = await state.get_open_positions()
+            for trade in positions:
+                elapsed_min = (time.time() - trade.entry_time) / 60
+                exit_price: float | None = None
+                reason = ""
+
+                # Simulated exit price drift (paper trading)
+                simulated_price = trade.entry_price * (1 + 0.001 * elapsed_min)
+
+                gain_pct = (simulated_price - trade.entry_price) / trade.entry_price
+                if gain_pct >= take_profit:
+                    exit_price = simulated_price
+                    reason = "take_profit"
+                elif gain_pct <= -stop_loss:
+                    exit_price = simulated_price
+                    reason = "stop_loss"
+                elif elapsed_min >= timeout_min:
+                    exit_price = simulated_price
+                    reason = "timeout"
+
+                if exit_price is not None:
+                    pnl = (exit_price - trade.entry_price) * trade.size - trade.fee
+                    await state.close_trade(trade.market_id, exit_price, pnl)
+
+                    if pnl >= 0:
+                        cb.record_win()
+                    else:
+                        cb.record_loss()
+
+                    await bus.publish(
+                        EventEnvelope(
+                            event_type=STATE_UPDATED,
+                            source="exit_monitor",
+                            correlation_id=trade.correlation_id,
+                            market_id=trade.market_id,
+                            payload={
+                                "action": "TRADE_CLOSED",
+                                "trade": {
+                                    "market_id": trade.market_id,
+                                    "question": trade.question,
+                                    "entry_price": trade.entry_price,
+                                    "exit_price": exit_price,
+                                    "size": trade.size,
+                                    "pnl": round(pnl, 4),
+                                    "reason": reason,
+                                },
+                            },
+                        )
+                    )
+        except Exception as exc:
+            log.error("exit_monitor_error", error=str(exc))
+
+        await asyncio.sleep(poll)
+
+
+async def main() -> None:
+    """Entry point for Phase 4 event-driven bot."""
+    load_dotenv()
+    import structlog
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ]
+    )
+
+    config_path = os.path.join(os.path.dirname(__file__), "..", "config.yaml")
+    cfg = _load_config(config_path)
+
+    trading_cfg = cfg.get("trading", {})
+    paper_cfg = cfg.get("paper", {})
+    cb_cfg = cfg.get("circuit_breaker", {})
+    health_port = cfg.get("health", {}).get("port", 8080)
+    initial_balance = paper_cfg.get("initial_balance", 1000.0)
+    poll_interval = trading_cfg.get("poll_interval_seconds", 20)
+    summary_every = trading_cfg.get("summary_every_n_cycles", 5)
+
+    # Infrastructure
+    state = StateManager(os.getenv("DB_PATH", "polyquantbot_phase4.db"))
+    await state.init()
+
+    bus = EventBus()
+    cb = CircuitBreaker(
+        bus=bus,
+        max_consecutive_losses=cb_cfg.get("max_consecutive_losses", 3),
+        max_api_failures=cb_cfg.get("max_api_failures", 5),
+        latency_breach_threshold_ms=cb_cfg.get("latency_breach_threshold_ms", 1000),
+        cooldown_seconds=cb_cfg.get("cooldown_seconds", 120),
+    )
+
+    model = BayesianSignalModel(cfg)
+    client = PolymarketClient()
+    tracker = PerformanceTracker()
+    telegram = TelegramService(
+        token=os.getenv("TELEGRAM_BOT_TOKEN", ""),
+        chat_id=os.getenv("TELEGRAM_CHAT_ID", ""),
+    )
+
+    # Wire pipeline handlers (stages 1–5)
+    make_handlers(bus, state, model, cb, cfg)
+
+    # Wire Telegram as pure STATE_UPDATED subscriber
+    bus.subscribe(STATE_UPDATED, telegram.handle_state_updated)
+
+    # Wire circuit breaker relay
+    async def handle_circuit_breaker_event(envelope: EventEnvelope) -> None:
+        """Relay CB open event to Telegram via STATE_UPDATED."""
+        await bus.publish(
+            EventEnvelope(
+                event_type=STATE_UPDATED,
+                source="circuit_breaker_relay",
+                correlation_id=envelope.correlation_id,
+                payload={
+                    "action": "CIRCUIT_OPEN",
+                    "reason": envelope.payload.get("reason", "unknown"),
+                    "cooldown_seconds": envelope.payload.get("cooldown_seconds", 120),
+                },
+            )
+        )
+
+    bus.subscribe(CIRCUIT_BREAKER_OPEN, handle_circuit_breaker_event)
+
+    # Pipeline state shared with health server
+    pipeline_state: dict[str, Any] = {
+        "state": "running",
+        "cycle": 0,
+        "initial_balance": initial_balance,
+    }
+
+    # Start background tasks
+    health_runner = await start_health_server(state, pipeline_state, port=health_port)
+    exit_task = asyncio.create_task(
+        exit_monitor_loop(state, bus, cb, cfg)
+    )
+
+    log.info("phase4_runner_started", initial_balance=initial_balance)
+
+    cycle = 0
+    try:
+        while True:
+            cycle += 1
+            pipeline_state["cycle"] = cycle
+
+            if not cb.is_open():
+                try:
+                    markets = await client.fetch_markets(limit=20)
+                    for market in markets:
+                        correlation_id = str(uuid.uuid4())
+                        await bus.publish(
+                            EventEnvelope(
+                                event_type=MARKET_DATA,
+                                source="polymarket_client",
+                                correlation_id=correlation_id,
+                                market_id=market.market_id,
+                                payload={"market": market.__dict__},
+                            )
+                        )
+                    cb._api_failures = 0  # reset on success
+                except Exception as exc:
+                    log.error("market_fetch_error", error=str(exc))
+                    cb.record_api_failure()
+            else:
+                log.warning("circuit_breaker_open_skip_cycle", cycle=cycle)
+
+            # Periodic summary
+            if cycle % summary_every == 0:
+                realized_pnl = await state.get_balance()
+                balance = initial_balance + realized_pnl
+                open_positions = await state.get_open_positions()
+                stats = tracker.snapshot()
+                await bus.publish(
+                    EventEnvelope(
+                        event_type=STATE_UPDATED,
+                        source="runner",
+                        payload={
+                            "action": "SUMMARY",
+                            "balance": balance,
+                            "initial_balance": initial_balance,
+                            "open_count": len(open_positions),
+                            "stats": stats,
+                        },
+                    )
+                )
+
+            await asyncio.sleep(poll_interval)
+
+    except asyncio.CancelledError:
+        log.info("runner_cancelled")
+    finally:
+        exit_task.cancel()
+        await bus.shutdown()
+        await state.close()
+        await health_runner.cleanup()
+        log.info("phase4_runner_stopped")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/projects/polymarket/polyquantbot/phase4/engine/state_manager.py
+++ b/projects/polymarket/polyquantbot/phase4/engine/state_manager.py
@@ -1,0 +1,263 @@
+"""Persistent state manager with event logging and correlation tracking."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+import aiosqlite
+import structlog
+
+from .event_bus import EventEnvelope
+
+log = structlog.get_logger()
+
+
+@dataclass
+class OpenTrade:
+    """Represents an active paper trade."""
+
+    market_id: str
+    question: str
+    entry_price: float
+    size: float
+    kelly_f: float
+    ev: float
+    fee: float
+    entry_time: float
+    correlation_id: str
+    exit_price: Optional[float] = None
+    exit_time: Optional[float] = None
+    pnl: Optional[float] = None
+
+
+class StateManager:
+    """SQLite-backed state manager (WAL mode) for trades and events."""
+
+    def __init__(self, db_path: str = "polyquantbot_phase4.db") -> None:
+        """Initialise with database path."""
+        self._db_path = db_path
+        self._db: Optional[aiosqlite.Connection] = None
+
+    async def init(self) -> None:
+        """Open database connection and create tables."""
+        self._db = await aiosqlite.connect(self._db_path)
+        await self._db.execute("PRAGMA journal_mode=WAL")
+        await self._create_tables()
+        log.info("state_manager_initialized", db=self._db_path)
+
+    async def close(self) -> None:
+        """Close database connection."""
+        if self._db:
+            await self._db.close()
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return active DB connection or raise."""
+        if self._db is None:
+            raise RuntimeError("StateManager.init() must be called before use")
+        return self._db
+
+    async def _create_tables(self) -> None:
+        """Create all required tables."""
+        db = self._conn()
+        await db.executescript("""
+            CREATE TABLE IF NOT EXISTS trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                market_id TEXT NOT NULL,
+                question TEXT,
+                entry_price REAL,
+                size REAL,
+                kelly_f REAL,
+                ev REAL,
+                fee REAL,
+                entry_time REAL,
+                exit_price REAL,
+                exit_time REAL,
+                pnl REAL,
+                correlation_id TEXT,
+                status TEXT DEFAULT 'open'
+            );
+
+            CREATE TABLE IF NOT EXISTS performance_stats (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                recorded_at REAL,
+                total_trades INTEGER,
+                winning_trades INTEGER,
+                total_pnl REAL,
+                win_rate REAL,
+                avg_ev REAL
+            );
+
+            CREATE TABLE IF NOT EXISTS event_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                correlation_id TEXT,
+                event_type TEXT,
+                source TEXT,
+                market_id TEXT,
+                timestamp_ms INTEGER,
+                payload TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS failed_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                correlation_id TEXT,
+                event_type TEXT,
+                error TEXT,
+                timestamp_ms INTEGER,
+                payload TEXT
+            );
+        """)
+        await db.commit()
+
+    async def log_event(self, envelope: EventEnvelope) -> None:
+        """Persist every event envelope to event_log."""
+        db = self._conn()
+        await db.execute(
+            """
+            INSERT INTO event_log
+            (correlation_id, event_type, source, market_id, timestamp_ms, payload)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                envelope.correlation_id,
+                envelope.event_type,
+                envelope.source,
+                envelope.market_id,
+                envelope.timestamp_ms,
+                json.dumps(envelope.payload),
+            ),
+        )
+        await db.commit()
+
+    async def save_failed_event(self, envelope: EventEnvelope, error: str) -> None:
+        """Record a failed event for debugging."""
+        db = self._conn()
+        await db.execute(
+            """
+            INSERT INTO failed_events
+            (correlation_id, event_type, error, timestamp_ms, payload)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                envelope.correlation_id,
+                envelope.event_type,
+                error,
+                envelope.timestamp_ms,
+                json.dumps(envelope.payload),
+            ),
+        )
+        await db.commit()
+
+    async def get_balance(self) -> float:
+        """Return current paper balance."""
+        db = self._conn()
+        async with db.execute(
+            "SELECT SUM(pnl) FROM trades WHERE status = 'closed'"
+        ) as cur:
+            row = await cur.fetchone()
+            realized_pnl = row[0] or 0.0
+        return realized_pnl  # caller adds initial_balance
+
+    async def save_trade(self, trade: OpenTrade) -> None:
+        """Insert a new open trade."""
+        db = self._conn()
+        await db.execute(
+            """
+            INSERT INTO trades
+            (market_id, question, entry_price, size, kelly_f, ev, fee,
+             entry_time, correlation_id, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open')
+            """,
+            (
+                trade.market_id,
+                trade.question,
+                trade.entry_price,
+                trade.size,
+                trade.kelly_f,
+                trade.ev,
+                trade.fee,
+                trade.entry_time,
+                trade.correlation_id,
+            ),
+        )
+        await db.commit()
+
+    async def close_trade(
+        self,
+        market_id: str,
+        exit_price: float,
+        pnl: float,
+    ) -> None:
+        """Mark trade as closed with exit data."""
+        db = self._conn()
+        await db.execute(
+            """
+            UPDATE trades
+            SET status = 'closed', exit_price = ?, exit_time = ?, pnl = ?
+            WHERE market_id = ? AND status = 'open'
+            """,
+            (exit_price, time.time(), pnl, market_id),
+        )
+        await db.commit()
+
+    async def get_open_positions(self) -> list[OpenTrade]:
+        """Return all currently open trades."""
+        db = self._conn()
+        async with db.execute(
+            "SELECT market_id, question, entry_price, size, kelly_f, ev, fee, "
+            "entry_time, correlation_id FROM trades WHERE status = 'open'"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            OpenTrade(
+                market_id=r[0],
+                question=r[1],
+                entry_price=r[2],
+                size=r[3],
+                kelly_f=r[4],
+                ev=r[5],
+                fee=r[6],
+                entry_time=r[7],
+                correlation_id=r[8],
+            )
+            for r in rows
+        ]
+
+    async def record_performance(
+        self,
+        total_trades: int,
+        winning_trades: int,
+        total_pnl: float,
+        win_rate: float,
+        avg_ev: float,
+    ) -> None:
+        """Snapshot current performance metrics."""
+        db = self._conn()
+        await db.execute(
+            """
+            INSERT INTO performance_stats
+            (recorded_at, total_trades, winning_trades, total_pnl, win_rate, avg_ev)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (time.time(), total_trades, winning_trades, total_pnl, win_rate, avg_ev),
+        )
+        await db.commit()
+
+    async def get_performance(self) -> dict:
+        """Return latest performance snapshot."""
+        db = self._conn()
+        async with db.execute(
+            "SELECT total_trades, winning_trades, total_pnl, win_rate, avg_ev "
+            "FROM performance_stats ORDER BY id DESC LIMIT 1"
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return {}
+        return {
+            "total_trades": row[0],
+            "winning_trades": row[1],
+            "total_pnl": row[2],
+            "win_rate": row[3],
+            "avg_ev": row[4],
+        }

--- a/projects/polymarket/polyquantbot/phase4/infra/__init__.py
+++ b/projects/polymarket/polyquantbot/phase4/infra/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4 infra package."""

--- a/projects/polymarket/polyquantbot/phase4/infra/polymarket_client.py
+++ b/projects/polymarket/polyquantbot/phase4/infra/polymarket_client.py
@@ -1,0 +1,79 @@
+"""Polymarket Gamma API client with retry logic."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import structlog
+
+log = structlog.get_logger()
+
+GAMMA_API = "https://gamma-api.polymarket.com/markets"
+MAX_RETRIES = 3
+TIMEOUT_S = 10
+
+
+@dataclass
+class MarketData:
+    """Parsed market snapshot from Gamma API."""
+
+    market_id: str
+    question: str
+    best_ask: float
+    best_bid: float
+    volume: float
+    active: bool
+
+
+class PolymarketClient:
+    """Fetches live market data from Polymarket Gamma API."""
+
+    async def fetch_markets(self, limit: int = 20) -> list[MarketData]:
+        """Fetch and parse markets with up to MAX_RETRIES retries."""
+        for attempt in range(MAX_RETRIES):
+            try:
+                async with httpx.AsyncClient(timeout=TIMEOUT_S) as client:
+                    resp = await client.get(
+                        GAMMA_API,
+                        params={"limit": limit, "active": "true", "closed": "false"},
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    markets = [self._parse_market(m) for m in data]
+                    return [m for m in markets if m is not None]  # type: ignore[misc]
+            except Exception as exc:
+                wait = 2 ** attempt
+                log.warning(
+                    "gamma_api_retry",
+                    attempt=attempt + 1,
+                    wait_seconds=wait,
+                    error=str(exc),
+                )
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(wait)
+        return []
+
+    def _parse_market(self, raw: dict[str, Any]) -> MarketData | None:
+        """Parse a raw API response dict into MarketData."""
+        try:
+            outcome_prices = raw.get("outcomePrices", [])
+            if isinstance(outcome_prices, str):
+                import json
+                outcome_prices = json.loads(outcome_prices)
+            if not outcome_prices or len(outcome_prices) < 1:
+                return None
+            best_ask = float(outcome_prices[0])
+            best_bid = 1.0 - best_ask
+            return MarketData(
+                market_id=str(raw.get("id", raw.get("conditionId", ""))),
+                question=str(raw.get("question", "")),
+                best_ask=best_ask,
+                best_bid=best_bid,
+                volume=float(raw.get("volume", 0.0)),
+                active=bool(raw.get("active", True)),
+            )
+        except Exception as exc:
+            log.warning("market_parse_error", error=str(exc))
+            return None

--- a/projects/polymarket/polyquantbot/phase4/infra/telegram_service.py
+++ b/projects/polymarket/polyquantbot/phase4/infra/telegram_service.py
@@ -1,0 +1,105 @@
+"""Telegram service — pure STATE_UPDATED subscriber in Phase 4."""
+from __future__ import annotations
+
+import structlog
+import httpx
+
+from ..engine.event_bus import EventEnvelope
+
+log = structlog.get_logger()
+
+
+class TelegramService:
+    """Sends Telegram notifications as a pure event subscriber."""
+
+    def __init__(self, token: str, chat_id: str) -> None:
+        """Initialise with bot token and chat ID."""
+        self._token = token
+        self._chat_id = chat_id
+        self._base = f"https://api.telegram.org/bot{token}"
+
+    async def handle_state_updated(self, envelope: EventEnvelope) -> None:
+        """Route STATE_UPDATED events to the correct notification method."""
+        action = envelope.payload.get("action", "")
+        if action == "TRADE_OPENED":
+            await self._send_trade_opened(envelope)
+        elif action == "TRADE_CLOSED":
+            await self._send_trade_closed(envelope)
+        elif action == "SUMMARY":
+            await self._send_summary(envelope)
+        elif action == "CIRCUIT_OPEN":
+            await self._send_circuit_open(envelope)
+
+    async def _send_trade_opened(self, envelope: EventEnvelope) -> None:
+        """Notify on new trade open."""
+        t = envelope.payload.get("trade", {})
+        balance = envelope.payload.get("balance", 0.0)
+        msg = (
+            f"\U0001f7e2 *TRADE OPENED*\n"
+            f"Market: {t.get('question', t.get('market_id', 'N/A'))[:60]}\n"
+            f"Entry: {t.get('entry_price', 0):.4f}\n"
+            f"Size: ${t.get('size', 0):.2f}\n"
+            f"EV: {t.get('ev', 0):.4f}\n"
+            f"Fee: ${t.get('fee', 0):.4f}\n"
+            f"Balance: ${balance:.2f}"
+        )
+        await self._send(msg)
+
+    async def _send_trade_closed(self, envelope: EventEnvelope) -> None:
+        """Notify on trade close."""
+        t = envelope.payload.get("trade", {})
+        pnl = t.get("pnl", 0.0)
+        exit_price = t.get("exit_price")
+        exit_str = f"{exit_price:.4f}" if exit_price is not None else "N/A"
+        emoji = "\U0001f7e2" if pnl >= 0 else "\U0001f534"
+        msg = (
+            f"{emoji} *TRADE CLOSED*\n"
+            f"Market: {t.get('question', t.get('market_id', 'N/A'))[:60]}\n"
+            f"Exit: {exit_str} | Reason: {t.get('reason', 'N/A')}\n"
+            f"PnL: ${pnl:+.4f}"
+        )
+        await self._send(msg)
+
+    async def _send_summary(self, envelope: EventEnvelope) -> None:
+        """Send periodic performance summary."""
+        balance = envelope.payload.get("balance", 0.0)
+        initial = envelope.payload.get("initial_balance", 1000.0)
+        open_count = envelope.payload.get("open_count", 0)
+        stats = envelope.payload.get("stats", {})
+        total_return = ((balance - initial) / initial) * 100
+        msg = (
+            f"\U0001f4ca *SUMMARY*\n"
+            f"Balance: ${balance:.2f} ({total_return:+.2f}%)\n"
+            f"Open positions: {open_count}\n"
+            f"Win rate: {stats.get('win_rate', 0):.1%}\n"
+            f"Total PnL: ${stats.get('total_pnl', 0):+.4f}"
+        )
+        await self._send(msg)
+
+    async def _send_circuit_open(self, envelope: EventEnvelope) -> None:
+        """Alert when circuit breaker trips."""
+        reason = envelope.payload.get("reason", "unknown")
+        cooldown = envelope.payload.get("cooldown_seconds", 120)
+        msg = (
+            f"\u26a0\ufe0f *CIRCUIT BREAKER OPEN*\n"
+            f"Reason: {reason}\n"
+            f"Cooldown: {cooldown}s"
+        )
+        await self._send(msg)
+
+    async def _send(self, text: str) -> None:
+        """Send message to Telegram. Never raises."""
+        if not self._token or not self._chat_id:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                await client.post(
+                    f"{self._base}/sendMessage",
+                    json={
+                        "chat_id": self._chat_id,
+                        "text": text,
+                        "parse_mode": "Markdown",
+                    },
+                )
+        except Exception as exc:
+            log.warning("telegram_send_failed", error=str(exc))

--- a/projects/polymarket/polyquantbot/phase4/requirements.txt
+++ b/projects/polymarket/polyquantbot/phase4/requirements.txt
@@ -1,0 +1,8 @@
+aiohttp>=3.9.0
+aiosqlite>=0.19.0
+yaml-config>=0.1.4
+pyyaml>=6.0.1
+structlog>=24.1.0
+httpx>=0.27.0
+python-dotenv>=1.0.0
+uuid>=1.30


### PR DESCRIPTION
## Summary

- **EventBus**: Async fan-out pub/sub with per-subscriber queues + worker tasks. 10 event type constants. `EventEnvelope` carries `correlation_id` end-to-end.
- **Pipeline**: 5-stage flow — `MARKET_DATA → SIGNAL → FILTERED_SIGNAL → POSITION_SIZED → ORDER_FILLED → STATE_UPDATED`
- **CircuitBreaker**: Trips on consecutive losses, API failures, or latency breaches. Auto-resets after configurable cooldown.
- **Health Server**: aiohttp `GET /health` on `:8080` — returns uptime, cycle, balance, open positions.
- **Telegram**: Rewritten as pure `STATE_UPDATED` subscriber — no direct handler calls.
- **StateManager**: Upgraded with `correlation_id` on trades, `event_log` and `failed_events` tables.

## Files (19 total, 5-file batches)

| File | Description |
|------|-------------|
| `config.yaml` | Adds `circuit_breaker`, `latency_budgets`, `health` sections |
| `engine/event_bus.py` | EventBus + EventEnvelope + event type constants |
| `engine/circuit_breaker.py` | Loss/API/latency trip with cooldown |
| `engine/pipeline_handlers.py` | `make_handlers()` factory — 5 stages |
| `engine/state_manager.py` | `correlation_id`, `event_log`, `failed_events` tables |
| `engine/health_server.py` | aiohttp `/health` on `:8080` |
| `engine/runner.py` | Main loop — publishes `MARKET_DATA`, wires all subscriptions |
| `engine/performance_tracker.py` | Win/loss metrics (copied from phase2) |
| `infra/telegram_service.py` | Pure `STATE_UPDATED` subscriber |
| `infra/polymarket_client.py` | Gamma API client (copied from phase2) |
| `core/signal_model.py` | Bayesian EV + edge_score (copied from phase2) |
| `core/risk_manager.py` | Fractional Kelly, no forced $1 min (copied from phase2) |
| `core/execution/paper_executor.py` | Partial fills, dynamic slippage, fees (copied from phase2) |

## Event Flow

```
PolymarketClient
      │
      ▼ MARKET_DATA (correlation_id per market)
 handle_market_data
      │
      ▼ SIGNAL
 handle_signal  (dedup + exposure check)
      │
      ▼ FILTERED_SIGNAL
 handle_filtered_signal  (Kelly sizing)
      │
      ▼ POSITION_SIZED
 handle_position_sized  (paper execution)
      │
      ▼ ORDER_FILLED
 handle_order_filled  (persist + notify)
      │
      ▼ STATE_UPDATED
 TelegramService.handle_state_updated
```

## Risk Rules Compliance
- Kelly α = 0.25 ✅
- Max position 10% bankroll ✅
- Circuit breaker kills trading on 3 consecutive losses ✅
- All secrets in `.env` only ✅