### PR TITLE
Telegram premium UI v3 — emoji hierarchy & tree readability

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,15 +1,16 @@
 Last Updated  : 2026-04-06
-Status        : FORGE-X Telegram Premium UI v2 presentation pass complete (pending SENTINEL validation)
+Status        : FORGE-X Telegram Premium UI v3 correction pass complete (pending SENTINEL validation)
 COMPLETED     :
-- Telegram premium UI v2 pass (2026-04-06): strengthened Telegram hierarchy, differentiated view personalities, improved human-readable position/market cards, and hardened sparse-payload fallback readability in interface UI formatting paths.
+- Telegram premium UI v3 correction pass (2026-04-06): enforced emoji-led hierarchy and mandatory `|->` tree readability, strengthened one-glance position/market cards, and differentiated Telegram view personalities for operator-first mobile scan.
+- Drift correction acknowledged: Telegram premium UI v2 was insufficient in actual Telegram presentation (output remained too flat/monotonous), requiring this v3 correction pass.
 
 IN PROGRESS   :
 - N/A
 
 NEXT PRIORITY :
-- SENTINEL validation required for telegram-ui-premium-v2 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/telegram_ui_premium_v2_20260406.md
+- SENTINEL validation required for telegram-emoji-hierarchy-v3 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md
 
 KNOWN ISSUES  :
-- Market context API lookup may be unreachable from this container; formatter safely falls back to market title/question or shortened market_id label without crashing.
-- Telegram client font/line wrapping may differ by device settings; readability is improved but can still vary slightly across mobile clients.
+- Market context API lookup may be unreachable from this container; formatter safely falls back to human-readable local fields and short market label without crashing.
+- Telegram client-specific font and wrapping differences may still produce minor line-wrap variation across devices despite mobile-first compact formatting.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -35,6 +35,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "trend": payload.get("trend", "neutral"),
         "edge": payload.get("edge", 0),
         "edge_label": payload.get("edge_label"),
+        "available_balance": payload.get("available_balance", payload.get("free_balance", payload.get("equity", payload.get("balance", 0)))),
         "insight": payload.get("insight"),
         "confidence": payload.get("confidence", 0),
         "decision": payload.get("decision"),
@@ -43,6 +44,9 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "market_question": payload.get("question"),
         "market_id": _first_present(payload, "market_id", "market"),
         "current": _first_present(payload, "current", "current_price", "last_price"),
+        "side": payload.get("side", payload.get("direction", "flat")),
+        "entry": payload.get("entry", payload.get("entry_price", 0)),
+        "size": payload.get("size", payload.get("allocation", 0)),
         "opened_at": _first_present(payload, "opened_at", "opened", "opened_time", "created_at"),
         "strategy_mode": payload.get("strategy_mode"),
         "signal_state": payload.get("signal_state"),
@@ -63,7 +67,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
                 "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
                 "decision": safe_payload.get("decision", "Deploy only if edge + liquidity both qualify"),
                 "operator_note": safe_payload.get("operator_note", "Review slippage and depth before send"),
-                "insight": safe_payload.get("insight", "Position card emphasizes what matters now"),
+                "insight": safe_payload.get("insight", "One-glance card highlights side, price, and risk posture"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -74,7 +78,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Capital intact — deployment is optional"),
                 "operator_note": safe_payload.get("operator_note", "Account summary only; no execution implied"),
-                "insight": safe_payload.get("insight", "Balance, exposure, and reserve are aligned"),
+                "insight": safe_payload.get("insight", "Wallet summary prioritizes capital readiness"),
                 "positions": safe_payload.get("positions_count", len(_as_list(safe_payload.get("open_positions")))),
             }
         )
@@ -89,7 +93,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
                 "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
                 "decision": safe_payload.get("decision", "Monitor active positions; protect downside"),
                 "operator_note": safe_payload.get("operator_note", "Prioritize drawdown and concentration risks"),
