### PR TITLE
sentinel: validate telegram tree hierarchy all menus

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_tree_hierarchy_all_menus_validation_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_tree_hierarchy_all_menus_validation_20260406.md
@@ -1,0 +1,182 @@
+# SENTINEL Validation — telegram-tree-hierarchy-all-menus (2026-04-06)
+
+## 1) Target
+- Branch: `feature/telegram-tree-hierarchy-all-menus-20260406`
+- FORGE-X report: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_tree_hierarchy_all_menus_20260406.md`
+- State file: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Code under validation:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+
+## 2) Score
+- **96 / 100**
+- Deduction rationale:
+  - `-2`: Telegram client-native screenshot/device rendering not reproducible in this environment.
+  - `-2`: External market-context network path unavailable during runtime checks (fallback behavior validated).
+
+## 3) Findings by phase
+
+### Phase 0 — Preconditions
+**PASS**
+- FORGE report exists at required path and includes 6 sections (`What was built`, `Design principles`, `Files changed`, `Before/after improvement summary`, `Issues`, `Next`).
+- `PROJECT_STATE.md` aligned: status indicates FORGE complete and pending SENTINEL validation with source path.
+- Target files exist and compile.
+- Scope check from latest commit is UI-only (`PROJECT_STATE.md`, `ui_formatter.py`, `view_handler.py`, forge report).
+
+### Phase 1 — Static evidence
+**PASS**
+- Tree branch renderer is centralized and enforces `├` for non-terminal rows and `└` for terminal row:
+  - `_tree_group(...)` builds branch prefixes with strict last-item logic.
+- Home/wallet/positions/trade/pnl/performance/exposure/risk/strategy/market/markets/refresh all route through `_primary_block(...)` where section rows are rendered with `_tree_group(...)`.
+- Title-first market label behavior is implemented in `_resolve_market_label(...)`, preferring title/question/name and falling back to market ID only when needed.
+- Legacy `|->` formatter traces were not found in validated UI files.
+
+### Phase 2 — Runtime render proof (all major views)
+**PASS**
+Runtime render executed for:
+- `home`, `wallet`, `positions`, `trade`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, `market`, `markets`, `refresh`, `summary`.
+
+Validated for each output:
+- emoji-led title present,
+- tree chars `├` and `└` present,
+- no `|->` legacy marker,
+- scan-friendly grouped section formatting.
+
+Observed examples:
+- home: `🏠 Home Command` with tree rows under status/now/risk and portfolio summary.
+- positions: `📈 Open Positions` + tree-structured position card.
+- market/markets: tree-structured market cards and scan blocks.
+- refresh/summary: routed to refresh mode with tree-structured snapshot.
+
+### Phase 3 — Empty-state validation
+**PASS**
+Validated outputs for:
+- positions empty (`positions_count=0`, empty list) → intentional message + guidance.
+- markets empty → intentional no-context message + guidance.
+- wallet sparse → default-safe account values, intentional operator note.
+- pnl/performance sparse → default-safe metrics, no `None` dump.
+
+### Phase 4 — Sparse payload / degraded input validation
+**PASS**
+Negative payloads tested:
+- only `market_id`,
+- missing `market_title` / `question`,
+- missing timestamps,
+- partial trade payload,
+- empty positions list,
+- missing optional account fields.
+
+Results:
+- no crash,
+- no `KeyError`,
+- no raw `None` leakage,
+- readable fallback maintained,
+- tree formatting preserved where applicable.
+
+### Phase 5 — Break attempt
+**PASS**
+Attempted to break formatting by checking for:
+- old `|->` outputs,
+- malformed tree terminal rows,
+- mixed old/new primary content style,
+- raw ID headline precedence when readable label exists.
+
+Result:
+- no legacy marker found in runtime outputs,
+- section-level terminal branch validation found zero malformed blocks,
+- title-first label behavior observed when human-readable title available,
+- ID used as fallback reference when only ID provided (expected behavior).
+
+### Phase 6 — Screenshot / real-output alignment
+**PARTIAL PASS (non-blocking)**
+- Renderer runtime outputs match FORGE claims for tree hierarchy and menu coverage.
+- Telegram client screenshot/device-level capture is not available in this Codex session, so validation is based on actual renderer outputs rather than in-app screenshots.
+
+### Phase 7 — Regression scope check
+**PASS**
+- Latest feature commit touched only:
+  - `PROJECT_STATE.md`
+  - `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - FORGE report file
+- No file changes detected under:
+  - `projects/polymarket/polyquantbot/strategy/`
+  - `projects/polymarket/polyquantbot/risk/`
+  - `projects/polymarket/polyquantbot/execution/`
+- No evidence of async/websocket/infra/pipeline behavior changes in target diff scope.
+
+## 4) Evidence
+
+### Commands run
+1. Compile check:
+```bash
+python -m py_compile projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+```
+
+2. Scope check (latest commit files):
+```bash
+git log -1 --name-only --pretty=format:'%H %s'
+```
+Output included only UI + state + forge report files.
+
+3. Legacy marker static scan:
+```bash
+rg -n "\|->|^-\s|^={3,}|^[-]{3,}|•" projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+```
+Result: no matches for legacy marker patterns in validated files.
+
+4. Runtime render sweep (all major views):
+```bash
+python - <<'PY'
+# async render_view() loop over home/wallet/positions/trade/pnl/performance/exposure/risk/strategy/market/markets/refresh/summary
+PY
+```
+Result: all views showed tree chars, no `|->`, emoji-led titles.
+
+5. Sparse/empty negative tests:
+```bash
+python - <<'PY'
+# cases: positions_empty, markets_empty, wallet_sparse, pnl_sparse, performance_sparse,
+# market_only_id, market_missing_title_question, trade_partial, refresh_missing_optional
+PY
+```
+Result: no crash, no KeyError, no None dump, readable fallbacks.
+
+6. Tree terminal integrity check:
+```bash
+python - <<'PY'
+# parse each section block; assert terminal row starts with └ and prior rows start with ├
+PY
+```
+Result: `TOTAL_BAD 0`.
+
+### Runtime snippets
+- Example (home):
+  - `🏠 Home Command`
+  - `├ Status: RUNNING`
+  - `├ Now: Prefer YES where edge is stable`
+  - `└ Risk: within limits`
+
+- Example (markets empty):
+  - `🛰️ Markets`
+  - `🗂️ Market Scan` with tree rows
+  - `No market context available.`
+  - `💡 Refresh markets to load a title-first summary.`
+
+- Example (positions empty):
+  - `📈 Open Positions`
+  - `No positions found.`
+  - `💡 Start trading to see your positions — use tabs to switch views.`
+
+## 5) Critical issues
+- No critical blocking defects found in tree hierarchy behavior for the validated menus.
+- Non-blocking limitations:
+  - Network-unreachable warning while fetching market context (`market_context_api_failed`) observed during runtime; UI fallback rendered correctly.
+  - Telegram client-native screenshot capture unavailable in this environment.
+
+## 6) Verdict
+**CONDITIONAL**
+
+Rationale:
+- Functional renderer behavior satisfies all-menu tree hierarchy requirements with strong code + runtime + negative-test evidence.
+- Conditional (not full approval) is assigned due to environment-level inability to capture real Telegram client screenshots and transient network unavailability on market-context fetch path during test session.


