### PR TITLE
Improve validation Telegram UX messaging and anti-spam behavior

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
 Last Updated: 2026-04-04
-Status: Phase 24.3b logging hotfix applied. structlog.stdlib.add_logger_name removed from production processor chain — incompatible with PrintLogger. System startup crash resolved. 24h validation run reset and active. Two P1 gates remain for LIVE promotion: (1) CRITICAL→kill-switch wiring, (2) LIVE/CLOB closed-trade hook. Report: reports/forge/24_3b_logging_hotfix.md
+Status: Phase 24.3d2 Telegram validation UX improvement applied in staging. Validation alerts now emit clear state-based operator messages (INSUFFICIENT_DATA/HEALTHY/WARNING/CRITICAL) with safe metric fallbacks and state-change-only anti-spam behavior. 24h validation run remains active.
 
 ---
 
@@ -68,6 +68,12 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+TELEGRAM VALIDATION UX IMPROVEMENT (Phase 24.3d2)
+
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): `_emit_validation_result` now emits clean 3–5 line Telegram validation alerts for INSUFFICIENT_DATA / HEALTHY / WARNING / CRITICAL using metrics trade_count/win_rate/profit_factor/max_drawdown with safe `0` fallbacks for missing/None values
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Telegram validation alerts now fire on **state change only** to prevent spam; Telegram send failures remain log-only and non-blocking
+- projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md (NEW): this phase's report
 
 LOGGING HOTFIX (Phase 24.3b)
 
@@ -685,6 +691,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
+- **Validation run (staging)** — active after Telegram UX improvement (Phase 24.3d2); monitoring clarity/readability of validation state transitions and operator response time from Telegram alerts
 - **24h validation observation run** — logging hotfix applied (Phase 24.3b); run reset and active in staging; collecting: uptime stats, crash count, validation state distribution, WR/PF/last_pnl metrics
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
 - Wire PriceFeedHandler to main.py as background asyncio task for continuous WS mark-to-market
@@ -714,11 +721,13 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` field now available in validation_update logs
-2. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-3. **Wire LIVE/CLOB closed-trade hook** — `_run_closed_validation_hook` must be called from `execution/clob_executor.py` close path for real-money fills
-4. Wire PriceFeedHandler to main.py as background task for continuous WS mark-to-market
-5. Add WS disconnect CRITICAL alert to Telegram (currently only WARNING)
+1. **Snapshot system (Phase 24.4)** — implement and wire periodic validation snapshots for Telegram + operator review in staging
+2. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` field now available in validation_update logs
+3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
+4. **Wire LIVE/CLOB closed-trade hook** — `_run_closed_validation_hook` must be called from `execution/clob_executor.py` close path for real-money fills
+5. Wire PriceFeedHandler to main.py as background task for continuous WS mark-to-market
+6. Add WS disconnect CRITICAL alert to Telegram (currently only WARNING)
+7. SENTINEL validation required for telegram validation UX improvement before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -280,15 +280,52 @@ async def run_trading_loop(
             validation_mode=_validation_mode,
         )
 
-        # ── Telegram alert on state change (with WARNING cooldown) ───────────
-        if _val_result.state != _prev_vs[0] or _val_result.state == ValidationState.CRITICAL:
-            _now_alert = time.time()
-            _send_alert = True
+        # ── Telegram alert on state change only (anti-spam) ──────────────────
+        if _val_result.state != _prev_vs[0]:
+            def _to_float(value: Any, default: float = 0.0) -> float:
+                """Safely coerce metric values for user-facing formatting."""
+                if value is None:
+                    return default
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    return default
 
