### PR TITLE
Add minimum trade sample guard to validation engine

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
 Last Updated: 2026-04-04
-Status: Phase 24.3b logging hotfix applied. structlog.stdlib.add_logger_name removed from production processor chain — incompatible with PrintLogger. System startup crash resolved. 24h validation run reset and active. Two P1 gates remain for LIVE promotion: (1) CRITICAL→kill-switch wiring, (2) LIVE/CLOB closed-trade hook. Report: reports/forge/24_3b_logging_hotfix.md
+Status: Phase 24.3d1 min sample guard applied. Validation now returns INSUFFICIENT_DATA when trade_count < 30, preventing misleading HEALTHY/WARNING/CRITICAL states on undersampled windows. 24h validation run remains active in staging. P1 gates unchanged for LIVE promotion: (1) CRITICAL→kill-switch wiring, (2) LIVE/CLOB closed-trade hook. Report: reports/forge/24_3d1_min_sample_guard.md
 
 ---
 
@@ -68,6 +68,12 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+MIN SAMPLE GUARD (Phase 24.3d1)
+
+- monitoring/metrics_engine.py (MODIFIED): `compute()` output now always includes `"trade_count"` using `len(trades)` (safe for empty trades)
+- monitoring/validation_engine.py (MODIFIED): `evaluate(metrics)` now applies top-of-function guard and returns `INSUFFICIENT_DATA` with reason `minimum 30 trades required` when `trade_count < 30`
+- reports/forge/24_3d1_min_sample_guard.md (NEW): this phase's report
 
 LOGGING HOTFIX (Phase 24.3b)
 
@@ -685,7 +691,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
-- **24h validation observation run** — logging hotfix applied (Phase 24.3b); run reset and active in staging; collecting: uptime stats, crash count, validation state distribution, WR/PF/last_pnl metrics
+- **24h validation observation run** — min sample guard applied (Phase 24.3d1); run active in staging; collecting: uptime stats, crash count, validation state distribution, WR/PF/last_pnl/trade_count metrics
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
 - Wire PriceFeedHandler to main.py as background asyncio task for continuous WS mark-to-market
 - Wire StrategyStateManager(db=db) into main.py startup and save(db=db) after every Telegram toggle
@@ -714,11 +720,11 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` field now available in validation_update logs
-2. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-3. **Wire LIVE/CLOB closed-trade hook** — `_run_closed_validation_hook` must be called from `execution/clob_executor.py` close path for real-money fills
-4. Wire PriceFeedHandler to main.py as background task for continuous WS mark-to-market
-5. Add WS disconnect CRITICAL alert to Telegram (currently only WARNING)
+1. **Telegram UX improvement** — simplify validation status messaging and improve readability for INSUFFICIENT_DATA vs actionable WARNING/CRITICAL alerts
+2. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` field now available in validation_update logs
+3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
+4. **Wire LIVE/CLOB closed-trade hook** — `_run_closed_validation_hook` must be called from `execution/clob_executor.py` close path for real-money fills
+5. Wire PriceFeedHandler to main.py as background task for continuous WS mark-to-market
 
 ---
 

