### PR TITLE
fix: enforce premium UI routing via render_view

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 Last Updated  : 2026-04-05
-Status        : Phase 24.7 market intelligence Telegram dashboard implemented as premium read-only UI with trading-loop intelligence payload hook and /markets routing.
-COMPLETED     : Market intelligence UI delivery (/markets command + premium market_view + trading_loop extraction for total scanned/active/classification/top EV opportunities + forge report 24_7_market_intelligence_ui.md).
-IN PROGRESS   : Staging validation run for /markets command rendering, hierarchy alignment, and max-width readability in live Telegram runtime.
-NOT STARTED   : SENTINEL validation pass for phase 24.7 market intelligence UI.
-NEXT PRIORITY : Strategy filtering kickoff after /markets validation. SENTINEL validation required for market intelligence UI before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_7_market_intelligence_ui.md
-KNOWN ISSUES  : Full end-to-end Telegram verification depends on external bot credentials/runtime chat availability; docs/CLAUDE.md is missing from repository checklist path.
+Status        : Phase 10.8 premium UI routing enforcement completed for Telegram start/menu entry commands via render_view("home") with legacy route removal.
+COMPLETED     : Enforced premium home render path for /start /help /menu /main_menu in command handler; removed legacy start handler dependency from those routes; eliminated legacy "Menu ready. Use the buttons below" text in reply keyboard layer; generated forge report 10_8_ui_routing_fix.md.
+IN PROGRESS   : Dev runtime verification for Telegram callback/button interactions after premium home route convergence.
+NOT STARTED   : SENTINEL validation pass for phase 10.8 UI routing enforcement.
+NEXT PRIORITY : SENTINEL validation required for UI routing premium enforcement before merge. Source: projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md
+KNOWN ISSUES  : docs/CLAUDE.md is missing from repository checklist path; full end-to-end Telegram validation depends on external bot credentials/runtime chat availability.

--- a/projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md
@@ -1,0 +1,51 @@
+# 10_8_ui_routing_fix
+
+## 1. What was built
+
+- Enforced premium UI routing for `/start`, `/help`, `/menu`, and `/main_menu` in `projects/polymarket/polyquantbot/telegram/command_handler.py` by replacing legacy `handle_start()` dispatch with direct `render_view("home", payload)` rendering.
+- Rewired the start/menu response payload source to `self._build_home_payload()` so all entry points resolve through the same premium view contract.
+- Applied optional hardening by removing the legacy ready-text phrase (`"Menu ready. Use the buttons below"`) from Telegram reply-keyboard messaging.
+
+## 2. Current system architecture
+
+Telegram command routing for home/menu now follows a single premium render path:
+
+```text
+/start | /help | /menu | /main_menu
+            ↓
+CommandHandler._dispatch(...)
+            ↓
+_build_home_payload()
+            ↓
+render_view("home", payload)
+            ↓
+CommandResult(message=<premium home UI>, payload=<home payload>)
+```
+
+This removes legacy split-rendering for these commands and keeps UI behavior aligned with premium view templates.
+
+## 3. Files created / modified (full paths)
+
+- `projects/polymarket/polyquantbot/telegram/command_handler.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md` (NEW)
+- `PROJECT_STATE.md` (MODIFIED)
+
+## 4. What is working
+
+- `/start` now returns premium home UI through `render_view("home", payload)`.
+- `/menu` now uses the same premium render path as `/start`.
+- Legacy start-handler dependency was removed from the command routing branch.
+- Home payload generation remains safe when `metrics_source` is `None` due to fallback values in `_build_home_payload()`.
+- The legacy string `"Menu ready. Use the buttons below"` is no longer present in the codebase.
+
+## 5. Known issues
+
+- `docs/CLAUDE.md` remains missing from repository path referenced by process checklist.
+- Full end-to-end Telegram runtime validation still depends on external bot credentials and live chat runtime availability.
+
+## 6. What is next
+
+- Run live Telegram dev verification for callback button paths to confirm interaction parity after premium route enforcement.
+- Request SENTINEL validation for UI routing before merge.
+- If approved, continue with remaining premium UI convergence points beyond home/menu entry commands.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -218,12 +218,11 @@ class CommandHandler:
     ) -> CommandResult:
         """Route command string to the corresponding handler method."""
         if cmd in ("start", "help", "menu", "main_menu"):
-            from .handlers.start import handle_start  # noqa: PLC0415
-            text, keyboard = await handle_start()
+            payload = self._build_home_payload()
             return CommandResult(
                 success=True,
-                message=text,
-                payload={"_keyboard": keyboard},
+                message=render_view("home", payload),
+                payload=payload,
             )
         if cmd == "status":
             return await self._handle_status()

--- a/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py
+++ b/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py
@@ -62,7 +62,7 @@ def get_main_reply_keyboard() -> ReplyKeyboardMarkup:
         "resize_keyboard": True,
     }
 
-_REPLY_KB_READY_MSG = "🤖 Menu ready. Use the buttons below to navigate."
+_REPLY_KB_READY_MSG = "✨ Premium home loaded. Use the controls below to navigate."
 
 
 def get_reply_keyboard_remove() -> dict[str, bool]:


### PR DESCRIPTION
### Motivation

- Converge all Telegram entry points to the premium view system so UI design changes render immediately and consistently.
- Remove legacy start-handler routing and duplicate rendering paths to reduce maintenance surface and prevent stale UI text from appearing.

### Description

- Replaced legacy start handler branch in `projects/polymarket/polyquantbot/telegram/command_handler.py` to build the home payload via `self._build_home_payload()` and render it with `render_view("home", payload)`, removing the `.handlers.start` dependency.
- Updated reply keyboard copy in `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` to remove the legacy phrase and reflect premium wording.
- Added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md` documenting the change and updated `PROJECT_STATE.md` to reflect phase 10.8 progress and SENTINEL handoff.

### Testing

- Compiled modified files with `python -m py_compile projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` and the compilation succeeded.
- Ran a runtime validation script that instantiates `CommandHandler` and verified `/start` and `/menu` responses exactly equal `render_view('home', payload)` output, and the checks passed.
- Searched the codebase with `rg` to confirm the legacy phrase `"Menu ready. Use the buttons below"` is no longer present in runtime code paths, and the search confirmed removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fc61d8e4832ebb9e61a2a6b4e82f)