### PR TITLE
feat: premium Telegram UI — global dashboard views & reply keyboard

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 Last Updated  : 2026-04-05
-Status        : Phase 10.8 premium UI routing enforcement completed for Telegram start/menu entry commands via render_view("home") with legacy route removal.
-COMPLETED     : Enforced premium home render path for /start /help /menu /main_menu in command handler; removed legacy start handler dependency from those routes; eliminated legacy "Menu ready. Use the buttons below" text in reply keyboard layer; generated forge report 10_8_ui_routing_fix.md.
-IN PROGRESS   : Dev runtime verification for Telegram callback/button interactions after premium home route convergence.
-NOT STARTED   : SENTINEL validation pass for phase 10.8 UI routing enforcement.
-NEXT PRIORITY : SENTINEL validation required for UI routing premium enforcement before merge. Source: projects/polymarket/polyquantbot/reports/forge/10_8_ui_routing_fix.md
+Status        : Phase 10.9 premium Telegram UI global deployment completed across all interface dashboard views and reply keyboard layout.
+COMPLETED     : Upgraded home/wallet/performance/exposure/market/strategy/risk views to premium section-row-separator format; removed tree glyph formatting; replaced N/A fallback with —; aligned label/value spacing; deployed new reply keyboard layout (Trade/Wallet, Performance/Exposure, Settings/Strategy, Refresh/Home); generated forge report 10_9_ui_premium_global.md.
+IN PROGRESS   : Dev runtime verification for /start rendering and callback/button parity across premium menus.
+NOT STARTED   : SENTINEL validation pass for phase 10.9 premium UI global deployment.
+NEXT PRIORITY : SENTINEL validation required for premium UI global deployment before merge. Source: projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md
 KNOWN ISSUES  : docs/CLAUDE.md is missing from repository checklist path; full end-to-end Telegram validation depends on external bot credentials/runtime chat availability.

--- a/projects/polymarket/polyquantbot/interface/ui/ui_blocks.py
+++ b/projects/polymarket/polyquantbot/interface/ui/ui_blocks.py
@@ -1,54 +1,52 @@
-"""Centralized UI formatting blocks for Telegram monospace views."""
+"""Centralized UI formatting blocks for Telegram premium views."""
 from __future__ import annotations
 
 from typing import Iterable
 
-_LABEL_WIDTH: int = 12
+_LABEL_WIDTH: int = 14
+_SEPARATOR = "━━━━━━━━━━━━━━━"
+_NULL = "—"
 
 
 def _safe_text(value: object) -> str:
     if value is None:
-        return "N/A"
-    if isinstance(value, (int, float)):
-        if isinstance(value, bool):
-            return str(value)
-        if isinstance(value, float):
-            if value.is_integer():
-                return f"{int(value):,}"
-            return f"{value:,.2f}"
+        return _NULL
+    if isinstance(value, str):
+        text = value.strip()
+        return _NULL if not text or text.upper() == "N/A" else text
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
         return f"{value:,}"
+    if isinstance(value, float):
+        if value.is_integer():
+            return f"{int(value):,}"
+        return f"{value:,.2f}"
     text = str(value).strip()
-    return text or "N/A"
+    return _NULL if not text or text.upper() == "N/A" else text
 
 
-def row(label: str, value: str) -> str:
-    """Render one strict-alignment key-value row."""
+def row(label: str, value: object) -> str:
+    """Render one aligned key-value row."""
     left = label.strip()[:_LABEL_WIDTH].ljust(_LABEL_WIDTH)
     return f"{left} {_safe_text(value)}"
 
 
 def section(title: str, rows: list[str]) -> str:
-    """Render one section with tree connectors and no extra spacing."""
-    body: list[str] = [str(title).strip()]
-    if not rows:
-        body.append(f"└ {row('Status', 'N/A')}")
-        return "\n".join(body)
-
-    for idx, item in enumerate(rows):
-        prefix = "└" if idx == len(rows) - 1 else "├"
-        body.append(f"{prefix} {item}")
-    return "\n".join(body)
+    """Render one section with a premium separator and no tree connectors."""
+    safe_rows = rows or [row("Status", _NULL)]
+    return "\n".join([str(title).strip(), *safe_rows, _SEPARATOR])
 
 
-def insight(text: str) -> str:
-    """Render one compact single-line insight section."""
-    return section("Insight", [row("Note", text)])
+def insight(text: object) -> str:
+    """Render one compact insight line."""
+    return section("🧠 Insight", [row("Note", text)])
 
 
 def format_position_lines(lines: Iterable[str]) -> list[str]:
     """Convert arbitrary position lines into safe renderable rows."""
     rendered = [str(line).strip() for line in lines if str(line).strip()]