--- a/projects/polymarket/polyquantbot/monitoring/metrics_engine.py
+++ b/projects/polymarket/polyquantbot/monitoring/metrics_engine.py
@@ -1,1 +1,71 @@
-# modified file with trade_count added
+"""Phase 24 — MetricsEngine for rolling validation metrics."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class MetricsEngine:
+    """Compute validation metrics from recent closed trades."""
+
+    @staticmethod
+    def compute_win_rate(trades: list[dict[str, Any]]) -> float:
+        if not trades:
+            return 0.0
+        wins = sum(1 for t in trades if float(t.get("pnl", 0.0)) > 0.0)
+        return wins / len(trades)
+
+    @staticmethod
+    def compute_profit_factor(trades: list[dict[str, Any]]) -> float:
+        gross_profit = sum(float(t.get("pnl", 0.0)) for t in trades if float(t.get("pnl", 0.0)) > 0.0)
+        gross_loss = sum(-float(t.get("pnl", 0.0)) for t in trades if float(t.get("pnl", 0.0)) < 0.0)
+
+        if gross_loss == 0.0:
+            return 999.0 if gross_profit > 0.0 else 0.0
+        return gross_profit / gross_loss
+
+    @staticmethod
+    def compute_expectancy(trades: list[dict[str, Any]]) -> float:
+        if not trades:
+            return 0.0
+
+        wins = [float(t.get("pnl", 0.0)) for t in trades if float(t.get("pnl", 0.0)) > 0.0]
+        losses = [-float(t.get("pnl", 0.0)) for t in trades if float(t.get("pnl", 0.0)) < 0.0]
+        win_rate = len(wins) / len(trades)
+
+        avg_win = sum(wins) / len(wins) if wins else 0.0
+        avg_loss = sum(losses) / len(losses) if losses else 0.0
+        return (win_rate * avg_win) - ((1.0 - win_rate) * avg_loss)
+
+    @staticmethod
+    def compute_drawdown(equity_curve: list[float]) -> float:
+        if len(equity_curve) < 2:
+            return 0.0
+
+        peak = equity_curve[0]
+        max_drawdown = 0.0
+
+        for value in equity_curve:
+            if value > peak:
+                peak = value
+            if peak > 0.0:
+                drawdown = (peak - value) / peak
+                if drawdown > max_drawdown:
+                    max_drawdown = drawdown
+
+        return max_drawdown
+
+    def compute(self, trades: list[dict[str, Any]]) -> dict[str, float]:
+        equity_curve = []
+        running = 0.0
+        for trade in trades:
+            running += float(trade.get("pnl", 0.0))
+            equity_curve.append(running)
+
+        return {
+            "win_rate": self.compute_win_rate(trades),
+            "profit_factor": self.compute_profit_factor(trades),
+            "expectancy": self.compute_expectancy(trades),
+            "max_drawdown": self.compute_drawdown(equity_curve),
+            "last_pnl": float(trades[-1].get("pnl", 0.0)) if trades else 0.0,
+            "trade_count": len(trades),
+        }

--- a/projects/polymarket/polyquantbot/monitoring/validation_engine.py
+++ b/projects/polymarket/polyquantbot/monitoring/validation_engine.py
@@ -1,1 +1,75 @@
-# modified validation engine with min sample guard
+"""Phase 24 — ValidationEngine maps metrics to HEALTHY/WARNING/CRITICAL."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ValidationState(Enum):
+    HEALTHY = "HEALTHY"
+    WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    state: ValidationState
+    reasons: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "state": self.state.value,
+            "reasons": list(self.reasons),
+        }
+
+
+class ValidationEngine:
+    """Applies validation thresholds to a metrics snapshot."""
+
+    _MIN_WIN_RATE: float = 0.70
+    _MIN_PROFIT_FACTOR: float = 1.50
+    _MAX_DRAWDOWN_WARNING: float = 0.06
+    _MAX_DRAWDOWN_CRITICAL: float = 0.08
+
+    def evaluate(self, metrics: dict[str, float]) -> ValidationResult:
+        trade_count = metrics.get("trade_count", 0)
+        if trade_count < 30:
+            return ValidationResult(
+                state=ValidationState.INSUFFICIENT_DATA,
+                reasons=["minimum 30 trades required"],
+            )
+
+        reasons: list[str] = []
+        violations = 0
+
+        win_rate = float(metrics.get("win_rate", 0.0))
+        if win_rate < self._MIN_WIN_RATE:
+            violations += 1
+            reasons.append(f"win_rate below minimum: {win_rate:.2f} < {self._MIN_WIN_RATE:.2f}")
+
+        profit_factor = float(metrics.get("profit_factor", 0.0))
+        if profit_factor < self._MIN_PROFIT_FACTOR:
+            violations += 1
+            reasons.append(
+                f"profit_factor below minimum: {profit_factor:.2f} < {self._MIN_PROFIT_FACTOR:.2f}"
+            )
+
+        max_drawdown = float(metrics.get("max_drawdown", 0.0))
+        if max_drawdown > self._MAX_DRAWDOWN_CRITICAL:
+            reasons.append(
+                f"max_drawdown exceeds hard limit: {max_drawdown:.2%} > {self._MAX_DRAWDOWN_CRITICAL:.2%}"
+            )
+            return ValidationResult(state=ValidationState.CRITICAL, reasons=reasons)
+
+        if max_drawdown > self._MAX_DRAWDOWN_WARNING:
+            violations += 1
+            reasons.append(
+                f"max_drawdown above warning: {max_drawdown:.2%} > {self._MAX_DRAWDOWN_WARNING:.2%}"
+            )
+
+        if violations == 0:
+            return ValidationResult(state=ValidationState.HEALTHY, reasons=[])
+        if violations == 1:
+            return ValidationResult(state=ValidationState.WARNING, reasons=reasons)
+        return ValidationResult(state=ValidationState.CRITICAL, reasons=reasons)

