### PR TITLE
feat: add shadow market intelligence layer in trading loop

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
 Last Updated: 2026-04-04
-Status: Phase 24.3d3 validation snapshot system added. Periodic system snapshots now emit every ~10 minutes from the validation path for real-time trend visibility without execution-path impact. 24h validation run remains active in staging. Next report: projects/polymarket/polyquantbot/reports/forge/24_3d3_validation_snapshot.md
+Status: Phase 24.3e market intelligence layer added in shadow-only mode. Market-type telemetry now logs and snapshots distribution data without affecting signal, risk, validation, or execution decisions. Validation run remains active in staging. Next report: projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
 
 ---
 
@@ -68,6 +68,14 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+MARKET INTELLIGENCE LAYER (Phase 24.3e)
+
+- projects/polymarket/polyquantbot/strategy/market_classifier.py (NEW): Added `MarketClassifier.classify(market)` with BONDS/HIGH_LIQUIDITY/SHORT_TERM/LONG_TERM/GENERAL classification and safe missing-field handling
+- projects/polymarket/polyquantbot/strategy/market_intelligence.py (NEW): Added `MarketIntelligenceEngine.analyze(market, signal=None)` to attach `market_type`, `tags`, optional `confidence`, and `signal_present`
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Integrated shadow-only intelligence analysis after market normalization and before signal generation; emits `market_intelligence` logs per market; tracks `trade_distribution` per market_type after successful fills
+- projects/polymarket/polyquantbot/monitoring/snapshot_engine.py (MODIFIED): Snapshot payload extended with `market_distribution` and `trade_distribution`
+- projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md (NEW): completion report
 
 VALIDATION SNAPSHOT SYSTEM (Phase 24.3d3)
 
@@ -702,7 +710,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
-- **24h validation observation run** — Snapshot system + Telegram UX improvements deployed (Phase 24.3d3/24.3d2); run active in staging; collecting: uptime stats, crash count, validation state distribution, WR/PF/last_pnl/trade_count metrics and 10-minute snapshot trend logs
+- **24h validation observation run** — Market intelligence shadow layer (Phase 24.3e) + snapshot system + Telegram UX improvements deployed; run active in staging; collecting uptime, state distribution, snapshot trend logs, and market_type distribution telemetry
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
 - Wire PriceFeedHandler to main.py as background asyncio task for continuous WS mark-to-market
 - Wire StrategyStateManager(db=db) into main.py startup and save(db=db) after every Telegram toggle
@@ -731,16 +739,17 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` + periodic snapshot logs for threshold tuning
-2. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-3. **Wire LIVE/CLOB closed-trade hook** — `_run_closed_validation_hook` must be called from `execution/clob_executor.py` close path for real-money fills
-4. SENTINEL validation required for validation snapshot system before merge.
-   Source: projects/polymarket/polyquantbot/reports/forge/24_3d3_validation_snapshot.md
+1. **Performance breakdown per market type** — compute PnL and win-rate slices by `market_type` using new shadow telemetry
+2. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` + periodic snapshot logs for threshold tuning
+3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
+4. SENTINEL validation required for market intelligence layer before merge.
+   Source: projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
+- `docs/CLAUDE.md` referenced by process checklist is missing from repository
 - **LIVE path closed-trade PnL hook missing** — `_run_closed_validation_hook` is wired only in the PAPER close-order pipeline; LIVE mode CLOB executor close events do not yet feed realized PnL into PerformanceTracker
 - ValidationEngine thresholds (WR≥0.70, PF≥1.5, MDD≤0.08) are hardcoded from knowledge base — require calibration against live paper trading data before LIVE deployment
 - `test_tl04` (PRE-EXISTING): market dict extra fields from `ingest_markets()` — cosmetic mismatch in test assertion

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -86,6 +86,7 @@ from ...monitoring.performance_tracker import PerformanceTracker
 from ...monitoring.metrics_engine import MetricsEngine
 from ...monitoring.validation_engine import ValidationEngine, ValidationState
 from ...monitoring.snapshot_engine import SnapshotEngine