-            if _val_result.state == ValidationState.CRITICAL:
+            _trade_count = int(_to_float(_computed.get("trade_count", 0), 0.0))
+            _win_rate = _to_float(_computed.get("win_rate", 0.0), 0.0)
+            _profit_factor = _to_float(_computed.get("profit_factor", 0.0), 0.0)
+            _drawdown = _to_float(_computed.get("max_drawdown", 0.0), 0.0)
+            _state_name = _val_result.state.value
+
+            if _state_name == "INSUFFICIENT_DATA":
                 _alert = (
-                    f"🚨 CRITICAL: validation state → CRITICAL\n"
-                    f"{', '.join(_val_result.reasons)}"
+                    "⚠️ VALIDATION: INSUFFICIENT DATA\n"
+                    f"Trades: {_trade_count}/30\n"
+                    "Status: Warming up..."
+                )
+            elif _val_result.state == ValidationState.HEALTHY:
+                _alert = (
+                    "✅ VALIDATION: HEALTHY\n"
+                    f"Trades: {_trade_count}\n"
+                    f"WR: {_win_rate:.2f}\n"
+                    f"PF: {_profit_factor:.2f}\n"
+                    f"MDD: {_drawdown:.2%}"
+                )
+            elif _val_result.state == ValidationState.WARNING:
+                _alert = (
+                    "⚠️ VALIDATION: WARNING\n"
+                    f"Trades: {_trade_count}\n"
+                    f"WR: {_win_rate:.2f} (target 0.70)\n"
+                    f"PF: {_profit_factor:.2f} (target 1.50)\n"
+                    f"MDD: {_drawdown:.2%}"
+                )
+            else:
+                _alert = (
+                    "🚨 VALIDATION: CRITICAL\n"
+                    f"Trades: {_trade_count}\n"
+                    f"WR: {_win_rate:.2f} < 0.70\n"
+                    f"PF: {_profit_factor:.2f} < 1.50\n"
+                    f"MDD: {_drawdown:.2%}"
                 )
                 # Engage kill switch on CRITICAL when not in observation-only mode
                 if _validation_mode != "LIVE_OBSERVATION":
@@ -299,28 +336,10 @@ async def run_trading_loop(
                             validation_mode=_validation_mode,
                         )
                         stop_event.set()
-            elif _val_result.state == ValidationState.WARNING:
-                # Apply 10-minute cooldown for WARNING alerts
-                if _now_alert - _warning_last_alerted[0] < _WARNING_ALERT_COOLDOWN_S:
-                    _send_alert = False
-                    log.debug(
-                        "validation_warning_cooldown_active",
-                        seconds_since_last=round(_now_alert - _warning_last_alerted[0], 1),
-                        cooldown_s=_WARNING_ALERT_COOLDOWN_S,
-                    )
-                _alert = (
-                    f"⚠️ WARNING: validation state → WARNING\n"
-                    f"{', '.join(_val_result.reasons)}"
-                )
-            else:
-                _alert = None  # HEALTHY transition — silent
 
-            if _val_result.state != _prev_vs[0]:
-                _prev_vs[0] = _val_result.state
+            _prev_vs[0] = _val_result.state
 
-            if _alert and _send_alert and tg_cb is not None:
-                if _val_result.state == ValidationState.WARNING:
-                    _warning_last_alerted[0] = _now_alert
+            if tg_cb is not None:
                 try:
                     await tg_cb(_alert)
                 except Exception as _tg_val_exc:  # noqa: BLE001
@@ -328,8 +347,6 @@ async def run_trading_loop(
                         "validation_telegram_failed",
                         error=str(_tg_val_exc),
                     )
