### PR TITLE
sentinel: re-validate 16_3 after UI formatter hotfix

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md
@@ -1,4 +1,4 @@
-# 16_3 SENTINEL Validation — Market Context Fix
+# 16_3 SENTINEL Re-Validation — Market Context Fix (Post UI Formatter Hotfix)
 
 **Date:** 2026-04-06  
 **Target:** `projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md`  
@@ -6,55 +6,71 @@
 
 ---
 
-Score: **52/100**
+Score: **64/100**
 
 Findings:
 - **Phase 0:**
-  - PASS: Forge report exists at the required path and name.
-  - PASS: `PROJECT_STATE.md` lists 16_3 as the active next-priority SENTINEL validation target.
-  - PASS: No `phase*` directories detected under `projects/polymarket/polyquantbot`.
+  - PASS: Latest FORGE-X report exists at `projects/polymarket/polyquantbot/reports/forge/16_3_market_context_fix.md`.
+  - PASS: `PROJECT_STATE.md` explicitly records UI formatter hotfix completion and SENTINEL re-validation as next priority.
+  - FAIL: Active branch name is `work`, which does **not** satisfy required `feature/[area]-[purpose]` format.
+  - PASS: Latest hotfix commit for syntax crash (`1c3302f`) touched only `interface/ui_formatter.py` + `PROJECT_STATE.md` (no unrelated scope drift).
 - **Phase 1:**
-  - PARTIAL PASS: `get_market_context()` returns valid fallback payload on API failure and avoids caching fallback.
-  - PARTIAL PASS: `fetch_market_details()` returns parsed JSON for `200` and raises on non-200.
-  - ISSUE: Null category from API propagates as `None` (`category` not normalized to safe default).
+  - PASS: `projects.polymarket.polyquantbot.interface.ui_formatter` imports successfully.
+  - PASS: `projects.polymarket.polyquantbot.interface.telegram.view_handler` imports successfully.
+  - PASS: `render_dashboard` executes and renders market context safely even when API is unreachable (fallback path active).
+  - FAIL: `render_view("trade", payload)` raises `TypeError` because `render_dashboard` now expects a single `dict` argument while `view_handler` passes keyword args.
+  - FAIL: Category normalization gap remains (`category=None` can propagate from corrupt payload instead of coercing to safe default).
 - **Phase 2:**
-  - PASS: Core execution pipeline keeps gating order and does not bypass pre-execution controls.
-  - ISSUE: Market context UI integration is broken because `interface/ui_formatter.py` has `SyntaxError` and cannot be imported by Telegram view layer.
+  - FAIL: Telegram/UI path is still broken functionally (`render_view` -> `TypeError`), so downstream UI consumers do not receive formatted dashboard output.
+  - PASS: No evidence of pipeline-order bypass in core path (DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION).
 - **Phase 3:**
-  - PASS: Market context fallback survives API failure and returns safe dict.
-  - PARTIAL: Corrupt payload handling is only partially safe; missing type normalization for some fields (e.g., category can be `None`).
+  - PASS: API failure simulation returns safe fallback context; no crash.
+  - PASS: Empty market data simulation returns safe fallback context; no crash.
+  - PARTIAL: Corrupt payload simulation does not crash, but returns `category=None` (normalization weakness).
+  - PASS: Degraded market context still renders in direct dashboard call.
+  - FAIL: Telegram render call under degraded context fails at adapter layer (`TypeError`), blocking expected safe output path.
 - **Phase 4:**
-  - BLOCKED: Async flow cannot be validated end-to-end in UI/Telegram path because formatter module fails at import-time (`SyntaxError`).
+  - PASS: Async imports and async render functions execute.
+  - FAIL: Async chain is functionally broken in Telegram adapter due interface mismatch, despite correct `await` usage at call sites.
+  - PASS: No newly introduced sync/blocking call found in hotfix area.
 - **Phase 5:**
-  - PASS: Risk constants and guards are present and aligned with required thresholds (`-2000`, `0.08`, `0.25`, max position cap `0.10`, dedup and kill switch hooks present).
+  - PASS: Kelly fraction remains `0.25` default.
+  - PASS: Max position hard cap remains `<= 0.10`.
+  - PASS: Daily loss limit remains `-2000`.
+  - PASS: Drawdown halt threshold remains `0.08`.
+  - PASS: Dedup controls remain present.
+  - PASS: Kill switch remains callable via `RiskGuard.trigger_kill_switch`.
 - **Phase 6:**
-  - PASS (limited evidence): API client uses async aiohttp with 5s timeout; no direct blocking calls in market context fetch path.
+  - PASS: Startup/import path proceeds past prior syntax crash point.
+  - PASS: Market context fetch/render path remains low-latency in current env (~0.135s observed with unreachable API + fallback).
+  - PASS: No blocking regression identified in hotfix path.
 - **Phase 7:**
