### PR TITLE
Fix UI contract (render_dashboard dict) and normalize market category

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
 Last Updated  : 2026-04-06
-Status        : UI formatter hotfix completed
+Status        : UI contract fixed
 COMPLETED     :
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
 - Added performance analytics (trade history + metrics) in execution/analytics.py
@@ -38,12 +38,13 @@ COMPLETED     :
 - Added await to all 6 render_view call sites in telegram/command_handler.py
 - SENTINEL validation 16_3 completed with BLOCKED verdict (critical UI formatter syntax failure)
 - Fixed fatal syntax crash in projects/polymarket/polyquantbot/interface/ui_formatter.py blocking startup/import path
+- Fixed UI contract mismatch in interface/telegram/view_handler.py and normalized market context category defaults in data/market_context.py
 
 IN PROGRESS   :
 - None
 
 NEXT PRIORITY :
-- Re-run SENTINEL validation for 16_3 after UI formatter hotfix
+- Re-run SENTINEL 16_3
 
 KNOWN ISSUES  :
 - `python projects/polymarket/polyquantbot/main.py` still exits with config/import bootstrap error: "attempted relative import with no known parent package" when run as a script.

--- a/projects/polymarket/polyquantbot/data/market_context.py
+++ b/projects/polymarket/polyquantbot/data/market_context.py
@@ -27,7 +27,7 @@ async def get_market_context(market_id: str) -> dict:
         name = q if isinstance(q, str) and q else f"Market #{market_id}"
         context = {
             "name": name,
-            "category": market_data.get("category", "Unknown"),
+            "category": market_data.get("category") or "unknown",
             "resolution": market_data.get(
                 "end_date_iso", market_data.get("end_date", "N/A")
             ),
@@ -38,6 +38,6 @@ async def get_market_context(market_id: str) -> dict:
         log.warning("market_context_api_failed", market_id=market_id, error=str(e))
         return {
             "name": f"Market #{market_id}",
-            "category": "Unknown",
+            "category": "unknown",
             "resolution": "N/A",
         }

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -9,58 +9,68 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     action = name.strip().lower()
     if action == "trade":
         return await render_dashboard(
-            equity=payload.get("equity", 0),
-            positions=len(payload.get("positions", [])),
-            exposure=payload.get("exposure", 0),
-            trend=payload.get("trend", "neutral"),
-            edge=payload.get("edge", "low"),
-            status=payload.get("status", "waiting"),
-            market_id=payload.get("market_id"),
-            side=payload.get("side"),
-            entry_price=payload.get("entry_price"),
-            size=payload.get("size"),
-            pnl=payload.get("pnl"),
-            exposure_safe=payload.get("exposure_safe", True),
-            position_safe=payload.get("position_safe", True),
-            drawdown=payload.get("drawdown", 0),
-            decision=payload.get("decision", "waiting for opportunity"),
+            {
+                "equity": payload.get("equity", 0),
+                "positions": len(payload.get("positions", [])),
+                "exposure": payload.get("exposure", 0),
+                "trend": payload.get("trend", "neutral"),
+                "edge": payload.get("edge", "low"),
+                "status": payload.get("status", "waiting"),
+                "market_id": payload.get("market_id"),
+                "side": payload.get("side"),
+                "entry": payload.get("entry", payload.get("entry_price")),
+                "size": payload.get("size"),
+                "pnl": payload.get("pnl"),
+                "exposure_safe": payload.get("exposure_safe", True),
+                "position_safe": payload.get("position_safe", True),
+                "drawdown": payload.get("drawdown", 0),
+                "decision": payload.get("decision", "waiting for opportunity"),
+            }
         )
     elif action == "wallet":
         return await render_dashboard(
-            equity=payload.get("equity", 0),
-            positions=0,
-            exposure=0,
-            trend="neutral",
-            edge="low",
-            status="waiting",
-            decision="no active trades",
+            {
+                "equity": payload.get("equity", 0),
+                "positions": 0,
+                "exposure": 0,
+                "trend": "neutral",
+                "edge": "low",
+                "status": "waiting",
+                "decision": "no active trades",
+            }
         )
     elif action == "performance":
         return await render_dashboard(
-            equity=payload.get("equity", 0),
-            positions=len(payload.get("positions", [])),
-            exposure=payload.get("exposure", 0),
-            trend=payload.get("trend", "neutral"),
-            edge=payload.get("edge", "low"),
-            status=payload.get("status", "waiting"),
-            decision="performance review mode",
+            {
+                "equity": payload.get("equity", 0),
+                "positions": len(payload.get("positions", [])),
+                "exposure": payload.get("exposure", 0),
+                "trend": payload.get("trend", "neutral"),
+                "edge": payload.get("edge", "low"),
+                "status": payload.get("status", "waiting"),
+                "decision": "performance review mode",
+            }
         )
     elif action in {"market", "markets"}:
         return await render_dashboard(
-            equity=payload.get("equity", 0),
-            positions=0,
-            exposure=0,
-            trend=payload.get("trend", "neutral"),
-            edge=payload.get("edge", "low"),
-            status=payload.get("status", "waiting"),
-            decision="market analysis mode",
+            {
+                "equity": payload.get("equity", 0),
+                "positions": 0,
+                "exposure": 0,
+                "trend": payload.get("trend", "neutral"),
+                "edge": payload.get("edge", "low"),
+                "status": payload.get("status", "waiting"),
+                "decision": "market analysis mode",
+            }
         )
     return await render_dashboard(
-        equity=payload.get("equity", 0),
-        positions=0,
-        exposure=0,
-        trend="neutral",
-        edge="low",
-        status="waiting",
-        decision="home view",
+        {
+            "equity": payload.get("equity", 0),
+            "positions": 0,
+            "exposure": 0,
+            "trend": "neutral",
+            "edge": "low",
+            "status": "waiting",
+            "decision": "home view",
+        }
     )


### PR DESCRIPTION
### Motivation
- Resolve SENTINEL blockers by making the Telegram UI adapter match the new `render_dashboard` contract and prevent `None` category values from propagating downstream.

### Description
- Updated `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` so every `render_dashboard(...)` call passes a single payload `dict` and the trade payload maps `entry` from `entry` or fallback `entry_price`.
- Normalized category handling in `projects/polymarket/polyquantbot/data/market_context.py` to use `market_data.get("category") or "unknown"` and set fallback responses to `"unknown"`.
- Updated `PROJECT_STATE.md` status and next priority to reflect that the UI contract was fixed.

### Testing
- `python -c "from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view"` executed successfully (module import passed).
- Async sanity check `python - <<'PY' ... await render_view("trade", {"equity":1000}) ... PY` executed successfully and no `TypeError` was raised.
- Running `python projects/polymarket/polyquantbot/main.py` still fails with the pre-existing bootstrap/import error (`attempted relative import with no known parent package`) and is unchanged by this scoped fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d318493fec832eb40c5dbcd9888ddc)