### PR TITLE
Fix dataclass init error in Position

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated  : 2026-04-05
-Status        : Repo cleaned. Main is the single source of truth.
+Last Updated  : 2026-04-06
+Status        : Hotfix applied for execution dataclass crash
 COMPLETED     :
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
 - Added performance analytics (trade history + metrics) in execution/analytics.py
@@ -23,7 +23,11 @@ COMPLETED     :
 - Merged all feature branches into main
 - Cleaned up obsolete branches
 - Updated PROJECT_STATE.md
+- Fixed dataclass initialization error in execution/models.py
+
 IN PROGRESS   :
 - None
+
 NEXT PRIORITY :
-- None
+- SENTINEL validation required for dataclass hotfix before merge.
+  Source: projects/polymarket/polyquantbot/reports/forge/14_4_1_dataclass_hotfix.md

--- a/projects/polymarket/polyquantbot/execution/models.py
+++ b/projects/polymarket/polyquantbot/execution/models.py
@@ -9,13 +9,13 @@ import time
 class Position:
     """Paper trading position state for execution engine."""
 
-    position_id: str = str(uuid.uuid4())
-    created_at: float = time.time()
     market_id: str
     side: str
     entry_price: float
     current_price: float
     size: float
+    position_id: str = str(uuid.uuid4())
+    created_at: float = time.time()
     pnl: float = 0.0
 
     def exposure(self) -> float:

--- a/projects/polymarket/polyquantbot/reports/forge/14_4_1_dataclass_hotfix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/14_4_1_dataclass_hotfix.md
@@ -1,0 +1,21 @@
+# 14_4_1 Dataclass Hotfix Report
+
+## 1. What was built
+Fixed dataclass field ordering in `Position` to resolve the "non-default argument follows default argument" error.
+
+## 2. Current system architecture
+The `Position` class is used in the execution engine for paper trading state management.
+
+## 3. Files created / modified
+- `projects/polymarket/polyquantbot/execution/models.py`
+
+## 4. What is working
+- The `Position` class now initializes without error.
+- All required fields are explicitly passed, and default fields are optional.
+
+## 5. Known issues
+None.
+
+## 6. What is next
+SENTINEL validation required for this hotfix before merge.
+Source: `projects/polymarket/polyquantbot/reports/forge/14_4_1_dataclass_hotfix.md`


### PR DESCRIPTION
Reordered fields in Position to place non-default args before default args, resolving the 'non-default argument follows default argument' error.

- Updated: projects/polymarket/polyquantbot/execution/models.py
- Added: projects/polymarket/polyquantbot/reports/forge/14_4_1_dataclass_hotfix.md
- Updated: PROJECT_STATE.md

SENTINEL validation required before merge.