### PR TITLE
fix: resolve ui_formatter syntax crash blocking startup

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
 Last Updated  : 2026-04-06
-Status        : Market context runtime errors fixed; async pipeline restored
+Status        : UI formatter crash fixed
 COMPLETED     :
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
 - Added performance analytics (trade history + metrics) in execution/analytics.py
@@ -37,11 +37,11 @@ COMPLETED     :
 - Made render_active_position, render_dashboard, render_view fully async
 - Added await to all 6 render_view call sites in telegram/command_handler.py
 - SENTINEL validation 16_3 completed with BLOCKED verdict (critical UI formatter syntax failure)
+- Fixed fatal syntax crash in projects/polymarket/polyquantbot/interface/ui_formatter.py blocking startup/import path
 
 IN PROGRESS   :
 - None
 
 NEXT PRIORITY :
-- FORGE-X fix required for `interface/ui_formatter.py` syntax/import crash and market_context null normalization.
-  Source: projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
+- Re-run SENTINEL 16_3
 

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -1,115 +1,149 @@
-"""Refactored Premium UI Formatter (Production-Ready)""" from future import annotations from typing import Optional
+"""Refactored Premium UI Formatter (Production-Ready)."""
+
+from __future__ import annotations
 
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
 
-=========================
 
-SAFETY HELPERS
+# =========================
+# SAFETY HELPERS
+# =========================
 
-=========================
+def _safe_float(value: object) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return 0.0
 
-def _safe_float(x) -> float: try: return float(x) except Exception: return 0.0
 
-def _safe_str(x) -> str: return str(x) if x is not None else "N/A"
+def _safe_str(value: object) -> str:
+    return str(value) if value is not None else "N/A"
 
-=========================
 
-EMOJI SYSTEM
+# =========================
+# EMOJI SYSTEM
+# =========================
 
-=========================
+EMOJI = {
+    "equity": "💰",
+    "positions": "📦",
+    "exposure": "📊",
+    "insight": "🧠",
+    "risk": "⚠️",
+    "action": "💡",
+    "system": "⚙️",
+}
 
-EMOJI = { "equity": "💰", "positions": "📦", "exposure": "📊", "insight": "🧠", "risk": "⚠️", "action": "💡", "system": "⚙️", }
 
-=========================
+# =========================
+# CORE UI BUILDERS
+# =========================
 
-CORE UI BUILDERS
+def _divider(title: str) -> str:
+    return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
 
-=========================
 
-def _divider(title: str) -> str: return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
+def _pnl(pnl: float) -> str:
+    pnl = _safe_float(pnl)
+    if pnl > 0:
+        return f"🟢 +{pnl:.2f}"
+    if pnl < 0:
+        return f"🔴 {pnl:.2f}"
+    return "🟡 0.00"
 
-def _pnl(pnl: float) -> str: pnl = _safe_float(pnl) if pnl > 0: return f"🟢 +{pnl:.2f}" elif pnl < 0: return f"🔴 {pnl:.2f}" return "🟡 0.00"
 
-=========================
+# =========================
+# BLOCKS
+# =========================
 
-BLOCKS
+def render_system(state: object, mode: object) -> str:
+    return (
+        _divider(f"{EMOJI['system']} SYSTEM")
+        + "\n"
+        + f"State : {_safe_str(state)}\n"
+        + f"Mode  : {_safe_str(mode)}"
+    )
 
-=========================
 
-def render_system(state: str, mode: str) -> str: return ( _divider(f"{EMOJI['system']} SYSTEM") + "\n" f"State : {_safe_str(state)}\n" f"Mode  : {_safe_str(mode)}" )
+def render_portfolio(equity: object, positions: object, exposure: object) -> str:
+    equity_value = _safe_float(equity)
+    exposure_value = _safe_float(exposure)
 
-def render_portfolio(equity, positions, exposure) -> str: equity = _safe_float(equity) exposure = _safe_float(exposure)
+    return (
+        _divider(f"{EMOJI['equity']} PORTFOLIO")
+        + "\n"
+        + f"Equity    : ${equity_value:,.2f}\n"
+        + f"Positions : {_safe_float(positions):.0f}\n"
+        + f"Exposure  : {exposure_value:.1%}"
+    )
 
-return (
-    _divider(f"{EMOJI['equity']} PORTFOLIO") + "\n"
-    f"Equity    : ${equity:,.2f}\n"
-    f"Positions : {_safe_float(positions):.0f}\n"
-    f"Exposure  : {exposure:.1%}"
-)
 
-async def render_position(market_id, side, entry, size, pnl) -> str: context = await get_market_context(market_id) or {}
+async def render_position(
+    market_id: object,
+    side: object,
+    entry: object,
+    size: object,
+    pnl: object,
+) -> str:
+    context = await get_market_context(market_id) or {}
+    name = context.get("name", "Unknown Market")
 
-name = context.get("name", "Unknown Market")
+    entry_value = _safe_float(entry)
+    size_value = _safe_float(size)
+    pnl_value = _safe_float(pnl)
 