-    return rendered or ["No open positions"]
+    return rendered or [_NULL]
 
 
 # Backward-compatible aliases for existing callers.

--- a/projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py
@@ -1,4 +1,4 @@
-"""EXPOSURE view with compact summary and positions."""
+"""EXPOSURE premium view with compact position rows."""
 from __future__ import annotations
 
 from typing import Any, Mapping
@@ -7,7 +7,7 @@ from ..ui_blocks import format_position_lines, row, section
 
 
 def _short_market_id(value: object) -> str:
-    text = str(value or "N/A").strip()
+    text = str(value or "—").strip()
     if len(text) <= 12:
         return text
     return f"{text[:6]}...{text[-3:]}"
@@ -15,22 +15,24 @@ def _short_market_id(value: object) -> str:
 
 def render_exposure_view(data: Mapping[str, Any]) -> str:
     summary_rows = [
-        row("Total Exp", str(data.get("total_exposure", data.get("exposure", "N/A")))),
-        row("Exposure", str(data.get("ratio", "N/A"))),
-        row("Positions", str(data.get("positions", "N/A"))),
-        row("Unrealized", str(data.get("unrealized", "N/A"))),
+        row("Total Exp", data.get("total_exposure", data.get("exposure"))),
+        row("Exposure", data.get("ratio")),
+        row("Positions", data.get("positions")),
+        row("Unrealized", data.get("unrealized")),
     ]
 
     position_items = data.get("position_lines")
-    if not isinstance(position_items, list):
-        position_items = []
+    safe_lines = format_position_lines(position_items if isinstance(position_items, list) else [])
+    compact_rows = [row(f"Pos {idx + 1}", _short_market_id(item)) for idx, item in enumerate(safe_lines[:3])]
+    if not compact_rows:
+        compact_rows = [row("Status", "No open positions")]
 
-    safe_lines = format_position_lines(position_items)
-    compact_rows = []
-    for idx, item in enumerate(safe_lines[:3]):
-        compact_rows.append(row(f"Pos {idx+1}", _short_market_id(item)))
+    insight_rows = [row("Summary", "Exposure concentrated in top positions; keep liquidity coverage active.")]
 
-    return "\n\n".join([
-        section("EXPOSURE", summary_rows),
-        section("POSITIONS", compact_rows),
-    ])
+    return "\n\n".join(
+        [
+            section("📉 EXPOSURE", summary_rows),
+            section("📊 POSITIONS", compact_rows),
+            section("🧠 INSIGHT", insight_rows),
+        ]
+    )

