### PR TITLE
fix: final stabilization for UI contract normalization and compliance

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 Last Updated  : 2026-04-06
-Status        : System stabilized after UI + context fixes
+Status        : Final stabilization implemented for UI contract and category normalization
 COMPLETED     :
-- Final stabilization batch: fixed UI contract adapter path, enforced category normalization fallback, and restored branch naming compliance
+- Final stabilization batch (2026-04-06): standardized `render_dashboard(payload: dict)` contract usage, aligned Telegram payload keys to formatter fields, enforced `raw.get("category") or "unknown"` normalization, and moved work to compliant branch `feature/final-stabilization-20260406`
 - Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
 - Added performance analytics (trade history + metrics) in execution/analytics.py
 - Upgraded strategy trigger with intelligence logic in execution/strategy_trigger.py
@@ -42,10 +42,10 @@ COMPLETED     :
 - Fixed UI contract mismatch in interface/telegram/view_handler.py and normalized market context category defaults in data/market_context.py
 
 IN PROGRESS   :
-- None
+- SENTINEL final stabilization validation handoff pending
 
 NEXT PRIORITY :
-- Final SENTINEL validation
+- Final SENTINEL validation after stabilization
 
 KNOWN ISSUES  :
-- `python projects/polymarket/polyquantbot/main.py` still exits with config/import bootstrap error: "attempted relative import with no known parent package" when run as a script.
+- Full runtime startup in this environment is blocked by unavailable PostgreSQL (`127.0.0.1:5432` connection refused), despite UI path initialization succeeding.

--- a/projects/polymarket/polyquantbot/data/market_context.py
+++ b/projects/polymarket/polyquantbot/data/market_context.py
@@ -22,15 +22,13 @@ async def get_market_context(market_id: str) -> dict:
         return market_cache[market_id]
 
     try:
-        market_data = await fetch_market_details(market_id)
-        q = market_data.get("question", "")
+        raw = await fetch_market_details(market_id) or {}
+        q = raw.get("question", "")
         name = q if isinstance(q, str) and q else f"Market #{market_id}"
         context = {
             "name": name,
-            "category": market_data.get("category") or "unknown",
-            "resolution": market_data.get(
-                "end_date_iso", market_data.get("end_date", "N/A")
-            ),
+            "category": raw.get("category") or "unknown",
+            "resolution": raw.get("end_date_iso", raw.get("end_date", "N/A")),
         }
         market_cache[market_id] = context
         return context

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -10,67 +10,78 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     if action == "trade":
         return await render_dashboard(
             {
+                "state": payload.get("status", "waiting"),
+                "mode": "trade",
                 "equity": payload.get("equity", 0),
                 "positions": len(payload.get("positions", [])),
                 "exposure": payload.get("exposure", 0),
-                "trend": payload.get("trend", "neutral"),
-                "edge": payload.get("edge", "low"),
-                "status": payload.get("status", "waiting"),
                 "market_id": payload.get("market_id"),
                 "side": payload.get("side"),
                 "entry": payload.get("entry", payload.get("entry_price")),
                 "size": payload.get("size"),
                 "pnl": payload.get("pnl"),
-                "exposure_safe": payload.get("exposure_safe", True),
-                "position_safe": payload.get("position_safe", True),
                 "drawdown": payload.get("drawdown", 0),
+                "insight": (
+                    f"trend={payload.get('trend', 'neutral')} | "
+                    f"edge={payload.get('edge', 'low')}"
+                ),
                 "decision": payload.get("decision", "waiting for opportunity"),
             }
         )
     elif action == "wallet":
         return await render_dashboard(
             {
+                "state": "waiting",
+                "mode": "wallet",
                 "equity": payload.get("equity", 0),
                 "positions": 0,
                 "exposure": 0,
-                "trend": "neutral",
-                "edge": "low",
-                "status": "waiting",
+                "drawdown": payload.get("drawdown", 0),
+                "insight": "wallet snapshot",
                 "decision": "no active trades",
             }
         )
     elif action == "performance":
         return await render_dashboard(
             {
+                "state": payload.get("status", "waiting"),
+                "mode": "performance",
                 "equity": payload.get("equity", 0),
                 "positions": len(payload.get("positions", [])),
                 "exposure": payload.get("exposure", 0),
-                "trend": payload.get("trend", "neutral"),
-                "edge": payload.get("edge", "low"),
-                "status": payload.get("status", "waiting"),
+                "drawdown": payload.get("drawdown", 0),
+                "insight": (
+                    f"trend={payload.get('trend', 'neutral')} | "
+                    f"edge={payload.get('edge', 'low')}"
+                ),
                 "decision": "performance review mode",
             }
         )
     elif action in {"market", "markets"}:
         return await render_dashboard(
             {
+                "state": payload.get("status", "waiting"),
+                "mode": "market",
                 "equity": payload.get("equity", 0),
                 "positions": 0,
                 "exposure": 0,
-                "trend": payload.get("trend", "neutral"),
-                "edge": payload.get("edge", "low"),
-                "status": payload.get("status", "waiting"),
+                "drawdown": payload.get("drawdown", 0),
+                "insight": (
+                    f"trend={payload.get('trend', 'neutral')} | "
+                    f"edge={payload.get('edge', 'low')}"
+                ),
                 "decision": "market analysis mode",
             }
         )
     return await render_dashboard(
         {
+            "state": "waiting",
+            "mode": "home",
             "equity": payload.get("equity", 0),
             "positions": 0,
             "exposure": 0,
-            "trend": "neutral",
-            "edge": "low",
-            "status": "waiting",
+            "drawdown": payload.get("drawdown", 0),
+            "insight": "home overview",
             "decision": "home view",
         }
     )

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -120,30 +120,32 @@ def render_decision(text: object) -> str:
 # SINGLE ENTRY POINT
 # =========================
 
