### PR TITLE
Phase 24.5: Closed‑trade Performance Breakdown + `/analysis` command

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 ## WALKER'S AI PROJECT STATE
 
 Last Updated: 2026-04-05
-Status: Phase 24.5 performance breakdown engine delivered in staging snapshot flow (market/signal/edge grouping with WR/PF). Next report: projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md
+Status: Phase 24.5 performance breakdown engine completed with closed-trade-only grouped analytics and Telegram /analysis visibility. Validation run in staging is now in progress; next priority is strategy filtering.
 
 ---
 
@@ -71,9 +71,9 @@ Structure:
 
 PERFORMANCE BREAKDOWN ENGINE (Phase 24.5)
 
-- projects/polymarket/polyquantbot/monitoring/performance_breakdown.py (NEW): Added `PerformanceBreakdown` grouped analytics for `by_market`, `by_signal`, and `by_edge` with safe WR/PF math and no-trade empty output.
-- projects/polymarket/polyquantbot/monitoring/snapshot_engine.py (MODIFIED): Snapshot payload now includes `performance_breakdown` with safe fallback payload on errors.
-- projects/polymarket/polyquantbot/core/pipeline/trading_loop.py (MODIFIED): Added performance data hook on executed trades (`result`, `market_type`, `signal`, `edge`) and wired rolling-trade feed into snapshot breakdown generation.
+- projects/polymarket/polyquantbot/monitoring/performance_breakdown.py (MODIFIED): Closed-trade-only analyzer with grouping by market/signal/edge, full group metrics (trades/wins/losses/WR/PF/avg_win/avg_loss/expectancy), min-sample quality guard, and safe missing-field handling.
+- projects/polymarket/polyquantbot/monitoring/performance_tracker.py (MODIFIED): Trade normalization now defaults status to `open`; `update_trade()` marks status `closed` with realized PnL for strict closed-trade analytics.
+- projects/polymarket/polyquantbot/telegram/command_handler.py (MODIFIED): Added `/analysis` command routing and grouped MARKET/SIGNAL/EDGE performance breakdown output with safe NO DATA fallback.
 - projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md (NEW): completion report.
 
 INTELLIGENCE + VALIDATION UI VISIBILITY (Phase 24.4)
@@ -774,8 +774,8 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## 🎯 NEXT PRIORITY
 
-1. **Strategy optimization** — use Phase 24.5 grouped WR/PF output to tune underperforming market/signal/edge cohorts.
-2. **Validation run (staging)** — monitor stability and consistency of performance breakdown under live paper traffic.
+1. **Strategy filtering** — apply grouped breakdown output to suppress low-quality cohorts and prioritize statistically meaningful edges.
+2. **Validation run (staging)** — verify closed-trade-only /analysis and snapshot consistency in live paper traffic.
 3. SENTINEL validation required for performance breakdown engine before merge.
    Source: projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md
 
@@ -783,7 +783,7 @@ ARCHITECTURE (CRITICAL ACHIEVEMENT)
 
 ## ⚠️ KNOWN ISSUES
 
-- `/analysis` Telegram command is not yet wired into command handler routing; breakdown currently ships through periodic `system_snapshot` payload/log path.
+- `/analysis` depends on snapshot payload availability from the wired metrics source; when payload is missing it safely returns `NO DATA`.
 - Telegram private chat ID persists locally; if missing after restart, operator must send /start again to re-capture DM target
 - Single-user overwrite behavior is active by design: latest /start caller replaces USER_CHAT_ID
 - `docs/CLAUDE.md` referenced by process checklist is missing from repository

--- a/projects/polymarket/polyquantbot/monitoring/performance_breakdown.py
+++ b/projects/polymarket/polyquantbot/monitoring/performance_breakdown.py
@@ -1,12 +1,19 @@
-"""monitoring.performance_breakdown — grouped trade performance analytics."""
+"""monitoring.performance_breakdown — grouped closed-trade edge analytics."""
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any
 
 
 class PerformanceBreakdown:
-    """Compute grouped WR/PF metrics by market type, signal, and edge."""
+    """Compute grouped edge metrics by market type, signal, and edge bucket."""
+
+    _EMPTY: dict[str, dict[str, dict[str, float | int | str]]] = {
+        "by_market": {},
+        "by_signal": {},
+        "by_edge": {},
+    }
 
     def _to_float(self, value: Any, default: float = 0.0) -> float:
         """Best-effort float conversion with safe fallback."""
@@ -24,70 +31,94 @@ class PerformanceBreakdown:
         text = str(value).strip().upper()
         return text or default
 
-    def _safe_profit_factor(self, total_profit: float, total_loss: float) -> float:
-        """Return safe PF: profit/loss, or profit when loss is zero."""
-        if total_loss == 0.0:
-            return total_profit
-        return total_profit / total_loss
+    def _is_closed_trade(self, trade: dict[str, Any]) -> bool:
+        """Return True only for explicitly closed trades."""
+        return self._normalize_label(trade.get("status"), default="").lower() == "closed"
 
-    def _build_group_metrics(self, trades: list[dict[str, Any]], key: str) -> dict[str, dict[str, float | int]]:
-        """Aggregate trade metrics by a single string key."""
-        grouped: dict[str, dict[str, float | int]] = {}
+    def _is_valid_trade(self, trade: Any) -> bool:
+        """Require dict shape + required grouping and pnl fields."""
+        if not isinstance(trade, dict):
+            return False
+        required = ("status", "pnl", "market_type", "signal", "edge")
+        return all(key in trade for key in required)
+
+    def _safe_profit_factor(self, total_profit: float, total_loss_abs: float) -> float:
+        """Return PF with divide-safe behavior for all-win groups."""
+        if total_loss_abs == 0.0:
+            return total_profit
+        return total_profit / total_loss_abs
+
+    def _build_group_metrics(
+        self,
+        trades: list[dict[str, Any]],
+        key: str,
+    ) -> dict[str, dict[str, float | int | str]]:
+        """Aggregate trade metrics by a single grouping key."""
+        buckets: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {
+                "trades": 0,
+                "wins": 0,
+                "losses": 0,
+                "total_profit": 0.0,
+                "total_loss_abs": 0.0,
+                "sum_win": 0.0,
+                "sum_loss_abs": 0.0,
+            }
+        )
+
         for trade in trades:
             label = self._normalize_label(trade.get(key))
             pnl = self._to_float(trade.get("pnl"), 0.0)
-
-            if label not in grouped:
-                grouped[label] = {
-                    "trades": 0,
-                    "wins": 0,
-                    "total_profit": 0.0,
-                    "total_loss": 0.0,
-                }
-
-            grouped[label]["trades"] = int(grouped[label]["trades"]) + 1
+            b = buckets[label]
+            b["trades"] += 1
             if pnl > 0.0:
-                grouped[label]["wins"] = int(grouped[label]["wins"]) + 1
-                grouped[label]["total_profit"] = float(grouped[label]["total_profit"]) + pnl
+                b["wins"] += 1
+                b["total_profit"] += pnl
+                b["sum_win"] += pnl
             elif pnl < 0.0:
-                grouped[label]["total_loss"] = float(grouped[label]["total_loss"]) + abs(pnl)
+                b["losses"] += 1
+                loss_abs = abs(pnl)
+                b["total_loss_abs"] += loss_abs
+                b["sum_loss_abs"] += loss_abs
 