--- a/projects/polymarket/polyquantbot/interface/ui/views/home_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/home_view.py
@@ -1,4 +1,4 @@
-"""HOME summary view."""
+"""HOME premium dashboard view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
@@ -8,24 +8,28 @@ from ..ui_blocks import row, section
 
 def render_home_view(data: Mapping[str, Any]) -> str:
     system_rows = [
-        row("State", str(data.get("status", "N/A"))),
-        row("Mode", str(data.get("mode", "N/A"))),
-        row("Latency", str(data.get("latency", "N/A"))),
+        row("State", data.get("status")),
+        row("Mode", data.get("mode")),
+        row("Latency", data.get("latency")),
     ]
     portfolio_rows = [
-        row("Balance", str(data.get("balance", "N/A"))),
-        row("Equity", str(data.get("equity", "N/A"))),
-        row("Positions", str(data.get("positions", "N/A"))),
+        row("Balance", data.get("balance")),
+        row("Equity", data.get("equity")),
+        row("Positions", data.get("positions")),
     ]
     performance_rows = [
-        row("Realized", str(data.get("realized", "N/A"))),
-        row("Unrealized", str(data.get("unrealized", "N/A"))),
+        row("Realized", data.get("realized")),
+        row("Unrealized", data.get("unrealized")),
     ]
-    insight_text = row("Insight", str(data.get("insight", "N/A")))
+    insight_rows = [
+        row("Summary", data.get("insight", "Portfolio and system telemetry synced.")),
+    ]
 
-    return "\n\n".join([
-        section("SYSTEM", system_rows),
-        section("PORTFOLIO", portfolio_rows),
-        section("PERFORMANCE", performance_rows),
-        section("Insight", [insight_text]),
-    ])
+    return "\n\n".join(
+        [
+            section("🏠 HOME", system_rows),
+            section("💼 PORTFOLIO", portfolio_rows),
+            section("📈 PERFORMANCE", performance_rows),
+            section("🧠 INSIGHT", insight_rows),
+        ]
+    )

--- a/projects/polymarket/polyquantbot/interface/ui/views/market_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/market_view.py
@@ -7,33 +7,33 @@ from ..ui_blocks import row, section
 
 
 def short_name(name: object) -> str:
-    text = str(name or "N/A").strip()
+    text = str(name or "—").strip()
     return text[:18] + "..." if len(text) > 18 else text
 
 
 def _safe_int(value: object) -> str:
     try:
         if value is None:
-            return "N/A"
+            return "—"
         return str(int(float(value)))
     except (TypeError, ValueError):
-        return "N/A"
+        return "—"
 
 
-def _safe_text(value: object, default: str = "N/A") -> str:
+def _safe_text(value: object, default: str = "—") -> str:
     text = str(value).strip() if value is not None else ""
-    return text if text else default
+    return text if text and text.upper() != "N/A" else default
 
 
 def _opportunity_line(item: Mapping[str, Any]) -> str:
-    name = short_name(item.get("name", "N/A"))
-    ev_raw = item.get("ev")
+    name = short_name(item.get("name", "—"))
     signal = _safe_text(item.get("signal"))
+    ev_raw = item.get("ev")
     try:
         ev_text = f"{float(ev_raw):.3f}"
     except (TypeError, ValueError):
-        ev_text = "N/A"
-    return f"{name:<22} EV {ev_text}   {signal}"
+        ev_text = "—"
+    return row(name, f"EV {ev_text} | {signal}")
 
 
 def render_market_view(data: Mapping[str, Any]) -> str:
@@ -47,17 +47,16 @@ def render_market_view(data: Mapping[str, Any]) -> str:
         row("Signal", _safe_text(data.get("dominant_signal"))),
     ]
 
-    if not opportunities:
-        opportunity_rows = [row("Status", "No data")]
-    else:
-        opportunity_rows = [
-            _opportunity_line(item if isinstance(item, Mapping) else {})
-            for item in opportunities[:5]
-        ]
+    opportunity_rows = [_opportunity_line(item if isinstance(item, Mapping) else {}) for item in opportunities[:5]]
+    if not opportunity_rows:
+        opportunity_rows = [row("Status", "No opportunities available")]
+
+    insight_rows = [row("Summary", "Signal quality is strongest when edge and momentum align.")]
 
     return "\n\n".join(
         [
             section("📡 MARKET INTEL", intel_rows),
-            section("🔥 TOP OPPORTUNITIES", opportunity_rows),
+            section("🔥 OPPORTUNITIES", opportunity_rows),
+            section("🧠 INSIGHT", insight_rows),
         ]
     )

--- a/projects/polymarket/polyquantbot/interface/ui/views/performance_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/performance_view.py
@@ -1,4 +1,4 @@
-"""PERFORMANCE compact metrics view."""
+"""PERFORMANCE premium metrics view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
@@ -8,9 +8,10 @@ from ..ui_blocks import row, section
 
 def render_performance_view(data: Mapping[str, Any]) -> str:
     rows = [
-        row("Total PnL", str(data.get("total_pnl", data.get("pnl", "N/A")))),
-        row("Winrate", str(data.get("winrate", data.get("wr", "N/A")))),
-        row("Trades", str(data.get("trades", data.get("total_trades", "N/A")))),
-        row("Drawdown", str(data.get("drawdown", "N/A"))),
+        row("Total PnL", data.get("total_pnl", data.get("pnl"))),
+        row("Win Rate", data.get("winrate", data.get("wr"))),
+        row("Trades", data.get("trades", data.get("total_trades"))),
+        row("Drawdown", data.get("drawdown")),
     ]