-async def render_dashboard(data: dict) -> str:
+async def render_dashboard(payload: dict) -> str:
     """ONLY ENTRY POINT — do not bypass this."""
 
     blocks: list[str] = []
 
-    blocks.append(render_system(data.get("state"), data.get("mode")))
+    blocks.append(render_system(payload.get("state"), payload.get("mode")))
 
     blocks.append(
-        render_portfolio(data.get("equity"), data.get("positions"), data.get("exposure"))
+        render_portfolio(
+            payload.get("equity"), payload.get("positions"), payload.get("exposure")
+        )
     )
 
-    if data.get("market_id"):
+    if payload.get("market_id"):
         blocks.append(
             await render_position(
-                data.get("market_id"),
-                data.get("side"),
-                data.get("entry"),
-                data.get("size"),
-                data.get("pnl"),
+                payload.get("market_id"),
+                payload.get("side"),
+                payload.get("entry"),
+                payload.get("size"),
+                payload.get("pnl"),
             )
         )
 
-    blocks.append(render_risk(data.get("drawdown")))
-    blocks.append(render_insight(data.get("insight")))
-    blocks.append(render_decision(data.get("decision")))
+    blocks.append(render_risk(payload.get("drawdown")))
+    blocks.append(render_insight(payload.get("insight")))
+    blocks.append(render_decision(payload.get("decision")))
 
     return "\n\n".join(blocks)

