### PR TITLE
feat: route trading loop telegram alerts to private DM chat

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
 Last Updated: 2026-04-04
-Status: Phase 24.3e market intelligence layer added in shadow-only mode. Market-type telemetry now logs and snapshots distribution data without affecting signal, risk, validation, or execution decisions. Validation run remains active in staging. Next report: projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
+Status: Phase 24.3f Telegram private mode enabled. Trade, validation, and snapshot notifications now route to private DM chat_id captured from /start; staging validation run remains active. Next report: projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md
 
 ---
 
@@ -68,6 +68,13 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+TELEGRAM PRIVATE MODE (Phase 24.3f)
+
+- projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py (NEW): Added centralized private-DM sender with USER_CHAT_ID capture/load/persist and safe no-chat-id warning behavior
+- projects/polymarket/polyquantbot/main.py (MODIFIED): Captures chat_id from /start and stores it as USER_CHAT_ID; wires centralized private sender implementation
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Trade, validation, and snapshot alerts now use centralized telegram_sender.send(msg) private routing
+- projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md (NEW): completion report
 
 MARKET INTELLIGENCE LAYER (Phase 24.3e)
 
@@ -710,7 +717,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
-- **24h validation observation run** — Market intelligence shadow layer (Phase 24.3e) + snapshot system + Telegram UX improvements deployed; run active in staging; collecting uptime, state distribution, snapshot trend logs, and market_type distribution telemetry
+- **Validation run (staging)** — Telegram private mode (Phase 24.3f) active with market intelligence shadow layer + snapshot system; collecting DM delivery checks, uptime, and state/snapshot telemetry
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
 - Wire PriceFeedHandler to main.py as background asyncio task for continuous WS mark-to-market
 - Wire StrategyStateManager(db=db) into main.py startup and save(db=db) after every Telegram toggle
@@ -739,16 +746,18 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Performance breakdown per market type** — compute PnL and win-rate slices by `market_type` using new shadow telemetry
-2. **Phase 24.4 — Truth extraction** — calibrate WR/PF/MDD thresholds against 24h run data; use `last_pnl` + periodic snapshot logs for threshold tuning
+1. **Phase 24.4 analysis** — truth extraction and threshold calibration (WR/PF/MDD) using 24h validation snapshots + last_pnl
+2. **Performance breakdown per market type** — compute PnL and win-rate slices by `market_type` using shadow telemetry
 3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-4. SENTINEL validation required for market intelligence layer before merge.
-   Source: projects/polymarket/polyquantbot/reports/forge/24_3e_market_intelligence.md
+4. SENTINEL validation required for telegram private mode before merge.
+   Source: projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
+- Telegram private chat ID persists locally; if missing after restart, operator must send /start again to re-capture DM target
+- Single-user overwrite behavior is active by design: latest /start caller replaces USER_CHAT_ID
 - `docs/CLAUDE.md` referenced by process checklist is missing from repository
 - **LIVE path closed-trade PnL hook missing** — `_run_closed_validation_hook` is wired only in the PAPER close-order pipeline; LIVE mode CLOB executor close events do not yet feed realized PnL into PerformanceTracker
 - ValidationEngine thresholds (WR≥0.70, PF≥1.5, MDD≤0.08) are hardcoded from knowledge base — require calibration against live paper trading data before LIVE deployment

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -87,6 +87,7 @@ from ...monitoring.metrics_engine import MetricsEngine
 from ...monitoring.validation_engine import ValidationEngine, ValidationState
 from ...monitoring.snapshot_engine import SnapshotEngine
 from ...strategy.market_intelligence import MarketIntelligenceEngine