-        metrics: dict[str, dict[str, float | int]] = {}
-        for label, bucket in grouped.items():
-            trades_count = int(bucket["trades"])
-            wins = int(bucket["wins"])
-            total_profit = float(bucket["total_profit"])
-            total_loss = float(bucket["total_loss"])
-            win_rate = (wins / trades_count) if trades_count > 0 else 0.0
-            metrics[label] = {
+        output: dict[str, dict[str, float | int | str]] = {}
+        for label, b in buckets.items():
+            trades_count = int(b["trades"])
+            if trades_count == 0:
+                continue
+
+            wins = int(b["wins"])
+            losses = int(b["losses"])
+            win_rate = wins / trades_count
+            total_profit = float(b["total_profit"])
+            total_loss_abs = float(b["total_loss_abs"])
+            avg_win = total_profit / wins if wins > 0 else 0.0
+            avg_loss = float(b["sum_loss_abs"]) / losses if losses > 0 else 0.0
+            expectancy = (avg_win * win_rate) - (avg_loss * (1.0 - win_rate))
+
+            output[label] = {
                 "trades": trades_count,
+                "wins": wins,
+                "losses": losses,
                 "win_rate": win_rate,
-                "profit_factor": self._safe_profit_factor(total_profit, total_loss),
+                "profit_factor": self._safe_profit_factor(total_profit, total_loss_abs),
+                "avg_win": avg_win,
+                "avg_loss": avg_loss,
+                "expectancy": expectancy,
+                "quality": "OK" if trades_count >= 10 else "LOW_SAMPLE",
             }
-        return metrics
+        return output
 
-    def analyze(self, trades: list[dict[str, Any]] | None) -> dict[str, dict[str, dict[str, float | int]]]:
-        """Return grouped breakdown from the rolling trades list.
+    def analyze(self, trades: list[dict[str, Any]] | None) -> dict[str, dict[str, dict[str, float | int | str]]]:
+        """Return grouped performance from closed trades only."""
+        safe_trades = [t for t in (trades or []) if self._is_valid_trade(t)]
+        valid_trades = [t for t in safe_trades if self._is_closed_trade(t)]
 
-        Expected trade shape:
-            {
-              "pnl": float,
-              "result": "win" | "loss",
-              "market_type": str,
-              "signal": str,
-              "edge": str
-            }
-        """
-        safe_trades = [t for t in (trades or []) if isinstance(t, dict)]
-        if not safe_trades:
-            return {
-                "by_market": {},
-                "by_signal": {},
-                "by_edge": {},
-            }
+        if not valid_trades:
+            return dict(self._EMPTY)
 
         return {
-            "by_market": self._build_group_metrics(safe_trades, "market_type"),
-            "by_signal": self._build_group_metrics(safe_trades, "signal"),
-            "by_edge": self._build_group_metrics(safe_trades, "edge"),
+            "by_market": self._build_group_metrics(valid_trades, "market_type"),
+            "by_signal": self._build_group_metrics(valid_trades, "signal"),
+            "by_edge": self._build_group_metrics(valid_trades, "edge"),
         }

--- a/projects/polymarket/polyquantbot/monitoring/performance_tracker.py
+++ b/projects/polymarket/polyquantbot/monitoring/performance_tracker.py
@@ -68,12 +68,16 @@ class PerformanceTracker:
                 f"Trade is missing required keys: {sorted(missing)}"
             )
 
+        _normalized_trade = dict(trade)
+        if "status" not in _normalized_trade:
+            _normalized_trade["status"] = "open"
+
         # Record trade_id → index before appending (index = current length)
-        _tid: str | None = trade.get("trade_id")
+        _tid: str | None = _normalized_trade.get("trade_id")
         if _tid:
             self._trade_id_index[_tid] = len(self.trades)
 
-        self.trades.append(trade)
+        self.trades.append(_normalized_trade)
 
         # Trim oldest entries beyond the rolling window
         if len(self.trades) > self.max_window:
@@ -92,8 +96,8 @@ class PerformanceTracker:
         log.debug(
             "performance_tracker_trade_added",
             trade_count=len(self.trades),
-            signal_type=trade.get("signal_type"),
-            pnl=trade.get("pnl"),
+            signal_type=_normalized_trade.get("signal_type"),
+            pnl=_normalized_trade.get("pnl"),
             trade_id=_tid,
         )
 
@@ -126,7 +130,7 @@ class PerformanceTracker:
             )
             return False
 
