### PR TITLE
fix(telegram): enforce full inline mode — zero message stacking

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE
 
 Last Updated: 2026-04-02
-Status: Full wiring activation complete — WS → pipeline → signal → trade → Telegram
+Status: Telegram inline enforcement complete — single-message navigation, zero stacking
 
 ---
 
@@ -19,6 +19,9 @@ Status: Full wiring activation complete — WS → pipeline → signal → trade
 - ws-fix-compatibility — WebSocket extra_headers → additional_headers; fail-fast after 5 retries; startup version log
 - system-activation-final — Telegram production-ready (6 new alert methods); SystemActivationMonitor (event/signal counters, 10s log, 60s assert); WSClientStats connection state; main.py Telegram init fix + startup alert + heartbeat task
 - full-wiring-activation — WS client wired into main.py (MARKET_IDS env var); event loop calls activation_monitor.record_event(); LivePaperRunner wired with activation_monitor (record_signal, record_trade) + alert_signal/alert_trade Telegram hooks; heartbeat ws_connected fixed to use ws_client.stats().connected
+- fix-entrypoint-runtime — Single entrypoint enforced (main.py); legacy menu (Markets/Rediscover) eliminated; startup assertions added
+- telegram-callback-fix — Centralized CallbackRouter; all keyboards standardized to action:<name> format; editMessageText as primary; telegram/ui/keyboard.py + screens.py + handlers/
+- telegram-inline-enforcement — Full inline mode enforced: legacy sendMessage callback branches removed from polling loop; INLINE_UPDATE log emitted on every action; non-action: callbacks answered silently (no stacking); try/except pattern explicit in CallbackRouter
 
 ---
 

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -276,17 +276,12 @@ async def main() -> None:
         offset = 0
         log.info("telegram_polling_started")
 