### PR DESCRIPTION
### Motivation
- Validate that the FORGE-X "Telegram all-menu tree hierarchy" pass is real in behavior (not only a report claim) and that all operator-facing Telegram menus render with the mandated tree grammar (`├` / `└`) and emoji-led titles.
- Ensure no residual legacy primary formatting (e.g. `|->`, flat bullet lists, divider-heavy layout) remains and that empty/sparse payloads render safe, premium empty states.

### Description
- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/telegram_tree_hierarchy_all_menus_validation_20260406.md` that documents phase-by-phase findings, evidence, and the final verdict (`CONDITIONAL`).
- Performed static inspection of `projects/polymarket/polyquantbot/interface/ui_formatter.py` and `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` and confirmed the centralized tree renderer (`_tree_group`) and mode routing (`render_dashboard` / `_primary_block`) implement strict `├`/`└` semantics and title-first market labeling.
- Confirmed scope is UI-only and there is no logic-layer drift: no changes under `strategy/`, `risk/`, or `execution/`, and no async/websocket/infra/pipeline behavior was altered.
- Recorded the SENTINEL verdict as `CONDITIONAL` due to environment-level limitations (no Telegram client screenshots and transient network-unreachable warnings during market-context fetch), while functional behavior passed all required checks.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py` — compilation passed.
- Static scan for legacy markers with `rg -n "\|->|^-\s|^={3,}|^[-]{3,}|•"` against the two UI files — no legacy primary-style matches found.
- Runtime render sweep calling `render_view(...)` for `home,wallet,positions,trade,pnl,performance,exposure,risk,strategy,market,markets,refresh,summary` — all views produced emoji-led titles and contained both `├` and `└` with no `|->` present (passed); network-unreachable warnings observed but UI fallback behavior validated.
- Sparse/empty negative tests (positions empty, markets empty, wallet sparse, pnl/performance sparse, market-only-id, missing title/question, partial trade, refresh missing optional) executed via the test harness — no crashes, no `KeyError`, no raw `None` dumps, and readable fallbacks produced.
- Tree terminal integrity check script (assert terminal row starts with `└` and prior rows start with `├`) run across sample payloads — `TOTAL_BAD 0` (passed).
- Final outcome: functional and behavioral validation passed with strong evidence, score `96/100`, verdict `CONDITIONAL` due to the two non-blocking environment limitations noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d4d9ca78832ea438365ce89859d1)