### PR TITLE
Harden startup & DB resilience; add startup phases and config validation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,52 +1,14 @@
 Last Updated  : 2026-04-06
-Status        : SENTINEL final stabilization validation approved (UI pipeline stable)
+Status        : FORGE-X prelaunch infra hardening implemented (awaiting SENTINEL validation)
 COMPLETED     :
-- SENTINEL final stabilization validation complete (2026-04-06): Score 96/100, Verdict APPROVED, evidence captured in `projects/polymarket/polyquantbot/reports/sentinel/24_8_final_stabilization_validation.md`
-- Final stabilization batch (2026-04-06): standardized `render_dashboard(payload: dict)` contract usage, aligned Telegram payload keys to formatter fields, enforced `raw.get("category") or "unknown"` normalization, and moved work to compliant branch `feature/final-stabilization-20260406`
-- Added execution intelligence (dynamic entry/exit scoring) in execution/intelligence.py
-- Added performance analytics (trade history + metrics) in execution/analytics.py
-- Upgraded strategy trigger with intelligence logic in execution/strategy_trigger.py
-- Integrated analytics into execution engine in execution/engine.py
-- Updated portfolio service for execution intelligence in telegram/handlers/portfolio_service.py
-- Added performance view for Telegram in views/performance_view.py
-- Added trade trace engine for immutable records in execution/trade_trace.py
-- Linked intelligence → execution → analytics → UI with trace validation
-- Added reconciliation check to ensure analytics match real trades
-- Added determinism check for consistent scoring
-- Added trace output to Telegram debug
-- Added real trade dataset for validation in execution/trade_dataset.json
-- Added pipeline validation, reconciliation, determinism, and decision trace logs
-- Hardened decision engine with strict threshold enforcement in execution/intelligence.py
-- Fixed position lifecycle with position_id integrity in execution/engine.py
-- Added edge-case guards in execution/analytics.py
-- Built UI hierarchy system with tree structure in ui/view_handler.py
-- Humanized output with market context in ui/view_handler.py
-- Added performance monitoring system in monitoring/performance_monitor.py
-- Merged all feature branches into main
-- Cleaned up obsolete branches
-- Fixed dataclass initialization error in execution/models.py
-- Fixed execution crash (TradeTraceEngine undefined) in execution/analytics.py and execution/engine.py
-- Upgraded UI system to premium human-readable format in interface/ui_formatter.py and interface/telegram/view_handler.py
-- Added dynamic market context resolver in data/market_context.py (16_1)
-- Created Polymarket CLOB API client in data/polymarket_api.py (16_3)
-- Fixed all 4 CRITICAL runtime errors from SENTINEL report 16_2 (16_3):
-  - CRITICAL-A: added get_market_context import to interface/ui_formatter.py
-  - CRITICAL-B: removed dead async render_active_position duplicate
-  - CRITICAL-C: removed undefined MARKET_NAMES / _market_name; replaced with live context
-  - CRITICAL-D: created data/polymarket_api.py (was missing)
-- Fixed cache poisoning in data/market_context.py (fallback no longer cached)
-- Fixed question field parsing for Polymarket CLOB API response format
-- Made render_active_position, render_dashboard, render_view fully async
-- Added await to all 6 render_view call sites in telegram/command_handler.py
-- SENTINEL validation 16_3 completed with BLOCKED verdict (critical UI formatter syntax failure)
-- Fixed fatal syntax crash in projects/polymarket/polyquantbot/interface/ui_formatter.py blocking startup/import path
-- Fixed UI contract mismatch in interface/telegram/view_handler.py and normalized market context category defaults in data/market_context.py
+- Prelaunch infra hardening (2026-04-06): added startup phase state tracking (BOOTING/DEGRADED/RUNNING/BLOCKED), startup env/config validation, PostgreSQL bounded retry with backoff, and explicit BLOCKED startup behavior when DB is unavailable.
 
 IN PROGRESS   :
-- None
+- SENTINEL validation pass for prelaunch infra hardening evidence and verdict.
 
 NEXT PRIORITY :