-    return section("PERFORMANCE", rows)
+    insight = [row("Summary", data.get("insight", "Risk-adjusted returns are within current guardrails."))]
+    return "\n\n".join([section("📈 PERFORMANCE", rows), section("🧠 INSIGHT", insight)])

--- a/projects/polymarket/polyquantbot/interface/ui/views/risk_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/risk_view.py
@@ -1,15 +1,16 @@
-"""RISK compact view."""
+"""RISK premium control view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
 
-from ..ui_blocks import format_block, format_row
+from ..ui_blocks import section, row
 
 
 def render_risk_view(data: Mapping[str, Any]) -> str:
     rows = [
-        format_row("kelly", str(data.get("kelly", "0.25f"))),
-        format_row("level", str(data.get("level", "N/A"))),
-        format_row("profile", str(data.get("profile", "Balanced"))),
+        row("Kelly", data.get("kelly", "0.25f")),
+        row("Level", data.get("level")),
+        row("Profile", data.get("profile", "Balanced")),
     ]
-    return format_block("🛡 RISK", rows)
+    insight_rows = [row("Summary", "Risk engine active: fractional Kelly and drawdown limits enforced.")]
+    return "\n\n".join([section("🛡️ RISK", rows), section("🧠 INSIGHT", insight_rows)])

--- a/projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py
@@ -1,4 +1,4 @@
-"""STRATEGY status list view."""
+"""STRATEGY premium status view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
@@ -19,8 +19,9 @@ def render_strategy_view(data: Mapping[str, Any]) -> str:
     liquidity_edge = _normalize_state(strategies.get("Liquidity Edge"), False)
 
     rows = [
-        row("EV Momentum", "🟢 ON" if ev_momentum else "🔴 OFF"),
-        row("Mean Revert", "🟢 ON" if mean_reversion else "🔴 OFF"),
-        row("Liquidity", "🟢 ON" if liquidity_edge else "🔴 OFF"),
+        row("EV Momentum", "ON" if ev_momentum else "OFF"),
+        row("Mean Revert", "ON" if mean_reversion else "OFF"),
+        row("Liquidity", "ON" if liquidity_edge else "OFF"),
     ]
-    return section("STRATEGIES", rows)
+    insight_rows = [row("Summary", "Blend momentum with reversion; enable liquidity mode during high depth windows.")]
+    return "\n\n".join([section("🧠 STRATEGY", rows), section("📌 INSIGHT", insight_rows)])