-        self.trades[idx] = {**self.trades[idx], "pnl": pnl}
+        self.trades[idx] = {**self.trades[idx], "pnl": pnl, "status": "closed"}
         log.debug(
             "performance_tracker_trade_updated",
             trade_id=trade_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md
@@ -2,72 +2,72 @@
 
 ## 1) What was built
 
-- Added `PerformanceBreakdown` engine to compute grouped performance by:
-  - market type
-  - signal strength
-  - edge classification
-- Implemented grouped metrics:
-  - `trades`
-  - `win_rate = wins / total`
-  - `profit_factor = total_profit / total_loss` (safe fallback: when `total_loss == 0`, PF = `total_profit`)
-- Integrated breakdown payload into periodic validation snapshots under:
-  - `performance_breakdown.by_market`
-  - `performance_breakdown.by_signal`
-  - `performance_breakdown.by_edge`
-- Added trading-loop data hook so tracked trades include:
-  - `pnl`
-  - `result`
+- Implemented a robust closed-trade performance breakdown analyzer in `projects/polymarket/polyquantbot/monitoring/performance_breakdown.py`.
+- Analyzer now groups closed trades by:
   - `market_type`
   - `signal`
   - `edge`
-- Preserved no-crash behavior:
-  - no trades → empty structure
-  - conversion errors → safe defaults
+- Added per-group metrics:
+  - `trades`
+  - `wins`
+  - `losses`
+  - `win_rate`
+  - `profit_factor`
+  - `avg_win`
+  - `avg_loss`
+  - `expectancy`
+  - `quality` (`LOW_SAMPLE` if trades < 10, otherwise `OK`)
+- Added safe guards:
+  - ignore malformed/missing-field trades
+  - ignore non-closed trades
+  - skip empty groups
+  - no divide-by-zero crash (PF falls back to total profit when total loss is zero)
+- Added Telegram command support for `/analysis` in `projects/polymarket/polyquantbot/telegram/command_handler.py` with grouped output blocks for MARKET / SIGNAL / EDGE.
+- Integrated closed-trade compatibility in `projects/polymarket/polyquantbot/monitoring/performance_tracker.py` by defaulting status to `open` and updating to `closed` on close update.
 
 ## 2) Current system architecture
 
 ```text
 DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING
-                                                │
-                                                ├─ PerformanceTracker (rolling trades)
-                                                │    └─ stores pnl/result/market_type/signal/edge
-                                                │
-                                                └─ SnapshotEngine.build_snapshot(...)
-                                                     └─ PerformanceBreakdown.analyze(trades)
-                                                          ├─ by_market (WR/PF/trades)
-                                                          ├─ by_signal (WR/PF/trades)
-                                                          └─ by_edge   (WR/PF/trades)
+                                             │
+                                             └─ closed trade recorded in PerformanceTracker
+                                                     │
+                                                     └─ SnapshotEngine uses PerformanceBreakdown
+                                                             │
+                                                             └─ Telegram /analysis renders by_market/by_signal/by_edge
 ```
 
-RISK remains before EXECUTION; monitoring receives post-execution events and snapshot analytics.
+Key flow:
+- open trade enters rolling tracker with `status=open`
+- close event updates tracked trade (`status=closed`, realized `pnl`)
+- snapshot builds grouped performance breakdown only from closed trades
+- `/analysis` command reads snapshot payload and formats operator view
 
 ## 3) Files created / modified (full paths)
 
-- `projects/polymarket/polyquantbot/monitoring/performance_breakdown.py` (NEW)
-- `projects/polymarket/polyquantbot/monitoring/snapshot_engine.py` (MODIFIED)
-- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/monitoring/performance_breakdown.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/monitoring/performance_tracker.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/telegram/command_handler.py` (MODIFIED)
 - `projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md` (NEW)
 - `PROJECT_STATE.md` (MODIFIED)
 
 ## 4) What is working
 
-- Breakdown by market type works (`by_market`).
-- Breakdown by signal strength works (`by_signal`).
-- Breakdown by edge class works (`by_edge`).
-- Snapshot payload now includes `performance_breakdown`.
-- Safe PF and WR calculations are active.
-- Empty trade input returns:
-  - `{"by_market": {}, "by_signal": {}, "by_edge": {}}`
-- Runtime remains defensive (no exception propagation from snapshot builder).
+- Closed-trade-only filtering is active (`status == closed`).
+- Grouping works for market/signal/edge buckets.
+- Expectancy formula implemented and returned per group.
+- Sample-size quality gate active (`LOW_SAMPLE` below 10).
+- Safe PF logic for all-win groups (no division by zero).
+- Missing trade fields are skipped safely.
+- `/analysis` command now produces a structured performance breakdown message for Telegram.
 
 ## 5) Known issues
 
-- `/analysis` Telegram command output is not yet wired in `telegram/command_handler.py`; current delivery path is periodic `system_snapshot` payload/log output.
-- `docs/CLAUDE.md` is still referenced by process checklist but missing from repository.
+- `/analysis` depends on snapshot payload availability from the wired metrics source; if snapshot does not include `performance_breakdown`, command returns `NO DATA` sections safely.
+- `docs/CLAUDE.md` is still referenced by process checklist but missing in repository.
 
 ## 6) What is next
 
-- Run staging validation to collect real grouped WR/PF distributions over live paper traffic.
-- Add `/analysis` command wiring in Telegram command path for operator-friendly direct view.
-- Start strategy optimization cycle using lowest-PF cohorts first.
-- Request SENTINEL validation before merge.
+- Run staging validation session on real closed-trade flow to verify operator-readability of MARKET/SIGNAL/EDGE breakdowns.
+- Start strategy filtering using breakdown quality gates (`LOW_SAMPLE` handling + underperforming bucket suppression candidates).
+- SENTINEL validation required before merge.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -248,6 +248,8 @@ class CommandHandler:
             return await self._handle_strategies()
         if cmd == "performance":
             return await self._handle_performance()
+        if cmd == "analysis":
+            return await self._handle_analysis()
         if cmd == "health":
             return await self._handle_health()
         if cmd == "settings":
@@ -739,6 +741,101 @@ class CommandHandler:
                     context="performance", error=str(exc), severity="ERROR"
                 ),
             )
+
+    def _safe_float(self, value: object, default: float = 0.0) -> float:
+        """Best-effort float conversion with fallback."""
+        try:
+            if value is None:
+                return default
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _extract_breakdown_payload(self) -> dict[str, object]:
+        """Load performance_breakdown payload from metrics source snapshot."""
+        if self._metrics_source is None or not hasattr(self._metrics_source, "snapshot"):
+            return {}
+        try:
+            snap = self._metrics_source.snapshot()
+            if not isinstance(snap, dict):
+                return {}
+            payload = snap.get("performance_breakdown", {})
+            return payload if isinstance(payload, dict) else {}
+        except Exception:
+            return {}
+
+    def _format_analysis_line(
+        self,
+        key: str,
+        payload: dict[str, object],
+        metric_mode: str = "all",
+    ) -> str:
+        """Format one grouped analysis line for Telegram."""
+        wr = self._safe_float(payload.get("win_rate"), 0.0) * 100.0
+        pf = self._safe_float(payload.get("profit_factor"), 0.0)
+        exp = self._safe_float(payload.get("expectancy"), 0.0)
+
+        if metric_mode == "wr":
+            stats = f"WR {wr:.0f}%"
+        elif metric_mode == "pf":
+            stats = f"PF {pf:.2f}"
+        else:
+            stats = f"WR {wr:.0f}% PF {pf:.2f} EXP {exp:.2f}"
+
+        return f"├ {key:<10} {stats}"
+
+    async def _handle_analysis(self) -> CommandResult:
+        """Return grouped closed-trade edge analysis."""
+        log.info("command_analysis_invoked")
+
+        breakdown = self._extract_breakdown_payload()
+        by_market = breakdown.get("by_market", {}) if isinstance(breakdown, dict) else {}
+        by_signal = breakdown.get("by_signal", {}) if isinstance(breakdown, dict) else {}
+        by_edge = breakdown.get("by_edge", {}) if isinstance(breakdown, dict) else {}
+
+        lines = ["📊 PERFORMANCE BREAKDOWN", "", "MARKET"]
+
+        if isinstance(by_market, dict) and by_market:
+            items = sorted(by_market.items())
+            for idx, (name, metrics) in enumerate(items):
+                if not isinstance(metrics, dict):
+                    continue
+                prefix = "└" if idx == len(items) - 1 else "├"
+                line = self._format_analysis_line(str(name), metrics, metric_mode="all")
+                lines.append(prefix + line[1:])
+        else:
+            lines.append("└ NO DATA")
+
+        lines += ["", "SIGNAL"]
+        if isinstance(by_signal, dict) and by_signal:
+            items = sorted(by_signal.items())
+            for idx, (name, metrics) in enumerate(items):
+                if not isinstance(metrics, dict):
+                    continue
+                prefix = "└" if idx == len(items) - 1 else "├"
+                line = self._format_analysis_line(str(name), metrics, metric_mode="wr")
+                lines.append(prefix + line[1:])
+        else:
+            lines.append("└ NO DATA")
+
+        lines += ["", "EDGE"]
+        if isinstance(by_edge, dict) and by_edge:
+            items = sorted(by_edge.items())
+            for idx, (name, metrics) in enumerate(items):
+                if not isinstance(metrics, dict):
+                    continue
+                prefix = "└" if idx == len(items) - 1 else "├"
+                line = self._format_analysis_line(str(name), metrics, metric_mode="pf")
+                lines.append(prefix + line[1:])
+        else:
+            lines.append("└ NO DATA")
+
+        message = "\n".join(lines)
+        return CommandResult(
+            success=True,
+            message=message,
+            payload={"performance_breakdown": breakdown},
+        )
 
     async def _handle_health(self) -> CommandResult:
         """Return full system health snapshot."""


### PR DESCRIPTION
### Motivation
- Provide a robust engine to surface real trading edge using only CLOSED trades and statistically meaningful samples grouped by `market_type`, `signal`, and `edge`. 
- Expose the breakdown to operators via snapshot payloads and a Telegram `/analysis` command while ensuring no crashes from missing fields or divide-by-zero cases.

### Description
- Added `projects/polymarket/polyquantbot/monitoring/performance_breakdown.py` implementing `PerformanceBreakdown.analyze()` which filters closed trades, groups by `market_type`/`signal`/`edge`, and computes `trades`, `wins`, `losses`, `win_rate`, `profit_factor`, `avg_win`, `avg_loss`, `expectancy`, and `quality` (`LOW_SAMPLE` if `<10` trades) with safe math (PF = total_profit when total_loss == 0). 
- Updated `projects/polymarket/polyquantbot/monitoring/performance_tracker.py` to normalize incoming trades (default `status='open'`) and mark tracked entries `status='closed'` when `update_trade()` writes realized PnL so breakdown strictly uses closed trades. 
- Extended `projects/polymarket/polyquantbot/telegram/command_handler.py` with an `/analysis` handler that reads `performance_breakdown` from the metrics snapshot, formats MARKET / SIGNAL / EDGE blocks (safe `NO DATA` fallback), and returns structured payload. 
- Added operator-facing report `projects/polymarket/polyquantbot/reports/forge/24_5_performance_breakdown.md` and updated `PROJECT_STATE.md` to reflect completion and staging validation run.

### Testing
- Compiled modified modules with `python -m py_compile` for `performance_breakdown.py`, `performance_tracker.py`, and `command_handler.py` (passed). 
- Ran a simulation script exercising `PerformanceBreakdown.analyze()` with mixed open/closed trades to verify closed-only filtering, grouping correctness, expectancy math, and divide-by-zero‑safe PF behavior (assertions passed). 
- Performed an async smoke test invoking `CommandHandler.handle('/analysis')` against a dummy metrics snapshot to verify formatted Telegram output and payload (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1ecb65594832ea3b0604e0e8b5f42)