--- a/projects/polymarket/polyquantbot/reports/forge/24_7_final_stabilization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_7_final_stabilization.md
@@ -1,0 +1,46 @@
+# 24_7 Final Stabilization Report
+
+**Date**: 2026-04-06  
+**Branch**: feature/final-stabilization-20260406  
+**Scope**: UI contract alignment, category normalization hardening, branch compliance
+
+## 1. What fixed
+
+- Standardized the dashboard interface contract to `render_dashboard(payload: dict)` and kept all call sites passing a single dict payload.
+- Aligned Telegram view payload keys with formatter expectations (`state`, `mode`, `insight`, `drawdown`) to remove semantic drift in UI rendering.
+- Hardened market context normalization so category can never be emitted as `None` by using `raw.get("category") or "unknown"`.
+
+## 2. Root causes
+
+- Prior UI payload construction used keys (`status`, `trend`, `edge`) that did not match formatter consumption (`state`, `mode`, `insight`), causing contract mismatch and degraded output quality.
+- Market context normalization depended on raw API payload shape without explicit `raw` fallback normalization in-path.
+- Working branch name did not comply with command requirement for this stabilization pass.
+
+## 3. Files changed
+
+- `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - Updated entry signature to `render_dashboard(payload: dict)` and normalized internal references from `data` to `payload`.
+- `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - Updated payload builders for `trade`, `wallet`, `performance`, `market`, and default view so contract fields are consistent.
+- `projects/polymarket/polyquantbot/data/market_context.py`
+  - Normalized raw API response via `raw = await fetch_market_details(...) or {}` and enforced category fallback to `"unknown"`.
+
+## 4. Validation results
+
+Passed:
+- `python -c "import projects.polymarket.polyquantbot.interface.ui_formatter"`
+- `python -c "from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view"`
+- Async render smoke test (`render_view("trade", {"equity": 1000})`) completed without import/type/runtime errors.
+
+Runtime check:
+- `python projects/polymarket/polyquantbot/main.py` reached startup and initialization path (Telegram initialized, metrics server started).
+- Process terminated due to environment DB connectivity (`127.0.0.1:5432` refused), not due to UI contract or formatter failure.
+
+## 5. Remaining issues
+
+- Local runtime still requires reachable PostgreSQL for full boot completion in this environment.
+- No additional blockers observed in UI contract path or market context category normalization path.
+
+## 6. Next
+
+- Hand off to SENTINEL for final stabilization validation evidence and verdict.


### PR DESCRIPTION
### Motivation

- Resolve UI contract mismatch by enforcing a single-entry `render_dashboard(payload: dict)` interface to eliminate TypeError from kwarg usage.
- Prevent market context from emitting `None` for category by normalizing raw API responses to a safe fallback.
- Ensure the stabilization work is delivered on the compliant branch name and recorded in project state and FORGE-X reporting.

### Description

- Updated the formatter entry to `async def render_dashboard(payload: dict)` and replaced internal `data.*` references with `payload.*` in `projects/polymarket/polyquantbot/interface/ui_formatter.py`.
- Normalized all Telegram view adapters in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to construct and pass a single dict payload with consistent keys (`state`, `mode`, `insight`, `drawdown`, etc.) to `render_dashboard`.
- Hardened market context fetching in `projects/polymarket/polyquantbot/data/market_context.py` to use `raw = await fetch_market_details(...) or {}` and `raw.get("category") or "unknown"` along with safe resolution fallback.
- Added the FORGE-X stabilization report `projects/polymarket/polyquantbot/reports/forge/24_7_final_stabilization.md` and updated `PROJECT_STATE.md` sections (`STATUS`, `COMPLETED`, `IN PROGRESS`, `NEXT PRIORITY`, `KNOWN ISSUES`).

### Testing

- Successfully imported the formatter with `python -c "import projects.polymarket.polyquantbot.interface.ui_formatter"` without error.
- Successfully imported the view adapter with `python -c "from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view"` without error.
- Ran an async smoke test invoking `render_view("trade", {"equity": 1000})` which completed without import/TypeError/runtime errors.
- Executed `python projects/polymarket/polyquantbot/main.py` which progressed through startup (Telegram and metrics initialization) but aborted due to an unavailable local PostgreSQL instance (`127.0.0.1:5432`), which is an environment dependency and not a UI contract regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3696aa374832e9f2efc7303605c48)