-entry = _safe_float(entry)
-size = _safe_float(size)
-pnl = _safe_float(pnl)
+    return (
+        _divider(f"{EMOJI['positions']} POSITION")
+        + "\n"
+        + f"Market : {name}\n"
+        + f"Side   : {_safe_str(side)}\n"
+        + f"Entry  : ${entry_value:,.2f}\n"
+        + f"Size   : ${size_value:,.2f}\n"
+        + f"PnL    : {_pnl(pnl_value)}"
+    )
 
-return (
-    _divider(f"{EMOJI['positions']} POSITION") + "\n"
-    f"Market : {name}\n"
-    f"Side   : {_safe_str(side)}\n"
-    f"Entry  : ${entry:,.2f}\n"
-    f"Size   : ${size:,.2f}\n"
-    f"PnL    : {_pnl(pnl)}"
-)
 
-def render_risk(drawdown) -> str: dd = _safe_float(drawdown) return ( _divider(f"{EMOJI['risk']} RISK") + "\n" f"Drawdown : {dd:.1%}" )
+def render_risk(drawdown: object) -> str:
+    dd = _safe_float(drawdown)
+    return _divider(f"{EMOJI['risk']} RISK") + "\n" + f"Drawdown : {dd:.1%}"
 
-def render_insight(text: str) -> str: return ( _divider(f"{EMOJI['insight']} INSIGHT") + "\n" f"{_safe_str(text)}" )
 
-def render_decision(text: str) -> str: return ( _divider(f"{EMOJI['action']} DECISION") + "\n" f"{_safe_str(text)}" )
+def render_insight(text: object) -> str:
+    return _divider(f"{EMOJI['insight']} INSIGHT") + "\n" + f"{_safe_str(text)}"
 
-=========================
 
-SINGLE ENTRY POINT
+def render_decision(text: object) -> str:
+    return _divider(f"{EMOJI['action']} DECISION") + "\n" + f"{_safe_str(text)}"
 
-=========================
 
-async def render_dashboard(data: dict) -> str: """ONLY ENTRY POINT — do not bypass this."""
+# =========================
+# SINGLE ENTRY POINT
+# =========================
 
-blocks = []
+async def render_dashboard(data: dict) -> str:
+    """ONLY ENTRY POINT — do not bypass this."""
 
-# SYSTEM
-blocks.append(render_system(
-    data.get("state"),
-    data.get("mode")
-))
+    blocks: list[str] = []
 
-# PORTFOLIO
-blocks.append(render_portfolio(
-    data.get("equity"),
-    data.get("positions"),
-    data.get("exposure")
-))
+    blocks.append(render_system(data.get("state"), data.get("mode")))
 
-# POSITION (optional)
-if data.get("market_id"):
-    blocks.append(await render_position(
-        data.get("market_id"),
-        data.get("side"),
-        data.get("entry"),
-        data.get("size"),
-        data.get("pnl")
-    ))
+    blocks.append(
+        render_portfolio(data.get("equity"), data.get("positions"), data.get("exposure"))
+    )
 
-# RISK
-blocks.append(render_risk(data.get("drawdown")))
+    if data.get("market_id"):
+        blocks.append(
+            await render_position(
+                data.get("market_id"),
+                data.get("side"),
+                data.get("entry"),
+                data.get("size"),
+                data.get("pnl"),
+            )
+        )
 
-# INSIGHT
-blocks.append(render_insight(data.get("insight")))
+    blocks.append(render_risk(data.get("drawdown")))
+    blocks.append(render_insight(data.get("insight")))
+    blocks.append(render_decision(data.get("decision")))
 
-# DECISION
-blocks.append(render_decision(data.get("decision")))
-
-return "\n\n".join(blocks)
+    return "\n\n".join(blocks)


### PR DESCRIPTION
### Motivation
- Resolve an import-time `SyntaxError` in `projects/polymarket/polyquantbot/interface/ui_formatter.py` that blocked Telegram UI rendering and prevented system startup.
- Keep scope minimal to only restore valid Python syntax and importability while preserving existing async market-context lookups and formatting behavior.

### Description
- Rewrote `projects/polymarket/polyquantbot/interface/ui_formatter.py` into valid Python 3.11 syntax, restoring `from __future__ import annotations`, safety helpers, emoji map, async renderers, and preserved `get_market_context(...)` usage. 
- Fixed function signatures, local variable names, and return formatting so the module imports cleanly and behaves as before. 
- Updated `PROJECT_STATE.md` to set `Status` → `UI formatter crash fixed`, add a completed entry for the fix, and set `NEXT PRIORITY` → `Re-run SENTINEL 16_3` as requested. 
- Changes were committed in a single commit with message `fix: resolve ui_formatter syntax crash blocking startup`.

### Testing
- Ran `python -c "import projects.polymarket.polyquantbot.interface.ui_formatter"` which completed successfully (import passed). 
- Ran `python -c "from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view"` which completed successfully (Telegram view import path passes). 
- Ran `timeout 25s python projects/polymarket/polyquantbot/main.py` which progressed past the formatter import but failed due to an existing unrelated runtime/config error (`attempted relative import with no known parent package`) outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d30d9eeb1c832eaeeab09cb872a2fa)