### PR TITLE
SENTINEL: validate 16_3 market context fix (BLOCKED)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated  : 2026-04-05
+Last Updated  : 2026-04-06
 Status        : Market context runtime errors fixed; async pipeline restored
 COMPLETED     :
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
@@ -36,10 +36,12 @@ COMPLETED     :
 - Fixed question field parsing for Polymarket CLOB API response format
 - Made render_active_position, render_dashboard, render_view fully async
 - Added await to all 6 render_view call sites in telegram/command_handler.py
+- SENTINEL validation 16_3 completed with BLOCKED verdict (critical UI formatter syntax failure)
 
 IN PROGRESS   :
 - None
 
 NEXT PRIORITY :
-- SENTINEL validation required for market context fix (16_3) before merge.
-  Source: projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md
+- FORGE-X fix required for `interface/ui_formatter.py` syntax/import crash and market_context null normalization.
+  Source: projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
+

--- a/projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
@@ -1,0 +1,60 @@
+# 16_3 SENTINEL Validation — Market Context Fix
+
+**Date:** 2026-04-06  
+**Target:** `projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md`  
+**Validator Role:** SENTINEL
+
+---
+
+Score: **52/100**
+
+Findings:
+- **Phase 0:**
+  - PASS: Forge report exists at the required path and name.
+  - PASS: `PROJECT_STATE.md` lists 16_3 as the active next-priority SENTINEL validation target.
+  - PASS: No `phase*` directories detected under `projects/polymarket/polyquantbot`.
+- **Phase 1:**
+  - PARTIAL PASS: `get_market_context()` returns valid fallback payload on API failure and avoids caching fallback.
+  - PARTIAL PASS: `fetch_market_details()` returns parsed JSON for `200` and raises on non-200.
+  - ISSUE: Null category from API propagates as `None` (`category` not normalized to safe default).
+- **Phase 2:**
+  - PASS: Core execution pipeline keeps gating order and does not bypass pre-execution controls.
+  - ISSUE: Market context UI integration is broken because `interface/ui_formatter.py` has `SyntaxError` and cannot be imported by Telegram view layer.
+- **Phase 3:**
+  - PASS: Market context fallback survives API failure and returns safe dict.
+  - PARTIAL: Corrupt payload handling is only partially safe; missing type normalization for some fields (e.g., category can be `None`).
+- **Phase 4:**
+  - BLOCKED: Async flow cannot be validated end-to-end in UI/Telegram path because formatter module fails at import-time (`SyntaxError`).
+- **Phase 5:**
+  - PASS: Risk constants and guards are present and aligned with required thresholds (`-2000`, `0.08`, `0.25`, max position cap `0.10`, dedup and kill switch hooks present).
+- **Phase 6:**
+  - PASS (limited evidence): API client uses async aiohttp with 5s timeout; no direct blocking calls in market context fetch path.
+- **Phase 7:**
+  - FAIL: Telegram/UI layer cannot render market context because `ui_formatter` is syntactically invalid, causing import failure in `view_handler`.
+
+Evidence:
+- Pre-check:
+  - `find projects/polymarket/polyquantbot -maxdepth 3 -type d -name 'phase*'` → no results.
+- Functional simulation:
+  - `python` async mock run of `get_market_context()`:
+    - valid payload: returns expected metadata.
+    - failure path: logs warning, returns fallback, fallback not cached.
+    - null payload: returned `{'category': None}` (normalization gap).
+  - `python` async mock run of `fetch_market_details()`:
+    - status 200: returns JSON payload.
+    - status 500: raises `Exception("API error: 500")`.
+- Pipeline/risk/static validation:
+  - `RiskGuard` constants and kill-switch trigger paths are in place.
+  - `ConfigManager` enforces risk multiplier default `0.25` and max position clamp `0.10`.
+  - `ExecutionGuard` enforces pre-trade position-size and dedup checks.
+- Critical runtime proof:
+  - Import check:
+    - `import projects.polymarket.polyquantbot.interface.ui_formatter` → `SyntaxError: invalid syntax (ui_formatter.py, line 1)`.
+    - `import projects.polymarket.polyquantbot.interface.telegram.view_handler` fails transitively on the same syntax error.
+
+Critical Issues:
+- `interface/ui_formatter.py` is syntactically invalid and breaks Telegram/UI rendering path (import-time crash).
+- Market context normalization gap: `category=None` from upstream API is passed through instead of coercing to a safe default.
+
+Verdict:
+- **BLOCKED**


### PR DESCRIPTION
### Motivation
- Run SENTINEL validation against the Forge report `projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md` to confirm the market-context fixes and end-to-end async UI pipeline.
- Surface any remaining functional, pipeline, async, or risk issues and update project state to hand back to FORGE‑X if remediation is required.

### Description
- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md` documenting phase 0–7 findings and a blocked verdict.
- Updated `PROJECT_STATE.md` to record the SENTINEL blocked verdict and set the next priority to a FORGE‑X fix for `interface/ui_formatter.py` import failure and `data/market_context.py` normalization gaps.
- Documented two critical issues found: `interface/ui_formatter.py` raises a `SyntaxError` on import which breaks the Telegram/UI rendering path, and `data/market_context.py` can propagate `None` for `category` instead of coercing a safe default.

### Testing
- Ran targeted import checks which reproduced `SyntaxError: invalid syntax (ui_formatter.py, line 1)` and caused `interface.telegram.view_handler` to fail transitively, and this import failure was recorded as critical evidence (pass/fail evidence collected via `importlib` checks). — SUCCESS: import failures reproduced and logged.
- Executed small async simulation scripts to exercise `get_market_context()` with mocked `fetch_market_details()` for success, null, and exception cases, confirming fallback behaviour and that fallback responses are not cached, but showing `category=None` normalization gap. — SUCCESS: behavior reproduced and logged.
- Executed `fetch_market_details()` mock test confirming JSON parsing on `200` and raising on non-`200` responses. — SUCCESS: API client behavior validated under mock.
- Attempted `pytest` runs for runtime validation suites which failed in this environment due to missing async pytest plugin and test collection import issues (async test support and import path in this runner), so the end-to-end test suite could not be fully executed here. — FAILURE: `pytest` runs blocked by environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d308badecc832eae2c63a1bb5c692f)