--- a/projects/polymarket/polyquantbot/reports/forge/24_3d1_min_sample_guard.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3d1_min_sample_guard.md
@@ -1,0 +1,61 @@
+# FORGE-X Report — 24_3d1_min_sample_guard.md
+
+**Phase:** 24.3d1  
+**Date:** 2026-04-04  
+**Environment:** staging  
+**Task:** Enforce minimum sample size before validation state evaluation
+
+---
+
+## 1. What was built
+
+Implemented a minimum-trade guard in the validation path to prevent misleading state classification on undersampled windows:
+
+- `MetricsEngine.compute()` now always includes `trade_count` (`len(trades)`), including when `trades` is empty.
+- `ValidationEngine.evaluate(metrics)` now checks `trade_count` at the very top and returns:
+  - `INSUFFICIENT_DATA`
+  - reason: `minimum 30 trades required`
+- Guard executes before all threshold logic and therefore overrides HEALTHY/WARNING/CRITICAL when sample size is below 30.
+
+## 2. Current system architecture
+
+Validation branch in pipeline is now:
+
+`PerformanceTracker.get_recent_trades()`
+→ `MetricsEngine.compute(trades)`
+→ metrics include `trade_count`
+→ `ValidationEngine.evaluate(metrics)`
+→ **Guard first:** `trade_count < 30` ⇒ `INSUFFICIENT_DATA`
+→ otherwise proceed with existing WR/PF/MDD threshold classification.
+
+No execution-path logic was changed.
+
+## 3. Files created / modified (full paths)
+
+- Modified: `projects/polymarket/polyquantbot/monitoring/metrics_engine.py`
+- Modified: `projects/polymarket/polyquantbot/monitoring/validation_engine.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_3d1_min_sample_guard.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+
+Manual validation scenarios executed:
+
+1. `trade_count = 1` → `INSUFFICIENT_DATA`
+2. `trade_count = 29` → `INSUFFICIENT_DATA`
+3. `trade_count = 30` → normal validation resumes (existing threshold logic applies)
+
+`trade_count` is present in computed metrics for all tested trade lists, including non-empty and empty-safe paths.
+
+## 5. Known issues
+
+- Existing LIVE promotion P1 gates remain unchanged:
+  1. CRITICAL → kill-switch wiring not yet enforced in runtime stop path.
+  2. LIVE/CLOB closed-trade validation hook still pending.
+- `docs/CLAUDE.md` referenced by process instructions is not present in repository.
+
+## 6. What is next
+
+1. Continue staging validation observation run with the new sample guard enabled.
+2. Improve Telegram UX to clearly distinguish `INSUFFICIENT_DATA` from actionable warning/critical alerts.
+3. Complete remaining LIVE promotion P1 gates (kill-switch + LIVE closed-trade hook).


### PR DESCRIPTION
### Motivation
- Prevent misleading HEALTHY/WARNING/CRITICAL validation outputs when the number of recent trades is too small to be statistically meaningful by making sample size explicit and enforcing a minimum sample guard.

### Description
- `MetricsEngine.compute()` now includes a `trade_count` key set to `len(trades)` so callers always have explicit sample-size context and the value is safe for empty trade lists.
- `ValidationEngine.evaluate(metrics)` adds a top-of-function guard that reads `trade_count = metrics.get("trade_count", 0)` and returns `INSUFFICIENT_DATA` with reason `minimum 30 trades required` when `trade_count < 30`, executing before all existing threshold checks and overriding HEALTHY/WARNING/CRITICAL.
- Added the Forge report `projects/polymarket/polyquantbot/reports/forge/24_3d1_min_sample_guard.md` documenting the change and updated `PROJECT_STATE.md` to reflect completion and next priorities.
- No thresholds or other evaluation logic were changed and there is no impact to execution paths beyond the new guard.

### Testing
- Ran small sanity scripts invoking `MetricsEngine.compute()` and `ValidationEngine.evaluate()` for trade counts of 0, 1, 29 and 30 and verified the engine returns `trade_count` and `INSUFFICIENT_DATA` for counts < 30 while resuming normal validation at 30; the checks succeeded.
- Performed repository hygiene checks (no `phase*/` folders present) and committed the code, report, and `PROJECT_STATE.md` together as required by the report system.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d108ea5964832e99db7b31fe669108)