### PR TITLE
feat: Telegram Premium UI v2 presentation pass

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,15 +1,15 @@
 Last Updated  : 2026-04-06
-Status        : Telegram premium UI pass validated by SENTINEL
+Status        : FORGE-X Telegram Premium UI v2 presentation pass complete (pending SENTINEL validation)
 COMPLETED     :
-- Telegram premium UI pass (2026-04-06): upgraded premium operator-grade formatting for dashboard/trade/wallet/performance/market views with safe payload fallbacks and consistent mobile-first section hierarchy.
-- SENTINEL validation (2026-04-06): approved Telegram premium UI rendering path across dashboard + all supported views, including fallback safety and mobile formatting checks.
+- Telegram premium UI v2 pass (2026-04-06): strengthened Telegram hierarchy, differentiated view personalities, improved human-readable position/market cards, and hardened sparse-payload fallback readability in interface UI formatting paths.
 
 IN PROGRESS   :
 - N/A
 
 NEXT PRIORITY :
-- BRIEFER handoff for Telegram premium UI validation summary
+- SENTINEL validation required for telegram-ui-premium-v2 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md
 
 KNOWN ISSUES  :
-- Market context API lookup may be unreachable from this container; formatter safely falls back to market_id/default labels without crashing.
-- Codex worktree may show branch as `work`; validation mapped to feature context via target forge report and commit scope.
+- Market context API lookup may be unreachable from this container; formatter safely falls back to market title/question or shortened market_id label without crashing.
+- Telegram client font/line wrapping may differ by device settings; readability is improved but can still vary slightly across mobile clients.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -11,16 +11,24 @@ def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def _first_present(payload: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in payload and payload.get(key) not in (None, ""):
+            return payload.get(key)
+    return default
+
+
 def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
     positions = _as_list(payload.get("positions"))
     return {
         "state": payload.get("status", "waiting"),
         "mode": mode,
         "cycle": payload.get("cycle", "active"),
-        "equity": payload.get("equity", 0),
+        "equity": payload.get("equity", payload.get("balance", 0)),
         "positions": payload.get("positions_count", len(positions)),
         "exposure": payload.get("exposure", 0),
         "pnl": payload.get("pnl", payload.get("unrealized_pnl", 0)),
+        "realized_pnl": payload.get("realized_pnl", 0),
         "drawdown": payload.get("drawdown", 0),
         "risk_level": payload.get("risk_level", "standard"),
         "risk_state": payload.get("risk_state", "within limits"),
@@ -31,6 +39,13 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "confidence": payload.get("confidence", 0),
         "decision": payload.get("decision"),
         "operator_note": payload.get("operator_note"),
+        "market_title": _first_present(payload, "market_title", "market_name", "question"),
+        "market_question": payload.get("question"),
+        "market_id": _first_present(payload, "market_id", "market"),
+        "current": _first_present(payload, "current", "current_price", "last_price"),
+        "opened_at": _first_present(payload, "opened_at", "opened", "opened_time", "created_at"),
+        "strategy_mode": payload.get("strategy_mode"),
+        "signal_state": payload.get("signal_state"),
     }
 
 
@@ -39,16 +54,16 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     safe_payload: Mapping[str, Any] = payload or {}
 
     if action == "trade":
-        dashboard_payload = _base_payload("trade", safe_payload)
+        dashboard_payload = _base_payload("positions", safe_payload)
         dashboard_payload.update(
             {
-                "market_id": safe_payload.get("market_id", safe_payload.get("market")),
+                "mode": "positions",
                 "side": safe_payload.get("side", safe_payload.get("direction", "flat")),
                 "entry": safe_payload.get("entry", safe_payload.get("entry_price", 0)),
                 "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
-                "decision": safe_payload.get("decision", "deploy setup if risk gate clears"),
-                "operator_note": safe_payload.get("operator_note", "review edge and liquidity before send"),
-                "insight": safe_payload.get("insight", "signal is live and monitored"),
+                "decision": safe_payload.get("decision", "Deploy only if edge + liquidity both qualify"),
+                "operator_note": safe_payload.get("operator_note", "Review slippage and depth before send"),
+                "insight": safe_payload.get("insight", "Position card emphasizes what matters now"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -57,10 +72,35 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
         dashboard_payload = _base_payload("wallet", safe_payload)
         dashboard_payload.update(
             {
-                "decision": safe_payload.get("decision", "capital preserved — no forced deployment"),
-                "operator_note": safe_payload.get("operator_note", "wallet view is informational"),
-                "insight": safe_payload.get("insight", "liquidity and collateral snapshot"),
+                "decision": safe_payload.get("decision", "Capital intact — deployment is optional"),
+                "operator_note": safe_payload.get("operator_note", "Account summary only; no execution implied"),
+                "insight": safe_payload.get("insight", "Balance, exposure, and reserve are aligned"),
                 "positions": safe_payload.get("positions_count", len(_as_list(safe_payload.get("open_positions")))),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action in {"positions", "position"}:
+        dashboard_payload = _base_payload("positions", safe_payload)
+        dashboard_payload.update(
+            {
+                "side": safe_payload.get("side", safe_payload.get("direction", "flat")),
+                "entry": safe_payload.get("entry", safe_payload.get("entry_price", 0)),
+                "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
+                "decision": safe_payload.get("decision", "Monitor active positions; protect downside"),
+                "operator_note": safe_payload.get("operator_note", "Prioritize drawdown and concentration risks"),
+                "insight": safe_payload.get("insight", "Positions sorted for quick read on mobile"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "pnl":
+        dashboard_payload = _base_payload("pnl", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Track realized vs unrealized before scaling"),
+                "operator_note": safe_payload.get("operator_note", "Evaluate losses before new entries"),
+                "insight": safe_payload.get("insight", "Pnl view highlights trend quality"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -69,9 +109,42 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
         dashboard_payload = _base_payload("performance", safe_payload)
         dashboard_payload.update(
             {
-                "decision": safe_payload.get("decision", "optimize based on realized performance"),
-                "operator_note": safe_payload.get("operator_note", "focus on drawdown and hit-rate trend"),
-                "insight": safe_payload.get("insight", "performance metrics refreshed"),
+                "decision": safe_payload.get("decision", "Optimize based on rolling scorecard"),
+                "operator_note": safe_payload.get("operator_note", "Keep drawdown stable while compounding edge"),
+                "insight": safe_payload.get("insight", "Performance consistency drives sizing confidence"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "exposure":
+        dashboard_payload = _base_payload("exposure", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Rebalance if concentration exceeds comfort"),
+                "operator_note": safe_payload.get("operator_note", "Exposure view tracks concentration pressure"),
+                "insight": safe_payload.get("insight", "Allocation split is readable under sparse payloads"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "risk":
+        dashboard_payload = _base_payload("risk", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Risk preset active — respect hard limits"),
+                "operator_note": safe_payload.get("operator_note", "Escalate when drawdown or liquidity warnings fire"),
+                "insight": safe_payload.get("insight", "Risk interpretation is surfaced before action"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "strategy":
+        dashboard_payload = _base_payload("strategy", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Strategy toggles define eligibility for execution"),
+                "operator_note": safe_payload.get("operator_note", "Confirm activation state after each config change"),
+                "insight": safe_payload.get("insight", "Strategy view emphasizes activation and gating"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -80,9 +153,9 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
         dashboard_payload = _base_payload("market", safe_payload)
         dashboard_payload.update(
             {
-                "decision": safe_payload.get("decision", "scan for asymmetric opportunity"),
-                "operator_note": safe_payload.get("operator_note", "rank by edge and confidence"),
-                "insight": safe_payload.get("insight", "market context prioritized for execution"),
+                "decision": safe_payload.get("decision", "Scan for asymmetric opportunity"),
+                "operator_note": safe_payload.get("operator_note", "Use market context before committing capital"),
+                "insight": safe_payload.get("insight", "Human-readable labels prioritized over raw ids"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -91,9 +164,9 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     dashboard_payload.update(
         {
             "state": safe_payload.get("status", "running"),
-            "decision": safe_payload.get("decision", "system healthy — await qualified signal"),
-            "operator_note": safe_payload.get("operator_note", "monitor risk gates and telemetry"),
-            "insight": safe_payload.get("insight", "home dashboard synchronized"),
+            "decision": safe_payload.get("decision", "System healthy — await qualified signal"),
+            "operator_note": safe_payload.get("operator_note", "Command center synced across major views"),
+            "insight": safe_payload.get("insight", "Home view surfaces what matters first"),
         }
     )
     return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
@@ -9,12 +10,15 @@ from projects.polymarket.polyquantbot.data.market_context import get_market_cont
 SECTION_DIVIDER = "────────────────────"
 
 EMOJI = {
-    "system": "🧭",
-    "portfolio": "💼",
+    "home": "🧭",
+    "wallet": "💼",
+    "positions": "📌",
+    "pnl": "📈",
+    "performance": "🏁",
+    "exposure": "🧩",
     "risk": "🛡️",
-    "decision": "🎯",
+    "strategy": "🎛️",
     "market": "🌐",
-    "trade": "📌",
 }
 
 
@@ -39,8 +43,18 @@ def _safe_text(value: object, default: str = "N/A") -> str:
     return text or default
 
 
+def _compact_text(value: object, default: str = "N/A", max_len: int = 72) -> str:
+    text = _safe_text(value, default)
+    return text if len(text) <= max_len else f"{text[: max_len - 1]}…"
+
+
 def _fmt_currency(value: object) -> str:
     return f"${_safe_float(value):,.2f}"
+
+
+def _fmt_signed_currency(value: object) -> str:
+    numeric = _safe_float(value)
+    return f"{numeric:+,.2f}"
 
 
 def _fmt_percent(value: object, *, already_percent: bool = False) -> str:
@@ -57,17 +71,43 @@ def _fmt_signed_percent(value: object, *, already_percent: bool = False) -> str:
     return f"{numeric:+.1f}%"
 
 
-def _fmt_signed_currency(value: object) -> str:
+def _fmt_probability_cents(value: object) -> str:
     numeric = _safe_float(value)
-    return f"{numeric:+,.2f}"
+    cents = numeric * 100 if numeric <= 1.0 else numeric
+    return f"{cents:.2f}¢"
+
+
+def _format_opened_time(value: object) -> str:
+    if value in (None, ""):
+        return "Unknown"
+
+    if isinstance(value, datetime):
+        dt_value = value.astimezone(timezone.utc)
+    else:
+        text = str(value).strip()
+        if not text:
+            return "Unknown"
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            dt_value = datetime.fromisoformat(text)
+        except ValueError:
+            return _compact_text(value, "Unknown", max_len=24)
+        if dt_value.tzinfo is None:
+            dt_value = dt_value.replace(tzinfo=timezone.utc)
+        dt_value = dt_value.astimezone(timezone.utc)
+
+    month = dt_value.strftime("%b")
+    day = dt_value.day
+    return f"{month} {day}, {dt_value.strftime('%H:%M')} UTC"
 
 
 def _direction(value: object) -> str:
     side = _safe_text(value, "FLAT").upper()
     if side in {"BUY", "LONG", "YES"}:
-        return f"🟢 {side}"
+        return "🟢 YES"
     if side in {"SELL", "SHORT", "NO"}:
-        return f"🔴 {side}"
+        return "🔴 NO"
     return f"🟡 {side}"
 
 
@@ -75,8 +115,116 @@ def _line(label: str, value: object) -> str:
     return f"• {label}: {value}"
 
 
+def _meta_line(label: str, value: object) -> str:
+    return f"◦ {label}: {value}"
+
+
 def _section(title: str, lines: list[str]) -> str:
     return "\n".join([SECTION_DIVIDER, title, *lines])
+
+
+def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]) -> str:
+    for candidate in (
+        payload.get("market_title"),
+        payload.get("market_question"),
+        context.get("name"),
+        context.get("question"),
+        payload.get("market"),
+    ):
+        text = _compact_text(candidate, "", max_len=86)
+        if text and text != "":
+            return text
+    market_id = _safe_text(payload.get("market_id"), "Unknown market")
+    return f"Market {market_id[:16]}"
+
+
+def _hero_block(mode: str, payload: Mapping[str, Any], market_label: str) -> str:
+    status = _safe_text(payload.get("state"), "waiting").upper()
+    decision = _compact_text(payload.get("decision"), "Await qualified setup")
+    icon = EMOJI.get(mode, EMOJI["home"])
+
+    hero_lines = [
+        f"{icon} {mode.upper()} COMMAND",
+        f"Status: {status}",
+        f"Now: {decision}",
+    ]
+
+    if payload.get("market_id") or payload.get("market"):
+        hero_lines.append(f"Market: {market_label}")
+
+    return "\n".join(hero_lines)
+
+
+def _primary_state(mode: str, payload: Mapping[str, Any]) -> str:
+    mode_map: dict[str, tuple[str, list[str]]] = {
+        "home": (
+            "PRIMARY STATE",
+            [
+                _line("Cycle", _safe_text(payload.get("cycle"), "active")),
+                _line("Open Positions", _safe_int(payload.get("positions"))),
+                _line("Risk State", _safe_text(payload.get("risk_state"), "within limits")),
+            ],
+        ),
+        "wallet": (
+            "ACCOUNT SNAPSHOT",
+            [
+                _line("Equity", _fmt_currency(payload.get("equity"))),
+                _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+                _line("Exposure", _fmt_percent(payload.get("exposure"))),
+            ],
+        ),
+        "positions": (
+            "POSITION MONITOR",
+            [
+                _line("Open Positions", _safe_int(payload.get("positions"))),
+                _line("Exposure", _fmt_percent(payload.get("exposure"))),
+                _line("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+            ],
+        ),
+        "pnl": (
+            "PNL SUMMARY",
+            [
+                _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+                _line("Realized", _fmt_signed_currency(payload.get("realized_pnl"))),
+                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+            ],
+        ),
+        "performance": (
+            "SCORECARD",
+            [
+                _line("PnL", _fmt_signed_currency(payload.get("pnl"))),
+                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                _line("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+            ],
+        ),
+        "exposure": (
+            "ALLOCATION VIEW",
+            [
+                _line("Exposure", _fmt_percent(payload.get("exposure"))),
+                _line("Open Positions", _safe_int(payload.get("positions"))),
+                _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+            ],
+        ),
+        "risk": (
+            "RISK PRESET",
+            [
+                _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+                _line("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
+                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+            ],
+        ),
+        "strategy": (
+            "STRATEGY STATE",
+            [
+                _line("Mode", _safe_text(payload.get("strategy_mode"), "default")),
+                _line("Signal", _safe_text(payload.get("signal_state"), "monitoring")),
+                _line("Decision", _compact_text(payload.get("decision"), "Await qualified setup", 56)),
+            ],
+        ),
+    }
+
+    title, lines = mode_map.get(mode, mode_map["home"])
+    return _section(title, lines)
 
 
 async def render_position(
@@ -87,82 +235,82 @@ async def render_position(
     pnl: object,
     confidence: object,
     edge: object,
+    *,
+    current: object = None,
+    opened_at: object = None,
+    market_title: object = None,
 ) -> str:
     context = await get_market_context(_safe_text(market_id, "")) or {}
-    market_name = _safe_text(context.get("name") or context.get("question") or market_id)
+    market_label = _resolve_market_label(
+        {
+            "market_title": market_title,
+            "market_id": market_id,
+        },
+        context,
+    )
 
+    now_value = current if current is not None else entry
     lines = [
-        _line("Market", market_name),
-        _line("Direction", _direction(side)),
-        _line("Entry", _fmt_currency(entry)),
-        _line("Sizing", _fmt_currency(size)),
-        _line("Edge", _fmt_signed_percent(edge)),
-        _line("Confidence", _fmt_percent(confidence, already_percent=True)),
-        _line("Open PnL", _fmt_signed_currency(pnl)),
+        _line("Market", market_label),
+        _line("Side", _direction(side)),
+        _line("Entry", _fmt_probability_cents(entry)),
+        _line("Now", _fmt_probability_cents(now_value)),
+        _line("Size", _fmt_currency(size)),
+        _line("UPNL", _fmt_signed_currency(pnl)),
+        _line("Opened", _format_opened_time(opened_at)),
+        _meta_line("Edge", _fmt_signed_percent(edge)),
+        _meta_line("Confidence", _fmt_percent(confidence, already_percent=True)),
+        _meta_line("Insight", "Healthy" if _safe_float(pnl) >= 0 else "Needs attention"),
     ]
-    return _section(f"{EMOJI['trade']} TRADE", lines)
+
+    raw_id = _safe_text(market_id, "N/A")
+    lines.append(_meta_line("Market ID", raw_id))
+    return _section("ACTIVE POSITION", lines)
 
 
-def _render_system(payload: Mapping[str, Any]) -> str:
+def _render_market_context(payload: Mapping[str, Any], market_label: str) -> str:
     lines = [
-        _line("Status", _safe_text(payload.get("state"), "waiting")),
-        _line("View", _safe_text(payload.get("mode"), "home")),
-        _line("Cycle", _safe_text(payload.get("cycle"), "active")),
-    ]
-    return _section(f"{EMOJI['system']} SYSTEM", lines)
-
-
-def _render_portfolio(payload: Mapping[str, Any]) -> str:
-    lines = [
-        _line("Equity", _fmt_currency(payload.get("equity"))),
-        _line("Open Positions", _safe_int(payload.get("positions"))),
-        _line("Exposure", _fmt_percent(payload.get("exposure"))),
-        _line("Unrealized PnL", _fmt_signed_currency(payload.get("pnl"))),
-    ]
-    return _section(f"{EMOJI['portfolio']} PORTFOLIO", lines)
-
-
-def _render_risk(payload: Mapping[str, Any]) -> str:
-    lines = [
-        _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
-        _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
-        _line("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
-    ]
-    return _section(f"{EMOJI['risk']} RISK", lines)
-
-
-def _render_decision(payload: Mapping[str, Any]) -> str:
-    action = _safe_text(payload.get("decision"), "wait for qualified setup")
-    confidence = _fmt_percent(payload.get("confidence", 0.0), already_percent=True)
-    lines = [
-        _line("Action", action),
-        _line("Confidence", confidence),
-        _line("Operator Note", _safe_text(payload.get("operator_note"), "execution ready")),
-    ]
-    return _section(f"{EMOJI['decision']} DECISION", lines)
-
-
-def _render_market_context(payload: Mapping[str, Any]) -> str:
-    lines = [
+        _line("Market", market_label),
         _line("Regime", _safe_text(payload.get("trend"), "neutral")),
         _line("Signal Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
-        _line("Narrative", _safe_text(payload.get("insight"), "monitoring flow")),
+        _line("Narrative", _compact_text(payload.get("insight"), "Monitoring flow")),
     ]
-    return _section(f"{EMOJI['market']} MARKET CONTEXT", lines)
+    if payload.get("market_id"):
+        lines.append(_meta_line("Ref", _safe_text(payload.get("market_id"))))
+    return _section("MARKET CONTEXT", lines)
+
+
+def _render_metrics(payload: Mapping[str, Any]) -> str:
+    lines = [
+        _line("Equity", _fmt_currency(payload.get("equity"))),
+        _line("Exposure", _fmt_percent(payload.get("exposure"))),
+        _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+        _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+    ]
+    return _section("KEY METRICS", lines)
+
+
+def _render_operator_note(payload: Mapping[str, Any]) -> str:
+    note = _compact_text(payload.get("operator_note"), "No operator note.", max_len=120)
+    return _section("OPERATOR NOTE", [f"• {note}"])
 
 
 async def render_dashboard(payload: Mapping[str, Any]) -> str:
-    """Premium dashboard entry point with safe defaults."""
+    """Premium dashboard entry point with safe defaults and view personality."""
     normalized: dict[str, Any] = dict(payload or {})
+    mode = _safe_text(normalized.get("mode"), "home").lower()
+
+    context = await get_market_context(_safe_text(normalized.get("market_id"), "")) or {}
+    market_label = _resolve_market_label(normalized, context)
 
     blocks: list[str] = [
-        _render_system(normalized),
-        _render_portfolio(normalized),
+        _hero_block(mode, normalized, market_label),
+        _primary_state(mode, normalized),
+        _render_metrics(normalized),
     ]
 
-    mode = _safe_text(normalized.get("mode"), "home").lower()
-    has_trade = bool(normalized.get("market_id")) or mode == "trade"
-    if has_trade:
+    has_position = bool(normalized.get("market_id")) or mode in {"trade", "positions"}
+    if has_position:
         blocks.append(
             await render_position(
                 normalized.get("market_id"),
@@ -172,14 +320,16 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
                 normalized.get("pnl"),
                 normalized.get("confidence"),
                 normalized.get("edge"),
+                current=normalized.get("current", normalized.get("current_price")),
+                opened_at=normalized.get("opened_at"),
+                market_title=normalized.get("market_title") or normalized.get("market_question"),
             )
         )
 
     blocks.extend(
         [
-            _render_risk(normalized),
-            _render_decision(normalized),
-            _render_market_context(normalized),
+            _render_market_context(normalized, market_label),
+            _render_operator_note(normalized),
         ]
     )
 

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md
@@ -1,0 +1,68 @@
+# telegram_ui_premium_v2_20260406
+
+## 1. What was built
+- Implemented Telegram Premium UI v2 presentation pass for operator-facing messages in:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Reworked screen composition to enforce a clearer order:
+  1) header/hero summary
+  2) primary state
+  3) key metrics
+  4) supporting detail (position card + market context)
+  5) operator note
+- Rebuilt position rendering into a single-glance card emphasizing market title, side, entry vs now, size, UPNL, opened time, and concise insight.
+- Added safer human-readable fallback behavior for missing market title/question values so raw IDs remain secondary metadata.
+- Added view personality routing for `home`, `wallet`, `positions`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, and `market(s)` while preserving one design language.
+
+## 2. Design principles
+- Hierarchy first: primary state is always visible near the top, with support data progressively disclosed below.
+- Mobile readability: concise labels, short lines, restrained separators, and reduced repetitive blocks.
+- Human-led labels: market title/question is preferred over IDs whenever available.
+- Graceful degradation: sparse/missing payload fields remain readable and non-crashing via safe defaults.
+- UI-only scope: no strategy, risk, execution, async pipeline, or infra behavior changes.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- Hierarchy improvement
+  - Before: sections had similar visual weight and repeated rhythm.
+  - After: each message begins with a hero command block (`MODE COMMAND`, status, now/decision), then a mode-specific primary block, then key metrics, then context/insight.
+
+- Position readability improvement
+  - Before: position emphasis started from raw market/ID-style references and mixed metrics.
+  - After: position card leads with human market label and explicit side; entry vs now, size, UPNL, opened time are grouped in a stable order; market ID is retained only as secondary metadata.
+
+- Market fallback readability improvement
+  - Before: missing enrichment could surface raw identifiers too prominently.
+  - After: market label resolution order now prefers `market_title`, `market_name`, `question`, context `name/question`, then short safe fallback (`Market {id-prefix}`), with raw ID kept as reference metadata.
+
+- View differentiation improvement
+  - Before: most views were variants of one generalized section stack.
+  - After: mode-specific primary blocks provide distinct personalities:
+    - `home`: command-center state
+    - `wallet`: account snapshot
+    - `positions/trade`: active monitor
+    - `pnl`: realized/unrealized summary
+    - `performance`: scorecard
+    - `exposure`: allocation view
+    - `risk`: preset interpretation
+    - `strategy`: activation/toggle state
+
+- Sparse payload safety
+  - Verified local render smoke checks across all major modes with sparse inputs (`market_id`-only payload) complete without crash and remain readable.
+
+- No logic-layer drift evidence
+  - Modified files are limited to Telegram UI formatter and Telegram view handler paths only.
+  - No edits under strategy/risk/execution directories.
+
+## 5. Issues
+- External market context enrichment may be unreachable in this container (`clob.polymarket.com` network unavailable); formatter falls back safely to local human-readable labels/short market fallback without crashing.
+- Telegram client rendering can vary slightly across device font metrics; compact line lengths were tuned for typical mobile clients but still depend on Telegram app font settings.
+
+## 6. Next
+- SENTINEL validation required for telegram-ui-premium-v2 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md


### PR DESCRIPTION
### Motivation
- Improve operator-facing Telegram output so primary state and actions are obvious at a glance with a clear visual hierarchy for mobile operators.
- Make position and market information human-readable and one-glance friendly while avoiding noisy, repetitive layouts.
- Keep this strictly a UI presentation pass with no changes to strategy, risk, execution, async, websocket, infra, or pipeline logic.

### Description
- Reworked dashboard composition and introduced hero/primary/metrics/context/operator-note blocks in `render_dashboard` and new helpers such as `_hero_block`, `_primary_state`, `_render_metrics`, and `_render_operator_note` in `projects/polymarket/polyquantbot/interface/ui_formatter.py` to enforce reading order and view personality.
- Rebuilt position rendering into a one-glance card in `render_position` that leads with a human-friendly market label, explicit side, `Entry` vs `Now`, `Size`, `UPNL`, `Opened` time, a concise insight line, and keeps raw `Market ID` only as secondary metadata.
- Added safer market-label resolution and compacting (`_resolve_market_label`, `_compact_text`) and better time formatting (`_format_opened_time`) so fallback outputs remain readable when enrichment is unavailable.
- Normalized and expanded payload preparation in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to provide distinct personalities for `home`, `wallet`, `positions/trade`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, and `market(s)` views while preserving a single design language.
- Files changed: `projects/polymarket/polyquantbot/interface/ui_formatter.py`, `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`, `projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md`, and `PROJECT_STATE.md`.

### Testing
- Executed an async smoke-render across `home`, `wallet`, `trade`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, and `markets` using `render_view(...)` and verified non-empty, human-readable output for full and sparse payloads (including a `market_id`-only payload); the smoke checks passed.
- Ran a compile check with `python -m compileall` for the changed formatter and view handler files which succeeded without syntax errors.
- The runtime produced warnings that the external market-context API was unreachable (network constraint), and those warnings were observed and validated to exercise the safe fallback paths so degraded payloads remain readable and non-crashing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a8e3ed6c832e90a222fcaa41ac4e)