### PR TITLE
feat: upgrade telegram ui to premium operator-grade design

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,15 +1,13 @@
 Last Updated  : 2026-04-06
-Status        : Paper trading active
+Status        : Telegram premium UI pass implemented
 COMPLETED     :
-- Prelaunch infra hardening (2026-04-06): added startup phase state tracking (BOOTING/DEGRADED/RUNNING/BLOCKED), startup env/config validation, PostgreSQL bounded retry with backoff, and explicit BLOCKED startup behavior when DB is unavailable.
-- SENTINEL validation (2026-04-06): validated startup state machine, DB bounded retry/backoff, config fail-fast behavior, DB-required execution gate, failure simulations, alerting behavior, and pipeline integrity.
+- Telegram premium UI pass (2026-04-06): upgraded premium operator-grade formatting for dashboard/trade/wallet/performance/market views with safe payload fallbacks and consistent mobile-first section hierarchy.
 
 IN PROGRESS   :
-- Live simulation monitoring
+- SENTINEL validation preparation for Telegram premium UI pass
 
 NEXT PRIORITY :
-- Final SENTINEL approval after branch fix
+- SENTINEL validation for Telegram premium UI pass
 
 KNOWN ISSUES  :
-- Full runtime startup in this environment remains blocked by unavailable PostgreSQL (`127.0.0.1:5432` connection refused).
-- Telegram alert delivery from this container can fail due to outbound network restrictions, while structured startup failure logging remains available.
+- Market context API lookup may be unreachable from this container; formatter safely falls back to market_id/default labels without crashing.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -1,87 +1,99 @@
 """Telegram view adapters for premium UI rendering."""
+
 from __future__ import annotations
 
 from typing import Any, Mapping
+
 from ..ui_formatter import render_dashboard
 
 
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    positions = _as_list(payload.get("positions"))
+    return {
+        "state": payload.get("status", "waiting"),
+        "mode": mode,
+        "cycle": payload.get("cycle", "active"),
+        "equity": payload.get("equity", 0),
+        "positions": payload.get("positions_count", len(positions)),
+        "exposure": payload.get("exposure", 0),
+        "pnl": payload.get("pnl", payload.get("unrealized_pnl", 0)),
+        "drawdown": payload.get("drawdown", 0),
+        "risk_level": payload.get("risk_level", "standard"),
+        "risk_state": payload.get("risk_state", "within limits"),
+        "trend": payload.get("trend", "neutral"),
+        "edge": payload.get("edge", 0),
+        "edge_label": payload.get("edge_label"),
+        "insight": payload.get("insight"),
+        "confidence": payload.get("confidence", 0),
+        "decision": payload.get("decision"),
+        "operator_note": payload.get("operator_note"),
+    }
+
+
 async def render_view(name: str, payload: Mapping[str, Any]) -> str:
-    action = name.strip().lower()
+    action = str(name or "home").strip().lower()
+    safe_payload: Mapping[str, Any] = payload or {}
+
     if action == "trade":
