### PR TITLE
Normalize Telegram menus to premium tree hierarchy (├/└) across all views

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,16 +1,16 @@
 Last Updated  : 2026-04-06
-Status        : FORGE-X Telegram Premium UI v3 correction pass complete (pending SENTINEL validation)
+Status        : FORGE-X Telegram all-menu tree hierarchy premium pass complete (pending SENTINEL validation)
 COMPLETED     :
-- Telegram premium UI v3 correction pass (2026-04-06): enforced emoji-led hierarchy and mandatory `|->` tree readability, strengthened one-glance position/market cards, and differentiated Telegram view personalities for operator-first mobile scan.
-- Drift correction acknowledged: Telegram premium UI v2 was insufficient in actual Telegram presentation (output remained too flat/monotonous), requiring this v3 correction pass.
+- Telegram all-menu tree hierarchy premium pass (2026-04-06): normalized operator-facing Telegram menus to one emoji-led tree grammar with mandatory `├` / `└`, added premium empty states, improved position/market readability, and unified footer/meta behavior.
+- Prior partial passes were insufficient in real Telegram output (residual flat style and mixed hierarchy persisted), requiring this all-menu normalization pass.
 
 IN PROGRESS   :
 - N/A
 
 NEXT PRIORITY :
-- SENTINEL validation required for telegram-emoji-hierarchy-v3 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/telegram_emoji_hierarchy_v3_20260406.md
+- SENTINEL validation required for telegram-tree-hierarchy-all-menus before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md
 
 KNOWN ISSUES  :
-- Market context API lookup may be unreachable from this container; formatter safely falls back to human-readable local fields and short market label without crashing.
-- Telegram client-specific font and wrapping differences may still produce minor line-wrap variation across devices despite mobile-first compact formatting.
+- Real Telegram screenshot capture is not available in this Codex environment; visual verification used formatter outputs instead.
+- Telegram client-specific font and wrapping differences may still produce minor line-wrap variation across devices.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -20,6 +20,7 @@ def _first_present(payload: Mapping[str, Any], *keys: str, default: Any = None) 
 
 def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
     positions = _as_list(payload.get("positions"))
+    markets = _as_list(payload.get("markets"))
     return {
         "state": payload.get("status", "waiting"),
         "mode": mode,
@@ -50,6 +51,9 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "opened_at": _first_present(payload, "opened_at", "opened", "opened_time", "created_at"),
         "strategy_mode": payload.get("strategy_mode"),
         "signal_state": payload.get("signal_state"),
+        "markets_total": payload.get("markets_total", payload.get("total_markets", len(markets))),
+        "markets_active": payload.get("markets_active", payload.get("active_markets", 0)),
+        "updated_at": _first_present(payload, "updated_at", "last_updated", "timestamp", "time"),
     }
 
 
@@ -58,10 +62,10 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
     safe_payload: Mapping[str, Any] = payload or {}
 
     if action == "trade":
