### PR TITLE
chore: fix branch naming for infra hardening compliance

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
 Last Updated  : 2026-04-06
-Status        : SENTINEL prelaunch infra hardening validation completed — BLOCKED on branch mismatch gate
+Status        : Infra hardening validated, awaiting final compliance pass
 COMPLETED     :
 - Prelaunch infra hardening (2026-04-06): added startup phase state tracking (BOOTING/DEGRADED/RUNNING/BLOCKED), startup env/config validation, PostgreSQL bounded retry with backoff, and explicit BLOCKED startup behavior when DB is unavailable.
 - SENTINEL validation (2026-04-06): validated startup state machine, DB bounded retry/backoff, config fail-fast behavior, DB-required execution gate, failure simulations, alerting behavior, and pipeline integrity.
@@ -8,7 +8,7 @@ IN PROGRESS   :
 - Remediation for SENTINEL Phase 0 branch gate failure (required branch: feature/prelaunch-infra-hardening-20260406; current branch observed during validation: work).
 
 NEXT PRIORITY :
-- Align branch/target to `feature/prelaunch-infra-hardening-20260406` and rerun SENTINEL final gate for APPROVED verdict.
+- Final SENTINEL approval after branch fix
 
 KNOWN ISSUES  :
 - Full runtime startup in this environment remains blocked by unavailable PostgreSQL (`127.0.0.1:5432` connection refused).

--- a/projects/polymarket/polyquantbot/reports/forge/25_3_branch_compliance_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_3_branch_compliance_fix.md
@@ -1,0 +1,33 @@
+# 25_3_branch_compliance_fix
+
+Date: 2026-04-06  
+Branch: feature/prelaunch-infra-hardening-20260406
+
+## 1. What was done
+- Created and switched to the compliant branch `feature/prelaunch-infra-hardening-20260406`.
+- Kept existing implementation commits intact; no code logic files were modified.
+- Added this FORGE compliance report for branch remediation tracking.
+- Updated `PROJECT_STATE.md` status and next-priority fields per COMMANDER scope.
+
+## 2. Why issue occurred
+- SENTINEL Phase 0 blocked validation because validation was executed on branch `work` instead of required policy branch `feature/prelaunch-infra-hardening-20260406`.
+- This was a branch-policy compliance issue, not a runtime or logic defect.
+
+## 3. Branch state before/after
+- Before: `work` (HEAD at `9f45c45`, containing infra hardening + SENTINEL blocked validation commit).
+- After: `feature/prelaunch-infra-hardening-20260406` (branched from same HEAD, then compliance metadata updates committed).
+- Logic parity: No application code path changed as part of this remediation task.
+
+## 4. Validation steps
+- Confirmed current branch with `git branch --show-current`.
+- Confirmed baseline ancestry with `git log --oneline --decorate -n 5`.
+- Verified comparison to `work` shows only compliance-doc/state delta and no logic file changes.
+- Verified target branch naming exactly matches required policy format.
+
+## 5. Issues (if any)
+- No technical blockers during branch correction.
+- Existing environment limitations from prior validation remain unchanged (local PostgreSQL/Telegram reachability constraints).
+
+## 6. Next
+- Hand off to SENTINEL for final gate re-check on this branch.
+- Expected action: rerun Phase 0 branch gate and issue final verdict.


### PR DESCRIPTION
### Motivation
- Resolve SENTINEL BLOCKED state caused by a branch-naming policy violation by moving the existing changes onto the required branch and updating project metadata without changing code logic.

### Description
- Created branch `feature/prelaunch-infra-hardening-20260406`, added `projects/polymarket/polyquantbot/reports/forge/25_3_branch_compliance_fix.md`, updated `PROJECT_STATE.md` status/NEXT PRIORITY, and committed as a single commit `chore: fix branch naming for infra hardening compliance` with no application logic changes.

### Testing
- Ran `git branch --show-current` to confirm current branch, `git diff --name-only work..feature/prelaunch-infra-hardening-20260406` and `git diff --name-only work..feature/prelaunch-infra-hardening-20260406 -- 'projects/polymarket/polyquantbot/*.py' 'projects/polymarket/polyquantbot/**/*.py'` to confirm no logic-file diffs, `git status --short` and `git log --oneline --decorate -n 3` to verify commit history and working tree, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d373160b40832eb6429d9db49c417b)