### PR TITLE
feat(portfolio): add portfolio intelligence (confidence/edge/signal/reason)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
-Last Updated: 2026-04-04
-Status: Phase 24.3h UI architecture refactor delivered for Telegram HOME / PORTFOLIO / WALLET / PERFORMANCE separation with dedicated formatter routing and duplication removal. Next report: projects/polymarket/polyquantbot/reports/forge/24_3h_ui_architecture.md
+Last Updated: 2026-04-05
+Status: Phase 24.4a portfolio intelligence layer delivered for PORTFOLIO active-position explainability (CONF / EDGE / SIGNAL / REASON) with safe missing-data fallbacks. Next report: projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md
 
 ---
 
@@ -68,6 +68,12 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+PORTFOLIO INTELLIGENCE LAYER (Phase 24.4a)
+
+- projects/polymarket/polyquantbot/utils/ui_formatter.py (MODIFIED): Portfolio ACTIVE POSITION block now renders CONF / EDGE / SIGNAL / REASON with N/A-safe fallbacks.
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Added portfolio intelligence classifiers and mapper (`classify_edge`, `classify_strength`, `build_portfolio_intelligence`) and wired portfolio mapping fields (`confidence`, `edge`, `signal`, `reason`) from signal probability + EV context.
+- projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md (NEW): completion report.
 
 UI ARCHITECTURE REFACTOR (Phase 24.3h)
 
@@ -723,7 +729,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
-- UI architecture validation run (staging) — manual Telegram view verification for `/home`, `/portfolio`, `/wallet`, `/performance`
+- Validation tracking (staging) — portfolio intelligence visibility checks for CONF / EDGE / SIGNAL / REASON across active positions
 - **Validation run (staging)** — Telegram private mode (Phase 24.3f) active with market intelligence shadow layer + snapshot system; collecting DM delivery checks, uptime, and state/snapshot telemetry
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
 - Wire PriceFeedHandler to main.py as background asyncio task for continuous WS mark-to-market
@@ -753,11 +759,11 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Performance analysis** — validate UI-driven telemetry readability and operator workflow speed from staging interactions
+1. **Validation visibility** — verify operator readability and decision-trace clarity for portfolio intelligence fields in staging runtime
 2. **Phase 24.4 analysis** — truth extraction and threshold calibration (WR/PF/MDD) using 24h validation snapshots + last_pnl
 3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-4. SENTINEL validation required for UI architecture refactor before merge.
-   Source: projects/polymarket/polyquantbot/reports/forge/24_3h_ui_architecture.md
+4. SENTINEL validation required for portfolio intelligence layer before merge.
+   Source: projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -153,14 +153,96 @@ def map_ui_data(command: str, source: dict[str, Any]) -> dict[str, Any]:
     if normalized == "/home":
         keys = {"status", "mode", "markets", "latency", "strategy", "scan", "distribution", "insight"}
     elif normalized == "/portfolio":
-        keys = {"positions", "exposure", "side", "risk", "market", "entry", "size", "pnl"}
+        keys = {
+            "positions",
+            "exposure",
+            "side",
+            "risk",
+            "market",
+            "entry",
+            "size",
+            "pnl",
+            "confidence",
+            "edge",
+            "signal",
+            "reason",
+        }
     elif normalized == "/wallet":
         keys = {"balance", "equity", "used", "free", "margin"}
     elif normalized == "/performance":
         keys = {"realized", "unreal", "wr", "pf"}
     else:
         keys = set(source.keys())