-- Optional: provision reachable PostgreSQL in staging/prod-like validation environment for full startup completion
+- SENTINEL validation for prelaunch infra hardening
 
 KNOWN ISSUES  :
-- Full runtime startup in this environment is blocked by unavailable PostgreSQL (`127.0.0.1:5432` connection refused), despite UI path initialization succeeding.
+- Full runtime startup in this environment remains blocked by unavailable PostgreSQL (`127.0.0.1:5432` connection refused).
+- Telegram alert delivery from this container can fail due to outbound network restrictions, while structured startup failure logging remains available.

--- a/projects/polymarket/polyquantbot/config/startup_validation.py
+++ b/projects/polymarket/polyquantbot/config/startup_validation.py
@@ -1,0 +1,109 @@
+"""Startup environment/config validation for PolyQuantBot infra readiness."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class StartupConfig:
+    db_host: str
+    db_port: int
+    db_name: str
+    db_user: str
+
+
+_REQUIRED_SECRETS_COMMON: tuple[str, ...] = (
+    "TELEGRAM_CHAT_ID",
+)
+_REQUIRED_SECRETS_PIPELINE: tuple[str, ...] = (
+    "CLOB_API_KEY",
+    "CLOB_API_SECRET",
+    "CLOB_API_PASSPHRASE",
+)
+_TELEGRAM_TOKEN_ALIASES: tuple[str, ...] = ("TELEGRAM_TOKEN", "TELEGRAM_BOT_TOKEN")
+
+
+def _read_env(name: str) -> str:
+    return os.getenv(name, "").strip()
+
+
+def _get_telegram_token() -> str:
+    for alias in _TELEGRAM_TOKEN_ALIASES:
+        value = _read_env(alias)
+        if value:
+            return value
+    return ""
+
+
+def parse_db_dsn(db_dsn: str) -> StartupConfig:
+    parsed = urlparse(db_dsn)
+    if parsed.scheme not in {"postgres", "postgresql"}:
+        raise ValueError("DB_DSN must use postgres/postgresql scheme")
+
+    db_host = (parsed.hostname or "").strip()
+    db_port = int(parsed.port or 5432)
+    db_name = parsed.path.lstrip("/").strip()
+    db_user = (parsed.username or "").strip()
+
+    missing: List[str] = []
+    if not db_host:
+        missing.append("DB host")
+    if not db_name:
+        missing.append("DB name")
+    if not db_user:
+        missing.append("DB user")
+    if db_port <= 0 or db_port > 65535:
+        raise ValueError("DB port must be between 1 and 65535")
+
+    if missing:
+        raise ValueError("Invalid DB_DSN; missing " + ", ".join(missing))
+
+    return StartupConfig(
+        db_host=db_host,
+        db_port=db_port,
+        db_name=db_name,
+        db_user=db_user,
+    )
+
+
+def validate_startup_environment(mode: str) -> StartupConfig:
+    """Validate startup environment consistency before runtime begins."""
+    db_dsn = _read_env("DB_DSN")
+    if not db_dsn:
+        raise ValueError("Missing required DB_DSN environment variable")
+
+    cfg = parse_db_dsn(db_dsn)
+
+    missing_secrets: List[str] = []
+    if not _get_telegram_token():
+        missing_secrets.append("TELEGRAM_TOKEN or TELEGRAM_BOT_TOKEN")
+
+    for name in _REQUIRED_SECRETS_COMMON:
+        if not _read_env(name):
+            missing_secrets.append(name)
+
+    # Pipeline secrets are required in both PAPER/LIVE because startup bootstraps
+    # market data + signal pipeline in all modes.
+    for name in _REQUIRED_SECRETS_PIPELINE:
+        if not _read_env(name):
+            missing_secrets.append(name)
+
+    if missing_secrets:
+        raise ValueError(
+            "Missing required startup secrets: " + ", ".join(missing_secrets)
+        )
+
+    enable_live = _read_env("ENABLE_LIVE_TRADING").lower() == "true"
+    if mode.upper() == "LIVE" and not enable_live:
+        raise ValueError(
+            "TRADING_MODE=LIVE requires ENABLE_LIVE_TRADING=true"
+        )
+    if mode.upper() == "PAPER" and enable_live:
+        raise ValueError(
+            "ENABLE_LIVE_TRADING=true is inconsistent with TRADING_MODE=PAPER"
+        )
+
+    return cfg

--- a/projects/polymarket/polyquantbot/core/startup_phase.py
+++ b/projects/polymarket/polyquantbot/core/startup_phase.py
@@ -1,0 +1,54 @@
+"""Startup phase state tracking for PolyQuantBot runtime lifecycle."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+class StartupPhase(str, Enum):
+    """Startup lifecycle phases for infra readiness."""
+
+    BOOTING = "BOOTING"
+    DEGRADED = "DEGRADED"
+    RUNNING = "RUNNING"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass
+class StartupState:
+    phase: StartupPhase
+    reason: str
+    updated_at: float
+
+
+class StartupStateTracker:
+    """Track and expose startup state transitions with structured logging."""
+
+    def __init__(self) -> None:
+        self._state = StartupState(
+            phase=StartupPhase.BOOTING,
+            reason="initializing",
+            updated_at=time.time(),
+        )
+        log.info("startup_phase_initialized", **self.snapshot())
+
+    def set_phase(self, phase: StartupPhase, reason: str) -> None:
+        self._state = StartupState(
+            phase=phase,
+            reason=reason,
+            updated_at=time.time(),
+        )
+        log.info("startup_phase_changed", **self.snapshot())
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "startup_phase": self._state.phase.value,
+            "startup_reason": self._state.reason,
+            "startup_updated_at": round(self._state.updated_at, 3),
+        }

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -244,6 +244,53 @@ class DatabaseClient:
                 )
                 raise RuntimeError(f"Database unavailable — cannot connect: {exc}") from exc
 
