### PR TITLE
feat: premium /markets market intelligence dashboard (read-only)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 Last Updated  : 2026-04-05
-Status        : Phase 24.6b UI integration fix completed in dev branch with strict premium alignment, centralized view routing, and legacy formatter cleanup.
-COMPLETED     : UI premium v2 integration fix (alignment engine + section standardization + home/wallet/strategy/exposure/performance cleanup + view_handler routing hard switch + legacy formatter removal + forge report 24_6b_ui_fix.md).
-IN PROGRESS   : Dev runtime Telegram command verification for /start /home /wallet /performance /exposure /strategies /risk in live chat client.
-NOT STARTED   : SENTINEL validation pass for phase 24.6b UI integration fix.
-NEXT PRIORITY : SENTINEL validation required for ui premium v2 fix before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_6b_ui_fix.md
-KNOWN ISSUES  : Full end-to-end bot run in this environment depends on external Telegram/API credentials and operator chat runtime availability.
+Status        : Phase 24.7 market intelligence Telegram dashboard implemented as premium read-only UI with trading-loop intelligence payload hook and /markets routing.
+COMPLETED     : Market intelligence UI delivery (/markets command + premium market_view + trading_loop extraction for total scanned/active/classification/top EV opportunities + forge report 24_7_market_intelligence_ui.md).
+IN PROGRESS   : Staging validation run for /markets command rendering, hierarchy alignment, and max-width readability in live Telegram runtime.
+NOT STARTED   : SENTINEL validation pass for phase 24.7 market intelligence UI.
+NEXT PRIORITY : Strategy filtering kickoff after /markets validation. SENTINEL validation required for market intelligence UI before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_7_market_intelligence_ui.md
+KNOWN ISSUES  : Full end-to-end Telegram verification depends on external bot credentials/runtime chat availability; docs/CLAUDE.md is missing from repository checklist path.

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -91,6 +91,7 @@ from ...telegram.utils import telegram_sender
 from ...interface.ui.views import (
     render_exposure_view,
     render_home_view,
+    render_market_view,
     render_performance_view,
     render_risk_view,
     render_strategy_view,
@@ -150,6 +151,8 @@ def build_ui_view(command: str, data: dict[str, Any]) -> str:
         return render_strategy_view(data)
     if normalized == "/risk":
         return render_risk_view(data)
+    if normalized == "/markets":
+        return render_market_view(data)
     return render_home_view(data)
 
 
@@ -188,6 +191,14 @@ def map_ui_data(command: str, source: dict[str, Any]) -> dict[str, Any]:
         keys = {"strategies"}
     elif normalized == "/risk":
         keys = {"kelly", "level", "profile"}
+    elif normalized == "/markets":
+        keys = {
+            "total_markets",
+            "active_markets",
+            "top_edge_type",
+            "dominant_signal",
+            "top_opportunities",
+        }
     else:
         keys = set(source.keys())
     payload = {key: source.get(key) for key in keys}
@@ -324,6 +335,79 @@ def build_portfolio_intelligence(
     }
 
 
+def short_name(name: str) -> str:
+    return name[:18] + "..." if len(name) > 18 else name
+
+
+def summarize_edge_type(distribution: dict[str, int]) -> str:
+    if not distribution:
+        return "N/A"
+    total = sum(distribution.values())
+    bond_count = sum(
+        count for key, count in distribution.items() if "bond" in key.strip().lower()
+    )
+    if bond_count > total / 2:
+        return "BOND ARB"
+    if len(distribution) > 1:
+        return "DIVERSIFIED"
+    return "TREND"
+
+
+def summarize_signal(signals: list[Any], distribution: dict[str, int]) -> str:
+    if not signals:
+        return "N/A"
+    avg_prob = 0.0
+    prob_count = 0
+    yes_count = 0
+    no_count = 0
+
+    for signal in signals:
+        try:
+            avg_prob += float(getattr(signal, "p_model", 0.0))
+            prob_count += 1
+        except (TypeError, ValueError):
+            continue
+        side = str(getattr(signal, "side", "")).upper()
+        if side == "YES":
+            yes_count += 1
+        elif side == "NO":
+            no_count += 1
+
+    dominant_class = max(distribution, key=distribution.get) if distribution else "GENERAL"
+    side_label = "YES" if yes_count >= no_count else "NO"
+    if prob_count <= 0:
+        return f"{side_label} • {dominant_class}"
+    return f"{side_label} {avg_prob / prob_count:.2f} • {dominant_class}"
+
+
+def build_market_intel_payload(
+    *,
+    markets: list[dict[str, Any]],
+    distribution: dict[str, int],
+    signals: list[Any],
+) -> dict[str, Any]:
+    opportunities: list[dict[str, Any]] = []
+    for signal in sorted(
+        signals,
+        key=lambda item: float(getattr(item, "ev", 0.0) or 0.0),
+        reverse=True,
+    )[:5]:
+        opportunities.append(
+            {
+                "name": short_name(str(getattr(signal, "market_id", "N/A"))),
+                "ev": round(float(getattr(signal, "ev", 0.0) or 0.0), 3),
+                "signal": classify_strength(float(getattr(signal, "p_model", 0.0) or 0.0)),
+            }
+        )
+    return {
+        "total_markets": len(markets),
+        "active_markets": len(signals),
+        "top_edge_type": summarize_edge_type(distribution),
+        "dominant_signal": summarize_signal(signals, distribution),
+        "top_opportunities": opportunities[:5],
+    }
+
+
 def _env_float(name: str, default: float) -> float:
     try:
         return float(os.getenv(name, str(default)))
@@ -457,6 +541,7 @@ async def run_trading_loop(
     _last_heartbeat: list[float] = [0.0]        # mutable so closure can mutate
     _validation_hook_errors: list[int] = [0]    # cumulative error counter
     _last_market_distribution: dict[str, int] = {}
+    _last_market_intel_payload: dict[str, Any] = {}
     _trade_type_distribution: dict[str, int] = {}
     _market_type_by_id: dict[str, str] = {}
 
@@ -844,6 +929,12 @@ async def run_trading_loop(
                     force_trade_fallback=_force_trade_fallback,
                     paper_edge_threshold=_paper_edge_override,
                 )
+                _last_market_intel_payload = build_market_intel_payload(
+                    markets=normalised_markets,
+                    distribution=_last_market_distribution,
+                    signals=signals,
+                )
+                log.info("market_intel_payload", payload=_last_market_intel_payload)
                 if not signals and len(normalised_markets) > 0:
                     log.warning(
                         "no_signals_generated",
@@ -1266,6 +1357,7 @@ async def run_trading_loop(
                     metrics["unrealized_pnl"] = unrealized
                     metrics["realized_pnl"] = realized
                     metrics["total_pnl"] = realized + unrealized
+                    metrics.update(_last_market_intel_payload)
 
                     log.info("pnl_update", pnl=metrics)
 

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 from ..ui.views import (
     render_exposure_view,
     render_home_view,
+    render_market_view,
     render_performance_view,
     render_risk_view,
     render_strategy_view,
@@ -27,4 +28,6 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
         return render_strategy_view(payload)
     if key == "risk":
         return render_risk_view(payload)
+    if key in {"market", "markets"}:
+        return render_market_view(payload)
     return render_home_view(payload)

--- a/projects/polymarket/polyquantbot/interface/ui/views/__init__.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/__init__.py
@@ -2,6 +2,7 @@
 
 from .exposure_view import render_exposure_view
 from .home_view import render_home_view
+from .market_view import render_market_view
 from .performance_view import render_performance_view
 from .risk_view import render_risk_view
 from .strategy_view import render_strategy_view
@@ -9,6 +10,7 @@ from .wallet_view import render_wallet_view
 
 __all__ = [
     "render_home_view",
+    "render_market_view",
     "render_wallet_view",
     "render_exposure_view",
     "render_performance_view",

--- a/projects/polymarket/polyquantbot/interface/ui/views/market_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/market_view.py
@@ -1,0 +1,63 @@
+"""MARKET INTELLIGENCE premium read-only view."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..ui_blocks import row, section
+
+
+def short_name(name: object) -> str:
+    text = str(name or "N/A").strip()
+    return text[:18] + "..." if len(text) > 18 else text
+
+
+def _safe_int(value: object) -> str:
+    try:
+        if value is None:
+            return "N/A"
+        return str(int(float(value)))
+    except (TypeError, ValueError):
+        return "N/A"
+
+
+def _safe_text(value: object, default: str = "N/A") -> str:
+    text = str(value).strip() if value is not None else ""
+    return text if text else default
+
+
+def _opportunity_line(item: Mapping[str, Any]) -> str:
+    name = short_name(item.get("name", "N/A"))
+    ev_raw = item.get("ev")
+    signal = _safe_text(item.get("signal"))
+    try:
+        ev_text = f"{float(ev_raw):.3f}"
+    except (TypeError, ValueError):
+        ev_text = "N/A"
+    return f"{name:<22} EV {ev_text}   {signal}"
+
+
+def render_market_view(data: Mapping[str, Any]) -> str:
+    top = data.get("top_opportunities")
+    opportunities = top if isinstance(top, list) else []
+
+    intel_rows = [
+        row("Scanned", _safe_int(data.get("total_markets"))),
+        row("Active", _safe_int(data.get("active_markets"))),
+        row("Top Edge", _safe_text(data.get("top_edge_type"))),
+        row("Signal", _safe_text(data.get("dominant_signal"))),
+    ]
+
+    if not opportunities:
+        opportunity_rows = [row("Status", "No data")]
+    else:
+        opportunity_rows = [
+            _opportunity_line(item if isinstance(item, Mapping) else {})
+            for item in opportunities[:5]
+        ]
+
+    return "\n\n".join(
+        [
+            section("📡 MARKET INTEL", intel_rows),
+            section("🔥 TOP OPPORTUNITIES", opportunity_rows),
+        ]
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/24_7_market_intelligence_ui.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_7_market_intelligence_ui.md
@@ -1,0 +1,72 @@
+# 24_7_market_intelligence_ui
+
+## 1) What was built
+
+- Added a new premium read-only Telegram dashboard view at `projects/polymarket/polyquantbot/interface/ui/views/market_view.py` for market intelligence output.
+- Added `/markets` view routing into centralized premium view dispatch in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`.
+- Upgraded `/markets` command handling in `projects/polymarket/polyquantbot/telegram/command_handler.py` to render premium market intelligence blocks (scan totals, edge summary, dominant signal, top opportunities).
+- Added a market intelligence data hook in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to derive and emit:
+  - total markets scanned
+  - active markets
+  - edge-type summary
+  - dominant signal summary
+  - top EV opportunities (capped to top 5)
+- All dashboard behavior is read-only and does not alter signal generation, risk checks, or execution paths.
+
+## 2) Current system architecture
+
+```text
+DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING
+                                       │
+                                       └─ trading_loop market intelligence hook
+                                            ├─ summarize_edge_type(distribution)
+                                            ├─ summarize_signal(signals, distribution)
+                                            └─ build_market_intel_payload(...)
+                                                     ↓
+                                            metrics payload / snapshot source
+                                                     ↓
+Telegram /markets
+  command_handler._handle_markets()
+      ↓
+  interface.telegram.view_handler.render_view("markets", payload)
+      ↓
+  interface.ui.views.market_view.render_market_view(payload)
+```
+
+## 3) Files created / modified (full paths)
+
+Created:
+- `projects/polymarket/polyquantbot/interface/ui/views/market_view.py`
+- `projects/polymarket/polyquantbot/reports/forge/24_7_market_intelligence_ui.md`
+
+Modified:
+- `projects/polymarket/polyquantbot/interface/ui/views/__init__.py`
+- `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `projects/polymarket/polyquantbot/telegram/command_handler.py`
+- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `PROJECT_STATE.md`
+
+## 4) What is working
+
+- `/markets` command now routes into the premium view system and renders hierarchical sections:
+  - `📡 MARKET INTEL`
+  - `🔥 TOP OPPORTUNITIES`
+- Missing values are rendered safely as `N/A`.
+- No-opportunity condition renders `No data` without crashing.
+- Top opportunities are capped to max 5 entries.
+- Market name shortening now uses the required function behavior (`18 chars + ...`).
+- Edge summary derivation is active:
+  - majority bonds → `BOND ARB`
+  - mixed classifications → `DIVERSIFIED`
+  - single dominant trend bucket → `TREND`
+
+## 5) Known issues
+
+- Full live visual verification of Telegram chat-width alignment still depends on runtime bot credentials and active Telegram connectivity in staging.
+- `docs/CLAUDE.md` is referenced in process checklist but missing in repository.
+
+## 6) What is next
+
+- Execute staging runtime validation pass for `/markets` with live market scan payload and operator UI signoff.
+- Start strategy filtering workflow using intelligence dashboard visibility as decision support.
+- SENTINEL validation required for market intelligence UI before merge.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -765,6 +765,39 @@ class CommandHandler:
         except Exception:
             return {}
 
+    def _derive_edge_type(self, distribution: dict[str, int]) -> str:
+        if not distribution:
+            return "N/A"
+        total = sum(distribution.values())
+        bond_count = sum(
+            count for key, count in distribution.items() if "bond" in str(key).lower()
+        )
+        if bond_count > total / 2:
+            return "BOND ARB"
+        if len(distribution) > 1:
+            return "DIVERSIFIED"
+        return "TREND"
+
+    def _build_market_payload(self, metrics: dict[str, object]) -> dict[str, object]:
+        distribution_raw = metrics.get("market_distribution", {})
+        distribution = distribution_raw if isinstance(distribution_raw, dict) else {}
+
+        top_raw = metrics.get("top_opportunities", [])
+        top_items = top_raw if isinstance(top_raw, list) else []
+
+        total_markets = metrics.get("total_markets", metrics.get("markets_scanned", 0))
+        active_markets = metrics.get("active_markets", len(top_items))
+        dominant_signal = metrics.get("dominant_signal", "N/A")
+        top_edge_type = metrics.get("top_edge_type", self._derive_edge_type(distribution))
+
+        return {
+            "total_markets": total_markets,
+            "active_markets": active_markets,
+            "top_edge_type": top_edge_type,
+            "dominant_signal": dominant_signal,
+            "top_opportunities": top_items[:5],
+        }
+
     def _format_analysis_line(
         self,
         key: str,
@@ -965,50 +998,13 @@ class CommandHandler:
         )
 
     async def _handle_markets(self) -> CommandResult:
-        """Show currently active markets with name, price and volume."""
-        snap = self._config.snapshot()
-        meta = self._config.market_meta
-
-        # Fallback: read from runner if meta not yet loaded
-        if not meta and self._runner is not None:
-            try:
-                ids = list(self._runner._market_ids)
-            except Exception:
-                ids = []
-            if not ids:
-                return CommandResult(success=True,
-                    message="No markets active. Tap 🔍 Rediscover or run /rediscover.")
-            lines = [f"📋 *ACTIVE MARKETS* ({len(ids)})\n"]
-            for i, mid in enumerate(ids[:15], 1):
-                short = mid[:10] + "…" + mid[-6:] if len(mid) > 18 else mid
-                lines.append(f"`{i}.` `{short}`")
-            return CommandResult(success=True, message="\n".join(lines))
-
-        if not meta:
-            return CommandResult(success=True,
-                message="No markets active. Tap 🔍 Rediscover or run /rediscover.")
-
-        lines = [f"📋 *ACTIVE MARKETS* ({len(meta)})\n"]
-        for i, m in enumerate(meta, 1):
-            q = m.get("question", "Unknown")
-            q = q if len(q) <= 55 else q[:52] + "…"
-            vol = m.get("volume", 0)
-            vol_str = f"${vol/1000:.0f}K" if vol >= 1000 else f"${vol:.0f}"
-            yes = m.get("yes_price")
-            no = m.get("no_price")
-            price_str = f"YES {yes:.0%} | NO {no:.0%}" if yes and no else ""
-            end = m.get("end_date", "")
-            lines.append(
-                f"*{i}.* {q}\n"
-                f"   {price_str}  Vol: {vol_str}"
-                + (f"  Ends: {end}" if end else "")
-            )
-            lines.append("")  # blank line between markets
-
+        """Read-only market intelligence dashboard."""
+        metrics = self._get_metrics_snapshot()
+        payload = self._build_market_payload(metrics)
         return CommandResult(
             success=True,
-            message="\n".join(lines),
-            payload={"markets": meta, "count": len(meta)},
+            message=render_view("markets", payload),
+            payload=payload,
         )
 
     async def _handle_rediscover(self) -> CommandResult:


### PR DESCRIPTION
### Motivation
- Expose the market scanner/intelligence output as a premium, read-only Telegram dashboard (`/markets`) so operators can view top opportunities without any effect on execution logic or risk checks. 
- Provide a compact, crash-safe UI representation with safe fallbacks for missing data and controlled width for Telegram rendering.

### Description
- Added a new premium renderer at `projects/polymarket/polyquantbot/interface/ui/views/market_view.py` implementing the required tree hierarchy and the `short_name` shortening rule (18 chars + `...`).
- Wired the view into the centralized view dispatch by exporting `render_market_view` in `projects/polymarket/polyquantbot/interface/ui/views/__init__.py` and routing `market/markets` in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`.
- Replaced the old market-list behavior for `/markets` in `projects/polymarket/polyquantbot/telegram/command_handler.py` to return the premium dashboard from a metrics snapshot payload (read-only) while keeping discovery/rediscover flows intact.
- Added market-intel data hooks and helpers in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (`summarize_edge_type`, `summarize_signal`, `build_market_intel_payload`) to derive `total_markets`, `active_markets`, `top_edge_type`, `dominant_signal`, and sorted top-EV `top_opportunities` (capped to 5) and merged that payload into emitted loop metrics; this is shadow-only and does not change signal generation, risk, or execution paths.
- Safety: all renderers and payload builders use N/A / `No data` fallbacks, opportunity list capped to 5, and do not mutate trading state (read-only telemetry only).

### Testing
- Ran Python byte-compile smoke test with `python -m compileall` on modified files (views, view_handler, command_handler, trading_loop); compilation succeeded.
- Executed a render smoke test (`render_view('markets', payload)`) via a small Python snippet to validate layout and short-name behavior; output rendered as expected (hierarchy, truncated names, EV formatting).
- Note: full live Telegram visual verification / screenshot was not executed here because staging Telegram credentials and runtime connectivity are required; staging validation run is listed as next priority and SENTINEL validation is required before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fa609e38832e9eae4d3646b0c3f7)