--- a/projects/polymarket/polyquantbot/interface/ui/views/wallet_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/wallet_view.py
@@ -1,4 +1,4 @@
-"""WALLET metrics-only view."""
+"""WALLET premium metrics view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
@@ -8,10 +8,13 @@ from ..ui_blocks import row, section
 
 def render_wallet_view(data: Mapping[str, Any]) -> str:
     rows = [
-        row("Cash", str(data.get("cash", data.get("balance", "N/A")))),
-        row("Equity", str(data.get("equity", "N/A"))),
-        row("Used Margin", str(data.get("used_margin", data.get("used", "N/A")))),
-        row("Free Margin", str(data.get("free_margin", data.get("free", "N/A")))),
-        row("Positions", str(data.get("positions", "N/A"))),
+        row("Cash", data.get("cash", data.get("balance"))),
+        row("Equity", data.get("equity")),
+        row("Used Margin", data.get("used_margin", data.get("used"))),
+        row("Free Margin", data.get("free_margin", data.get("free"))),
+        row("Positions", data.get("positions")),
     ]
-    return section("WALLET", rows)
+    insight = [
+        row("Summary", "Margin profile stable; monitor free cash for new entries."),
+    ]
+    return "\n\n".join([section("💼 WALLET", rows), section("🧠 INSIGHT", insight)])

--- a/projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md
+++ b/projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md
@@ -1,0 +1,77 @@
+# 10_9_ui_premium_global
+
+## 1. What was built
+
+- Upgraded Telegram premium UI rendering across all interface views in `projects/polymarket/polyquantbot/interface/ui/views/` to a consistent sectioned dashboard style.
+- Standardized formatting rules globally in `projects/polymarket/polyquantbot/interface/ui/ui_blocks.py`:
+  - Removed tree-style glyph formatting (`├ └ │`)
+  - Added premium separator `━━━━━━━━━━━━━━━`
+  - Replaced `N/A` fallback with `—`
+  - Enforced aligned label/value spacing
+- Updated reply keyboard layout in `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` to the new 4-row premium grid:
+  - `📊 Trade` / `💼 Wallet`
+  - `📈 Performance` / `📉 Exposure`
+  - `⚙️ Settings` / `🧠 Strategy`
+  - `🔄 Refresh` / `🏠 Home`
+
+## 2. Current system architecture
+
+Telegram premium UI flow after this task:
+
+```text
+/start | /menu | callback actions
+            ↓
+interface.telegram.view_handler.render_view(name, payload)
+            ↓
+interface.ui.views.<target_view>.render_*_view(payload)
+            ↓
+interface.ui.ui_blocks.section()/row() premium formatter
+            ↓
+Unified dashboard text output with separator + aligned rows
+```
+
+Reply keyboard navigation flow:
+
+```text
+reply_keyboard.get_main_reply_keyboard()
+            ↓
+button label → REPLY_MENU_MAP action
+            ↓
+callback routing/render path
+            ↓
+premium dashboard view update
+```
+
+## 3. Files created / modified (full paths)
+
+- `projects/polymarket/polyquantbot/interface/ui/ui_blocks.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/home_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/wallet_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/performance_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/market_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/interface/ui/views/risk_view.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` (MODIFIED)
+- `projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md` (NEW)
+- `PROJECT_STATE.md` (MODIFIED)
+
+## 4. What is working
+
+- All targeted premium views now render section headers + aligned data rows + separator pattern.
+- No targeted view output contains legacy tree characters (`├`, `└`, `│`).
+- No targeted view output uses `N/A`; fallback now renders as `—`.
+- Exposure view shows clean empty-state behavior when positions are missing.
+- Opportunity and metric rows remain readable with truncated IDs/labels where needed.
+- Reply keyboard now uses the requested premium 4x2 layout and action mappings.
+
+## 5. Known issues
+
+- Runtime `/start` and button-click validation against live Telegram chat remains environment-dependent on bot token/chat connectivity.
+- `docs/CLAUDE.md` remains absent in repository path expected by checklist.
+
+## 6. What is next
+
+- SENTINEL validation required for premium global Telegram UI deployment before merge.
+- Verify live Telegram rendering in dev chat for `/start`, refresh, and all reply keyboard buttons.
+- NEXT PRIORITY for COMMANDER: SENTINEL validation required for premium UI global deployment before merge. Source: `projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md`.

--- a/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py
+++ b/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py
@@ -1,25 +1,4 @@
-"""Reply keyboard builder — persistent bottom menu for Telegram hybrid UI.
-
-The reply keyboard stays permanently visible at the bottom of the chat
-(``resize_keyboard=True``) and serves as a navigation trigger only.
-
-Each button press sends a plain text message that is intercepted by
-``on_text_message()`` in the polling loop, mapped to an ``action:<name>``
-string, and dispatched through ``CallbackRouter`` which edits the single
-active inline message in-place (``editMessageText``).
-
-Architecture:
-    Reply keyboard  →  text message  →  on_text_message()
-                                            ↓
-                                     CallbackRouter.dispatch(action)
-                                            ↓
-                                     editMessageText  (single active message)
-
-This separation ensures:
-    - Bottom menu is always visible (reply keyboard).
-    - All dynamic content lives in a single inline message (no stacking).
-    - Zero logic duplication — reply buttons reuse the inline callback system.
-"""
+"""Reply keyboard builder — persistent bottom menu for Telegram hybrid UI."""
 from __future__ import annotations
 
 from typing import Any
@@ -29,46 +8,43 @@ ReplyKeyboardMarkup = dict[str, Any]
 
 # ── Button labels ──────────────────────────────────────────────────────────────
 _TRADE_BTN = "📊 Trade"
-_WALLET_BTN = "💰 Wallet"
+_WALLET_BTN = "💼 Wallet"
+_PERFORMANCE_BTN = "📈 Performance"
+_EXPOSURE_BTN = "📉 Exposure"
 _SETTINGS_BTN = "⚙️ Settings"
-_CONTROL_BTN = "▶ Control"
+_STRATEGY_BTN = "🧠 Strategy"
+_REFRESH_BTN = "🔄 Refresh"
+_HOME_BTN = "🏠 Home"
 
 # ── Mapping: reply keyboard button text → callback action name ─────────────────
 REPLY_MENU_MAP: dict[str, str] = {
-    _TRADE_BTN:    "status",
-    _WALLET_BTN:   "wallet",
+    _TRADE_BTN: "status",
+    _WALLET_BTN: "wallet",
+    _PERFORMANCE_BTN: "performance",
+    _EXPOSURE_BTN: "exposure",
     _SETTINGS_BTN: "settings",
-    _CONTROL_BTN:  "control",
+    _STRATEGY_BTN: "strategy",
+    _REFRESH_BTN: "refresh",
+    _HOME_BTN: "back_main",
 }
 
 
 def get_main_reply_keyboard() -> ReplyKeyboardMarkup:
-    """Build the persistent bottom reply keyboard.
-
-    Layout::
-
-        [📊 Trade]    [💰 Wallet  ]
-        [⚙️ Settings] [▶ Control  ]
-
-    Returns:
-        Telegram ``ReplyKeyboardMarkup`` dict ready for the ``reply_markup``
-        field in ``sendMessage``.
-    """
+    """Build the persistent bottom reply keyboard with premium global layout."""
     return {
         "keyboard": [
-            [_TRADE_BTN,    _WALLET_BTN],
-            [_SETTINGS_BTN, _CONTROL_BTN],
+            [_TRADE_BTN, _WALLET_BTN],
+            [_PERFORMANCE_BTN, _EXPOSURE_BTN],
+            [_SETTINGS_BTN, _STRATEGY_BTN],
+            [_REFRESH_BTN, _HOME_BTN],
         ],
         "resize_keyboard": True,
     }
 
-_REPLY_KB_READY_MSG = "✨ Premium home loaded. Use the controls below to navigate."
+
+_REPLY_KB_READY_MSG = "✨ Premium dashboard ready. Tap a section to navigate."
 
 
 def get_reply_keyboard_remove() -> dict[str, bool]:
-    """Build a ``ReplyKeyboardRemove`` object to hide the bottom menu.
-
-    Returns:
-        Telegram ``ReplyKeyboardRemove`` dict.
-    """
+    """Build a ``ReplyKeyboardRemove`` object to hide the bottom menu."""
     return {"remove_keyboard": True}


### PR DESCRIPTION
### Motivation

- Converge all Telegram UI views to a single premium dashboard style with consistent layout, spacing and hierarchy. 
- Remove legacy CLI-style tree glyphs and ambiguous `N/A` fallbacks to improve readability and mobile presentation. 
- Standardize keyboard navigation to a compact 4x2 premium layout for predictable user flows.

### Description

- Reworked UI primitives in `projects/polymarket/polyquantbot/interface/ui/ui_blocks.py` to use a premium separator (`━━━━━━━━━━━━━━━`), `_NULL = "—"` fallback, wider label column and aligned `row`/`section` primitives. 
- Updated all view renderers to the new premium format in `projects/polymarket/polyquantbot/interface/ui/views/` (`home_view.py`, `wallet_view.py`, `performance_view.py`, `exposure_view.py`, `market_view.py`, `strategy_view.py`, `risk_view.py`) to use section headers, aligned rows, compact insight sections, truncation where needed, and no tree glyphs. 
- Replaced the reply keyboard with the requested premium layout in `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` with mappings and labels: `['📊 Trade','💼 Wallet']`, `['📈 Performance','📉 Exposure']`, `['⚙️ Settings','🧠 Strategy']`, `['🔄 Refresh','🏠 Home']`. 
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/10_9_ui_premium_global.md` and updated `PROJECT_STATE.md` to reflect completion and SENTINEL handoff instructions.

### Testing

- Ran Python render validations that call each view via `render_view(...)` and verified that each output contains the separator, contains no legacy glyphs (`├`, `└`, `│`) and does not include `N/A`; these checks passed. 
- Compiled modules with `python -m compileall projects/polymarket/polyquantbot/interface/ui projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py` and observed successful compilation. 
- Executed focused Python assertions that validate `render_view` dispatch for `home`, `wallet`, `performance`, `exposure`, `strategy`, `risk`, and `markets` and confirmed the premium formatting constraints; these validations passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22d3f2138832ea71037b5257e3279)