-        async def _send_result(session, reply_chat_id, result, callback_query_id=None):
-            """Send a new message for text command responses."""
-            if callback_query_id:
-                # Answer legacy callback (non-action: format) to clear spinner
-                try:
-                    await session.post(
-                        f"{_tg_api}/answerCallbackQuery",
-                        json={"callback_query_id": callback_query_id},
-                    )
-                except Exception:
-                    pass
+        async def _send_result(session, reply_chat_id, result):
+            """Send a new message for text command responses (/start, /status, etc.).
+
+            sendMessage is ONLY used for user-typed text commands.
+            All button-press navigation uses editMessageText via CallbackRouter.
+            """
             if not result or not result.message:
                 return
             payload = {
@@ -316,40 +311,36 @@ async def main() -> None:
                         offset = update["update_id"] + 1
 
                         # ── Inline button press ────────────────────────────
+                        # RULE: ALL callbacks MUST use action: prefix.
+                        # ONLY action: callbacks trigger an inline update
+                        # (editMessageText).  Non-action: callbacks are
+                        # answered silently — NO sendMessage, NO stacking.
                         cq = update.get("callback_query")
                         if cq:
                             cb_data = (cq.get("data") or "").strip()
                             cb_chat = cq.get("message", {}).get("chat", {}).get("id")
-                            cb_user = cq.get("from", {}).get("id", 0)
                             if cb_data and cb_chat:
                                 if cb_data.startswith("action:"):
-                                    # ── New system: edit in-place ──────────
+                                    # Inline update via CallbackRouter
                                     await _callback_router.route(session, cq)
-                                elif cb_data.endswith("_prompt"):
-                                    # ── Legacy prompt helper ───────────────
-                                    cmd_key = cb_data.replace("_prompt", "")
-                                    await _send_result(
-                                        session, cb_chat,
-                                        CommandResult(
-                                            success=True,
-                                            message=f"Type: `/{cmd_key} <value>`",
-                                        ),
-                                        callback_query_id=cq["id"],
-                                    )
                                 else:
-                                    # ── Legacy fallback: route via text ───
-                                    fake = {
-                                        "update_id": update["update_id"],
-                                        "message": {
-                                            "text": f"/{cb_data}",
-                                            "chat": {"id": cb_chat},
-                                            "from": {"id": cb_user},
-                                        },
-                                    }
-                                    result = await router.route_update(fake)
-                                    await _send_result(
-                                        session, cb_chat, result,
-                                        callback_query_id=cq["id"],
+                                    # Non-action: callback (old message in chat)
+                                    # Answer query to clear spinner — NO new message
+                                    try:
+                                        await session.post(
+                                            f"{_tg_api}/answerCallbackQuery",
+                                            json={
+                                                "callback_query_id": cq["id"],
+                                                "text": "⚠️ Outdated button — send /start to refresh.",
+                                                "show_alert": False,
+                                            },
+                                        )
+                                    except Exception as exc:
+                                        log.warning("callback_answer_legacy_failed", error=str(exc))
+                                    log.warning(
+                                        "callback_non_action_ignored",
+                                        callback_data=cb_data,
+                                        chat_id=cb_chat,
                                     )
                             continue
 

--- a/projects/polymarket/polyquantbot/reports/forge/TELEGRAM_INLINE_ENFORCEMENT.md
+++ b/projects/polymarket/polyquantbot/reports/forge/TELEGRAM_INLINE_ENFORCEMENT.md
@@ -1,0 +1,158 @@
+# FORGE-X REPORT — Telegram Inline Enforcement
+**Date:** 2026-04-02
+**Branch:** feature/forge/telegram-inline-enforcement
+**Role:** FORGE-X
+
+---
+
+## 1. Inline Architecture
+
+```
+User sends /start (text command)
+    └─ _polling_loop → _send_result → sendMessage
+           └─ NEW message created with build_main_menu() keyboard
+                  (all buttons have action: prefix)
+
+User clicks any button (callback_query, data = "action:<name>")
+    └─ _polling_loop detects action: prefix
+           └─ _callback_router.route(session, cq)
+                  ├─ 1. answerCallbackQuery()     ← clears spinner
+                  ├─ 2. log INLINE_UPDATE(action) ← audit trail
+                  ├─ 3. _dispatch(action)         ← handler returns (text, keyboard)
+                  ├─ 4. editMessageText()         ← PRIMARY: edits existing message
+                  └─ 5. sendMessage() fallback    ← ONLY if message >48h / deleted
+```
+
+**Key contract:**
+- `action:*` callback → `editMessageText` ONLY
+- Non-`action:` callback → `answerCallbackQuery` only (no new message, no stacking)
+- Text command (`/start`, `/status`) → `sendMessage` (user explicitly typed it)
+
+---
+
+## 2. Before vs After
+
+### BEFORE (stacking problem)
+
+```
+User: /start                        → Bot sends Message #1 (main menu)
+User: clicks Settings               → Bot sends Message #2 (settings)
+User: clicks Risk Level             → Bot sends Message #3 (risk prompt)
+User: clicks Back                   → Bot sends Message #4 (main menu)
+```
+Result: 4 messages, chat cluttered, confusing UX.
+
+Also: non-`action:` legacy callbacks routed via `CommandRouter → sendMessage`,
+each creating a new message.
+
+### AFTER (inline enforcement)
+
+```
+User: /start                        → Bot sends Message #1 (main menu)
+User: clicks Settings               → Message #1 EDITED (now shows settings)
+User: clicks Risk Level             → Message #1 EDITED (now shows risk prompt)
+User: clicks Back                   → Message #1 EDITED (back to main menu)
+```
+Result: 1 message, always updated in-place.
+
+---
+
+## 3. Code Changes
+
+### `telegram/handlers/callback_router.py`
+
+**Added `INLINE_UPDATE` log at route entry** (after action parsed):
+```python
+log.info("INLINE_UPDATE", action=action, chat_id=chat_id, message_id=message_id)
+```
+
+**Added `INLINE_UPDATE` log in `_dispatch`** (replaces `callback_dispatching`):
+```python
+log.info("INLINE_UPDATE", action=action)
+```
+
+**Made try/except inline enforcement explicit in `route()`**:
+```python
+# Step 3: edit in-place (primary path)
+#         fallback to sendMessage ONLY if edit is truly unavailable
+try:
+    edited = await self._edit_message(session, chat_id, message_id, text, keyboard)
+    if not edited:
+        await self._send_message(session, chat_id, text, keyboard)
+except asyncio.CancelledError:
+    raise
+except Exception as exc:
+    log.error("callback_inline_update_failed", ...)
+    await self._send_message(session, chat_id, text, keyboard)
+```
+
+---
+
+### `main.py` — `_polling_loop`
+
+**Removed legacy sendMessage callback branches:**
+
+Old branches (REMOVED):
+- `cb_data.endswith("_prompt")` → called `_send_result()` → `sendMessage` ❌
+- Else fallback → routed via `CommandRouter` → `_send_result()` → `sendMessage` ❌
+
+New callback handling:
+```python
+if cb_data.startswith("action:"):
+    await _callback_router.route(session, cq)   # editMessageText
+else:
+    # Answer only — NO new message, NO stacking
+    await session.post("/answerCallbackQuery", json={
+        "callback_query_id": cq["id"],
+        "text": "⚠️ Outdated button — send /start to refresh.",
+        "show_alert": False,
+    })
+    log.warning("callback_non_action_ignored", ...)
+```
+
+**Cleaned up `_send_result` signature:**
+
+Removed unused `callback_query_id` parameter. `_send_result` now only handles
+text command responses (sendMessage for `/start`, `/status`, etc.).
+
+---
+
+## 4. UX Improvement
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Messages per navigation session | N (one per action) | 1 (always same message) |
+| Button click behavior | New message spawned | Existing message edited |
+| Chat scroll needed | Yes (messages accumulate) | No (single fixed message) |
+| Old button clicks | Spawned new messages | Toast: "use /start to refresh" |
+| Logs per callback | `callback_dispatching` | `INLINE_UPDATE` (explicit) |
+
+---
+
+## 5. Known Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Message >48h old | `editMessageText` returns 400, fallback to `sendMessage` |
+| Message deleted by user | Same as above — fallback to `sendMessage` |
+| Bot restarted, old message clicked | Callback answered with toast, no new message |
+| `/start` typed | `sendMessage` — correct, creates fresh entry point |
+| Multiple users | Each `message_id` is per-user, edits only affect that message |
+| No `TELEGRAM_TOKEN` set | Polling loop never starts, no callbacks processed |
+| Network timeout on edit | Retried 3× with backoff; falls back to send on exhaustion |
+
+---
+
+## 6. Log Output (Expected)
+
+On every button press:
+```json
+{"event": "callback_received", "callback_data": "action:status", "chat_id": 123, "message_id": 456}
+{"event": "INLINE_UPDATE", "action": "status", "chat_id": 123, "message_id": 456}
+{"event": "INLINE_UPDATE", "action": "status"}
+{"event": "callback_edit_success", "chat_id": 123, "message_id": 456, "attempt": 1}
+```
+
+---
+
+**Status: COMPLETE**

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -132,7 +132,10 @@ class CallbackRouter:
 
         action = cb_data[len(ACTION_PREFIX):]
 
-        # Step 2: dispatch
+        # INLINE_UPDATE — all menu navigation is edit-only from this point
+        log.info("INLINE_UPDATE", action=action, chat_id=chat_id, message_id=message_id)
+
+        # Step 2: dispatch to handler → (text, keyboard)
         try:
             text, keyboard = await self._dispatch(action)
         except asyncio.CancelledError:
@@ -151,17 +154,31 @@ class CallbackRouter:
         if not text:
             return
 
-        # Step 3: edit in-place; fallback to send on failure
+        # Step 3: edit in-place (primary path)
+        #         fallback to sendMessage ONLY if edit is truly unavailable
+        #         (message >48h old or deleted — not a navigation flow error)
         if chat_id and message_id:
-            edited = await self._edit_message(session, chat_id, message_id, text, keyboard)
-            if not edited:
-                log.warning(
-                    "callback_edit_failed_sending_new",
-                    chat_id=chat_id,
+            try:
+                edited = await self._edit_message(session, chat_id, message_id, text, keyboard)
+                if not edited:
+                    log.warning(
+                        "callback_edit_failed_sending_new",
+                        chat_id=chat_id,
+                        action=action,
+                    )
+                    await self._send_message(session, chat_id, text, keyboard)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log.error(
+                    "callback_inline_update_failed",
                     action=action,
+                    chat_id=chat_id,
+                    error=str(exc),
                 )
                 await self._send_message(session, chat_id, text, keyboard)
         elif chat_id:
+            # No message_id — cannot edit; send new (only happens on first interaction)
             await self._send_message(session, chat_id, text, keyboard)
 
     # ── Dispatch table ─────────────────────────────────────────────────────────
@@ -173,7 +190,7 @@ class CallbackRouter:
             ``(text, inline_keyboard)`` tuple — text is Markdown-formatted,
             keyboard is a list[list[dict]] for Telegram ``inline_keyboard``.
         """
-        log.info("callback_dispatching", action=action)
+        log.info("INLINE_UPDATE", action=action)
 
         # Lazy imports — avoids circular deps and speeds up module load
         from .status import handle_status, handle_performance, handle_health, handle_strategies


### PR DESCRIPTION
callback_router.py:
- Add INLINE_UPDATE log at route() entry (after action parsed) with action, chat_id, message_id — explicit audit trail per requirement.
- Add INLINE_UPDATE log in _dispatch() replacing callback_dispatching.
- Wrap editMessageText call in explicit try/except block to make inline enforcement contract clear: edit is primary, sendMessage is emergency fallback only (message deleted / >48h old).

main.py _polling_loop:
- REMOVE legacy sendMessage callback branches:
  * _prompt suffix branch → sendMessage (deleted)
  * Non-action: else branch → CommandRouter → sendMessage (deleted)
- Replace with: non-action: callbacks get answerCallbackQuery only (toast: "Outdated button — send /start to refresh"), NO new message.
- _send_result stripped of unused callback_query_id param — now only serves user-typed text commands (/start, /status, etc.).

Result: button clicks NEVER create new messages. Only /start and explicit text commands use sendMessage. Complete inline enforcement.

reports/forge/TELEGRAM_INLINE_ENFORCEMENT.md: full forge report.
PROJECT_STATE.md: updated with completed phase.

https://claude.ai/code/session_01DRM6eTeGqmpmoutx9hvtuC