+    async def connect_with_retry(
+        self,
+        max_attempts: int = 4,
+        base_backoff_s: float = 1.0,
+    ) -> None:
+        """Connect to PostgreSQL with bounded retries and exponential backoff.
+
+        Raises:
+            RuntimeError: If all connection attempts fail.
+        """
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+
+        last_exc: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                log.info(
+                    "db_connect_attempt",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                )
+                await self.connect()
+                await self.ensure_schema()
+                log.info(
+                    "db_connect_ready",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                wait_s = round(base_backoff_s * (2 ** (attempt - 1)), 2)
+                log.warning(
+                    "db_connect_attempt_failed",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    wait_s=wait_s,
+                    error=str(exc),
+                )
+                if attempt < max_attempts:
+                    await asyncio.sleep(wait_s)
+
+        raise RuntimeError(
+            "Database unavailable after retries; startup cannot continue"
+            + (f": {last_exc}" if last_exc else "")
+        )
+
     async def ensure_schema(self) -> None:
         """Ensure all tables exist.  Raises if pool is not connected."""
         if self._pool is None:

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -58,6 +58,12 @@ async def main() -> None:
 
     log.info("polyquantbot_startup", ts=start_ts)
 
+    from projects.polymarket.polyquantbot.core.startup_phase import (
+        StartupPhase,
+        StartupStateTracker,
+    )
+    startup_state = StartupStateTracker()
+
     # ── Entrypoint assertion — confirms correct runtime path ───────────────────
     print("🚀 NEW TELEGRAM SYSTEM ACTIVE")
     print("ENTRYPOINT: main.py")
@@ -72,18 +78,36 @@ async def main() -> None:
     # ── Load live config from environment ──────────────────────────────────────
     try:
         from projects.polymarket.polyquantbot.infra.live_config import LiveConfig
+        from projects.polymarket.polyquantbot.config.startup_validation import (
+            validate_startup_environment,
+        )
+
         config = LiveConfig.from_env()
         config.validate()
+        mode: str = config.trading_mode.value  # "PAPER" | "LIVE"
+        startup_cfg = validate_startup_environment(mode=mode)
+        log.info(
+            "startup_config_validated",
+            mode=mode,
+            db_host=startup_cfg.db_host,
+            db_port=startup_cfg.db_port,
+            db_name=startup_cfg.db_name,
+            db_user=startup_cfg.db_user,
+        )
     except Exception as exc:
+        startup_state.set_phase(
+            StartupPhase.BLOCKED,
+            reason=f"config_validation_failed: {exc}",
+        )
         log.error(
             "polyquantbot_config_error",
             error=str(exc),
-            hint="Check TRADING_MODE and ENABLE_LIVE_TRADING env vars",
+            hint="Validate DB_DSN, required secrets, and paper/live mode consistency",
+            **startup_state.snapshot(),
         )
         sys.exit(1)
 
-    mode: str = config.trading_mode.value  # "PAPER" | "LIVE"
-    log.info("polyquantbot_mode", mode=mode)
+    log.info("polyquantbot_mode", mode=mode, **startup_state.snapshot())
 
     # ── Core components ────────────────────────────────────────────────────────
     from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
@@ -185,10 +209,15 @@ async def main() -> None:
             asyncio.create_task(dashboard.start(), name="dashboard_server")
             log.info("dashboard_server_task_created")
         except Exception as exc:
+            startup_state.set_phase(
+                StartupPhase.DEGRADED,
+                reason=f"dashboard_init_failed: {exc}",
+            )
             log.error(
                 "dashboard_server_init_failed",
                 error=str(exc),
                 hint="Dashboard disabled — trading pipeline continues",
+                **startup_state.snapshot(),
             )
     else:
         log.info("dashboard_disabled", hint="Set DASHBOARD_ENABLED=true to enable")
@@ -504,22 +533,34 @@ async def main() -> None:
         mode=mode,
         dashboard_enabled=dashboard_enabled,
         startup_s=round(time.time() - start_ts, 3),
+        **startup_state.snapshot(),
     )
 
     # ── Database initialisation (required — no silent fallback) ───────────────
     from projects.polymarket.polyquantbot.infra.db import DatabaseClient
     db = DatabaseClient()
     try:
-        await db.connect()
-        await db.ensure_schema()
+        await db.connect_with_retry(max_attempts=4, base_backoff_s=1.0)
         log.info("db_enabled", status=True)
     except Exception as db_exc:
+        startup_state.set_phase(
+            StartupPhase.BLOCKED,
+            reason=f"database_unavailable: {db_exc}",
+        )
         log.error(
             "db_init_failed",
             error=str(db_exc),
-            hint="Check DB_DSN env var and ensure PostgreSQL is reachable",
+            hint="Check DB_DSN and PostgreSQL network reachability; execution remains blocked",
+            final_reason="database_required_for_audit_and_trade_safety",
+            **startup_state.snapshot(),
+        )
+        await tg.alert_error(
+            f"Startup blocked: database unavailable ({db_exc})",
+            context="startup_database",
         )
         raise RuntimeError(f"Database required — startup aborted: {db_exc}") from db_exc
+
+    startup_state.set_phase(StartupPhase.RUNNING, reason="database_ready")
 
     # ── Load strategy state from DB and wire DB into callback router ──────────
     await strategy_mgr.load(db=db)

--- a/projects/polymarket/polyquantbot/reports/forge/25_1_prelaunch_infra_hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_1_prelaunch_infra_hardening.md
@@ -1,0 +1,50 @@
+# 25_1_prelaunch_infra_hardening
+
+Date: 2026-04-06  
+Branch: feature/prelaunch-infra-hardening-20260406
+
+## 1. What was built
+- Added infra startup hardening for DB dependency resilience with bounded retry + exponential backoff and explicit terminal fail reason.
+- Added startup phase state tracking with BOOTING, DEGRADED, RUNNING, BLOCKED phases and structured transition logs.
+- Added startup environment/config validation for DB DSN shape (host/port/name/user), required secret presence, and paper/live mode consistency checks.
+- Blocked execution path when DB is unavailable by hard-failing startup after bounded retries (no partial execution startup).
+- Wired startup failure alert emission through Telegram alert path when enabled.
+
+## 2. Architecture
+- New `StartupStateTracker` in `core/` acts as an infra lifecycle source for startup readiness transitions.
+- New `startup_validation` module in `config/` validates critical pre-runtime inputs before long-lived services continue.
+- `DatabaseClient` now exposes `connect_with_retry()` for explicit startup-time resilience (bounded attempts, per-attempt logs, deterministic failure).
+- `main.py` orchestrates ordered startup:
+  1) BOOTING
+  2) config/env validation
+  3) optional DEGRADED for non-critical dashboard init failure
+  4) DB retry/connect gate
+  5) RUNNING only after DB readiness
+  6) BLOCKED on DB failure with alert + clear terminal reason.
+
+## 3. Files
+- `projects/polymarket/polyquantbot/main.py`
+- `projects/polymarket/polyquantbot/infra/db/database.py`
+- `projects/polymarket/polyquantbot/core/startup_phase.py` (new)
+- `projects/polymarket/polyquantbot/config/startup_validation.py` (new)
+- `PROJECT_STATE.md`
+
+## 4. Working
+- `python -m py_compile` passes for changed startup/infra files.
+- Missing-DB startup test confirms:
+  - bounded DB retries with backoff
+  - explicit `BLOCKED` startup phase
+  - explicit terminal DB failure reason
+  - execution does not proceed into trading startup path.
+- Alert attempt path is executed on startup DB failure; in this container Telegram network is unreachable but failure is logged explicitly.
+
+## 5. Issues
+- Environment still lacks reachable PostgreSQL at `127.0.0.1:5432`; therefore RUNNING-state full startup cannot be validated end-to-end here.
+- Outbound network for Telegram API is unavailable in this environment, so alert delivery cannot be confirmed despite invocation path evidence.
+
+## 6. Next
+- SENTINEL should validate:
+  - startup phase transition correctness under BOOTING→RUNNING and BOOTING→BLOCKED paths
+  - DB retry boundedness and backoff behavior
+  - no execution path enablement under DB unavailable state
+  - config validation clarity and operator actionability.


