### PR TITLE
fix: critical market context runtime errors

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated  : 2026-04-06
-Status        : UI system upgraded to human-readable premium format
+Last Updated  : 2026-04-05
+Status        : Market context runtime errors fixed; async pipeline restored
 COMPLETED     :
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
 - Added performance analytics (trade history + metrics) in execution/analytics.py
@@ -22,14 +22,24 @@ COMPLETED     :
 - Added performance monitoring system in monitoring/performance_monitor.py
 - Merged all feature branches into main
 - Cleaned up obsolete branches
-- Updated PROJECT_STATE.md
 - Fixed dataclass initialization error in execution/models.py
 - Fixed execution crash (TradeTraceEngine undefined) in execution/analytics.py and execution/engine.py
 - Upgraded UI system to premium human-readable format in interface/ui_formatter.py and interface/telegram/view_handler.py
+- Added dynamic market context resolver in data/market_context.py (16_1)
+- Created Polymarket CLOB API client in data/polymarket_api.py (16_3)
+- Fixed all 4 CRITICAL runtime errors from SENTINEL report 16_2 (16_3):
+  - CRITICAL-A: added get_market_context import to interface/ui_formatter.py
+  - CRITICAL-B: removed dead async render_active_position duplicate
+  - CRITICAL-C: removed undefined MARKET_NAMES / _market_name; replaced with live context
+  - CRITICAL-D: created data/polymarket_api.py (was missing)
+- Fixed cache poisoning in data/market_context.py (fallback no longer cached)
+- Fixed question field parsing for Polymarket CLOB API response format
+- Made render_active_position, render_dashboard, render_view fully async
+- Added await to all 6 render_view call sites in telegram/command_handler.py
 
 IN PROGRESS   :
 - None
 
 NEXT PRIORITY :
-- SENTINEL validation required for UI upgrade before merge.
-  Source: projects/polymarket/polyquantbot/reports/forge/16_0_ui_humanization.md
+- SENTINEL validation required for market context fix (16_3) before merge.
+  Source: projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md

--- a/projects/polymarket/polyquantbot/data/market_context.py
+++ b/projects/polymarket/polyquantbot/data/market_context.py
@@ -1,38 +1,43 @@
-from typing import Dict, Optional
+from typing import Dict
 import structlog
-from data.polymarket_api import fetch_market_details  # Assume this exists
+from data.polymarket_api import fetch_market_details
 
 log = structlog.get_logger(__name__)
 market_cache: Dict[str, dict] = {}
 
+
 async def get_market_context(market_id: str) -> dict:
-    """
-    Fetch market context from Polymarket API.
+    """Fetch market context from Polymarket API with in-memory cache.
+
     Returns:
         {
             "name": str,
             "category": str,
             "resolution": str,
         }
