### PR TITLE
Final premium Telegram UI: unified formatter, market context, humanized views

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
 Last Updated  : 2026-04-05
-Status        : Telegram data consistency fix implemented in dev; home/positions/performance/wallet/exposure now render from a shared portfolio snapshot service.
-COMPLETED     : Added single-source portfolio snapshot service in projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py; updated projects/polymarket/polyquantbot/telegram/handlers/start.py, positions.py, performance.py, wallet.py, and exposure.py to consume portfolio_service.get_state() with guard fallback "⚠️ Data unavailable"; wired service dependencies in projects/polymarket/polyquantbot/main.py; generated forge report projects/polymarket/polyquantbot/reports/forge/10_11c_data_consistency_fix.md.
-IN PROGRESS   : Dev runtime chat validation for open-position and empty-position parity across Home, Positions, and Exposure views.
-NEXT PRIORITY : SENTINEL validation required for data consistency fix before merge. Source: projects/polymarket/polyquantbot/reports/forge/10_11c_data_consistency_fix.md
+Status        : Final premium Telegram UI hierarchy system implemented on feature/forge/final-ui-system in staging scope.
+COMPLETED     : Added shared formatter at projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py; upgraded projects/polymarket/polyquantbot/interface/ui/views/home_view.py, portfolio_view.py, positions_view.py, performance_view.py, exposure_view.py, strategy_view.py; routed portfolio action in projects/polymarket/polyquantbot/interface/telegram/view_handler.py; created forge report projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md.
+IN PROGRESS   : Staging runtime Telegram visual parity check for hierarchy readability and market-context consistency across all upgraded views.
+NEXT PRIORITY : SENTINEL validation required for final premium UI system before merge. Source: projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -8,6 +8,7 @@ from ..ui.views import (
     render_home_view,
     render_market_view,
     render_performance_view,
+    render_portfolio_view,
     render_positions_view,
     render_risk_view,
     render_strategy_view,
@@ -32,7 +33,7 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
     elif action == "positions":
         return render_positions_view(payload)
     elif action == "portfolio":
-        return render_exposure_view(payload)
+        return render_portfolio_view(payload)
     elif action == "strategies":
         return render_strategy_view(payload)
     elif action == "risk":

--- a/projects/polymarket/polyquantbot/interface/ui/formatters/__init__.py
+++ b/projects/polymarket/polyquantbot/interface/ui/formatters/__init__.py
@@ -1,0 +1,1 @@
+"""Formatter package for premium Telegram UI output."""

--- a/projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py
@@ -1,0 +1,128 @@
+"""Unified premium formatter for Telegram UI hierarchy views."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterable, Mapping
+
+
+def section(title: str) -> str:
+    """Render a premium section header."""
+    return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
+
+
+def item(label: str, value: Any) -> str:
+    """Render a tree item with sibling connector."""
+    return f"├─ {label:<12} {_safe_text(value)}"
+
+
+def item_last(label: str, value: Any) -> str:
+    """Render a tree item with terminal connector."""
+    return f"└─ {label:<12} {_safe_text(value)}"
+
+
+def block(lines: Iterable[str]) -> str:
+    """Join lines into one display block."""
+    return "\n".join(lines)
+
+
+def divider() -> str:
+    """Render premium divider line."""
+    return "━━━━━━━━━━━━━━"
+
+
+def _safe_text(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, str):
+        text = value.strip()
+        return text if text else "N/A"
+    return str(value)
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(str(value).replace("$", "").replace(",", "").replace("%", "").strip())
+    except (AttributeError, TypeError, ValueError):
+        return default
+
+
+def _market_obj_from_mapping(data: Mapping[str, Any]) -> Any:
+    market_id = data.get("market_id") or data.get("id") or "N/A"
+    return SimpleNamespace(
+        id=market_id,
+        title=data.get("market_title") or data.get("question") or data.get("title") or "N/A",
+        category=data.get("market_category") or data.get("category") or "N/A",
+    )
+
+
+def format_market(market: Any) -> list[str]:
+    """Render market context tree with truncation and N/A fallback."""
+    if isinstance(market, Mapping):
+        market = _market_obj_from_mapping(market)
+
+    market_id = getattr(market, "id", "N/A")
+    title = getattr(market, "title", "N/A")
+    category = getattr(market, "category", "N/A")
+
+    title_text = str(title) if title is not None else "N/A"
+    if len(title_text) > 40:
+        title_text = title_text[:40] + "..."
+
+    return [
+        "🆔 Market",
+        f"├─ ID        : {market_id}",
+        f"├─ Title     : {title_text}",
+        f"└─ Category  : {category}",
+    ]
+
+
+def format_position(position: Any, market: Any) -> str:
+    """Render one fully humanized position card."""
+    side = getattr(position, "side", "NO")
+    direction = "🟢 YES" if side == "YES" else "🔴 NO"
+    entry_price = _to_float(getattr(position, "entry_price", getattr(position, "avg_price", 0.0)))
+    current_price = _to_float(getattr(position, "current_price", entry_price))
+    size = _to_float(getattr(position, "size", 0.0))
+    pnl = _to_float(getattr(position, "pnl", getattr(position, "unrealized_pnl", 0.0)))
+
+    lines: list[str] = []
+    lines += [
+        "📊 POSITION",
+        "━━━━━━━━━━━━━━",
+    ]
+    lines += format_market(market)
+    lines += [
+        "",
+        "📍 Your Position",
+        f"├─ Direction   : {direction}",
+        f"├─ Entry Price : {entry_price:.4f}",
+        f"├─ Current     : {current_price:.4f}",
+        f"└─ Position Size ($): ${size:.0f}",
+        "",
+        "💰 Profit / Loss",
+        f"└─ Unrealized  : ${pnl:.2f}",
+        "",
+        "🧠 Insight",
+        "└─ Monitoring active position",
+        "━━━━━━━━━━━━━━",
+    ]
+    return "\n".join(lines)
+
+
+
+def format_count(value: Any) -> int:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, tuple):
+        return len(value)
+    return int(_to_float(value, default=0.0))
+
+def format_money(value: Any) -> str:
+    return f"${_to_float(value):,.2f}"
+
+
+def format_percent(value: Any) -> str:
+    num = _to_float(value)
+    if num > 1:
+        return f"{num:.2f}%"
+    return f"{num * 100:.2f}%"

--- a/projects/polymarket/polyquantbot/interface/ui/views/__init__.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/__init__.py
@@ -4,6 +4,7 @@ from .exposure_view import render_exposure_view
 from .home_view import render_home_view
 from .market_view import render_market_view
 from .performance_view import render_performance_view
+from .portfolio_view import render_portfolio_view
 from .positions_view import render_positions_view
 from .risk_view import render_risk_view
 from .strategy_view import render_strategy_view
@@ -16,6 +17,7 @@ __all__ = [
     "render_exposure_view",
     "render_positions_view",
     "render_performance_view",
+    "render_portfolio_view",
     "render_strategy_view",
     "render_risk_view",
 ]

--- a/projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py
@@ -1,23 +1,23 @@
-"""EXPOSURE product dashboard view."""
+"""EXPOSURE unified premium hierarchy dashboard view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .helpers import SEPARATOR, block, generate_insight, pnl
-
-
-TITLE = "📉 EXPOSURE"
-SUBTITLE = "Polymarket AI Trader"
+from ..formatters.premium_formatter import block, divider, format_market, format_money, format_percent, item, item_last, section
 
 
 def render_exposure_view(data: Mapping[str, Any]) -> str:
-    total_exposure = data.get("total_exposure", data.get("exposure"))
-
-    sections = [
-        f"{TITLE}\n{SUBTITLE}",
-        block(total_exposure, "Total Exposure"),
-        block(data.get("ratio", data.get("exposure_ratio")), "Exposure Ratio"),
-        block(pnl(data.get("unrealized")), "Unrealized"),
-        f"🧠 Insight\n{generate_insight(data)}",
-    ]
-    return f"\n{SEPARATOR}\n".join(sections)
+    lines = [section("📉 EXPOSURE")]
+    lines.extend(format_market(data))
+    lines.extend([
+        "",
+        "📉 Market Exposure",
+        item("Total", format_money(data.get("total_exposure", data.get("exposure", 0.0)))),
+        item("Ratio", format_percent(data.get("ratio", data.get("exposure_ratio", 0.0)))),
+        item_last("Unrealized", format_money(data.get("unrealized", 0.0))),
+        "",
+        "🧠 Insight",
+        "└─ Exposure monitored against limits",
+        divider(),
+    ])
+    return block(lines)

--- a/projects/polymarket/polyquantbot/interface/ui/views/home_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/home_view.py
@@ -1,82 +1,30 @@
-"""HOME elite premium dashboard view."""
+"""HOME unified premium hierarchy dashboard view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .helpers import SEPARATOR, block, generate_insight, pnl
-
-
-TITLE = "🏠 HOME"
-SUBTITLE = "Polymarket AI Trader"
-
-
-def _to_float(value: Any) -> float | None:
-    """Parse numeric-like values from mixed inputs."""
-    try:
-        return float(str(value).replace("%", "").replace("$", "").replace(",", "").strip())
-    except (AttributeError, TypeError, ValueError):
-        return None
-
-
-def _fmt_money(value: Any) -> str:
-    """Format values as compact currency for premium inline layout."""
-    numeric = _to_float(value)
-    if numeric is None:
-        return "$0"
-    return f"${numeric:,.0f}"
-
-
-def _fmt_positions(value: Any) -> str:
-    """Format open position count for compact portfolio block."""
-    numeric = _to_float(value)
-    if numeric is None:
-        return "0 pos"
-    return f"{int(numeric)} pos"
-
-
-def _fmt_exposure_ratio(data: Mapping[str, Any]) -> str:
-    """Format exposure ratio into percent text."""
-    for key in ("ratio", "exposure_ratio", "exposure_pct", "exposure_percent"):
-        numeric = _to_float(data.get(key))
-        if numeric is None:
-            continue
-        if numeric > 1:
-            return f"{numeric:.1f}%"
-        return f"{numeric * 100:.1f}%"
-    return "0.0%"
-
-
-def _build_portfolio_line(data: Mapping[str, Any]) -> str:
-    """Compose compressed portfolio summary line."""
-    balance = _fmt_money(data.get("balance") or 0)
-    equity = _fmt_money(data.get("equity") or data.get("net_worth") or 0)
-    positions = _fmt_positions(data.get("positions") or data.get("open_positions") or 0)
-    return f"{balance} • {equity} • {positions}"
-
-
-def _build_exposure_line(data: Mapping[str, Any]) -> str:
-    """Compose compact exposure line: percent and absolute value."""
-    ratio = _fmt_exposure_ratio(data)
-    exposure = _fmt_money(
-        data.get("total_exposure")
-        or data.get("exposure")
-        or data.get("unrealized")
-        or 0
-    )
-    return f"{ratio} • {exposure}"
+from ..formatters.premium_formatter import block, divider, format_count, format_market, format_money, format_percent, item, item_last, section
 
 
 def render_home_view(data: Mapping[str, Any]) -> str:
-    hero_metric = block(pnl(data.get("total_pnl") or data.get("pnl") or 0.0), "Total PnL")
-    portfolio = block(_build_portfolio_line(data), "Portfolio")
-    exposure = block(_build_exposure_line(data), "Exposure")
-    insight = f"🧠 Insight\n{generate_insight(data)}"
-    return (
-        f"{hero_metric}\n"
-        f"{TITLE}\n{SUBTITLE}\n"
-        f"{SEPARATOR}\n"
-        f"{portfolio}\n"
-        f"{exposure}\n"
-        f"{SEPARATOR}\n"
-        f"{insight}"
-    )
+    lines = [section("🏠 HOME")]
+    lines.extend(format_market(data))
+    lines.extend([
+        "",
+        "💼 Portfolio",
+        item("Balance", format_money(data.get("balance", data.get("cash", 0.0)))),
+        item("Equity", format_money(data.get("equity", 0.0))),
+        item_last("Positions", format_count(data.get("positions", data.get("open_positions", 0)))),
+        "",
+        "📉 Market Exposure",
+        item("Ratio", format_percent(data.get("ratio", data.get("exposure_ratio", 0.0)))),
+        item_last("Value", format_money(data.get("total_exposure", data.get("exposure", 0.0)))),
+        "",
+        "💰 Profit / Loss",
+        item_last("Total", format_money(data.get("total_pnl", data.get("pnl", 0.0)))),
+        "",
+        "🧠 Insight",
+        "└─ Unified premium dashboard active",
+        divider(),
+    ])
+    return block(lines)

--- a/projects/polymarket/polyquantbot/interface/ui/views/performance_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/performance_view.py
@@ -1,24 +1,27 @@
-"""PERFORMANCE product dashboard view."""
+"""PERFORMANCE unified premium hierarchy dashboard view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .helpers import SEPARATOR, block, generate_insight, pnl
-
-
-TITLE = "📈 PERFORMANCE"
-SUBTITLE = "Polymarket AI Trader"
+from ..formatters.premium_formatter import block, divider, format_count, format_market, format_money, format_percent, item, item_last, section
 
 
 def render_performance_view(data: Mapping[str, Any]) -> str:
-    total_pnl = data.get("total_pnl", data.get("pnl", 0.0))
-    unrealized = data.get("unrealized", 0.0)
-
-    sections = [
-        f"{TITLE}\n{SUBTITLE}",
-        block(pnl(total_pnl), "Total PnL"),
-        block(pnl(unrealized), "Unrealized"),
-        block(data.get("trades", data.get("total_trades")), "Trades"),
-        f"🧠 Insight\n{generate_insight(data)}",
-    ]
-    return f"\n{SEPARATOR}\n".join(sections)
+    lines = [section("📈 PERFORMANCE")]
+    lines.extend(format_market(data))
+    lines.extend([
+        "",
+        "💰 Profit / Loss",
+        item("Total", format_money(data.get("total_pnl", data.get("pnl", 0.0)))),
+        item_last("Unrealized", format_money(data.get("unrealized", 0.0))),
+        "",
+        "📊 Trading Quality",
+        item("Trades", format_count(data.get("trades", data.get("total_trades", 0)))),
+        item("Win Rate", format_percent(data.get("win_rate", 0.0))),
+        item_last("Drawdown", format_percent(data.get("drawdown", 0.0))),
+        "",
+        "🧠 Insight",
+        "└─ Performance telemetry synchronized",
+        divider(),
+    ])
+    return block(lines)

--- a/projects/polymarket/polyquantbot/interface/ui/views/portfolio_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/portfolio_view.py
@@ -1,0 +1,26 @@
+"""PORTFOLIO unified premium hierarchy dashboard view."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..formatters.premium_formatter import block, divider, format_market, format_money, item, item_last, section
+
+
+def render_portfolio_view(data: Mapping[str, Any]) -> str:
+    lines = [section("💼 PORTFOLIO")]
+    lines.extend(format_market(data))
+    lines.extend([
+        "",
+        "💼 Account",
+        item("Balance", format_money(data.get("balance", data.get("cash", 0.0)))),
+        item("Equity", format_money(data.get("equity", 0.0))),
+        item_last("Free Margin", format_money(data.get("free_margin", data.get("free", 0.0)))),
+        "",
+        "💰 Profit / Loss",
+        item_last("Total", format_money(data.get("total_pnl", data.get("pnl", 0.0)))),
+        "",
+        "🧠 Insight",
+        "└─ Portfolio state synchronized",
+        divider(),
+    ])
+    return block(lines)

--- a/projects/polymarket/polyquantbot/interface/ui/views/positions_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/positions_view.py
@@ -1,32 +1,41 @@
-"""POSITIONS product dashboard view."""
+"""POSITIONS unified premium hierarchy dashboard view."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, Mapping
 
-from .helpers import SEPARATOR, block, fmt, generate_insight
+from ..formatters.premium_formatter import format_position
 
 
-TITLE = "📊 POSITIONS"
-SUBTITLE = "Polymarket AI Trader"
+def _to_position_obj(item: Mapping[str, Any]) -> Any:
+    return SimpleNamespace(
+        side=item.get("side", "NO"),
+        entry_price=float(item.get("entry_price", item.get("avg_price", 0.0)) or 0.0),
+        current_price=float(item.get("current_price", item.get("entry_price", item.get("avg_price", 0.0)) or 0.0)),
+        size=float(item.get("size", 0.0) or 0.0),
+        pnl=float(item.get("pnl", item.get("unrealized_pnl", 0.0)) or 0.0),
+    )
 
 
-def _top_position(item: Any) -> str:
-    text = fmt(item)
-    if text == "—":
-        return text
-    return text if len(text) <= 56 else f"{text[:53]}..."
+def _to_market_obj(item: Mapping[str, Any]) -> Any:
+    return SimpleNamespace(
+        id=item.get("market_id", "N/A"),
+        title=item.get("question", item.get("title", "N/A")),
+        category=item.get("category", "N/A"),
+    )
 
 
 def render_positions_view(data: Mapping[str, Any]) -> str:
-    raw_lines = data.get("position_lines")
-    items = raw_lines if isinstance(raw_lines, list) else []
-    count = len(items)
+    positions = data.get("positions")
+    if isinstance(positions, list) and positions:
+        first = positions[0] if isinstance(positions[0], Mapping) else {}
+    else:
+        first = None
 
-    sections = [
-        f"{TITLE}\n{SUBTITLE}",
-        block(count, "Open Positions"),
-        block(_top_position(items[0]) if count else "No open positions", "Top Position"),
-        block(_top_position(items[1]) if count > 1 else "—", "Second Position"),
-        f"🧠 Insight\n{generate_insight({**data, 'positions': count})}",
-    ]
-    return f"\n{SEPARATOR}\n".join(sections)
+    if first is None:
+        return "━━━━━━━━━━━━━━\n📊 POSITIONS\n━━━━━━━━━━━━━━\nNo active positions."
+
+    return format_position(
+        position=_to_position_obj(first),
+        market=_to_market_obj(first),
+    )

--- a/projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py
+++ b/projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py
@@ -1,13 +1,9 @@
-"""STRATEGY product dashboard view."""
+"""STRATEGY unified premium hierarchy dashboard view."""
 from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .helpers import SEPARATOR, block, generate_insight
-
-
-TITLE = "🧠 STRATEGY"
-SUBTITLE = "Polymarket AI Trader"
+from ..formatters.premium_formatter import block, divider, format_market, item, item_last, section
 
 
 def _is_on(value: Any, default: bool) -> bool:
@@ -16,17 +12,27 @@ def _is_on(value: Any, default: bool) -> bool:
     return bool(value)
 
 
+def _status(value: bool) -> str:
+    return "🟢 ON" if value else "🔴 OFF"
+
+
 def render_strategy_view(data: Mapping[str, Any]) -> str:
     strategies = data.get("strategies") if isinstance(data.get("strategies"), dict) else {}
     ev_momentum = _is_on(strategies.get("EV Momentum"), True)
     mean_reversion = _is_on(strategies.get("Mean Reversion"), True)
     liquidity_edge = _is_on(strategies.get("Liquidity Edge"), False)
 
-    sections = [
-        f"{TITLE}\n{SUBTITLE}",
-        block("ON" if ev_momentum else "OFF", "EV Momentum"),
-        block("ON" if mean_reversion else "OFF", "Mean Reversion"),
-        block("ON" if liquidity_edge else "OFF", "Liquidity Edge"),
-        f"🧠 Insight\n{generate_insight(data)}",
-    ]
-    return f"\n{SEPARATOR}\n".join(sections)
+    lines = [section("🧠 STRATEGY")]
+    lines.extend(format_market(data))
+    lines.extend([
+        "",
+        "🧠 Active Engines",
+        item("EV Momentum", _status(ev_momentum)),
+        item("Mean Revert", _status(mean_reversion)),
+        item_last("Liquidity", _status(liquidity_edge)),
+        "",
+        "🧠 Insight",
+        "└─ Strategy toggles ready for execution",
+        divider(),
+    ])
+    return block(lines)

--- a/projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md
+++ b/projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md
@@ -1,0 +1,68 @@
+# 10_13_final_ui_system
+
+## 1. What was built
+
+- Implemented a new global premium formatter at `projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py` to standardize hierarchy sections, tree rows, dividers, market context, and humanized position rendering.
+- Reworked all requested UI views to use one shared formatter system and removed duplicated local rendering logic in those view files.
+- Added `portfolio_view.py` and connected `portfolio` routing in `interface/telegram/view_handler.py` so Portfolio now has a dedicated premium hierarchy view instead of aliasing Exposure.
+- Applied humanized labels across upgraded views (`Direction`, `Entry Price`, `Position Size ($)`, `Profit / Loss`, `Market Exposure`).
+- Implemented empty-position fallback text exactly as requested for the positions screen.
+
+## 2. Architecture
+
+```text
+Telegram view action
+  -> interface/telegram/view_handler.py
+  -> interface/ui/views/[home|portfolio|positions|performance|exposure|strategy]_view.py
+  -> interface/ui/formatters/premium_formatter.py
+  -> Unified hierarchy output (tree + market context + humanized labels)
+```
+
+Design principles applied:
+- Single shared formatter API for all target views
+- Tree hierarchy (`├─`, `└─`) for readability
+- Market context block normalized and reusable
+- Position card uses one dedicated formatter path (`format_position`)
+- Safe fallbacks for missing market fields, no positions, and float formatting
+
+## 3. Files changed
+
+Modified:
+- `PROJECT_STATE.md`
+- `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/__init__.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/home_view.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/performance_view.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/positions_view.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/exposure_view.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/strategy_view.py`
+
+Added:
+- `projects/polymarket/polyquantbot/interface/ui/formatters/__init__.py`
+- `projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py`
+- `projects/polymarket/polyquantbot/interface/ui/views/portfolio_view.py`
+- `projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md`
+
+## 4. What is working
+
+- All requested views now render through a consistent premium hierarchy format.
+- Market context (`ID`, `Title`, `Category`) is now present with safe fallback and title truncation.
+- No-position fallback is clean and stable in `positions_view`.
+- Humanized labels are applied in rendered outputs and raw abbreviations are avoided in UI blocks.
+- Portfolio action now routes to a dedicated portfolio view instead of exposure aliasing.
+- Validation checks completed:
+  - no legacy `|-` tokens in upgraded UI formatter/view files
+  - Python compile check passes for updated UI modules
+
+## 5. Issues / edge cases
+
+- Some upstream payloads may not provide market metadata (`market_id`, title/question, category), so UI displays `N/A` by design.
+- Current `positions_view` renders the first active position card in premium detail mode; multi-position list expansion can be added in a subsequent scoped task if requested.
+- `docs/CLAUDE.md` remains absent in repository despite AGENTS checklist path.
+
+## 6. Next
+
+- Run staging chat-level visual validation for all upgraded menus (`home`, `portfolio`, `positions`, `performance`, `exposure`, `strategy`) to confirm hierarchy readability in Telegram client rendering.
+- Confirm callback parity and keyboard navigation against updated `portfolio` routing behavior.
+- SENTINEL validation required for final premium UI system before merge.
+  Source: `projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md`


### PR DESCRIPTION
### Motivation
- Replace ad-hoc/legacy Telegram formatting with a single premium formatter for consistent, human-readable view outputs.
- Surface market context and a hierarchy/tree structure across all views to improve operator comprehension and debugging.
- Humanize labels and provide safe fallbacks so missing/stale data never breaks the UI layout.

### Description
- Added a centralized formatter `projects/polymarket/polyquantbot/interface/ui/formatters/premium_formatter.py` exposing `section`, `item`, `item_last`, `block`, `divider`, `format_market`, `format_position`, `format_money`, `format_percent`, and safe helpers for numeric/text coercion.
- Reworked view renderers to use the shared formatter and remove duplicated legacy logic in `projects/polymarket/polyquantbot/interface/ui/views/` (updated: `home_view.py`, `performance_view.py`, `exposure_view.py`, `positions_view.py`, `strategy_view.py`; added: `portfolio_view.py`) and exported the portfolio view in `views/__init__.py`.
- Updated Telegram routing so the `portfolio` action now uses the dedicated `render_portfolio_view` instead of aliasing exposure, and ensured all views use the tree connectors and consistent emoji system.
- Applied mandatory humanized label changes (`Side → Direction`, `Avg → Entry Price`, `Size → Position Size ($)`, `PnL → Profit / Loss`, `Exposure → Market Exposure`) and implemented the exact empty-position fallback string for positions.
- Added a FORGE report `projects/polymarket/polyquantbot/reports/forge/10_13_final_ui_system.md` and updated `PROJECT_STATE.md` to reflect staging status and next steps.

### Testing
- Compiled updated modules with `python -m compileall projects/polymarket/polyquantbot/interface/ui/views projects/polymarket/polyquantbot/interface/ui/formatters projects/polymarket/polyquantbot/interface/telegram/view_handler.py` which completed successfully.
- Searched for legacy tokens with `rg -n "\|-" projects/polymarket/polyquantbot/interface/ui/views projects/polymarket/polyquantbot/interface/ui/formatters` and confirmed no legacy `|-` formatting remains in the updated formatter/view files.
- Performed smoke rendering via the adapter `render_view(...)` for views `home`, `portfolio`, `positions`, `performance`, `exposure`, and `strategy` using a representative payload and confirmed each route returned rendered output without error.
- All automated checks above passed; staging visual parity and SENTINEL validation are listed as next steps in the report and `PROJECT_STATE.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24f9447d8832eaad998f8e66c4f84)