-        dashboard_payload = _base_payload("positions", safe_payload)
+        dashboard_payload = _base_payload("trade", safe_payload)
         dashboard_payload.update(
             {
-                "mode": "positions",
+                "mode": "trade",
                 "side": safe_payload.get("side", safe_payload.get("direction", "flat")),
                 "entry": safe_payload.get("entry", safe_payload.get("entry_price", 0)),
                 "size": safe_payload.get("size", safe_payload.get("allocation", 0)),
@@ -154,12 +158,24 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
         return await render_dashboard(dashboard_payload)
 
     if action in {"market", "markets"}:
-        dashboard_payload = _base_payload("market", safe_payload)
+        mode = "markets" if action == "markets" else "market"
+        dashboard_payload = _base_payload(mode, safe_payload)
         dashboard_payload.update(
             {
                 "decision": safe_payload.get("decision", "Scan for asymmetric opportunity"),
                 "operator_note": safe_payload.get("operator_note", "Use market context before committing capital"),
                 "insight": safe_payload.get("insight", "Market title-first rendering keeps ids secondary"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action in {"refresh", "summary"}:
+        dashboard_payload = _base_payload("refresh", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Snapshot refreshed — review posture before next action"),
+                "operator_note": safe_payload.get("operator_note", "Refresh confirms current state only; execution remains gated"),
+                "insight": safe_payload.get("insight", "Refresh summary keeps operators aligned with latest values"),
             }
         )
         return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -9,16 +9,17 @@ from projects.polymarket.polyquantbot.data.market_context import get_market_cont
 
 VIEW_TITLE = {
     "home": "🏠 Home Command",
-    "wallet": "🧾 Wallet",
-    "positions": "🎯 Position Monitor",
-    "trade": "🎯 Position Monitor",
+    "wallet": "💼 Wallet Snapshot",
+    "positions": "📈 Open Positions",
+    "trade": "🎯 Trade Detail",
     "pnl": "💰 PnL",
     "performance": "📈 Performance",
     "exposure": "📊 Exposure",
     "risk": "⚠️ Risk",
     "strategy": "⚙️ Strategy",
     "market": "📡 Market",
-    "markets": "📡 Market",
+    "markets": "🛰️ Markets",
+    "refresh": "🔄 Refresh Summary",
 }
 
 
@@ -108,8 +109,15 @@ def _direction(value: object) -> str:
     return f"🟡 {side}"
 
 
-def _tree(label: str, value: object) -> str:
-    return f"|-> {label}: {value}"
+def _tree_group(items: list[tuple[str, object]]) -> list[str]:
+    if not items:
+        return []
+    lines: list[str] = []
+    last_index = len(items) - 1
+    for idx, (label, value) in enumerate(items):
+        branch = "└" if idx == last_index else "├"
+        lines.append(f"{branch} {label}: {value}")
+    return lines
 
 
 def _section(title: str, lines: list[str]) -> str:
@@ -117,6 +125,10 @@ def _section(title: str, lines: list[str]) -> str:
 
 
 def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]) -> str:
+    def _is_generic_label(text: str) -> bool:
+        compact = text.strip().lower()
+        return compact in {"market", "market #", "untitled"} or compact.startswith("market #")
+
     for candidate in (
         payload.get("market_title"),
         payload.get("market_name"),
@@ -126,7 +138,7 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
         payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
-        if text:
+        if text and not _is_generic_label(text):
             return text
 
     market_id = _safe_text(payload.get("market_id"), "")
@@ -141,91 +153,117 @@ def _hero_block(mode: str, payload: Mapping[str, Any]) -> str:
     risk_state = _compact_text(payload.get("risk_state"), "within limits", max_len=56)
     return _section(
         VIEW_TITLE.get(mode, VIEW_TITLE["home"]),
-        [
-            _tree("Status", status),
-            _tree("Now", decision),
-            _tree("Risk", risk_state),
-        ],
+        _tree_group(
+            [
+                ("Status", status),
+                ("Now", decision),
+                ("Risk", risk_state),
+            ]
+        ),
     )
 
 
 def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
-    personalities: dict[str, tuple[str, list[str]]] = {
+    personalities: dict[str, tuple[str, list[tuple[str, object]]]] = {
         "home": (
             "📊 Portfolio",
             [
-                _tree("Equity", _fmt_currency(payload.get("equity"))),
-                _tree("Exposure", _fmt_percent(payload.get("exposure"))),
-                _tree("Open Positions", _safe_int(payload.get("positions"))),
+                ("Total Value", _fmt_currency(payload.get("equity"))),
+                ("Exposure", _fmt_percent(payload.get("exposure"))),
+                ("Open Positions", _safe_int(payload.get("positions"))),
             ],
         ),
         "wallet": (
-            "🧾 Wallet",
+            "💰 Account",
             [
-                _tree("Equity", _fmt_currency(payload.get("equity"))),
-                _tree("Available", _fmt_currency(payload.get("available_balance", payload.get("equity")))),
-                _tree("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+                ("Total Value", _fmt_currency(payload.get("equity"))),
+                ("Available Balance", _fmt_currency(payload.get("available_balance", payload.get("equity")))),
+                ("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
             ],
         ),
         "positions": (
-            "🎯 Position Monitor",
+            "💼 Portfolio",
             [
-                _tree("Open Positions", _safe_int(payload.get("positions"))),
-                _tree("Exposure", _fmt_percent(payload.get("exposure"))),
-                _tree("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+                ("Total Value", _fmt_currency(payload.get("equity"))),
+                ("PNL", _fmt_signed_currency(payload.get("pnl"))),
+                ("Markets Traded", _safe_int(payload.get("positions"))),
+            ],
+        ),
+        "trade": (
+            "🧭 Trade Focus",
+            [
+                ("Status", _safe_text(payload.get("state"), "ready").upper()),
+                ("Signal Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+                ("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
             ],
         ),
         "pnl": (
             "💰 PnL",
             [
-                _tree("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
-                _tree("Realized", _fmt_signed_currency(payload.get("realized_pnl"))),
-                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                ("Unrealized", _fmt_signed_currency(payload.get("pnl"))),
+                ("Realized", _fmt_signed_currency(payload.get("realized_pnl"))),
+                ("Drawdown", _fmt_percent(payload.get("drawdown"))),
             ],
         ),
         "performance": (
-            "📈 Performance",
+            "🏁 Scorecard",
             [
-                _tree("Net PnL", _fmt_signed_currency(payload.get("pnl"))),
-                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
-                _tree("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
+                ("Net PnL", _fmt_signed_currency(payload.get("pnl"))),
+                ("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                ("Confidence", _fmt_percent(payload.get("confidence"), already_percent=True)),
             ],
         ),
         "exposure": (
-            "📊 Exposure",
+            "🧱 Concentration",
             [
-                _tree("Portfolio Exposure", _fmt_percent(payload.get("exposure"))),
-                _tree("Open Positions", _safe_int(payload.get("positions"))),
-                _tree("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+                ("Portfolio Exposure", _fmt_percent(payload.get("exposure"))),
+                ("Open Positions", _safe_int(payload.get("positions"))),
+                ("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
             ],
         ),
         "risk": (
-            "⚠️ Risk",
+            "🛡️ Risk Preset",
             [
-                _tree("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
-                _tree("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
-                _tree("Drawdown", _fmt_percent(payload.get("drawdown"))),
+                ("Risk Tier", _safe_text(payload.get("risk_level"), "standard")),
+                ("Limit State", _safe_text(payload.get("risk_state"), "within limits")),
+                ("Drawdown", _fmt_percent(payload.get("drawdown"))),
             ],
         ),
         "strategy": (
-            "⚙️ Strategy",
+            "🎛️ Activation",
             [
-                _tree("Mode", _safe_text(payload.get("strategy_mode"), "default")),
-                _tree("Signal", _safe_text(payload.get("signal_state"), "monitoring")),
-                _tree("Activation", _safe_text(payload.get("state"), "active")),
+                ("Mode", _safe_text(payload.get("strategy_mode"), "default")),
+                ("Signal", _safe_text(payload.get("signal_state"), "monitoring")),
+                ("Activation", _safe_text(payload.get("state"), "active")),
             ],
         ),
         "market": (
             "📡 Market",
             [
-                _tree("Regime", _safe_text(payload.get("trend"), "neutral")),
-                _tree("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
-                _tree("Context", "Risk 0.25 · Max Pos 0.10"),
+                ("Regime", _safe_text(payload.get("trend"), "neutral")),
+                ("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
+                ("Summary", "Risk 0.25 · Max Pos 0.10"),
+            ],
+        ),
+        "markets": (
+            "🗂️ Market Scan",
+            [
+                ("Scanned", _safe_int(payload.get("markets_total"))),
+                ("Active", _safe_int(payload.get("markets_active"))),
+                ("Focus", _compact_text(payload.get("decision"), "Scan for asymmetric opportunity", max_len=56)),
+            ],
+        ),
+        "refresh": (
+            "🔄 Snapshot",
+            [
+                ("State", _safe_text(payload.get("state"), "running").upper()),
+                ("Open Positions", _safe_int(payload.get("positions"))),
+                ("PNL", _fmt_signed_currency(payload.get("pnl"))),
             ],
         ),
     }
     title, lines = personalities.get(mode, personalities["home"])
-    return _section(title, lines)
+    return _section(title, _tree_group(lines))
 
 
 def _render_position_card(payload: Mapping[str, Any], market_label: str) -> str:
@@ -234,36 +272,65 @@ def _render_position_card(payload: Mapping[str, Any], market_label: str) -> str:
 
     now_value = payload.get("current") if payload.get("current") is not None else payload.get("entry")
     lines = [
-        _tree("Market", market_label),
-        _tree("Side", _direction(payload.get("side"))),
-        _tree("Entry", _fmt_probability_cents(payload.get("entry"))),
-        _tree("Now", _fmt_probability_cents(now_value)),
-        _tree("Size", _fmt_currency(payload.get("size"))),
-        _tree("UPNL", _fmt_signed_currency(payload.get("pnl"))),
-        _tree("Opened", _format_opened_time(payload.get("opened_at"))),
-        _tree("Status", _safe_text(payload.get("position_status"), "Monitoring")),
+        ("Market", market_label),
+        ("Side", _direction(payload.get("side"))),
+        ("Entry", _fmt_probability_cents(payload.get("entry"))),
+        ("Now", _fmt_probability_cents(now_value)),
+        ("Size", _fmt_currency(payload.get("size"))),
+        ("UPNL", _fmt_signed_currency(payload.get("pnl"))),
+        ("Opened", _format_opened_time(payload.get("opened_at"))),
+        ("Status", _safe_text(payload.get("position_status"), "Monitoring")),
     ]
     market_id = _safe_text(payload.get("market_id"), "")
     if market_id:
-        lines.append(_tree("Ref", market_id[:18]))
-    return _section("🎯 Position", lines)
+        lines.append(("Ref", market_id[:18]))
+    return _section("🎯 Position", _tree_group(lines))
 
 
 def _render_market_card(payload: Mapping[str, Any], market_label: str) -> str:
-    lines = [
-        _tree("Title", market_label),
-        _tree("Regime", _safe_text(payload.get("trend"), "neutral")),
-        _tree("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
-        _tree("Summary", _compact_text(payload.get("insight"), "Monitoring market context", max_len=84)),
+    lines: list[tuple[str, object]] = [
+        ("Title", market_label),
+        ("Regime", _safe_text(payload.get("trend"), "neutral")),
+        ("Edge", _safe_text(payload.get("edge_label"), _fmt_signed_percent(payload.get("edge")))),
+        ("Summary", _compact_text(payload.get("insight"), "Monitoring market context", max_len=84)),
     ]
     if payload.get("market_id"):
-        lines.append(_tree("Ref", _safe_text(payload.get("market_id"))))
-    return _section("📡 Market", lines)
+        lines.append(("Ref", _safe_text(payload.get("market_id"))))
+    return _section("📡 Market", _tree_group(lines))
 
 
 def _render_operator_note(payload: Mapping[str, Any]) -> str:
     note = _compact_text(payload.get("operator_note"), "Monitoring with current safeguards.", max_len=100)
-    return _section("🧠 Operator Note", [_tree("Note", note)])
+    return _section("💡 Operator Note", _tree_group([("Guidance", note)]))
+
+
+def _render_empty_state(mode: str, payload: Mapping[str, Any]) -> str:
+    if mode in {"positions", "trade"} and _safe_int(payload.get("positions")) <= 0:
+        return "\n".join(
+            [
+                "No positions found.",
+                "",
+                "💡 Start trading to see your positions — use tabs to switch views.",
+            ]
+        )
+    if mode in {"market", "markets"} and not (
+        payload.get("market_title") or payload.get("market_question") or payload.get("market_id")
+    ):
+        return "\n".join(
+            [
+                "No market context available.",
+                "",
+                "💡 Refresh markets to load a title-first summary.",
+            ]
+        )
+    return ""
+
+
+def _render_meta(payload: Mapping[str, Any]) -> str:
+    updated = _safe_text(payload.get("updated_at"), "")
+    if not updated:
+        updated = datetime.now(timezone.utc).strftime("%H:%M:%S.%f")[:12]
+    return f"🕒 Last updated: {updated}"
 
 
 async def render_position(
@@ -307,16 +374,17 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
     context = await get_market_context(_safe_text(normalized.get("market_id"), "")) or {}
     market_label = _resolve_market_label(normalized, context)
 
-    blocks: list[str] = [
-        _hero_block(mode, normalized),
-        _primary_block(mode, normalized),
-    ]
+    blocks: list[str] = [_hero_block(mode, normalized), _primary_block(mode, normalized)]
 
     position_card = _render_position_card(normalized, market_label)
     if position_card:
         blocks.append(position_card)
 
     blocks.append(_render_market_card(normalized, market_label))
+    empty_state = _render_empty_state(mode, normalized)
+    if empty_state:
+        blocks.append(empty_state)
     blocks.append(_render_operator_note(normalized))
+    blocks.append(_render_meta(normalized))
 
     return "\n\n".join(blocks)

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md
@@ -1,0 +1,66 @@
+# telegram_tree_hierarchy_all_menus_20260406
+
+## 1. What was built
+- Implemented an all-menu Telegram hierarchy pass to normalize every operator-facing menu onto one premium tree grammar using `├` and `└`.
+- Replaced primary content rendering in the core Telegram formatter from legacy `|->` lines to strict tree-branch lines with correct terminal-branch behavior.
+- Upgraded all key view personalities to remain distinct while sharing the same visual system:
+  - home (command center)
+  - wallet (account snapshot)
+  - positions (active monitor)
+  - trade (focused trade detail)
+  - pnl (money summary)
+  - performance (scorecard)
+  - exposure (concentration monitor)
+  - risk (preset + consequence)
+  - strategy (activation control)
+  - market/markets (context + readable market summary)
+  - refresh/summary (freshness snapshot)
+- Added premium empty-state rendering and guidance blocks so sparse/no-data payloads remain intentional, readable, and mobile-safe.
+- Added consistent footer/meta behavior with `🕒 Last updated` across all modes.
+
+## 2. Design principles
+- Emoji-led title first on every menu.
+- Grouped sections always rendered as explicit tree lines (`├` / `└`) for primary content.
+- Human-readable label-first ordering for positions and markets, with reference IDs only as trailing metadata.
+- Compact, scan-friendly spacing with no separator spam and no flat primary bullet lists.
+- Sparse payload safety by default: no crashes, no `None` dumping, no raw-id-first headlines when readable labels exist.
+- View-specific personalities preserved through distinct section labels and intent text while retaining one shared visual grammar.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- **All-menu hierarchy normalization**
+  - Before: mixed rendering behavior and old flat-style traces in output.
+  - After: all core menu payloads route through the same tree renderer and mode personalities.
+- **Mandatory tree char implementation**
+  - Before: primary lines used `|->`.
+  - After: primary grouped content uses `├`/`└` with last-item branch correctness.
+- **Empty-state improvement**
+  - Before: sparse states could feel plain and less intentional.
+  - After: no-data states now include clean message + guidance + footer timestamp.
+- **Position readability improvement**
+  - Before: position output was less aligned to one-glance ordering requirements.
+  - After: position cards prioritize market label, side, entry/now, size, UPNL, opened, status, and reference last.
+- **Market readability improvement**
+  - Before: market rendering could feel generic and ID-heavy.
+  - After: market card leads with title, regime, edge, and summary, with `Ref` trailing.
+- **Monotony reduction**
+  - Before: repeated list rhythm and less differentiated view identity.
+  - After: title + grouped blocks + optional empty state + guidance + consistent meta footer.
+- **Sparse payload safety**
+  - Confirmed missing/partial payloads render with safe defaults and no key errors.
+- **No logic-layer drift**
+  - Changes are strictly within Telegram UI presentation paths.
+  - No strategy/risk/execution/infra/async/websocket pipeline behavior touched.
+
+## 5. Issues
+- Real Telegram screenshot capture could not be produced in this Codex environment because browser/screenshot tooling for Telegram UI capture is not available in-session.
+- Device-specific Telegram line wrapping can still vary by client font and viewport width, despite mobile-first short-line formatting.
+
+## 6. Next
+- SENTINEL validation required for telegram-tree-hierarchy-all-menus before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md


### PR DESCRIPTION
### Motivation
- Consolidate all Telegram operator-facing menus onto a single premium visual grammar to improve mobile-first scanability and eliminate mixed/flat formatting across views.
- Replace legacy primary-line rendering (`|->` and flat bullets) with explicit tree branching (`├` / `└`) and ensure human-readable headlines before raw IDs.

### Description
- Reworked `projects/polymarket/polyquantbot/interface/ui_formatter.py` to introduce `_tree_group`, convert view titles, replace `|->` outputs with `├`/`└` grouped lines, prioritize human-readable market labels, add empty-state messaging, and append a `🕒 Last updated` meta footer.
- Updated `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to provide payload plumbing for `markets`/`refresh` modes, timestamp metadata (`updated_at`), and correct `mode` for `trade` rendering while keeping all changes UI-only.
- Added the FORGE-X report `projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md` and updated `PROJECT_STATE.md` to reflect completion and next steps for SENTINEL validation.
- Files changed: `interface/ui_formatter.py`, `interface/telegram/view_handler.py`, `reports/forge/telegram_tree_hierarchy_all_menus_20260406.md`, and `PROJECT_STATE.md`.

### Testing
- Compiled modified modules with `python -m compileall projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py` and the compilation succeeded.
- Exercised `render_view(...)` across required menus (`home`, `wallet`, `positions`, `trade`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, `market`, `markets`, `refresh`) and validated consistent `├`/`└` tree output and view personalities in automated runs, which passed.
- Tested sparse/no-data flows via `render_view('positions', sparse_payload)` and `render_view('market', sparse_payload)` to verify premium empty-state messaging and safe fallbacks, which passed; grep confirmed legacy `|->` primary-lines are no longer generated.
- Note: real Telegram screenshots could not be captured in this environment and are documented in the report as a known limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b6e78b30832e87d9ad5c410444f8)