### PR TITLE
feat: expose intelligence and validation blocks in Telegram UI

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
-Last Updated: 2026-04-04
-Status: Phase 24.3h UI architecture refactor delivered for Telegram HOME / PORTFOLIO / WALLET / PERFORMANCE separation with dedicated formatter routing and duplication removal. Next report: projects/polymarket/polyquantbot/reports/forge/24_3h_ui_architecture.md
+Last Updated: 2026-04-05
+Status: Phase 24.4 delivered intelligence + validation visibility in Telegram UI (`/portfolio` and `/home`) with safe classifier mapping and no-crash fallbacks. Next report: projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md
 
 ---
 
@@ -68,6 +68,12 @@ Structure:
 ---
 
 ## ✅ COMPLETED
+
+INTELLIGENCE + VALIDATION UI VISIBILITY (Phase 24.4)
+
+- projects/polymarket/polyquantbot/utils/ui_formatter.py (MODIFIED): `/portfolio` active position now exposes `CONF`, `EDGE`, `SIGNAL`, `REASON`; `/home` now includes `🧪 VALIDATION` with STATUS/TRADES/WR/PF.
+- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Added UI classifier/mapping logic for intelligence + validation data (`classify_edge`, `classify_strength`, `resolve_validation_status`) with missing-data-safe `N/A` handling.
+- projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md (NEW): completion report.
 
 UI ARCHITECTURE REFACTOR (Phase 24.3h)
 
@@ -723,6 +729,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🚧 IN PROGRESS
 
+- Validation run (staging) — verify `/home` validation block and `/portfolio` intelligence fields under live paper telemetry
 - UI architecture validation run (staging) — manual Telegram view verification for `/home`, `/portfolio`, `/wallet`, `/performance`
 - **Validation run (staging)** — Telegram private mode (Phase 24.3f) active with market intelligence shadow layer + snapshot system; collecting DM delivery checks, uptime, and state/snapshot telemetry
 - Validation metrics tuning — calibrate WR/PF thresholds against live paper trading data
@@ -753,11 +760,11 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Performance analysis** — validate UI-driven telemetry readability and operator workflow speed from staging interactions
-2. **Phase 24.4 analysis** — truth extraction and threshold calibration (WR/PF/MDD) using 24h validation snapshots + last_pnl
+1. **Performance analysis** — validate operator decision speed and readability impact from new intelligence + validation blocks
+2. **Validation run completion** — confirm PASS/WARMING/CRITICAL transitions against observed WR/PF/trade-count telemetry
 3. **Wire CRITICAL → kill-switch** — `ValidationState.CRITICAL` must call `stop_event.set()` before LIVE promotion
-4. SENTINEL validation required for UI architecture refactor before merge.
-   Source: projects/polymarket/polyquantbot/reports/forge/24_3h_ui_architecture.md
+4. SENTINEL validation required for intelligence + validation visibility before merge.
+   Source: projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -147,20 +147,129 @@ def build_ui_view(command: str, data: dict[str, Any]) -> str:
     return build_home(data)
 
 
+def classify_edge(ev: Any) -> str:
+    """Classify EV into LOW/MEDIUM/HIGH buckets with safe fallback."""
+    try:
+        ev_value = float(ev)
+    except (TypeError, ValueError):
+        return "N/A"
+    if ev_value < 0.01:
+        return "LOW"
+    if ev_value <= 0.05:
+        return "MEDIUM"
+    return "HIGH"
+
+
+def classify_strength(probability: Any) -> str:
+    """Classify probability confidence into WEAK/MODERATE/STRONG buckets."""
+    try:
+        probability_value = float(probability)
+    except (TypeError, ValueError):
+        return "N/A"
+    if probability_value < 0.55:
+        return "WEAK"
+    if probability_value <= 0.65:
+        return "MODERATE"
+    return "STRONG"
+
+
+def resolve_validation_status(
+    trades_count: Any,
+    winrate: Any,
+    profit_factor: Any,
+) -> str:
+    """Resolve validation status label for HOME view."""
+    try:
+        trade_count_value = int(float(trades_count))
+    except (TypeError, ValueError):
+        return "N/A"
+
+    if trade_count_value < 30:
+        return "WARMING"
+
+    try:
+        winrate_value = float(winrate)
+        profit_factor_value = float(profit_factor)
+    except (TypeError, ValueError):
+        return "N/A"
+
+    if winrate_value >= 0.70 and profit_factor_value >= 1.50:
+        return "PASS"
+    return "CRITICAL"
+
+
 def map_ui_data(command: str, source: dict[str, Any]) -> dict[str, Any]:
     """Return command-scoped data to enforce no duplication between views."""