-                "insight": safe_payload.get("insight", "Positions sorted for quick read on mobile"),
+                "insight": safe_payload.get("insight", "Active risk and side exposure are visible first"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -100,7 +104,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Track realized vs unrealized before scaling"),
                 "operator_note": safe_payload.get("operator_note", "Evaluate losses before new entries"),
-                "insight": safe_payload.get("insight", "Pnl view highlights trend quality"),
+                "insight": safe_payload.get("insight", "Cash impact is grouped for rapid operator scan"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -111,7 +115,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Optimize based on rolling scorecard"),
                 "operator_note": safe_payload.get("operator_note", "Keep drawdown stable while compounding edge"),
-                "insight": safe_payload.get("insight", "Performance consistency drives sizing confidence"),
+                "insight": safe_payload.get("insight", "Scorecard emphasizes trend stability"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -122,7 +126,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Rebalance if concentration exceeds comfort"),
                 "operator_note": safe_payload.get("operator_note", "Exposure view tracks concentration pressure"),
-                "insight": safe_payload.get("insight", "Allocation split is readable under sparse payloads"),
+                "insight": safe_payload.get("insight", "Concentration pressure is shown before action"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -133,7 +137,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Risk preset active — respect hard limits"),
                 "operator_note": safe_payload.get("operator_note", "Escalate when drawdown or liquidity warnings fire"),
-                "insight": safe_payload.get("insight", "Risk interpretation is surfaced before action"),
+                "insight": safe_payload.get("insight", "Risk consequences are shown in plain language"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -144,7 +148,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Strategy toggles define eligibility for execution"),
                 "operator_note": safe_payload.get("operator_note", "Confirm activation state after each config change"),
-                "insight": safe_payload.get("insight", "Strategy view emphasizes activation and gating"),
+                "insight": safe_payload.get("insight", "Activation gates are explicit for operator control"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -155,7 +159,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             {
                 "decision": safe_payload.get("decision", "Scan for asymmetric opportunity"),
                 "operator_note": safe_payload.get("operator_note", "Use market context before committing capital"),
-                "insight": safe_payload.get("insight", "Human-readable labels prioritized over raw ids"),
+                "insight": safe_payload.get("insight", "Market title-first rendering keeps ids secondary"),
             }
         )
         return await render_dashboard(dashboard_payload)
@@ -166,7 +170,7 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
             "state": safe_payload.get("status", "running"),
             "decision": safe_payload.get("decision", "System healthy — await qualified signal"),
             "operator_note": safe_payload.get("operator_note", "Command center synced across major views"),
-            "insight": safe_payload.get("insight", "Home view surfaces what matters first"),
+            "insight": safe_payload.get("insight", "Command center highlights immediate posture"),
         }
     )
     return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -7,18 +7,18 @@ from typing import Any, Mapping
 
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
 
-SECTION_DIVIDER = "────────────────────"
-
-EMOJI = {
-    "home": "🧭",
-    "wallet": "💼",
-    "positions": "📌",
-    "pnl": "📈",
-    "performance": "🏁",
-    "exposure": "🧩",
-    "risk": "🛡️",
-    "strategy": "🎛️",
-    "market": "🌐",
+VIEW_TITLE = {
+    "home": "🏠 Home Command",
+    "wallet": "🧾 Wallet",
+    "positions": "🎯 Position Monitor",
+    "trade": "🎯 Position Monitor",
+    "pnl": "💰 PnL",
+    "performance": "📈 Performance",
+    "exposure": "📊 Exposure",
+    "risk": "⚠️ Risk",
+    "strategy": "⚙️ Strategy",
+    "market": "📡 Market",
+    "markets": "📡 Market",
 }
 
 
@@ -53,15 +53,14 @@ def _fmt_currency(value: object) -> str:
 
 
 def _fmt_signed_currency(value: object) -> str:
-    numeric = _safe_float(value)
-    return f"{numeric:+,.2f}"
+    return f"{_safe_float(value):+,.2f}"
 
 
 def _fmt_percent(value: object, *, already_percent: bool = False) -> str:
     numeric = _safe_float(value)
-    if already_percent:
-        return f"{numeric:.1f}%"
-    return f"{numeric * 100:.1f}%"
+    if not already_percent:
+        numeric *= 100
+    return f"{numeric:.1f}%"
 
 
 def _fmt_signed_percent(value: object, *, already_percent: bool = False) -> str:
@@ -97,9 +96,7 @@ def _format_opened_time(value: object) -> str:
             dt_value = dt_value.replace(tzinfo=timezone.utc)
         dt_value = dt_value.astimezone(timezone.utc)
 
-    month = dt_value.strftime("%b")
-    day = dt_value.day
-    return f"{month} {day}, {dt_value.strftime('%H:%M')} UTC"
+    return f"{dt_value.strftime('%b')} {dt_value.day}, {dt_value.strftime('%H:%M')} UTC"
 
 
 def _direction(value: object) -> str:
@@ -111,120 +108,162 @@ def _direction(value: object) -> str:
     return f"🟡 {side}"
 
 
-def _line(label: str, value: object) -> str:
-    return f"• {label}: {value}"
-
-
-def _meta_line(label: str, value: object) -> str:
-    return f"◦ {label}: {value}"
+def _tree(label: str, value: object) -> str:
+    return f"|-> {label}: {value}"
 
 
 def _section(title: str, lines: list[str]) -> str:
-    return "\n".join([SECTION_DIVIDER, title, *lines])
+    return "\n".join([title, *lines])
 
 
 def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]) -> str:
     for candidate in (
         payload.get("market_title"),
+        payload.get("market_name"),
         payload.get("market_question"),
         context.get("name"),
         context.get("question"),
         payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
-        if text and text != "":
+        if text:
             return text
-    market_id = _safe_text(payload.get("market_id"), "Unknown market")
-    return f"Market {market_id[:16]}"
+
+    market_id = _safe_text(payload.get("market_id"), "")
+    if market_id:
+        return f"Market {market_id[:12]}"
+    return "Untitled market"
 
 
-def _hero_block(mode: str, payload: Mapping[str, Any], market_label: str) -> str:
+def _hero_block(mode: str, payload: Mapping[str, Any]) -> str:
     status = _safe_text(payload.get("state"), "waiting").upper()
-    decision = _compact_text(payload.get("decision"), "Await qualified setup")
-    icon = EMOJI.get(mode, EMOJI["home"])
-
-    hero_lines = [
-        f"{icon} {mode.upper()} COMMAND",
-        f"Status: {status}",
-        f"Now: {decision}",
-    ]
-
-    if payload.get("market_id") or payload.get("market"):
-        hero_lines.append(f"Market: {market_label}")
-
-    return "\n".join(hero_lines)
+    decision = _compact_text(payload.get("decision"), "Await qualified signal", max_len=84)
+    risk_state = _compact_text(payload.get("risk_state"), "within limits", max_len=56)
+    return _section(
+        VIEW_TITLE.get(mode, VIEW_TITLE["home"]),
+        [
+            _tree("Status", status),
+            _tree("Now", decision),
+            _tree("Risk", risk_state),
+        ],
+    )
 
 
-def _primary_state(mode: str, payload: Mapping[str, Any]) -> str:
-    mode_map: dict[str, tuple[str, list[str]]] = {
+def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
+    personalities: dict[str, tuple[str, list[str]]] = {
         "home": (
-            "PRIMARY STATE",
+            "📊 Portfolio",
             [
-                _line("Cycle", _safe_text(payload.get("cycle"), "active")),
-                _line("Open Positions", _safe_int(payload.get("positions"))),
-                _line("Risk State", _safe_text(payload.get("risk_state"), "within limits")),
+                _tree("Equity", _fmt_currency(payload.get("equity"))),
+                _tree("Exposure", _fmt_percent(payload.get("exposure"))),
+                _tree("Open Positions", _safe_int(payload.get("positions"))),
             ],
         ),
         "wallet": (
-            "ACCOUNT SNAPSHOT",
+            "🧾 Wallet",
             [
-                _line("Equity", _fmt_currency(payload.get("equity"))),
-                _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
-                _line("Exposure", _fmt_percent(payload.get("exposure"))),
+                _tree("Equity", _fmt_currency(payload.get("equity"))),
+                _tree("Available", _fmt_currency(payload.get("available_balance", payload.get("equity")))),
+                _tree("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
             ],
         ),
         "positions": (
-            "POSITION MONITOR",
+            "🎯 Position Monitor",
             [
-                _line("Open Positions", _safe_int(payload.get("positions"))),
-                _line("Exposure", _fmt_percent(payload.get("exposure"))),
-                _line("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+                _tree("Open Positions", _safe_int(payload.get("positions"))),
+                _tree("Exposure", _fmt_percent(payload.get("exposure"))),
+                _tree("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
             ],
         ),
         "pnl": (
-            "PNL SUMMARY",
+            "💰 PnL",
             [
-                _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
-                _line("Realized", _fmt_signed_currency(payload.get("realized_pnl"))),
-                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                _tree("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+                _tree("Realized", _fmt_signed_currency(payload.get("realized_pnl"))),
+                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
             ],
         ),
         "performance": (
-            "SCORECARD",
+            "📈 Performance",
             [
-                _line("PnL", _fmt_signed_currency(payload.get("pnl"))),
-                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
-                _line("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+                _tree("Net PnL", _fmt_signed_currency(payload.get("pnl"))),
+                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                _tree("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
             ],
         ),
         "exposure": (
-            "ALLOCATION VIEW",
+            "📊 Exposure",
             [
-                _line("Exposure", _fmt_percent(payload.get("exposure"))),
-                _line("Open Positions", _safe_int(payload.get("positions"))),
-                _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+                _tree("Portfolio Exposure", _fmt_percent(payload.get("exposure"))),
+                _tree("Open Positions", _safe_int(payload.get("positions"))),
+                _tree("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
             ],
         ),
         "risk": (
-            "RISK PRESET",
+            "⚠️ Risk",
             [
-                _line("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
-                _line("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
-                _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                _tree("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+                _tree("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
+                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
             ],
         ),
         "strategy": (
-            "STRATEGY STATE",
+            "⚙️ Strategy",
             [
-                _line("Mode", _safe_text(payload.get("strategy_mode"), "default")),
-                _line("Signal", _safe_text(payload.get("signal_state"), "monitoring")),
-                _line("Decision", _compact_text(payload.get("decision"), "Await qualified setup", 56)),
+                _tree("Mode", _safe_text(payload.get("strategy_mode"), "default")),
+                _tree("Signal", _safe_text(payload.get("signal_state"), "monitoring")),
+                _tree("Activation", _safe_text(payload.get("state"), "active")),
+            ],
+        ),
+        "market": (
+            "📡 Market",
+            [
+                _tree("Regime", _safe_text(payload.get("trend"), "neutral")),
+                _tree("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
+                _tree("Context", "Risk 0.25 · Max Pos 0.10"),
             ],
         ),
     }
-
-    title, lines = mode_map.get(mode, mode_map["home"])
+    title, lines = personalities.get(mode, personalities["home"])
     return _section(title, lines)
+
+
+def _render_position_card(payload: Mapping[str, Any], market_label: str) -> str:
+    if not (payload.get("market_id") or payload.get("market_title") or payload.get("entry") or payload.get("size")):
+        return ""
+
+    now_value = payload.get("current") if payload.get("current") is not None else payload.get("entry")
+    lines = [
+        _tree("Market", market_label),
+        _tree("Side", _direction(payload.get("side"))),
+        _tree("Entry", _fmt_probability_cents(payload.get("entry"))),
+        _tree("Now", _fmt_probability_cents(now_value)),
+        _tree("Size", _fmt_currency(payload.get("size"))),
+        _tree("UPNL", _fmt_signed_currency(payload.get("pnl"))),
+        _tree("Opened", _format_opened_time(payload.get("opened_at"))),
+        _tree("Status", _safe_text(payload.get("position_status"), "Monitoring")),
+    ]
+    market_id = _safe_text(payload.get("market_id"), "")
+    if market_id:
+        lines.append(_tree("Ref", market_id[:18]))
+    return _section("🎯 Position", lines)
+
+
+def _render_market_card(payload: Mapping[str, Any], market_label: str) -> str:
+    lines = [
+        _tree("Title", market_label),
+        _tree("Regime", _safe_text(payload.get("trend"), "neutral")),
+        _tree("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
+        _tree("Summary", _compact_text(payload.get("insight"), "Monitoring market context", max_len=84)),
+    ]
+    if payload.get("market_id"):
+        lines.append(_tree("Ref", _safe_text(payload.get("market_id"))))
+    return _section("📡 Market", lines)
+
+
+def _render_operator_note(payload: Mapping[str, Any]) -> str:
+    note = _compact_text(payload.get("operator_note"), "Monitoring with current safeguards.", max_len=100)
+    return _section("🧠 Operator Note", [_tree("Note", note)])
 
 
 async def render_position(
@@ -242,61 +281,26 @@ async def render_position(
 ) -> str:
     context = await get_market_context(_safe_text(market_id, "")) or {}
     market_label = _resolve_market_label(
-        {
-            "market_title": market_title,
-            "market_id": market_id,
-        },
+        {"market_id": market_id, "market_title": market_title},
         context,
     )
-
-    now_value = current if current is not None else entry
-    lines = [
-        _line("Market", market_label),
-        _line("Side", _direction(side)),
-        _line("Entry", _fmt_probability_cents(entry)),
-        _line("Now", _fmt_probability_cents(now_value)),
-        _line("Size", _fmt_currency(size)),
-        _line("UPNL", _fmt_signed_currency(pnl)),
-        _line("Opened", _format_opened_time(opened_at)),
-        _meta_line("Edge", _fmt_signed_percent(edge)),
-        _meta_line("Confidence", _fmt_percent(confidence, already_percent=True)),
-        _meta_line("Insight", "Healthy" if _safe_float(pnl) >= 0 else "Needs attention"),
-    ]
-
-    raw_id = _safe_text(market_id, "N/A")
-    lines.append(_meta_line("Market ID", raw_id))
-    return _section("ACTIVE POSITION", lines)
-
-
-def _render_market_context(payload: Mapping[str, Any], market_label: str) -> str:
-    lines = [
-        _line("Market", market_label),
-        _line("Regime", _safe_text(payload.get("trend"), "neutral")),
-        _line("Signal Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
-        _line("Narrative", _compact_text(payload.get("insight"), "Monitoring flow")),
-    ]
-    if payload.get("market_id"):
-        lines.append(_meta_line("Ref", _safe_text(payload.get("market_id"))))
-    return _section("MARKET CONTEXT", lines)
-
-
-def _render_metrics(payload: Mapping[str, Any]) -> str:
-    lines = [
-        _line("Equity", _fmt_currency(payload.get("equity"))),
-        _line("Exposure", _fmt_percent(payload.get("exposure"))),
-        _line("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
-        _line("Drawdown", _fmt_percent(payload.get("drawdown"))),
-    ]
-    return _section("KEY METRICS", lines)
-
-
-def _render_operator_note(payload: Mapping[str, Any]) -> str:
-    note = _compact_text(payload.get("operator_note"), "No operator note.", max_len=120)
-    return _section("OPERATOR NOTE", [f"• {note}"])
+    payload = {
+        "market_id": market_id,
+        "market_title": market_title,
+        "side": side,
+        "entry": entry,
+        "size": size,
+        "pnl": pnl,
+        "confidence": confidence,
+        "edge": edge,
+        "current": current,
+        "opened_at": opened_at,
+    }
+    return _render_position_card(payload, market_label)
 
 
 async def render_dashboard(payload: Mapping[str, Any]) -> str:
-    """Premium dashboard entry point with safe defaults and view personality."""
+    """Premium dashboard entry point with emoji hierarchy and tree readability."""
     normalized: dict[str, Any] = dict(payload or {})
     mode = _safe_text(normalized.get("mode"), "home").lower()
 
@@ -304,33 +308,15 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
     market_label = _resolve_market_label(normalized, context)
 
     blocks: list[str] = [
-        _hero_block(mode, normalized, market_label),
-        _primary_state(mode, normalized),
-        _render_metrics(normalized),
+        _hero_block(mode, normalized),
+        _primary_block(mode, normalized),
     ]
 
-    has_position = bool(normalized.get("market_id")) or mode in {"trade", "positions"}
-    if has_position:
-        blocks.append(
-            await render_position(
-                normalized.get("market_id"),
-                normalized.get("side"),
-                normalized.get("entry"),
-                normalized.get("size"),
-                normalized.get("pnl"),
-                normalized.get("confidence"),
-                normalized.get("edge"),
-                current=normalized.get("current", normalized.get("current_price")),
-                opened_at=normalized.get("opened_at"),
-                market_title=normalized.get("market_title") or normalized.get("market_question"),
-            )
-        )
+    position_card = _render_position_card(normalized, market_label)
+    if position_card:
+        blocks.append(position_card)
 
-    blocks.extend(
-        [
-            _render_market_context(normalized, market_label),
-            _render_operator_note(normalized),
-        ]
-    )
+    blocks.append(_render_market_card(normalized, market_label))
+    blocks.append(_render_operator_note(normalized))
 
     return "\n\n".join(blocks)

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md
@@ -1,0 +1,75 @@
+# telegram_emoji_hierarchy_v3_20260406
+
+## 1. What was built
+- Completed FORGE-X correction pass for Telegram premium UI presentation v3 in the Telegram UI-only scope.
+- Reworked formatter output to enforce emoji-led section hierarchy and mandatory tree-line readability using the exact visual pattern: `|-> field: value`.
+- Reframed screen structure into clear operator scan flow:
+  - hero state first
+  - primary view summary second
+  - position and market cards next
+  - operator note last
+- Upgraded position card ordering and readability to one-glance structure with side visibility (`🟢 YES` / `🔴 NO`) and stable metric order.
+- Hardened market card label prioritization so human-readable market title/question appears first; raw market ID is kept as secondary metadata only (`Ref`).
+- Kept changes limited to Telegram UI formatting and view adaptation paths only; no strategy/risk/execution/infra/async logic changed.
+
+## 2. Design principles
+- **Emoji-led hierarchy is structural, not decorative**: every major block has a consistent emoji title (e.g., `🏠 Home Command`, `📊 Portfolio`, `📡 Market`, `🎯 Position`, `🧠 Operator Note`).
+- **Tree-style readability is mandatory**: primary data lines now use `|->` consistently for fast mobile scanning.
+- **View personalities are differentiated**: home/wallet/positions/pnl/performance/exposure/risk/strategy/market each has distinct primary block semantics under one visual language.
+- **Human readability before raw identifiers**: market title/question is headline; IDs appear only as secondary reference metadata.
+- **Sparse payload resilience**: missing fields render intentional defaults without `None`, crashes, or raw dumps.
+- **Monotony reduction**: removed separator-heavy rhythm and flat bullets in favor of compact grouped blocks.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+### Emoji hierarchy improvement
+- **Before**: repeated flat section rhythm with weak visual identity across views.
+- **After**: explicit emoji-led blocks anchor each screen and improve 2-second scan recognition.
+
+### Tree structure implementation
+- **Before**: bullet/flat lines (`•`, `◦`) and separator-centric grouping.
+- **After**: all primary content is tree style (`|-> ...`) with compact section grouping.
+
+### Monotony reduction
+- **Before**: repeating pattern of divider + flat bullet stacks.
+- **After**: hero + summary + cards + operator note flow, with purposeful spacing and reduced visual sameness.
+
+### Market readability improvement
+- **Before**: market context could present too generically and feel report-like.
+- **After**: `📡 Market` card now prioritizes human-readable `Title`, `Regime`, `Edge`, and short `Summary`, with `Ref` only as secondary metadata.
+
+### Position readability improvement
+- **Before**: position emphasis could be less glanceable and less clearly prioritized.
+- **After**: `🎯 Position` card now uses stable, operator-first order:
+  - Market
+  - Side
+  - Entry
+  - Now
+  - Size
+  - UPNL
+  - Opened
+  - Status
+  - Ref (secondary)
+
+### Sparse payload safety
+- Verified sparse payload render (`{"market_id": "0x1234"}`) produces intentional output with no crash, no `None` dump, and valid fallback labels.
+
+### No logic-layer drift
+- Verified touched files are limited to UI formatter and Telegram view handler.
+- No edits under:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/strategy/`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/risk/`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/`
+
+## 5. Issues
+- In this container, market context API can be unreachable (`clob.polymarket.com` network unavailable). UI degrades safely to local label resolution and short market fallback while preserving hierarchy.
+- Telegram client font scaling and line wrapping can vary by device; layout is tuned for mobile-first short lines but final line wraps remain client-dependent.
+
+## 6. Next
+- SENTINEL validation required for telegram-emoji-hierarchy-v3 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md


### PR DESCRIPTION
### Motivation
- Correct a presentation drift where the v2 Telegram UI output remained flat and insufficiently hierarchical in operator-facing messages. 
- Deliver a mobile-first, premium-feeling Telegram presentation that makes market and position information readable at a glance using emoji-led section titles and a strict `|-> field: value` tree pattern.

### Description
- Implemented a new emoji-led presentation and tree-line rendering in `projects/polymarket/polyquantbot/interface/ui_formatter.py`, including `VIEW_TITLE`, `_tree` lines, `🎯 Position` and `📡 Market` card renderers, and robust human-readable market label resolution. 
- Updated `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to strengthen payload shaping (added `available_balance`, and stable `side`/`entry`/`size` fields) and to route view personalities for `home`, `wallet`, `positions`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, and `market(s)` without touching strategy/risk/execution logic. 
- Added the required FORGE-X report at `projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md` and updated `PROJECT_STATE.md` to record the v3 correction pass and link the report. 
- Changes are UI-only and limited to the two formatter/view files plus the report and `PROJECT_STATE.md` per scope guard.

### Testing
- Successfully type-checked/compiled both modified modules with `python -m py_compile projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py`. (Passed)
- Ran a smoke rendering script calling `render_view(...)` for `home`, `wallet`, `market`, and `positions` and asserted that each rendered message begins with an emoji-led title and contains the `|-> ` tree pattern; the smoke assertions passed and sample outputs were observed. (Passed)
- Verified there are no forbidden `phase*/` folders with `find` and verified modified files list shows only the allowed UI paths; checks passed. (Passed)
- Created the FORGE-X report and updated `PROJECT_STATE.md` to reflect v3 status as required by the FORGE-X workflow. (Completed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b0242488832ea5b750e53c1209b7)