+from ...strategy.market_intelligence import MarketIntelligenceEngine
 from ..validation_state import ValidationStateStore
 from ..logging.logger import (
     log_market_metadata_used,
@@ -246,6 +247,7 @@ async def run_trading_loop(
     _metrics_engine = MetricsEngine()
     _validation_engine = ValidationEngine()
     _snapshot_engine = SnapshotEngine()
+    _market_intel_engine = MarketIntelligenceEngine()
     _validation_state = ValidationStateStore()
     # Mutable container for previous validation state — enables change detection
     _prev_vs: list[ValidationState] = [ValidationState.HEALTHY]
@@ -256,6 +258,9 @@ async def run_trading_loop(
     _last_snapshot_time: list[float] = [0.0]
     _last_heartbeat: list[float] = [0.0]        # mutable so closure can mutate
     _validation_hook_errors: list[int] = [0]    # cumulative error counter
+    _last_market_distribution: dict[str, int] = {}
+    _trade_type_distribution: dict[str, int] = {}
+    _market_type_by_id: dict[str, str] = {}
 
     def _to_float(value: Any) -> float:
         """Return float-safe value for Telegram formatting."""
@@ -348,7 +353,12 @@ async def run_trading_loop(
 
         _now = time.time()
         if _now - _last_snapshot_time[0] >= _SNAPSHOT_INTERVAL_S:
-            _snapshot = _snapshot_engine.build_snapshot(_computed, _val_result.state.value)
+            _snapshot = _snapshot_engine.build_snapshot(
+                _computed,
+                _val_result.state.value,
+                market_distribution=_last_market_distribution,
+                trade_distribution=_trade_type_distribution,
+            )
             log.info(
                 "system_snapshot",
                 snapshot=_snapshot,
@@ -558,6 +568,37 @@ async def run_trading_loop(
                         capped_to=_MAX_MARKETS_PER_TICK,
                     )
                     normalised_markets = normalised_markets[:_MAX_MARKETS_PER_TICK]
+
+                # ── 1d. Shadow-only market intelligence (no decision impact) ─────
+                market_distribution: dict[str, int] = {}
+                _market_type_by_id = {}
+                for market in normalised_markets:
+                    market_id = str(market.get("market_id", "unknown"))
+                    try:
+                        intel = _market_intel_engine.analyze(market)
+                    except Exception as _intel_exc:  # noqa: BLE001
+                        log.warning(
+                            "market_intelligence_warning",
+                            market_id=market_id,
+                            error=str(_intel_exc),
+                        )
+                        intel = {"market_type": "GENERAL", "tags": []}
+
+                    market_type = str(intel.get("market_type", "GENERAL"))
+                    tags = intel.get("tags", [])
+                    if not isinstance(tags, list):
+                        tags = []
+
+                    _market_type_by_id[market_id] = market_type
+                    market_distribution[market_type] = market_distribution.get(market_type, 0) + 1
+
+                    log.info(
+                        "market_intelligence",
+                        market_id=market_id,
+                        type=market_type,
+                        tags=tags,
+                    )
+                _last_market_distribution = market_distribution
 
                 # ── 2. Feed price data into alpha model ───────────────────────────
                 market_prices: dict[str, float] = {}
@@ -827,6 +868,18 @@ async def run_trading_loop(
 
                     if result.success:
                         _trades_this_tick += 1
+
+                        _signal_market_type = _market_type_by_id.get(signal.market_id, "GENERAL")
+                        _trade_type_distribution[_signal_market_type] = (
+                            _trade_type_distribution.get(_signal_market_type, 0) + 1
+                        )
+                        log.info(
+                            "market_type_trade_recorded",
+                            market_id=result.market_id,
+                            market_type=_signal_market_type,
+                            trade_count=_trade_type_distribution[_signal_market_type],
+                        )
+
                         log.info(
                             "trade_loop_executed",
                             market_id=result.market_id,

--- a/projects/polymarket/polyquantbot/monitoring/snapshot_engine.py
+++ b/projects/polymarket/polyquantbot/monitoring/snapshot_engine.py
@@ -32,7 +32,19 @@ class SnapshotEngine:
         except (TypeError, ValueError):
             return default
 
-    def build_snapshot(self, metrics: dict[str, Any], state: str) -> dict[str, Any]:
+    def _to_distribution(self, value: Any) -> dict[str, int]:
+        """Normalize market distribution payload into ``dict[str, int]``."""
+        if not isinstance(value, dict):
+            return {}
+        return {str(k): self._to_int(v, 0) for k, v in value.items()}
+
+    def build_snapshot(
+        self,
+        metrics: dict[str, Any],
+        state: str,
+        market_distribution: dict[str, int] | None = None,
+        trade_distribution: dict[str, int] | None = None,
+    ) -> dict[str, Any]:
         """Return periodic validation snapshot payload with safe defaults."""
         try:
             _metrics = metrics if isinstance(metrics, dict) else {}
@@ -43,6 +55,8 @@ class SnapshotEngine:
                 "drawdown": self._to_float(_metrics.get("max_drawdown", 0.0), 0.0),
                 "state": str(state) if state is not None else "UNKNOWN",
                 "last_pnl": self._to_float(_metrics.get("last_pnl", 0.0), 0.0),
+                "market_distribution": self._to_distribution(market_distribution),
+                "trade_distribution": self._to_distribution(trade_distribution),
             }
         except Exception:
             return {
@@ -52,4 +66,6 @@ class SnapshotEngine:
                 "drawdown": 0.0,
                 "state": str(state) if state is not None else "UNKNOWN",
                 "last_pnl": 0.0,
+                "market_distribution": {},
+                "trade_distribution": {},
             }

--- a/projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
@@ -1,0 +1,78 @@
+# FORGE-X Report — 24_3e_market_intelligence.md
+
+**Phase:** 24.3e  
+**Date:** 2026-04-04  
+**Environment:** staging  
+**Task:** Add shadow-only market intelligence layer for market-type classification and observability
+
+---
+
+## 1. What was built
+
+Implemented a shadow-only market intelligence layer that classifies markets and emits telemetry without changing signal generation, risk gating, or execution behavior:
+
+- Added `MarketClassifier.classify(market)` in `projects/polymarket/polyquantbot/strategy/market_classifier.py`.
+- Added `MarketIntelligenceEngine.analyze(market, signal=None)` in `projects/polymarket/polyquantbot/strategy/market_intelligence.py`.
+- Integrated market intelligence analysis in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` after market fetch/normalization and before signal generation.
+- Extended `projects/polymarket/polyquantbot/monitoring/snapshot_engine.py` to include:
+  - `market_distribution` (current market mix by classified type)
+  - `trade_distribution` (cumulative executed trades by classified market type)
+
+## 2. Current system architecture
+
+Pipeline remains unchanged in trading decision flow:
+
+`DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING`
+
+Added observational branch (shadow-only):
+
+`normalised_markets`
+→ `MarketIntelligenceEngine.analyze(market)`
+→ `log.info(event="market_intelligence", ...)`
+→ `market_distribution` aggregation
+→ snapshot inclusion (`system_snapshot.market_distribution`)
+
+Trade tracking branch (observational):
+
+`successful execution`
+→ lookup market type by `market_id`
+→ increment `trade_distribution`
+→ `log.info(event="market_type_trade_recorded", ...)`
+
+No filtering, weighting, risk bypass, or execution mutation was introduced.
+
+## 3. Files created / modified (full paths)
+
+- Created: `projects/polymarket/polyquantbot/strategy/market_classifier.py`
+- Created: `projects/polymarket/polyquantbot/strategy/market_intelligence.py`
+- Modified: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- Modified: `projects/polymarket/polyquantbot/monitoring/snapshot_engine.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Classification returns stable shape:
+  - `{ "type": str, "tags": list[str] }`
+- Classification rules applied:
+  - `BONDS` when `price_yes >= 0.95` or `<= 0.05`
+  - `HIGH_LIQUIDITY` when `volume_24h > 500000`
+  - `SHORT_TERM` when expiry is within 7 days
+  - `LONG_TERM` when expiry is beyond 30 days
+  - `GENERAL` fallback
+- Missing fields (`price_yes`, `expiry`) are handled safely with fallback behavior.
+- Malformed market inputs are handled via warning log and `GENERAL` fallback in pipeline integration.
+- Snapshot payload now includes `market_distribution` and `trade_distribution` fields.
+- Trading behavior remains unchanged (shadow-only logging and snapshot enrichment).
+
+## 5. Known issues
+
+- `docs/CLAUDE.md` referenced in process checklist is not present in repository.
+- `trade_distribution` currently tracks executed trade counts per market type only; win-rate per market type is intentionally deferred (future phase).
+
+## 6. What is next
+
+1. Run staging validation observation with new market intelligence logs and distribution snapshots.
+2. Build performance breakdown per market type (PnL/WR/PF slices).
+3. SENTINEL validation required for market intelligence layer before merge.  
+   Source: `projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md`

--- a/projects/polymarket/polyquantbot/strategy/market_classifier.py
+++ b/projects/polymarket/polyquantbot/strategy/market_classifier.py
@@ -1,0 +1,86 @@
+"""strategy.market_classifier — shadow-only market type classification."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+class MarketClassifier:
+    """Classifies markets into broad observable market types.
+
+    Classification is designed for telemetry only and never mutates trading
+    decisions, filtering, or execution behavior.
+    """
+
+    def _to_float(self, value: Any) -> float | None:
+        """Best-effort float conversion with ``None`` fallback."""
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _days_to_expiry(self, expiry: Any) -> float | None:
+        """Return days until expiry, or ``None`` when parsing fails."""
+        if expiry is None:
+            return None
+
+        try:
+            if isinstance(expiry, (int, float)):
+                expiry_dt = datetime.fromtimestamp(float(expiry), tz=timezone.utc)
+            elif isinstance(expiry, str):
+                normalized = expiry.replace("Z", "+00:00")
+                expiry_dt = datetime.fromisoformat(normalized)
+                if expiry_dt.tzinfo is None:
+                    expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
+                else:
+                    expiry_dt = expiry_dt.astimezone(timezone.utc)
+            elif isinstance(expiry, datetime):
+                expiry_dt = expiry if expiry.tzinfo else expiry.replace(tzinfo=timezone.utc)
+                expiry_dt = expiry_dt.astimezone(timezone.utc)
+            else:
+                return None
+
+            now = datetime.now(timezone.utc)
+            delta = expiry_dt - now
+            return delta.total_seconds() / 86400.0
+        except (TypeError, ValueError, OSError):
+            return None
+
+    def classify(self, market: dict[str, Any]) -> dict[str, Any]:
+        """Classify a market into type + tags with safe fallbacks."""
+        tags: list[str] = []
+
+        price_yes = self._to_float(market.get("price_yes"))
+        volume_24h = self._to_float(market.get("volume_24h"))
+        days_to_expiry = self._days_to_expiry(market.get("expiry"))
+
+        if price_yes is not None and (price_yes >= 0.95 or price_yes <= 0.05):
+            tags.append("BONDS")
+
+        if volume_24h is not None and volume_24h > 500_000:
+            tags.append("HIGH_LIQUIDITY")
+
+        if days_to_expiry is not None and days_to_expiry <= 7:
+            tags.append("SHORT_TERM")
+
+        if days_to_expiry is not None and days_to_expiry > 30:
+            tags.append("LONG_TERM")
+
+        if "BONDS" in tags:
+            market_type = "BONDS"
+        elif "HIGH_LIQUIDITY" in tags:
+            market_type = "HIGH_LIQUIDITY"
+        elif "SHORT_TERM" in tags:
+            market_type = "SHORT_TERM"
+        elif "LONG_TERM" in tags:
+            market_type = "LONG_TERM"
+        else:
+            market_type = "GENERAL"
+
+        return {
+            "type": market_type,
+            "tags": tags,
+        }

--- a/projects/polymarket/polyquantbot/strategy/market_intelligence.py
+++ b/projects/polymarket/polyquantbot/strategy/market_intelligence.py
@@ -1,0 +1,37 @@
+"""strategy.market_intelligence — shadow-only market intelligence analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .market_classifier import MarketClassifier
+
+
+class MarketIntelligenceEngine:
+    """Builds observational market intelligence payloads for logging/snapshots."""
+
+    def __init__(self, classifier: MarketClassifier | None = None) -> None:
+        self._classifier = classifier or MarketClassifier()
+
+    def _to_float(self, value: Any) -> float | None:
+        """Best-effort float conversion with ``None`` fallback."""
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def analyze(self, market: dict[str, Any], signal: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Analyze a market and return shadow-only intelligence metadata."""
+        classified = self._classifier.classify(market if isinstance(market, dict) else {})
+
+        confidence = self._to_float((signal or {}).get("confidence")) if signal else None
+        result: dict[str, Any] = {
+            "market_type": classified["type"],
+            "tags": classified["tags"],
+            "signal_present": signal is not None,
+        }
+        if confidence is not None:
+            result["confidence"] = confidence
+        return result


### PR DESCRIPTION
### Motivation

- Add an observational market intelligence layer to classify markets and emit telemetry without affecting any trading, signal, or risk decisions.  
- Improve observability by exposing market-type distributions in the existing snapshot system to enable future performance breakdowns per market type.  

### Description

- Added `MarketClassifier.classify(market)` at `projects/polymarket/polyquantbot/strategy/market_classifier.py` to detect `BONDS`, `HIGH_LIQUIDITY`, `SHORT_TERM`, `LONG_TERM`, and fallback `GENERAL`, returning `{"type": str, "tags": [str]}`.  
- Added `MarketIntelligenceEngine.analyze(market, signal=None)` at `projects/polymarket/polyquantbot/strategy/market_intelligence.py` to attach `market_type`, `tags`, optional `confidence`, and `signal_present` (shadow-only).  
- Integrated shadow-only intelligence in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` after market normalization and before signal generation to emit `market_intelligence` logs per market and to track per-market-type executed trade counts (`market_type_trade_recorded`) without changing filtering, sizing, or execution logic.  
- Extended `projects/polymarket/polyquantbot/monitoring/snapshot_engine.py` to include `market_distribution` and `trade_distribution` in the periodic `system_snapshot`, and added the FORGE report `projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md` and `PROJECT_STATE.md` updates for Phase 24.3e.  

### Testing

- `python -m py_compile` passed for the modified modules (`market_classifier.py`, `market_intelligence.py`, `snapshot_engine.py`, `core/pipeline/trading_loop.py`).  
- Manual smoke checks executed the classifier + engine on sample market dicts and produced expected `BONDS`/`SHORT_TERM`/`GENERAL` outputs.  
- Ran `pytest` targets for the stability suite; initial collection failed without `PYTHONPATH` set, and with `PYTHONPATH=.` the `projects/polymarket/polyquantbot/tests/test_stability_phase24_3.py` run produced environment-related failures because the test run requires an async pytest plugin (`pytest-asyncio` / anyio) that is not installed in the current environment, so async tests could not complete (some tests passed, others failed due to missing async test support).  
- No runtime changes to signal/risk/execution paths were introduced and all intelligence logic is defensive and log-only to ensure zero impact on trading behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13625cfb4832ea15bb5f684239670)