+    Never returns None — falls back to safe defaults on API failure.
+    Fallback responses are NOT cached so recovery is possible on retry.
     """
     if market_id in market_cache:
         return market_cache[market_id]
 
     try:
         market_data = await fetch_market_details(market_id)
+        q = market_data.get("question", "")
+        name = q if isinstance(q, str) and q else f"Market #{market_id}"
         context = {
-            "name": market_data.get("question", {}).get("title", f"Market #{market_id}"),
+            "name": name,
             "category": market_data.get("category", "Unknown"),
-            "resolution": market_data.get("end_date", "N/A"),
+            "resolution": market_data.get(
+                "end_date_iso", market_data.get("end_date", "N/A")
+            ),
         }
         market_cache[market_id] = context
         return context
     except Exception as e:
-        log.warning(f"API failed for {market_id}: {e}")
-        fallback = {
+        log.warning("market_context_api_failed", market_id=market_id, error=str(e))
+        return {
             "name": f"Market #{market_id}",
             "category": "Unknown",
             "resolution": "N/A",
         }
-        market_cache[market_id] = fallback
-        return fallback

--- a/projects/polymarket/polyquantbot/data/polymarket_api.py
+++ b/projects/polymarket/polyquantbot/data/polymarket_api.py
@@ -1,0 +1,23 @@
+"""Async Polymarket CLOB API client."""
+import aiohttp
+
+
+async def fetch_market_details(market_id: str) -> dict:
+    """Fetch market details from Polymarket CLOB API.
+
+    Args:
+        market_id: The market condition ID.
+
+    Returns:
+        Market metadata dict from the API.
+
+    Raises:
+        Exception: On non-200 response.
+    """
+    url = f"https://clob.polymarket.com/markets/{market_id}"
+    timeout = aiohttp.ClientTimeout(total=5)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                raise Exception(f"API error: {resp.status}")
+            return await resp.json()

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 from typing import Any, Mapping
 from ..ui_formatter import render_dashboard
 
-def render_view(name: str, payload: Mapping[str, Any]) -> str:
+
+async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     action = name.strip().lower()
     if action == "trade":
-        return render_dashboard(
+        return await render_dashboard(
             equity=payload.get("equity", 0),
             positions=len(payload.get("positions", [])),
             exposure=payload.get("exposure", 0),
@@ -25,7 +26,7 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
             decision=payload.get("decision", "waiting for opportunity"),
         )
     elif action == "wallet":
-        return render_dashboard(
+        return await render_dashboard(
             equity=payload.get("equity", 0),
             positions=0,
             exposure=0,
@@ -35,7 +36,7 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
             decision="no active trades",
         )
     elif action == "performance":
-        return render_dashboard(
+        return await render_dashboard(
             equity=payload.get("equity", 0),
             positions=len(payload.get("positions", [])),
             exposure=payload.get("exposure", 0),
@@ -45,7 +46,7 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
             decision="performance review mode",
         )
     elif action in {"market", "markets"}:
-        return render_dashboard(
+        return await render_dashboard(
             equity=payload.get("equity", 0),
             positions=0,
             exposure=0,
@@ -54,7 +55,7 @@ def render_view(name: str, payload: Mapping[str, Any]) -> str:
             status=payload.get("status", "waiting"),
             decision="market analysis mode",
         )
-    return render_dashboard(
+    return await render_dashboard(
         equity=payload.get("equity", 0),
         positions=0,
         exposure=0,

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -1,7 +1,9 @@
 """Premium UI formatter for human-readable Telegram output."""
 from __future__ import annotations
-from typing import Dict, List, Optional, Union
+from typing import List, Optional
 import structlog
+
+from data.market_context import get_market_context
 
 log = structlog.get_logger(__name__)
 
@@ -24,8 +26,63 @@ EMOJI = {
     "notrade": "🛑",
 }
 
-# Market name mapping (fallback to ID if not found)
-async def render_active_position(market_id: str, side: str, entry_price: float, size: float, pnl: float) -> str:
+
+def _divider(title: str) -> str:
+    """Render a section divider with title."""
+    return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
+
+
+def _hierarchy(items: List[str], prefix: str = "┣") -> str:
+    """Render a hierarchy tree."""
+    return "\n".join(f"{prefix} {item}" for item in items)
+
+
+def _humanize_pnl(pnl: float) -> str:
+    """Convert PnL to human-readable string with emoji."""
+    if pnl > 0:
+        return f"🟢 +{pnl:.2f}"
+    elif pnl < 0:
+        return f"🔴 {pnl:.2f}"
+    return "🟡 0.00"
+
+
+def _humanize_exposure(exposure: float) -> str:
+    """Convert exposure to human-readable string."""
+    if exposure < 0.1:
+        return "Capital mostly idle, ready to deploy"
+    elif exposure > 0.8:
+        return "High exposure, consider reducing"
+    return "Moderate exposure"
+
+
+def render_portfolio_block(equity: float, positions: int, exposure: float) -> str:
+    """Render the portfolio block."""
+    return (
+        _divider(f"{EMOJI['equity']} PORTFOLIO") + "\n"
+        f"{EMOJI['equity']} Equity: ${equity:,.2f}\n"
+        f"{EMOJI['positions']} Active Positions: {positions}\n"
+        f"{EMOJI['exposure']} Exposure: {exposure:.1%} ({_humanize_exposure(exposure)})"
+    )
+
+
+def render_market_insight(trend: str, edge: str, status: str) -> str:
+    """Render the market insight block."""
+    return (
+        _divider(f"{EMOJI['insight']} MARKET INSIGHT") + "\n"
+        f"{EMOJI['bullish' if trend == 'bullish' else 'bearish' if trend == 'bearish' else 'neutral']} Trend: {trend.capitalize()}\n"
+        f"{EMOJI[edge]} Edge: {edge.capitalize()}\n"
+        f"{EMOJI[status]} Status: {status.replace('_', ' ').capitalize()}"
+    )
+
+
+async def render_active_position(
+    market_id: str,
+    side: str,
+    entry_price: float,
+    size: float,
+    pnl: float,
+) -> str:
+    """Render the active position block using live market context."""
     context = await get_market_context(market_id)
     return (
         _divider(f"{EMOJI['positions']} ACTIVE POSITION") + "\n"
@@ -37,63 +94,7 @@ async def render_active_position(market_id: str, side: str, entry_price: float, 
         f"Size: ${size:,.2f}\n"
         f"PnL: {_humanize_pnl(pnl)}"
     )
-    
-def _divider(title: str) -> str:
-    """Render a section divider with title."""
-    return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
 
-def _hierarchy(items: List[str], prefix: str = "┣") -> str:
-    """Render a hierarchy tree."""
-    return "\n".join(f"{prefix} {item}" for item in items)
-
-def _humanize_pnl(pnl: float) -> str:
-    """Convert PnL to human-readable string with emoji."""
-    if pnl > 0:
-        return f"🟢 +{pnl:.2f}"
-    elif pnl < 0:
-        return f"🔴 {pnl:.2f}"
-    return "🟡 0.00"
-
-def _humanize_exposure(exposure: float) -> str:
-    """Convert exposure to human-readable string."""
-    if exposure < 0.1:
-        return "Capital mostly idle, ready to deploy"
-    elif exposure > 0.8:
-        return "High exposure, consider reducing"
-    return "Moderate exposure"
-
-def _market_name(market_id: str) -> str:
-    """Convert market_id to human-readable name."""
-    return MARKET_NAMES.get(market_id, market_id)
-
-def render_portfolio_block(equity: float, positions: int, exposure: float) -> str:
-    """Render the portfolio block."""
-    return (
-        _divider(f"{EMOJI['equity']} PORTFOLIO") + "\n"
-        f"{EMOJI['equity']} Equity: ${equity:,.2f}\n"
-        f"{EMOJI['positions']} Active Positions: {positions}\n"
-        f"{EMOJI['exposure']} Exposure: {exposure:.1%} ({_humanize_exposure(exposure)})"
-    )
-
-def render_market_insight(trend: str, edge: str, status: str) -> str:
-    """Render the market insight block."""
-    return (
-        _divider(f"{EMOJI['insight']} MARKET INSIGHT") + "\n"
-        f"{EMOJI['bullish' if trend == 'bullish' else 'bearish' if trend == 'bearish' else 'neutral']} Trend: {trend.capitalize()}\n"
-        f"{EMOJI[edge]} Edge: {edge.capitalize()}\n"
-        f"{EMOJI[status]} Status: {status.replace('_', ' ').capitalize()}"
-    )
-
-def render_active_position(market_id: str, side: str, entry_price: float, size: float, pnl: float) -> str:
-    """Render the active position block."""
-    return (
-        _divider(f"{EMOJI['positions']} ACTIVE POSITION") + "\n"
-        f"{EMOJI['positions']} Market: {_market_name(market_id)}\n"
-        f"Side: {side}\n"
-        f"Entry Price: ${entry_price:,.2f}\n"
-        f"Size: ${size:,.2f}\n"
-        f"PnL: {_humanize_pnl(pnl)}"
-    )
 
 def render_risk_status(exposure_safe: bool, position_safe: bool, drawdown: float) -> str:
     """Render the risk status block."""
@@ -104,6 +105,7 @@ def render_risk_status(exposure_safe: bool, position_safe: bool, drawdown: float
         f"Drawdown: {drawdown:.1%}"
     )
 
+
 def render_bot_decision(decision: str) -> str:
     """Render the bot decision block."""
     return (
@@ -111,7 +113,8 @@ def render_bot_decision(decision: str) -> str:
         f"{EMOJI['action']} {decision.capitalize()}"
     )
 
-def render_dashboard(
+
+async def render_dashboard(
     equity: float,
     positions: int,
     exposure: float,
@@ -135,7 +138,7 @@ def render_dashboard(
     ]
     if market_id:
         blocks.append(
-            render_active_position(market_id, side, entry_price, size, pnl)
+            await render_active_position(market_id, side, entry_price, size, pnl)
         )
     blocks.extend([
         render_risk_status(exposure_safe, position_safe, drawdown),

--- a/projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md
@@ -1,0 +1,79 @@
+# 16_3 Market Context Fix Report
+
+**Date**: 2026-04-05
+**Environment**: staging
+**Branch**: claude/fix-market-context-errors-2UlzS
+**Source**: `projects/polymarket/polyquantbot/reports/sentinel/16_2_market_context_validation.md`
+
+---
+
+## 1. What was built
+
+Resolved all four CRITICAL and two HIGH issues identified by SENTINEL in validation report 16_2.
+Restored working end-to-end pipeline: API → cache → market context → async UI → Telegram.
+
+---
+
+## 2. Architecture
+
+```
+Polymarket CLOB API
+      │
+      ▼
+data/polymarket_api.py          ← NEW: async fetch with aiohttp + 5s timeout
+      │
+      ▼
+data/market_context.py          ← FIXED: question parsing, no cache poisoning
+      │
+      ▼
+interface/ui_formatter.py       ← FIXED: single async render_active_position,
+      │                                   async render_dashboard, correct import
+      ▼
+interface/telegram/view_handler.py  ← FIXED: async render_view, all await
+      │
+      ▼
+telegram/command_handler.py     ← FIXED: all render_view calls awaited (6 sites)
+```
+
+Async flow is now fully consistent end-to-end. No blocking I/O. No missing awaits.
+
+---
+
+## 3. Files created / modified
+
+| File | Action | Fix |
+|---|---|---|
+| `data/polymarket_api.py` | **CREATED** | CRITICAL-D: missing module now exists; async aiohttp with 5s timeout |
+| `data/market_context.py` | **MODIFIED** | Fix `question` field parsing (string, not nested dict); fix cache poisoning (fallback not cached); structured log |
+| `interface/ui_formatter.py` | **MODIFIED** | CRITICAL-A: added `from data.market_context import get_market_context`; CRITICAL-B: removed dead async duplicate; CRITICAL-C: removed `_market_name`/`MARKET_NAMES`; made `render_active_position` and `render_dashboard` async |
+| `interface/telegram/view_handler.py` | **MODIFIED** | Made `render_view` async; added `await` to all 5 `render_dashboard` calls |
+| `telegram/command_handler.py` | **MODIFIED** | Added `await` to all 6 `render_view` call sites |
+
+---
+
+## 4. What is working
+
+- **CRITICAL-A resolved**: `get_market_context` is now imported correctly in `ui_formatter.py`
+- **CRITICAL-B resolved**: Dead async duplicate removed; single async `render_active_position` is the only definition
+- **CRITICAL-C resolved**: `MARKET_NAMES` and `_market_name()` removed entirely; live context used instead
+- **CRITICAL-D resolved**: `data/polymarket_api.py` created with async `aiohttp` implementation and 5s timeout
+- **Cache poisoning resolved**: Fallback responses are no longer written to cache; API can recover on next request
+- **Question field parsing fixed**: Handles Polymarket CLOB response where `question` is a string
+- **Async flow consistent**: `render_dashboard → render_active_position → get_market_context → fetch_market_details` fully async with `await` at every level
+- **Fallback guaranteed**: `get_market_context` always returns a valid dict; never returns `None`
+- **All 6 `render_view` call sites** in `command_handler.py` updated with `await`
+
+---
+
+## 5. Known issues
+
+- Cache has no TTL or size bound (MEDIUM — pre-existing, deferred to P2 improvement)
+- No Redis backing for cache persistence across restarts (MEDIUM — pre-existing, deferred to P2)
+- No retry with backoff on API failure (LOW — single attempt with immediate fallback is acceptable for display-only metadata)
+
+---
+
+## 6. What is next
+
+SENTINEL validation required for market context fix before merge.
+Source: `projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md`

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -199,7 +199,7 @@ class CommandHandler:
             payload = self._build_home_payload()
             return CommandResult(
                 success=True,
-                message=render_view("home", payload),
+                message=await render_view("home", payload),
                 payload=payload,
             )
         if cmd == "status":
@@ -380,7 +380,7 @@ class CommandHandler:
         )
         return CommandResult(
             success=True,
-            message=render_view("positions", payload),
+            message=await render_view("positions", payload),
             payload=payload,
         )
 
@@ -419,7 +419,7 @@ class CommandHandler:
         payload = await export_execution_payload()
         return CommandResult(
             success=True,
-            message=render_view("positions", payload),
+            message=await render_view("positions", payload),
             payload=payload,
         )
 
@@ -455,7 +455,7 @@ class CommandHandler:
 
     async def _handle_home(self) -> CommandResult:
         payload = self._build_home_payload()
-        return CommandResult(success=True, message=render_view("home", payload), payload=payload)
+        return CommandResult(success=True, message=await render_view("home", payload), payload=payload)
 
     async def _handle_pause(self) -> CommandResult:
         current = self._state.state
@@ -762,7 +762,7 @@ class CommandHandler:
                     strategy_states["Mean Reversion"] = enabled
                 elif "liq" in sid or "edge" in sid:
                     strategy_states["Liquidity Edge"] = enabled
-            msg = render_view("strategy", {"strategies": strategy_states})
+            msg = await render_view("strategy", {"strategies": strategy_states})
             return CommandResult(
                 success=True,
                 message=msg,
@@ -821,7 +821,7 @@ class CommandHandler:
             }
             return CommandResult(
                 success=True,
-                message=render_view("performance", ui_payload),
+                message=await render_view("performance", ui_payload),
                 payload={
                     "total_pnl": round(total_pnl, 4),
                     "total_trades": self._multi_metrics.total_trades,


### PR DESCRIPTION
Resolves all 4 CRITICALs from SENTINEL 16_2:
- CRITICAL-D: create data/polymarket_api.py (async aiohttp, 5s timeout)
- CRITICAL-A: add get_market_context import to ui_formatter.py
- CRITICAL-B: remove dead async render_active_position duplicate
- CRITICAL-C: remove undefined MARKET_NAMES/_market_name; use live context

Also fixes HIGH issues:
- Cache poisoning: fallback no longer written to cache
- question field parsing: handle Polymarket string response

Async flow restored end-to-end:
render_dashboard → render_active_position → get_market_context → fetch_market_details
All 6 render_view call sites in command_handler.py updated with await

https://claude.ai/code/session_01SWAPgxF31Vwm5zF1QCkEwD