-  - FAIL: Telegram/UI layer cannot render market context because `ui_formatter` is syntactically invalid, causing import failure in `view_handler`.
+  - PARTIAL: Telegram/UI modules load.
+  - FAIL: `render_view` runtime contract mismatch prevents stable dashboard/view output.
+  - BLOCKED: Railway/Telegram runtime cannot be considered validated while view adapter throws at normal trade render path.
 
 Evidence:
-- Pre-check:
-  - `find projects/polymarket/polyquantbot -maxdepth 3 -type d -name 'phase*'` → no results.
-- Functional simulation:
-  - `python` async mock run of `get_market_context()`:
-    - valid payload: returns expected metadata.
-    - failure path: logs warning, returns fallback, fallback not cached.
-    - null payload: returned `{'category': None}` (normalization gap).
-  - `python` async mock run of `fetch_market_details()`:
-    - status 200: returns JSON payload.
-    - status 500: raises `Exception("API error: 500")`.
-- Pipeline/risk/static validation:
-  - `RiskGuard` constants and kill-switch trigger paths are in place.
-  - `ConfigManager` enforces risk multiplier default `0.25` and max position clamp `0.10`.
-  - `ExecutionGuard` enforces pre-trade position-size and dedup checks.
-- Critical runtime proof:
-  - Import check:
-    - `import projects.polymarket.polyquantbot.interface.ui_formatter` → `SyntaxError: invalid syntax (ui_formatter.py, line 1)`.
-    - `import projects.polymarket.polyquantbot.interface.telegram.view_handler` fails transitively on the same syntax error.
+- commands run:
+  - `git branch --show-current`
+  - `git log -1 --name-only --pretty=format:'%H%n%s%n%b'`
+  - `git show --name-only --pretty=format:'%h %s' 1c3302f`
+  - `python - <<'PY' ... importlib.import_module(...) ... PY` (module import checks)
+  - `python - <<'PY' ... await render_dashboard(...) / await render_view(...) ... PY` (functional checks)
+  - `python - <<'PY' ... unittest.mock.AsyncMock/patch over fetch_market_details ... PY` (failure simulations)
+  - `rg -n "render_view\(" projects/polymarket/polyquantbot/telegram/command_handler.py` (await-chain inspection)
+  - `rg -n "0\.25|0\.10|2000|0\.08|dedup|kill" ...` (risk constants and controls scan)
+- logs/import/runtime results:
+  - Import success:
+    - `OK projects.polymarket.polyquantbot.interface.ui_formatter`
+    - `OK projects.polymarket.polyquantbot.interface.telegram.view_handler`
+  - Functional failure:
+    - `TypeError: render_dashboard() got an unexpected keyword argument 'equity'`
+  - Fallback behavior:
+    - `market_context_api_failed ... Network is unreachable` warnings observed, with successful fallback render outputs.
 
 Critical Issues:
-- `interface/ui_formatter.py` is syntactically invalid and breaks Telegram/UI rendering path (import-time crash).
-- Market context normalization gap: `category=None` from upstream API is passed through instead of coercing to a safe default.
+- Telegram/UI adapter contract mismatch: `interface/telegram/view_handler.py` calls `render_dashboard` with keyword args, but formatter now requires a single dict argument. This breaks normal render path.
+- Branch naming policy violation: active branch is `work` instead of required `feature/[area]-[purpose]`.
 
 Verdict:
 - **BLOCKED**


### PR DESCRIPTION
### Motivation
- Re-run SENTINEL validation after the FORGE-X hotfix to verify the `ui_formatter` import/runtime path and confirm whether the market-context fix restored safe UI/Telegram behavior without scope drift.

### Description
- Updated `projects/polymarket/polyquantbot/reports/sentinel/16_3_market_context_validation.md` with a post-hotfix re-validation report showing `Score: 64/100` and `Verdict: BLOCKED`.
- Recorded Phase 0–7 findings including successful imports of `interface.ui_formatter` and `interface.telegram.view_handler`, a runtime contract mismatch causing `TypeError` when `render_view` calls `render_dashboard` with kwargs, and a branch-naming policy violation (`work` not following `feature/[area]-[purpose]`).
- Documented remaining normalization gap where upstream `category` can be `None`, confirmed risk constants/guards unchanged, and attached commands/evidence used for reproduction.

### Testing
- Module import checks via `importlib.import_module(...)` for `projects.polymarket.polyquantbot.interface.ui_formatter` and `...view_handler` passed.
- Functional async checks calling `await render_dashboard(...)` succeeded while `await render_view('trade', ...)` failed with `TypeError: render_dashboard() got an unexpected keyword argument 'equity'` as recorded.
- Failure simulations using `unittest.mock.AsyncMock` for API failure, empty payload, and corrupt payload passed fallback behavior checks and a latency sample of `render_dashboard` was measured (~0.135s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3149cbdd4832eb630ecbf19aec03e)