-        elif _val_result.state != _prev_vs[0]:
-            _prev_vs[0] = _val_result.state
 
     async def _run_validation_hook(
         trade: dict[str, Any],

--- a/projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md
@@ -1,0 +1,58 @@
+# 24_3d2_validation_telegram_ux
+
+## 1. What was built
+
+Implemented Telegram validation alert UX improvements in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to make alerts clear, contextual, and actionable for operators in `staging`.
+
+Changes include:
+- Added explicit message templates for `INSUFFICIENT_DATA`, `HEALTHY`, `WARNING`, and `CRITICAL` validation states.
+- Added safe metric fallback handling for missing/`None` metric values using default `0`.
+- Updated alert dispatch logic to send only when validation state changes (anti-spam behavior).
+- Preserved existing non-blocking behavior for Telegram failures (`validation_telegram_failed` log warning only).
+- Preserved CRITICAL kill-switch behavior outside `LIVE_OBSERVATION` mode.
+
+## 2. Current system architecture
+
+Validation path in trading loop remains:
+
+`DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING`
+
+Runtime validation flow (unchanged stage order):
+1. Trade updates tracker state.
+2. Metrics computed via metrics engine.
+3. Validation engine evaluates state.
+4. `_emit_validation_result()` updates in-memory validation store and logs `validation_update`.
+5. Telegram alert is emitted only on state transitions with state-specific human-readable text.
+6. If state is `CRITICAL` and mode is not `LIVE_OBSERVATION`, kill-switch (`stop_event.set()`) is triggered.
+
+## 3. Files created / modified (full paths)
+
+- Modified: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+
+- `INSUFFICIENT_DATA` now emits:
+  - `⚠️ VALIDATION: INSUFFICIENT DATA`
+  - `Trades: {trade_count}/30`
+  - `Status: Warming up...`
+- `HEALTHY` now emits concise 5-line metrics summary with WR/PF/MDD.
+- `WARNING` now emits target-aware WR/PF lines and MDD summary.
+- `CRITICAL` now emits threshold-breach WR/PF lines and MDD summary.
+- All formatting is human-readable text (no JSON), with emoji cues.
+- Metrics source keys used: `trade_count`, `win_rate`, `profit_factor`, `max_drawdown`.
+- Missing/invalid/`None` metric values safely fall back to `0`.
+- Alerting is state-change-only to avoid spam.
+- Telegram send exceptions are handled with warning log only (no execution interruption).
+
+## 5. Known issues
+
+- Existing repository issue remains: `projects/polymarket/polyquantbot/monitoring/validation_engine.py` currently contains placeholder content only; full runtime validation behavior cannot be end-to-end validated in this task scope.
+- Existing cooldown state variables for WARNING alerts remain in module state for backward compatibility context, but alert spam control is now governed by strict state-change-only behavior.
+
+## 6. What is next
+
+- Implement snapshot system for validation state + metrics rollups (next priority).
+- Run SENTINEL validation on Telegram validation UX text and state-transition behavior before merge.
+- Continue 24h staging validation observation and collect operator feedback on alert clarity/actionability.


### PR DESCRIPTION
### Motivation
- Operators need clear, contextual, and actionable Telegram validation alerts during the staging validation run to reduce noise and speed operator response. 
- Current alerts were terse/ambiguous and could spam operators on repeated evaluations, so messages must be human-readable and emitted only on meaningful state transitions.

### Description
- Updated `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` `->_emit_validation_result()` to emit concise, state-specific Telegram messages for `INSUFFICIENT_DATA`, `HEALTHY`, `WARNING`, and `CRITICAL` using human-friendly templates. 
- Added safe coercion/fallbacks for metrics (`trade_count`, `win_rate`, `profit_factor`, `max_drawdown`) so missing or `None` values format to `0` without raising exceptions. 
- Changed alert dispatch to fire only on validation state changes (anti-spam) while preserving the existing `CRITICAL` kill-switch behavior (calls `stop_event.set()` outside `LIVE_OBSERVATION`) and keeping Telegram failures log-only. 
- Files updated/added: modified `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`, updated `PROJECT_STATE.md`, and added report `projects/polymarket/polyquantbot/reports/forge/24_3d2_validation_telegram_ux.md`.

### Testing
- Ran `python -m compileall projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to verify Python bytecode compilation, which completed successfully. 
- Performed static checks with `rg` for the new message templates and state-change guard, which located the updated logic as expected. 
- Verified no legacy `phase*` directories exist via `find`, which returned no matches. 
- Commit was created with the changes; no runtime test failures were introduced by the local compilation and static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d11c1f68bc832eb246cc6499a3ac6f)