-    return {key: source.get(key) for key in keys}
+    payload = {key: source.get(key) for key in keys}
+    if normalized == "/portfolio":
+        _portfolio = build_portfolio_intelligence(
+            probability=source.get("confidence", source.get("probability")),
+            expected_value=source.get("ev"),
+            reason=source.get("reason"),
+        )
+        payload.update(
+            {
+                key: payload.get(key) if payload.get(key) is not None else value
+                for key, value in _portfolio.items()
+            }
+        )
+    return payload
+
+
+def classify_edge(expected_value: Optional[float]) -> str:
+    """Classify EV into LOW/MEDIUM/HIGH buckets for portfolio UI."""
+    if expected_value is None:
+        return "N/A"
+    if expected_value < 0.01:
+        return "LOW"
+    if expected_value <= 0.05:
+        return "MEDIUM"
+    return "HIGH"
+
+
+def classify_strength(probability: Optional[float]) -> str:
+    """Classify probability into WEAK/MODERATE/STRONG buckets for portfolio UI."""
+    if probability is None:
+        return "N/A"
+    if probability < 0.55:
+        return "WEAK"
+    if probability <= 0.65:
+        return "MODERATE"
+    return "STRONG"
+
+
+def build_portfolio_intelligence(
+    *,
+    probability: Any,
+    expected_value: Any,
+    reason: Any,
+) -> dict[str, str]:
+    """Build portfolio intelligence fields from signal/scoring values with safe fallbacks."""
+    _prob: Optional[float] = None
+    _ev: Optional[float] = None
+
+    try:
+        if probability is not None:
+            _prob = float(probability)
+    except (TypeError, ValueError):
+        _prob = None
+    try:
+        if expected_value is not None:
+            _ev = float(expected_value)
+    except (TypeError, ValueError):
+        _ev = None
+
+    _confidence = f"{round(_prob, 2):.2f}" if _prob is not None else "N/A"
+    _reason = str(reason).strip() if reason is not None and str(reason).strip() else "N/A"
+    if _reason == "N/A" and _prob is not None and _ev is not None:
+        _reason = f"p={_prob:.2f}, ev={_ev:.3f}"
+
+    return {
+        "confidence": _confidence,
+        "edge": classify_edge(_ev),
+        "signal": classify_strength(_prob),
+        "reason": _reason,
+    }
 
 
 def _env_float(name: str, default: float) -> float:
@@ -905,6 +987,11 @@ async def run_trading_loop(
 
                     if result.success:
                         _trades_this_tick += 1
+                        _portfolio_intelligence = build_portfolio_intelligence(
+                            probability=signal.p_model,
+                            expected_value=signal.ev,
+                            reason=signal.extra.get("decision_reason"),
+                        )
 
                         _signal_market_type = _market_type_by_id.get(signal.market_id, "GENERAL")
                         _trade_type_distribution[_signal_market_type] = (
@@ -925,6 +1012,10 @@ async def run_trading_loop(
                             filled_size_usd=round(result.filled_size_usd or 0.0, 4),
                             fill_price=round(result.fill_price or 0.0, 6),
                             force_mode=_active_force,
+                            confidence=_portfolio_intelligence["confidence"],
+                            edge_class=_portfolio_intelligence["edge"],
+                            signal_class=_portfolio_intelligence["signal"],
+                            decision_reason=_portfolio_intelligence["reason"],
                         )
 
                         # Record trade time for cooldown tracking and force-fallback reset

--- a/projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md
@@ -1,0 +1,67 @@
+# 24.4a — Portfolio Intelligence Layer
+
+## 1) What was built
+
+- Extended the portfolio data model used by UI routing to include intelligence fields:
+  - `confidence` (0–1, rounded to 2 decimals when available)
+  - `edge` (`LOW | MEDIUM | HIGH`)
+  - `signal` (`WEAK | MODERATE | STRONG`)
+  - `reason` (short decision string)
+- Updated the PORTFOLIO formatter block so active position output now renders:
+  - CONF
+  - EDGE
+  - SIGNAL
+  - REASON
+- Added defensive fallback behavior (`"N/A"`) for missing or invalid intelligence inputs.
+- Added lightweight classification helpers in pipeline routing:
+  - `classify_edge(ev)`
+  - `classify_strength(probability)`
+  - `build_portfolio_intelligence(...)`
+
+## 2) Current system architecture
+
+```
+Signal engine output (p_model, ev, extra decision context)
+        ↓
+core/pipeline/trading_loop.py
+  - build_portfolio_intelligence(probability, expected_value, reason)
+  - classify_edge(ev) → LOW/MEDIUM/HIGH
+  - classify_strength(probability) → WEAK/MODERATE/STRONG
+  - map_ui_data('/portfolio', source) merges intelligence with safe defaults
+        ↓
+utils/ui_formatter.py
+  - build_portfolio() renders CONF / EDGE / SIGNAL / REASON
+        ↓
+Telegram PORTFOLIO text output (missing fields fall back to N/A)
+```
+
+## 3) Files created / modified (full paths)
+
+- `projects/polymarket/polyquantbot/utils/ui_formatter.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md` (NEW)
+- `PROJECT_STATE.md` (MODIFIED)
+
+## 4) What is working
+
+- Portfolio active-position block now displays intelligence fields in aligned UI format.
+- EV classification rule is applied exactly:
+  - `< 0.01` → LOW
+  - `0.01–0.05` → MEDIUM
+  - `> 0.05` → HIGH
+- Probability classification rule is applied exactly:
+  - `< 0.55` → WEAK
+  - `0.55–0.65` → MODERATE
+  - `> 0.65` → STRONG
+- Missing confidence/ev/reason data no longer crashes routing/formatting; values degrade to `N/A`.
+
+## 5) Known issues
+
+- End-to-end Telegram rendering in staging still depends on runtime bot session and active open positions for visual confirmation.
+- `docs/CLAUDE.md` remains missing in repository docs checklist (pre-existing).
+
+## 6) What is next
+
+- Run staging validation pass with live open positions to confirm operator readability of CONF/EDGE/SIGNAL/REASON.
+- Extend portfolio intelligence visibility to include threshold calibration context after validation analysis.
+- Request SENTINEL validation for phase 24.4a before merge.

--- a/projects/polymarket/polyquantbot/utils/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/utils/ui_formatter.py
@@ -57,7 +57,11 @@ def build_portfolio(data: Mapping[str, Any]) -> str:
 ├ MARKET     {_value(data, "market")}
 ├ ENTRY      {_value(data, "entry")}
 ├ SIZE       {_value(data, "size")}
-└ PNL        {_value(data, "pnl")}
+├ PNL        {_value(data, "pnl")}
+├ CONF       {_value(data, "confidence")}
+├ EDGE       {_value(data, "edge")}
+├ SIGNAL     {_value(data, "signal")}
+└ REASON     {_value(data, "reason")}
 """.strip()
 
 


### PR DESCRIPTION
### Motivation

- Surface AI intelligence in the PORTFOLIO view so operators can see why a trade exists (confidence, edge bucket, signal strength, short reason).
- Keep UI stable under missing data by providing safe fallbacks and avoid any rendering crashes.

### Description

- Extended PORTFOLIO formatter in `projects/polymarket/polyquantbot/utils/ui_formatter.py` to render the ACTIVE POSITION block with `CONF`, `EDGE`, `SIGNAL`, and `REASON` fields while preserving layout alignment and `N/A` fallbacks.
- Expanded `map_ui_data()` in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to include `confidence`, `edge`, `signal`, and `reason` keys and merge intelligence values with safe defaults for the `/portfolio` command scope.
- Implemented lightweight intelligence helpers in `trading_loop.py`: `classify_edge(ev)`, `classify_strength(probability)`, and `build_portfolio_intelligence(...)` to map `ev` and `p_model` → edge/strength/confidence/reason per the requested thresholds and fallback rules.
- Wired intelligence extraction from signal execution context (`signal.p_model`, `signal.ev`, optional `decision_reason`) into runtime trade metadata logging so the portfolio view is sourced from the signal/EV path.
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_4a_portfolio_intelligence.md` and updated `PROJECT_STATE.md` to reflect completion, in-progress validation tracking, and next priorities.

### Testing

- Compiled modified modules with `python -m compileall projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/utils/ui_formatter.py` (succeeded).
- Ran a manual smoke Python check that builds a sample `/portfolio` payload and verifies: populated output shows `CONF/EDGE/SIGNAL/REASON`, missing-data path falls back to `N/A`, and classification mapping examples match thresholds (succeeded).
- Performed repository structure checks (`find . -type d -name 'phase*'` and greps for `phase*` imports) to ensure no forbidden phase folders or legacy imports (succeeded).
- All changes committed on branch `feature/forge/portfolio-intelligence` (single commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e656c65c832eb9d8711ad45d2210)