-        return await render_dashboard(
+        dashboard_payload = _base_payload("trade", safe_payload)
+        dashboard_payload.update(
             {
-                "state": payload.get("status", "waiting"),
-                "mode": "trade",
-                "equity": payload.get("equity", 0),
-                "positions": len(payload.get("positions", [])),
-                "exposure": payload.get("exposure", 0),
-                "market_id": payload.get("market_id"),
-                "side": payload.get("side"),
-                "entry": payload.get("entry", payload.get("entry_price")),
-                "size": payload.get("size"),
-                "pnl": payload.get("pnl"),
-                "drawdown": payload.get("drawdown", 0),
-                "insight": (
-                    f"trend={payload.get('trend', 'neutral')} | "
-                    f"edge={payload.get('edge', 'low')}"
-                ),
-                "decision": payload.get("decision", "waiting for opportunity"),
+                "market_id": safe_payload.get("market_id", safe_payload.get("market")),
+                "side": safe_payload.get("side", safe_payload.get("direction", "flat")),
+                "entry": safe_payload.get("entry", safe_payload.get("entry_price", 0)),
+                "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
+                "decision": safe_payload.get("decision", "deploy setup if risk gate clears"),
+                "operator_note": safe_payload.get("operator_note", "review edge and liquidity before send"),
+                "insight": safe_payload.get("insight", "signal is live and monitored"),
             }
         )
-    elif action == "wallet":
-        return await render_dashboard(
+        return await render_dashboard(dashboard_payload)
+
+    if action == "wallet":
+        dashboard_payload = _base_payload("wallet", safe_payload)
+        dashboard_payload.update(
             {
-                "state": "waiting",
-                "mode": "wallet",
-                "equity": payload.get("equity", 0),
-                "positions": 0,
-                "exposure": 0,
-                "drawdown": payload.get("drawdown", 0),
-                "insight": "wallet snapshot",
-                "decision": "no active trades",
+                "decision": safe_payload.get("decision", "capital preserved — no forced deployment"),
+                "operator_note": safe_payload.get("operator_note", "wallet view is informational"),
+                "insight": safe_payload.get("insight", "liquidity and collateral snapshot"),
+                "positions": safe_payload.get("positions_count", len(_as_list(safe_payload.get("open_positions")))),
             }
         )
-    elif action == "performance":
-        return await render_dashboard(
+        return await render_dashboard(dashboard_payload)
+
+    if action == "performance":
+        dashboard_payload = _base_payload("performance", safe_payload)
+        dashboard_payload.update(
             {
-                "state": payload.get("status", "waiting"),
-                "mode": "performance",
-                "equity": payload.get("equity", 0),
-                "positions": len(payload.get("positions", [])),
-                "exposure": payload.get("exposure", 0),
-                "drawdown": payload.get("drawdown", 0),
-                "insight": (
-                    f"trend={payload.get('trend', 'neutral')} | "
-                    f"edge={payload.get('edge', 'low')}"
-                ),
-                "decision": "performance review mode",
+                "decision": safe_payload.get("decision", "optimize based on realized performance"),
+                "operator_note": safe_payload.get("operator_note", "focus on drawdown and hit-rate trend"),
+                "insight": safe_payload.get("insight", "performance metrics refreshed"),
             }
         )
-    elif action in {"market", "markets"}:
-        return await render_dashboard(
+        return await render_dashboard(dashboard_payload)
+
+    if action in {"market", "markets"}:
+        dashboard_payload = _base_payload("market", safe_payload)
+        dashboard_payload.update(
             {
-                "state": payload.get("status", "waiting"),
-                "mode": "market",
-                "equity": payload.get("equity", 0),
-                "positions": 0,
-                "exposure": 0,
-                "drawdown": payload.get("drawdown", 0),
-                "insight": (
-                    f"trend={payload.get('trend', 'neutral')} | "
-                    f"edge={payload.get('edge', 'low')}"
-                ),
-                "decision": "market analysis mode",
+                "decision": safe_payload.get("decision", "scan for asymmetric opportunity"),
+                "operator_note": safe_payload.get("operator_note", "rank by edge and confidence"),
+                "insight": safe_payload.get("insight", "market context prioritized for execution"),
             }
         )
-    return await render_dashboard(
+        return await render_dashboard(dashboard_payload)
+
+    dashboard_payload = _base_payload("home", safe_payload)
+    dashboard_payload.update(
         {
-            "state": "waiting",
-            "mode": "home",
-            "equity": payload.get("equity", 0),
-            "positions": 0,
-            "exposure": 0,
-            "drawdown": payload.get("drawdown", 0),
-            "insight": "home overview",
-            "decision": "home view",
+            "state": safe_payload.get("status", "running"),
+            "decision": safe_payload.get("decision", "system healthy — await qualified signal"),
+            "operator_note": safe_payload.get("operator_note", "monitor risk gates and telemetry"),
+            "insight": safe_payload.get("insight", "home dashboard synchronized"),
         }
     )
+    return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -1,81 +1,82 @@
-"""Refactored Premium UI Formatter (Production-Ready)."""
+"""Premium Telegram UI formatter for operator-grade summaries."""
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
 
-
-# =========================
-# SAFETY HELPERS
-# =========================
-
-def _safe_float(value: object) -> float:
-    try:
-        return float(value)
-    except Exception:
-        return 0.0
-
-
-def _safe_str(value: object) -> str:
-    return str(value) if value is not None else "N/A"
-
-
-# =========================
-# EMOJI SYSTEM
-# =========================
+SECTION_DIVIDER = "────────────────────"
 
 EMOJI = {
-    "equity": "💰",
-    "positions": "📦",
-    "exposure": "📊",
-    "insight": "🧠",
-    "risk": "⚠️",
-    "action": "💡",
-    "system": "⚙️",
+    "system": "🧭",
+    "portfolio": "💼",
+    "risk": "🛡️",
+    "decision": "🎯",
+    "market": "🌐",
+    "trade": "📌",
 }
 
 
-# =========================
-# CORE UI BUILDERS
-# =========================
-
-def _divider(title: str) -> str:
-    return f"━━━━━━━━━━━━━━\n{title}\n━━━━━━━━━━━━━━"
-
-
-def _pnl(pnl: float) -> str:
-    pnl = _safe_float(pnl)
-    if pnl > 0:
-        return f"🟢 +{pnl:.2f}"
-    if pnl < 0:
-        return f"🔴 {pnl:.2f}"
-    return "🟡 0.00"
+def _safe_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
-# =========================
-# BLOCKS
-# =========================
-
-def render_system(state: object, mode: object) -> str:
-    return (
-        _divider(f"{EMOJI['system']} SYSTEM")
-        + "\n"
-        + f"State : {_safe_str(state)}\n"
-        + f"Mode  : {_safe_str(mode)}"
-    )
+def _safe_int(value: object, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
 
 
-def render_portfolio(equity: object, positions: object, exposure: object) -> str:
-    equity_value = _safe_float(equity)
-    exposure_value = _safe_float(exposure)
+def _safe_text(value: object, default: str = "N/A") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
 
-    return (
-        _divider(f"{EMOJI['equity']} PORTFOLIO")
-        + "\n"
-        + f"Equity    : ${equity_value:,.2f}\n"
-        + f"Positions : {_safe_float(positions):.0f}\n"
-        + f"Exposure  : {exposure_value:.1%}"
-    )
+
+def _fmt_currency(value: object) -> str:
+    return f"${_safe_float(value):,.2f}"
+
+
+def _fmt_percent(value: object, *, already_percent: bool = False) -> str:
+    numeric = _safe_float(value)
+    if already_percent:
+        return f"{numeric:.1f}%"
+    return f"{numeric * 100:.1f}%"
+
+
+def _fmt_signed_percent(value: object, *, already_percent: bool = False) -> str:
+    numeric = _safe_float(value)
+    if not already_percent:
+        numeric *= 100
+    return f"{numeric:+.1f}%"
+
+
+def _fmt_signed_currency(value: object) -> str:
+    numeric = _safe_float(value)
+    return f"{numeric:+,.2f}"
+
+
+def _direction(value: object) -> str:
+    side = _safe_text(value, "FLAT").upper()
+    if side in {"BUY", "LONG", "YES"}:
+        return f"🟢 {side}"
+    if side in {"SELL", "SHORT", "NO"}:
+        return f"🔴 {side}"
+    return f"🟡 {side}"
+
+
+def _line(label: str, value: object) -> str:
+    return f"• {label}: {value}"
+
+
+def _section(title: str, lines: list[str]) -> str:
+    return "\n".join([SECTION_DIVIDER, title, *lines])
 
 
 async def render_position(
@@ -84,68 +85,102 @@ async def render_position(
     entry: object,
     size: object,
     pnl: object,
+    confidence: object,
+    edge: object,
 ) -> str:
-    context = await get_market_context(market_id) or {}
-    name = context.get("name", "Unknown Market")
+    context = await get_market_context(_safe_text(market_id, "")) or {}
+    market_name = _safe_text(context.get("name") or context.get("question") or market_id)
 
-    entry_value = _safe_float(entry)
-    size_value = _safe_float(size)
-    pnl_value = _safe_float(pnl)
-
-    return (
-        _divider(f"{EMOJI['positions']} POSITION")
-        + "\n"
-        + f"Market : {name}\n"
-        + f"Side   : {_safe_str(side)}\n"
-        + f"Entry  : ${entry_value:,.2f}\n"
-        + f"Size   : ${size_value:,.2f}\n"
-        + f"PnL    : {_pnl(pnl_value)}"
-    )
+    lines = [
+        _line("Market", market_name),
+        _line("Direction", _direction(side)),
+        _line("Entry", _fmt_currency(entry)),
+        _line("Sizing", _fmt_currency(size)),
+        _line("Edge", _fmt_signed_percent(edge)),
+        _line("Confidence", _fmt_percent(confidence, already_percent=True)),
+        _line("Open PnL", _fmt_signed_currency(pnl)),
+    ]
+    return _section(f"{EMOJI['trade']} TRADE", lines)
 
 
-def render_risk(drawdown: object) -> str:
-    dd = _safe_float(drawdown)
-    return _divider(f"{EMOJI['risk']} RISK") + "\n" + f"Drawdown : {dd:.1%}"
+def _render_system(payload: Mapping[str, Any]) -> str:
+    lines = [
+        _line("Status", _safe_text(payload.get("state"), "waiting")),
+        _line("View", _safe_text(payload.get("mode"), "home")),
+        _line("Cycle", _safe_text(payload.get("cycle"), "active")),
+    ]
+    return _section(f"{EMOJI['system']} SYSTEM", lines)
 
 
-def render_insight(text: object) -> str:
-    return _divider(f"{EMOJI['insight']} INSIGHT") + "\n" + f"{_safe_str(text)}"
+def _render_portfolio(payload: Mapping[str, Any]) -> str:
+    lines = [
+        _line("Equity", _fmt_currency(payload.get("equity"))),
+        _line("Open Positions", _safe_int(payload.get("positions"))),
+        _line("Exposure", _fmt_percent(payload.get("exposure"))),
+        _line("Unrealized PnL", _fmt_signed_currency(payload.get("pnl"))),
+    ]
+    return _section(f"{EMOJI['portfolio']} PORTFOLIO", lines)
 
 
-def render_decision(text: object) -> str:
-    return _divider(f"{EMOJI['action']} DECISION") + "\n" + f"{_safe_str(text)}"
+def _render_risk(payload: Mapping[str, Any]) -> str:
+    lines = [
+        _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+        _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+        _line("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
+    ]
+    return _section(f"{EMOJI['risk']} RISK", lines)
 
 
-# =========================
-# SINGLE ENTRY POINT
-# =========================
+def _render_decision(payload: Mapping[str, Any]) -> str:
+    action = _safe_text(payload.get("decision"), "wait for qualified setup")
+    confidence = _fmt_percent(payload.get("confidence", 0.0), already_percent=True)
+    lines = [
+        _line("Action", action),
+        _line("Confidence", confidence),
+        _line("Operator Note", _safe_text(payload.get("operator_note"), "execution ready")),
+    ]
+    return _section(f"{EMOJI['decision']} DECISION", lines)
 
-async def render_dashboard(payload: dict) -> str:
-    """ONLY ENTRY POINT — do not bypass this."""
 
-    blocks: list[str] = []
+def _render_market_context(payload: Mapping[str, Any]) -> str:
+    lines = [
+        _line("Regime", _safe_text(payload.get("trend"), "neutral")),
+        _line("Signal Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
+        _line("Narrative", _safe_text(payload.get("insight"), "monitoring flow")),
+    ]
+    return _section(f"{EMOJI['market']} MARKET CONTEXT", lines)
 
-    blocks.append(render_system(payload.get("state"), payload.get("mode")))
 
-    blocks.append(
-        render_portfolio(
-            payload.get("equity"), payload.get("positions"), payload.get("exposure")
-        )
-    )
+async def render_dashboard(payload: Mapping[str, Any]) -> str:
+    """Premium dashboard entry point with safe defaults."""
+    normalized: dict[str, Any] = dict(payload or {})
 
-    if payload.get("market_id"):
+    blocks: list[str] = [
+        _render_system(normalized),
+        _render_portfolio(normalized),
+    ]
+
+    mode = _safe_text(normalized.get("mode"), "home").lower()
+    has_trade = bool(normalized.get("market_id")) or mode == "trade"
+    if has_trade:
         blocks.append(
             await render_position(
-                payload.get("market_id"),
-                payload.get("side"),
-                payload.get("entry"),
-                payload.get("size"),
-                payload.get("pnl"),
+                normalized.get("market_id"),
+                normalized.get("side"),
+                normalized.get("entry"),
+                normalized.get("size"),
+                normalized.get("pnl"),
+                normalized.get("confidence"),
+                normalized.get("edge"),
             )
         )
 
-    blocks.append(render_risk(payload.get("drawdown")))
-    blocks.append(render_insight(payload.get("insight")))
-    blocks.append(render_decision(payload.get("decision")))
+    blocks.extend(
+        [
+            _render_risk(normalized),
+            _render_decision(normalized),
+            _render_market_context(normalized),
+        ]
+    )
 
     return "\n\n".join(blocks)

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_premium_ui_pass_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_premium_ui_pass_20260406.md
@@ -1,0 +1,37 @@
+# telegram_premium_ui_pass_20260406
+
+## 1) What was built
+
+- Upgraded Telegram message rendering to a premium, mobile-first layout using a consistent section system in `interface/ui_formatter.py`.
+- Refined Telegram view routing payloads in `interface/telegram/view_handler.py` for `home`, `trade`, `wallet`, `performance`, `market`, and `markets` views with stronger operator-focused copy and safer defaults.
+- Added graceful fallbacks for absent optional values to prevent key errors and formatting failures.
+
+## 2) Design principles
+
+- **Premium hierarchy:** clear section headers for SYSTEM, PORTFOLIO, RISK, DECISION, MARKET CONTEXT (+ TRADE block when relevant).
+- **Mobile readability:** short bullet lines, stable ordering, compact spacing, and low-noise separators.
+- **Operational tone:** concise action-first phrasing for decisions and operator notes.
+- **Safety-first formatting:** payload normalization and default values for optional keys.
+
+## 3) Files changed
+
+- `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `projects/polymarket/polyquantbot/reports/forge/telegram_premium_ui_pass_20260406.md`
+- `PROJECT_STATE.md`
+
+## 4) Before/after improvement summary
+
+- **Before:** generic block formatting with lower visual hierarchy and limited trade emphasis.
+- **After:** premium standardized sections, clearer direction/sizing/edge/confidence visibility for trade outputs, and consistent investor-grade wallet/performance presentation.
+- **Before:** fragmented view-level defaults.
+- **After:** centralized base payload normalization with safer fallback handling and consistent message tone.
+
+## 5) Issues
+
+- Trade market-name enrichment depends on external market context lookup; in this container, network access to `clob.polymarket.com` can fail, so market fallback text is used safely when needed.
+
+## 6) Next
+
+- SENTINEL validation for Telegram premium UI pass.
+- Live Telegram client visual verification across multiple device widths for final spacing signoff.


### PR DESCRIPTION
### Motivation

- Upgrade Telegram UI/UX to a premium, mobile-first, operator-focused layout while keeping strategy, risk, and execution logic unchanged. 
- Improve readability and consistency across dashboard, trade, wallet, performance, and market views and ensure safe fallbacks for missing payload fields.

### Description

- Rewrote the Telegram formatter as a premium, sectioned renderer in `projects/polymarket/polyquantbot/interface/ui_formatter.py` with standardized dividers, compact bullet lines, currency/percent formatters, direction icons, and a dedicated `TRADE` block exposing direction/entry/size/edge/confidence/PnL. 
- Hardened and centralized view payload normalization in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` by adding `_base_payload`, `_as_list`, safe defaults, and consistent mapping for `trade`, `wallet`, `performance`, `market(s)`, and `home` render paths. 
- Added a FORGE report `projects/polymarket/polyquantbot/reports/forge/telegram_premium_ui_pass_20260406.md` and updated `PROJECT_STATE.md` fields (`Status`, `COMPLETED`, `IN PROGRESS`, `NEXT PRIORITY`, `KNOWN ISSUES`) to reflect the change and handoff to SENTINEL. 
- Changes limited to formatting and view adapters only; no strategy, execution, risk, or API refactors were made.

### Testing

- Compiled the modified modules with `python -m py_compile projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py` and the compilation succeeded. 
- Ran smoke checks that invoked `render_dashboard(payload)` and `render_view(...)` for `trade`, `wallet`, `performance`, `market`, `markets`, and default/home paths, and all render paths returned non-empty output without crashing. 
- Observed a network warning from the market context lookup during a `trade` check when external network was unreachable, but the formatter provided safe fallback text and did not fail. 
- No automated tests failed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d391388130832e9fc2fdab37a2a91c)