+from ...telegram.utils import telegram_sender
 from ..validation_state import ValidationStateStore
 from ..logging.logger import (
     log_market_metadata_used,
@@ -364,9 +365,9 @@ async def run_trading_loop(
                 snapshot=_snapshot,
             )
 
-            if _snapshot_telegram_enabled and tg_cb is not None:
+            if _snapshot_telegram_enabled:
                 try:
-                    await tg_cb(_format_snapshot_alert(_snapshot))
+                    await telegram_sender.send(_format_snapshot_alert(_snapshot))
                 except Exception as _snap_tg_exc:  # noqa: BLE001
                     log.warning(
                         "snapshot_telegram_failed",
@@ -389,9 +390,9 @@ async def run_trading_loop(
                     stop_event.set()
 
             _alert = _format_validation_alert(_val_result.state, _computed)
-            if _alert and tg_cb is not None:
+            if _alert:
                 try:
-                    await tg_cb(_alert)
+                    await telegram_sender.send(_alert)
                 except Exception as _tg_val_exc:  # noqa: BLE001
                     log.warning(
                         "validation_telegram_failed",
@@ -977,7 +978,7 @@ async def run_trading_loop(
                                 )
 
                         # ── 4i. Send enriched Telegram trade alert ────────────────
-                        if telegram_callback is not None and result.fill_price > 0.0:
+                        if result.fill_price > 0.0:
                             try:
                                 # Pick the outcome label matching the traded side, or
                                 # fall back to result.side if no matching outcome found.
@@ -1003,7 +1004,7 @@ async def run_trading_loop(
                                     realized_pnl=_pos_realized if pnl_tracker is not None else None,
                                     unrealized_pnl=_pos_unrealized if position_manager is not None else None,
                                 )
-                                await telegram_callback(_trade_msg)
+                                await telegram_sender.send(_trade_msg)
                                 log_telegram_trade_detailed(
                                     trade_id=result.trade_id,
                                     market_id=result.market_id,
@@ -1174,7 +1175,6 @@ async def run_trading_loop(
                                         )
                                         await paper_engine._wallet.persist(db)  # type: ignore[attr-defined]
                                     # Telegram close alert
-                                    if telegram_callback is not None:
                                         try:
                                             _close_msg = (
                                                 f"🔒 CLOSE [{_trigger_reason.upper()}] "
@@ -1182,7 +1182,7 @@ async def run_trading_loop(
                                                 f"@ {_cur_price:.4f} | "
                                                 f"Entry: {_pos.entry_price:.4f}"
                                             )
-                                            await telegram_callback(_close_msg)
+                                            await telegram_sender.send(_close_msg)
                                         except Exception:
                                             pass
                                 except Exception as _close_exc:
@@ -1262,17 +1262,16 @@ async def run_trading_loop(
                                                     telegram_callback,
                                                 )
                                             )
-                                        if telegram_callback is not None:
-                                            try:
-                                                _live_close_msg = (
-                                                    f"🔒 LIVE CLOSE [{_live_trigger.upper()}] "
-                                                    f"{_lpos.market_id[:12]}… "
-                                                    f"@ {_cur_price:.4f} | "
-                                                    f"Entry: {_lpos.avg_price:.4f}"
-                                                )
-                                                await telegram_callback(_live_close_msg)
-                                            except Exception:
-                                                pass
+                                        try:
+                                            _live_close_msg = (
+                                                f"🔒 LIVE CLOSE [{_live_trigger.upper()}] "
+                                                f"{_lpos.market_id[:12]}… "
+                                                f"@ {_cur_price:.4f} | "
+                                                f"Entry: {_lpos.avg_price:.4f}"
+                                            )
+                                            await telegram_sender.send(_live_close_msg)
+                                        except Exception:
+                                            pass
                                 except Exception as _live_close_exc:
                                     log.error(
                                         "live_close_order_failed",

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -109,6 +109,7 @@ async def main() -> None:
 
     # ── Telegram (optional) ────────────────────────────────────────────────────
     from .telegram.telegram_live import TelegramLive
+    from .telegram.utils import telegram_sender as _telegram_sender
     tg = TelegramLive.from_env()
     await tg.start()
     chat_id: str = os.getenv("TELEGRAM_CHAT_ID", "")
@@ -269,6 +270,8 @@ async def main() -> None:
         mode=mode,
         strategy_state=strategy_mgr,
     )
+
+    _telegram_sender.load_user_chat_id()
 
     async def _polling_loop() -> None:
         """Long-poll Telegram getUpdates and route commands + callback_query.
@@ -452,6 +455,8 @@ async def main() -> None:
                         if reply_chat:
                             # ── /start: send reply keyboard first ─────────
                             if cmd_name in ("start", "help", "menu", "main_menu"):
+                                if cmd_name == "start":
+                                    _telegram_sender.set_user_chat_id(reply_chat)
                                 try:
                                     await session.post(
                                         f"{_tg_api}/sendMessage",
@@ -596,6 +601,32 @@ async def main() -> None:
                     error=str(exc),
                 )
         log.error("telegram_callback_failed", retries=2, message_preview=message[:80])
+
+    async def _tg_send_private(chat_id: int, message: str) -> None:
+        """Send message to explicit private chat_id using Telegram Bot API."""
+        import aiohttp
+
+        if not tg.enabled:
+            return
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{_tg_api}/sendMessage",
+                    json={"chat_id": chat_id, "text": message, "parse_mode": "Markdown"},
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        log.warning(
+                            "telegram_private_send_non_200",
+                            status=resp.status,
+                            body=body[:200],
+                            chat_id=chat_id,
+                        )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("telegram_private_send_failed", error=str(exc), chat_id=chat_id)
+
+    _telegram_sender.set_sender(_tg_send_private)
 
     # ── Bootstrap: market discovery + pipeline startup ─────────────────────────
     from .core.bootstrap import run_bootstrap

--- a/projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md
@@ -1,0 +1,59 @@
+# FORGE-X Report — 24_3f_telegram_private_mode.md
+
+**Phase:** 24.3f  
+**Date:** 2026-04-04  
+**Environment:** staging  
+**Task:** Route trade/validation/snapshot Telegram notifications to private DM only
+
+---
+
+## 1. What was built
+
+Implemented private-mode Telegram routing for trading-loop notifications:
+
+- Added centralized sender module at `projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py`.
+- `/start` now captures `chat_id` and stores it as active `USER_CHAT_ID` (overwrite allowed for single-user operation).
+- `USER_CHAT_ID` is persisted to local file (`projects/polymarket/polyquantbot/infra/telegram_user_chat_id.txt` by default) and restored on startup.
+- Trading loop notifications for **trade**, **validation**, and **snapshot** now call `telegram_sender.send(msg)`.
+- Missing `USER_CHAT_ID` is handled as warning-only behavior (no crash).
+
+## 2. Current system architecture
+
+Private notification flow now works as follows:
+
+`Telegram /start` (main polling loop)
+→ `telegram_sender.set_user_chat_id(chat_id)`
+→ persisted chat id
+→ trading loop emits trade / validation / snapshot message
+→ `telegram_sender.send(msg)`
+→ private DM delivery to `USER_CHAT_ID`
+
+No group-only dependency remains in this notification path.
+
+## 3. Files created / modified (full paths)
+
+- Created: `projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py`
+- Modified: `projects/polymarket/polyquantbot/main.py`
+- Modified: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+
+- `/start` captures and updates private target chat id.
+- Trade alerts now route through centralized private sender.
+- Validation state-change alerts now route through centralized private sender.
+- Snapshot alerts now route through centralized private sender.
+- If no user chat id is available, sender logs warning and safely returns.
+
+## 5. Known issues
+
+- If bot restarts and no persisted chat id is available, operator must run `/start` again.
+- Multi-user mode is not isolated: latest `/start` caller overrides `USER_CHAT_ID` (accepted for current single-user staging).
+- Existing repository issue remains: `docs/CLAUDE.md` is missing.
+
+## 6. What is next
+
+1. Continue staging validation run and verify DM delivery for trade/validation/snapshot events.
+2. Phase 24.4 analysis: calibrate thresholds using snapshot + validation stream.
+3. SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md`.

--- a/projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py
+++ b/projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py
@@ -1,0 +1,114 @@
+"""telegram.utils.telegram_sender — private-chat Telegram sender.
+
+Routes bot notifications to the most recently captured Telegram user chat ID
+(``/start`` DM) and avoids any fixed group-channel dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+import aiohttp
+import structlog
+
+log = structlog.get_logger(__name__)
+
+USER_CHAT_ID: Optional[int] = None
+_TOKEN_ENV_KEYS: tuple[str, ...] = ("TELEGRAM_TOKEN", "TELEGRAM_BOT_TOKEN")
+_CHAT_ID_FILE: Path = Path(
+    os.getenv(
+        "TELEGRAM_USER_CHAT_ID_FILE",
+        "projects/polymarket/polyquantbot/infra/telegram_user_chat_id.txt",
+    )
+)
+_custom_sender: Optional[Callable[[int, str], Awaitable[None]]] = None
+
+
+def _resolve_token() -> str:
+    """Return Telegram bot token from environment."""
+    for key in _TOKEN_ENV_KEYS:
+        token = os.getenv(key, "").strip()
+        if token:
+            return token
+    return ""
+
+
+def set_sender(sender: Optional[Callable[[int, str], Awaitable[None]]]) -> None:
+    """Inject optional async sender(chat_id, msg) implementation."""
+    global _custom_sender  # noqa: PLW0603
+    _custom_sender = sender
+
+
+def set_user_chat_id(chat_id: Optional[int]) -> None:
+    """Set and persist active private chat ID.
+
+    Overwrite is intentionally allowed (single-user system behavior).
+    """
+    global USER_CHAT_ID  # noqa: PLW0603
+    if chat_id is None:
+        USER_CHAT_ID = None
+        return
+
+    USER_CHAT_ID = int(chat_id)
+    try:
+        _CHAT_ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _CHAT_ID_FILE.write_text(str(USER_CHAT_ID), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        log.warning("telegram_sender_chat_id_persist_failed", error=str(exc))
+
+
+def load_user_chat_id() -> None:
+    """Load persisted private chat ID if present."""
+    global USER_CHAT_ID  # noqa: PLW0603
+    if USER_CHAT_ID is not None:
+        return
+    try:
+        raw = _CHAT_ID_FILE.read_text(encoding="utf-8").strip()
+        if raw:
+            USER_CHAT_ID = int(raw)
+    except FileNotFoundError:
+        return
+    except Exception as exc:  # noqa: BLE001
+        log.warning("telegram_sender_chat_id_load_failed", error=str(exc))
+
+
+async def send(msg: str) -> None:
+    """Send message to captured private chat.
+
+    If no private chat ID is known, logs warning and returns without raising.
+    """
+    load_user_chat_id()
+    if USER_CHAT_ID is None:
+        log.warning("telegram_sender_no_user_chat_id")
+        return
+
+    if _custom_sender is not None:
+        try:
+            await _custom_sender(USER_CHAT_ID, msg)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("telegram_sender_custom_send_failed", error=str(exc))
+        return
+
+    token = _resolve_token()
+    if not token:
+        log.warning("telegram_sender_missing_token")
+        return
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"https://api.telegram.org/bot{token}/sendMessage",
+                json={"chat_id": USER_CHAT_ID, "text": msg, "parse_mode": "Markdown"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    log.warning(
+                        "telegram_sender_non_200",
+                        status=resp.status,
+                        body=body[:200],
+                    )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("telegram_sender_request_failed", error=str(exc))


### PR DESCRIPTION
### Motivation
- Operators require all runtime notifications (trade, validation, snapshot) to be delivered to the operator's private Telegram DM rather than a group channel to remove group dependency and simplify monitoring.
- Keep behavior safe for staging: single-user capture, persistent local storage, and no crashes when no chat id is available.

### Description
- Added a centralized private-chat sender `projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py` providing `set_user_chat_id`, `load_user_chat_id`, and async `send(msg)` with safe no-chat-id warnings and optional injected sender override.
- Captured operator `chat_id` on `/start` in `projects/polymarket/polyquantbot/main.py` and persisted it to `projects/polymarket/polyquantbot/infra/telegram_user_chat_id.txt` by default, with overwrite allowed for single-user behavior; injected a private-send function into the sender module via `set_sender`.
- Rewired runtime notifications in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to call `telegram_sender.send(msg)` for trade alerts, validation state-change alerts, and snapshot messages instead of any group-targeted callback; snapshot/validation behavior remains throttled and non-blocking.
- Added FORGE-X report `projects/polymarket/polyquantbot/reports/forge/24_3f_telegram_private_mode.md` and updated `PROJECT_STATE.md` to reflect Phase 24.3f completion and staging validation run.

### Testing
- Ran compile-time checks: `python -m py_compile projects/polymarket/polyquantbot/main.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/telegram/utils/telegram_sender.py`, which completed successfully. 
- Verified code references and integrations via repository search and module import checks (local verification of `telegram_sender.send`, `set_user_chat_id`, and routing points) with no unresolved imports. 
- No new unit tests were added in this change; runtime verification recommended in staging: open bot DM, send `/start`, trigger trade/validation/snapshot flows and confirm messages arrive in the private DM (manual staging steps documented in the FORGE-X report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d14100dbc4832eae6b8cda2284ce64)