### PR DESCRIPTION
### Motivation
- Prevent ambiguous crashes and unsafe partial startups by making PostgreSQL dependency and environment/config errors explicit and actionable during boot.
- Ensure the system exposes a concise startup lifecycle (BOOTING / DEGRADED / RUNNING / BLOCKED) so monitoring and operators can react deterministically.
- Avoid accidental execution when critical infra (DB/audit) is unavailable and surface clear alerts/root-cause for on-call channels when possible.

### Description
- Added a startup lifecycle tracker with `StartupPhase` and `StartupStateTracker` to `projects/polymarket/polyquantbot/core/startup_phase.py` and used it from `main.py` to emit structured phase transitions and reasons.
- Added environment/config validation (`parse_db_dsn` + `validate_startup_environment`) in `projects/polymarket/polyquantbot/config/startup_validation.py` to check DB DSN components, required secrets, and paper/live mode consistency before runtime continues.
- Implemented bounded DB connect with exponential backoff via `DatabaseClient.connect_with_retry(...)` in `projects/polymarket/polyquantbot/infra/db/database.py` and gated startup on DB readiness (no partial execution when DB is required for audit/safety).
- Updated `projects/polymarket/polyquantbot/main.py` to orchestrate BOOTING→(DEGRADED for non-critical failures)→RUNNING or BLOCKED, emit structured logs on phase changes, invoke Telegram error alert on terminal DB failure, and set RUNNING only after DB readiness; also added a FORGE-X report and updated `PROJECT_STATE.md` for SENTINEL handoff.

### Testing
- Ran `python -m py_compile` on the changed modules (`main.py`, `startup_validation.py`, `startup_phase.py`, `database.py`) and compilation succeeded without errors.
- Executed a missing-DB startup test with environment variables (`TRADING_MODE=PAPER ENABLE_LIVE_TRADING=false DB_DSN='postgresql://tester:pass@127.0.0.1:5432/polyquantbot' ...`) and verified bounded DB retries with exponential backoff, an explicit `BLOCKED` startup phase and clear terminal DB failure logs (Telegram alert path invoked but delivery failed due to outbound network restrictions in this environment).
- Noted that full RUNNING-state end-to-end validation could not be performed in this container because PostgreSQL is not reachable at `127.0.0.1:5432`, so SENTINEL should validate the BOOTING→RUNNING path in a reachable-DB staging environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36e03e94c832e8ca6635a60244199)