+    source_probability = source.get("probability")
+    source_ev = source.get("ev")
+    source_trades_count = source.get("trades_count", source.get("trade_count"))
+    source_winrate = source.get("winrate", source.get("wr", source.get("win_rate")))
+    source_profit_factor = source.get("profit_factor", source.get("pf"))
+
+    confidence: Any = "N/A"
+    if source_probability is not None:
+        try:
+            confidence = round(float(source_probability), 2)
+        except (TypeError, ValueError):
+            confidence = "N/A"
+
+    intelligence_values: dict[str, Any] = {
+        "confidence": confidence,
+        "edge": classify_edge(source_ev),
+        "signal": classify_strength(source_probability),
+        "reason": source.get("reason", "N/A"),
+    }
+
+    validation_values: dict[str, Any] = {
+        "validation_status": resolve_validation_status(
+            trades_count=source_trades_count,
+            winrate=source_winrate,
+            profit_factor=source_profit_factor,
+        ),
+        "trades_count": source_trades_count if source_trades_count is not None else "N/A",
+        "winrate": source_winrate if source_winrate is not None else "N/A",
+        "profit_factor": source_profit_factor if source_profit_factor is not None else "N/A",
+    }
+
     normalized = command.strip().lower()
     if normalized == "/home":
-        keys = {"status", "mode", "markets", "latency", "strategy", "scan", "distribution", "insight"}
+        keys = {
+            "status",
+            "mode",
+            "markets",
+            "latency",
+            "strategy",
+            "scan",
+            "distribution",
+            "insight",
+            "validation_status",
+            "trades_count",
+            "winrate",
+            "profit_factor",
+        }
     elif normalized == "/portfolio":
-        keys = {"positions", "exposure", "side", "risk", "market", "entry", "size", "pnl"}
+        keys = {
+            "positions",
+            "exposure",
+            "side",
+            "risk",
+            "market",
+            "entry",
+            "size",
+            "pnl",
+            "confidence",
+            "edge",
+            "signal",
+            "reason",
+        }
     elif normalized == "/wallet":
         keys = {"balance", "equity", "used", "free", "margin"}
     elif normalized == "/performance":
         keys = {"realized", "unreal", "wr", "pf"}
     else:
         keys = set(source.keys())
-    return {key: source.get(key) for key in keys}
+    merged: dict[str, Any] = {**source, **intelligence_values, **validation_values}
+    return {key: merged.get(key) for key in keys}
 
 
 def _env_float(name: str, default: float) -> float:

--- a/projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md
@@ -1,0 +1,74 @@
+# 24.4 — Intelligence + Validation UI Visibility
+
+## 1) What was built
+
+- Extended `/portfolio` UI output to expose active intelligence context directly in Telegram:
+  - `CONF` (confidence from model probability)
+  - `EDGE` (EV class)
+  - `SIGNAL` (probability strength class)
+  - `REASON` (trade rationale, safe fallback)
+- Extended `/home` UI output with a dedicated validation block directly below intelligence:
+  - `STATUS`
+  - `TRADES` (x/30)
+  - `WR`
+  - `PF`
+- Added mapping and classifier logic in trading loop UI data mapping:
+  - `classify_edge(ev)`
+  - `classify_strength(probability)`
+  - `resolve_validation_status(trades_count, winrate, profit_factor)`
+- Added safe defaults (`"N/A"`) for missing/unparseable intelligence and validation fields to ensure no crash/no UI break behavior.
+
+## 2) Current system architecture
+
+Telegram UI mapping flow now includes derived intelligence + validation states:
+
+```text
+command input (/home|/portfolio|/wallet|/performance)
+        ↓
+core/pipeline/trading_loop.py
+  - map_ui_data(command, source)
+    - classify_edge(ev)
+    - classify_strength(probability)
+    - resolve_validation_status(...)
+        ↓
+utils/ui_formatter.py
+  - build_home()      + VALIDATION block
+  - build_portfolio() + ACTIVE POSITION intelligence fields
+        ↓
+formatted Telegram text output
+```
+
+Pipeline order remains unchanged and compliant:
+
+`DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING`
+
+## 3) Files created / modified (full paths)
+
+- `projects/polymarket/polyquantbot/utils/ui_formatter.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md` (NEW)
+- `PROJECT_STATE.md` (MODIFIED)
+
+## 4) What is working
+
+- `/portfolio` now shows `CONF / EDGE / SIGNAL / REASON` in `📌 ACTIVE POSITION`.
+- `/home` now shows `🧪 VALIDATION` with status + trade count + WR + PF.
+- Classification behavior implemented:
+  - EDGE: LOW / MEDIUM / HIGH from EV thresholds
+  - SIGNAL: WEAK / MODERATE / STRONG from probability thresholds
+- Validation status behavior implemented:
+  - `<30 trades` → `WARMING`
+  - Meets thresholds (`WR >= 0.70` and `PF >= 1.50`) → `PASS`
+  - Otherwise → `CRITICAL`
+- Missing/invalid fields are safely rendered as `N/A` (no formatting exceptions).
+
+## 5) Known issues
+
+- `docs/CLAUDE.md` is referenced in process checklist but still absent in repository.
+- End-to-end Telegram visual confirmation depends on active staging bot session and operator-triggered `/home` and `/portfolio` commands.
+
+## 6) What is next
+
+- Continue staging validation run to collect WR/PF trend reliability and confidence-to-outcome alignment.
+- Run performance analysis on telemetry readability under active market load.
+- SENTINEL validation required for intelligence + validation visibility before merge.

--- a/projects/polymarket/polyquantbot/utils/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/utils/ui_formatter.py
@@ -39,6 +39,12 @@ def build_home(data: Mapping[str, Any]) -> str:
 ├ SCAN       {_value(data, "scan")}
 └ DISTRIB    {_value(data, "distribution")}
 
+🧪 VALIDATION
+├ STATUS     {_value(data, "validation_status")}
+├ TRADES     {_value(data, "trades_count")}/30
+├ WR         {_value(data, "winrate")}
+└ PF         {_value(data, "profit_factor")}
+
 ━━━━━━━━━━━━━━━━━━━━━━
 💡 {_value(data, "insight")}
 """.strip()
@@ -57,7 +63,11 @@ def build_portfolio(data: Mapping[str, Any]) -> str:
 ├ MARKET     {_value(data, "market")}
 ├ ENTRY      {_value(data, "entry")}
 ├ SIZE       {_value(data, "size")}
-└ PNL        {_value(data, "pnl")}
+├ PNL        {_value(data, "pnl")}
+├ CONF       {_value(data, "confidence")}
+├ EDGE       {_value(data, "edge")}
+├ SIGNAL     {_value(data, "signal")}
+└ REASON     {_value(data, "reason")}
 """.strip()
 
 


### PR DESCRIPTION
### Motivation

- Surface model intelligence (confidence, edge, signal, reason) and validation metrics (status, trades, WR, PF) directly in Telegram so operators can understand why trades exist and the system performance state at a glance.

### Description

- Updated `projects/polymarket/polyquantbot/utils/ui_formatter.py` to add an `🧪 VALIDATION` block to `build_home()` and to expose `CONF`, `EDGE`, `SIGNAL`, and `REASON` in `build_portfolio()` for the active position.
- Added classifier and mapping helpers in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`: `classify_edge(ev)`, `classify_strength(probability)`, and `resolve_validation_status(trades_count, winrate, profit_factor)`, and extended `map_ui_data()` to merge derived intelligence and validation values into the view payload with `N/A` fallbacks.
- Saved a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_4_intelligence_validation.md` documenting the change and updated `PROJECT_STATE.md` to reflect Phase 24.4 completion and next steps.

### Testing

- Ran `python -m py_compile projects/polymarket/polyquantbot/utils/ui_formatter.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` which succeeded with no syntax errors.
- Executed an inline Python smoke check that calls `map_ui_data()` + `build_ui_view()` for `/home` and `/portfolio` and asserts presence of the `🧪 VALIDATION` block and `CONF/EDGE/SIGNAL/REASON` fields, which passed.
- Verified repository structure for forbidden `phase*` folders using `rg` checks; none were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e7856194832e900b3a1bf5cdd0a1)