### PR TITLE
feat: Telegram full menu fix — unify renderer, isolate Position/Market cards, title-first labels

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,17 +1,19 @@
 Last Updated  : 2026-04-06
-Status        : FORGE-X Telegram live coverage fix pass complete (pending SENTINEL validation)
+Status        : FORGE-X Telegram full menu fix pass complete (pending SENTINEL validation)
 COMPLETED     :
-- Telegram live coverage fix pass (2026-04-06): audited callback/menu/operator-facing Telegram output paths and rerouted core live actions to one normalized renderer path (`render_view` -> `render_dashboard`) for command/callback parity.
-- Enforced premium tree-grammar consistency for empty/sparse states in final formatter (`├` / `└`) so no-data screens follow the same design language.
-- Confirmed previous all-menu normalization was incomplete across real live callback/edit-message entry paths and resolved those bypasses in this pass.
+- Telegram live coverage fix pass (2026-04-06) normalized core callback/menu render paths but left remaining utility/control menu correctness gaps.
+- Telegram full menu fix pass (2026-04-06): completed full operator-facing menu correctness coverage across home/system/status, wallet, positions, trade, pnl, performance, exposure, risk, strategy, settings, notifications, auto-trade, mode, control, market/markets, and refresh callback/edit/send paths.
+- Enforced strict view isolation so Position/Market blocks render only in context-relevant menus; removed cross-menu bleed from unrelated utility/system/settings/control menus.
+- Upgraded settings and utility callback menus to final renderer design language with callback/command parity in live navigation paths.
+- Updated market label resolution to title/question/name-first with raw market id only as fallback reference metadata.
 
 IN PROGRESS   :
 - N/A
 
 NEXT PRIORITY :
-- SENTINEL validation required for telegram-live-coverage-fix-20260406 before merge.
-Source: /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_live_coverage_fix_20260406.md
+- SENTINEL validation required for telegram-full-menu-fix-20260406 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md
 
 KNOWN ISSUES  :
-- Real Telegram screenshot capture is not available in this Codex environment; visual verification used formatter and callback-dispatch outputs instead.
-- Some non-primary utility/settings responses outside this coverage scope may still retain legacy phrasing styles and can be normalized in a dedicated follow-up if requested.
+- Real Telegram screenshot capture is not available in this Codex environment; visual verification used formatter/callback render outputs.
+- External market-context endpoint is unreachable from this container, so live context fetches produce warning logs and fallback labels during local checks.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -11,9 +11,13 @@ _ACTION_ALIAS: dict[str, str] = {
     "menu": "home",
     "main_menu": "home",
     "dashboard": "home",
-    "status": "home",
+    "status": "system",
     "position": "positions",
     "summary": "refresh",
+    "settings_notify": "notifications",
+    "settings_auto": "auto_trade",
+    "settings_mode": "mode",
+    "settings_risk": "risk",
 }
 
 
@@ -64,6 +68,14 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "markets_total": payload.get("markets_total", payload.get("total_markets", len(markets))),
         "markets_active": payload.get("markets_active", payload.get("active_markets", 0)),
         "updated_at": _first_present(payload, "updated_at", "last_updated", "timestamp", "time"),
+        "mode_label": _first_present(payload, "mode_label", "mode", default="PAPER"),
+        "target_mode": payload.get("target_mode"),
+        "mode_guard": payload.get("mode_guard"),
+        "auto_trade_state": payload.get("auto_trade_state", "manual"),
+        "critical_alerts": payload.get("critical_alerts", "enabled"),
+        "trade_alerts": payload.get("trade_alerts", "enabled"),
+        "summary_alerts": payload.get("summary_alerts", "hourly"),
+        "control_action": payload.get("control_action", "standby"),
     }
 
 
@@ -187,6 +199,72 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
                 "decision": safe_payload.get("decision", "Snapshot refreshed — review posture before next action"),
                 "operator_note": safe_payload.get("operator_note", "Refresh confirms current state only; execution remains gated"),
                 "insight": safe_payload.get("insight", "Refresh summary keeps operators aligned with latest values"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "system":
+        dashboard_payload = _base_payload("system", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "System state synchronized across menu paths"),
+                "operator_note": safe_payload.get("operator_note", "Use status menu tabs for detailed operational views"),
+                "insight": safe_payload.get("insight", "System summary stays isolated from trade-specific cards"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "settings":
+        dashboard_payload = _base_payload("settings", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Adjust runtime preferences with guardrails enabled"),
+                "operator_note": safe_payload.get("operator_note", "Settings menus now follow the same renderer grammar"),
+                "insight": safe_payload.get("insight", "Configuration context is isolated from market and position cards"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "notifications":
+        dashboard_payload = _base_payload("notifications", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Notification delivery profile ready"),
+                "operator_note": safe_payload.get("operator_note", "Critical alerts remain always on"),
+                "insight": safe_payload.get("insight", "Alert settings are grouped in one consistent card style"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "auto_trade":
+        dashboard_payload = _base_payload("auto_trade", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Enable only after confirming risk and mode settings"),
+                "operator_note": safe_payload.get("operator_note", "Auto-trade changes execution automation, not risk limits"),
+                "insight": safe_payload.get("insight", "Automation state is explicit and isolated from market cards"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "mode":
+        dashboard_payload = _base_payload("mode", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Review target mode and environment guard before switching"),
+                "operator_note": safe_payload.get("operator_note", "Mode confirmation should match runtime safety flags"),
+                "insight": safe_payload.get("insight", "Mode transition details are rendered consistently for callbacks and commands"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "control":
+        dashboard_payload = _base_payload("control", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Control actions are available with kill-switch safeguards"),
+                "operator_note": safe_payload.get("operator_note", "Pause, resume, and stop remain explicit operator actions"),
+                "insight": safe_payload.get("insight", "Control menu is isolated from unrelated market and position cards"),
             }
         )
         return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -9,6 +9,7 @@ from projects.polymarket.polyquantbot.data.market_context import get_market_cont
 
 VIEW_TITLE = {
     "home": "🏠 Home Command",
+    "system": "🧠 System Status",
     "wallet": "💼 Wallet Snapshot",
     "positions": "📈 Open Positions",
     "trade": "🎯 Trade Detail",
@@ -20,6 +21,11 @@ VIEW_TITLE = {
     "market": "📡 Market",
     "markets": "🛰️ Markets",
     "refresh": "🔄 Refresh Summary",
+    "settings": "⚙️ Settings",
+    "notifications": "🔔 Notifications",
+    "auto_trade": "🤖 Auto Trade",
+    "mode": "🔀 Mode",
+    "control": "🎛️ Control",
 }
 
 
@@ -131,10 +137,10 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
 
     for candidate in (
         payload.get("market_title"),
-        payload.get("market_name"),
         payload.get("market_question"),
-        context.get("name"),
+        payload.get("market_name"),
         context.get("question"),
+        context.get("name"),
         payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
@@ -143,7 +149,7 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
 
     market_id = _safe_text(payload.get("market_id"), "")
     if market_id:
-        return f"Market {market_id[:12]}"
+        return f"Untitled market (ref {market_id[:12]})"
     return "Untitled market"
 
 
@@ -171,6 +177,14 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
                 ("Total Value", _fmt_currency(payload.get("equity"))),
                 ("Exposure", _fmt_percent(payload.get("exposure"))),
                 ("Open Positions", _safe_int(payload.get("positions"))),
+            ],
+        ),
+        "system": (
+            "🧠 Runtime",
+            [
+                ("State", _safe_text(payload.get("state"), "running").upper()),
+                ("Risk State", _safe_text(payload.get("risk_state"), "within limits")),
+                ("Cycle", _safe_text(payload.get("cycle"), "active")),
             ],
         ),
         "wallet": (
@@ -259,6 +273,46 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
                 ("State", _safe_text(payload.get("state"), "running").upper()),
                 ("Open Positions", _safe_int(payload.get("positions"))),
                 ("PNL", _fmt_signed_currency(payload.get("pnl"))),
+            ],
+        ),
+        "settings": (
+            "⚙️ Config Surface",
+            [
+                ("Risk Level", _safe_text(payload.get("risk_level"), "standard")),
+                ("Mode", _safe_text(payload.get("mode_label"), "PAPER")),
+                ("Auto Trade", _safe_text(payload.get("auto_trade_state"), "manual")),
+            ],
+        ),
+        "notifications": (
+            "🔔 Alerting",
+            [
+                ("Critical Alerts", _safe_text(payload.get("critical_alerts"), "enabled")),
+                ("Trade Updates", _safe_text(payload.get("trade_alerts"), "enabled")),
+                ("Summary", _safe_text(payload.get("summary_alerts"), "hourly")),
+            ],
+        ),
+        "auto_trade": (
+            "🤖 Execution Mode",
+            [
+                ("Mode", _safe_text(payload.get("mode_label"), "PAPER")),
+                ("Auto Trade", _safe_text(payload.get("auto_trade_state"), "manual")),
+                ("Risk Guard", "Kelly 0.25 · Max Pos 0.10"),
+            ],
+        ),
+        "mode": (
+            "🔀 Mode Switch",
+            [
+                ("Current", _safe_text(payload.get("mode_label"), "PAPER")),
+                ("Target", _safe_text(payload.get("target_mode"), "N/A")),
+                ("Guard", _safe_text(payload.get("mode_guard"), "Validated before switch")),
+            ],
+        ),
+        "control": (
+            "🎛️ System Control",
+            [
+                ("State", _safe_text(payload.get("state"), "running").upper()),
+                ("Action", _safe_text(payload.get("control_action"), "standby")),
+                ("Kill Switch", "Armed"),
             ],
         ),
     }
@@ -382,11 +436,16 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
 
     blocks: list[str] = [_hero_block(mode, normalized), _primary_block(mode, normalized)]
 
-    position_card = _render_position_card(normalized, market_label)
-    if position_card:
-        blocks.append(position_card)
+    position_modes = {"positions", "trade", "exposure"}
+    market_modes = {"market", "markets", "positions", "trade", "exposure"}
 
-    blocks.append(_render_market_card(normalized, market_label))
+    if mode in position_modes:
+        position_card = _render_position_card(normalized, market_label)
+        if position_card:
+            blocks.append(position_card)
+
+    if mode in market_modes:
+        blocks.append(_render_market_card(normalized, market_label))
     empty_state = _render_empty_state(mode, normalized)
     if empty_state:
         blocks.append(empty_state)

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md
@@ -1,0 +1,49 @@
+# telegram_full_menu_fix_20260406
+
+## 1. What was built
+- Completed a full Telegram operator-menu correctness pass covering command/callback/render/edit live paths for: `/start`, home/main/status/system, wallet, positions, trade, pnl, performance, exposure, risk, strategy, settings, notifications, auto-trade, mode, control, market/markets, and refresh.
+- Removed cross-menu card bleed in the final renderer by making Position and Market cards context-gated instead of globally appended.
+- Extended final renderer mode coverage for utility/control menus so settings/notifications/auto-trade/mode/control/system all use the same final tree-grammar design language.
+- Unified callback routing for settings/control utility menus into the normalized renderer path so callback-driven output matches command/menu navigation output style.
+- Fixed market label priority order to title/question/name-first with raw market id now reference-only fallback text.
+
+## 2. Design principles
+- **Menu isolation first:** operator-facing views only render context-relevant cards (no position/market bleed in unrelated menus).
+- **Single renderer grammar:** all operator-facing menus in scope use one premium tree layout and section language.
+- **Parity across entry paths:** command, callback, refresh, and edit-message paths for the same views resolve through the same `render_view -> render_dashboard` pipeline.
+- **Human-readable market labels:** visible market labels prioritize title/question/name context; raw ids are only trailing fallback metadata.
+- **UI-only scope lock:** no strategy/risk/execution/infra/websocket/async behavior changes.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- **Full menu audit coverage (before):**
+  - Status/system/home/menu paths were partially normalized, but utility/control/settings callback screens still used mixed legacy formatter blocks.
+  - Settings utility actions (`settings`, `settings_risk`, `settings_mode`, `settings_notify`, `settings_auto`) and control action feedback screens were not consistently rendered through final renderer.
+  - Position and Market cards were always appended regardless of menu context, causing bleed into unrelated screens.
+  - Market label fallback order preferred less-readable id-style outputs earlier than desired in some sparse payloads.
+- **After this pass:**
+  - Added explicit final-renderer modes for `system`, `settings`, `notifications`, `auto_trade`, `mode`, and `control`.
+  - Updated view alias mapping so `status -> system`, and settings utility callbacks normalize into final renderer modes.
+  - Callback router now normalizes settings/control menu actions through one renderer path and applies keyboard parity by context.
+  - Control action responses (`pause`, `resume`, `stop_confirm`, `stop_execute`) now return unified renderer output with state-accurate context.
+  - Cross-menu bleed fixed: Position card only in `positions/trade/exposure`; Market card only in `market/markets/positions/trade/exposure`.
+  - Market labeling now resolves title/question/name-first and only falls back to `Untitled market (ref <id>)` when no readable label exists.
+  - Empty/sparse states remain intentional and tree-consistent in normalized views (no `None` leakage introduced).
+- **Verification evidence used in this pass:**
+  - Render sweep script exercised all target operator menu actions and confirmed card isolation/parity expectations.
+  - Syntax compile pass confirmed updated live-path files are import-valid.
+  - No non-UI domains were modified.
+
+## 5. Issues
+- Live Telegram screenshot capture remains unavailable in this Codex container.
+- `get_market_context` network calls cannot reach external endpoint in this environment; formatter behavior validated with in-process render outputs and safe fallbacks.
+
+## 6. Next
+- SENTINEL validation required for telegram-full-menu-fix-20260406 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -37,11 +37,6 @@ from ..ui.keyboard import (
 )
 from ..ui.screens import (
     main_screen,
-    settings_risk_screen,
-    settings_mode_screen,
-    settings_notify_screen,
-    settings_auto_screen,
-    control_stop_confirm_screen,
     error_screen,
     noop_screen,
 )
@@ -374,14 +369,30 @@ class CallbackRouter:
         return payload
 
     async def _render_normalized_callback(self, action: str) -> tuple[str, list]:
-        from ..ui.keyboard import build_status_menu  # noqa: PLC0415
+        from ..ui.keyboard import (
+            build_status_menu,
+            build_mode_confirm_menu,
+            build_control_menu,
+            build_main_menu,
+            build_settings_menu,
+            build_risk_level_menu,
+        )  # noqa: PLC0415
 
-        normalized_action = "home" if action in {"back_main", "back", "start", "menu", "status", "home"} else action
+        normalized_action = "home" if action in {"back_main", "back", "start", "menu", "home"} else action
         payload = self._build_normalized_payload(normalized_action)
+        payload["mode_label"] = self._mode.upper()
+        if normalized_action == "settings_mode":
+            payload["target_mode"] = "PAPER" if self._mode.upper() == "LIVE" else "LIVE"
+            payload["mode_guard"] = "ENABLE_LIVE_TRADING=true required for LIVE"
+        if normalized_action == "control":
+            payload["control_action"] = "standby"
+
         text = await render_view(normalized_action, payload)
 
         if normalized_action == "home":
             return text, build_main_menu()
+        if normalized_action in {"status", "system", "refresh", "positions", "trade", "pnl", "performance", "exposure", "risk"}:
+            return text, build_status_menu()
         if normalized_action == "wallet":
             if self._mode == "PAPER" and self._paper_wallet_engine is not None:
                 from ..ui.keyboard import build_paper_wallet_menu  # noqa: PLC0415
@@ -394,7 +405,17 @@ class CallbackRouter:
                 strategies=sorted(strategy_states.keys()) if strategy_states else [],
                 active_states=strategy_states,
             )
-        return text, build_status_menu()
+        if normalized_action in {"settings", "settings_notify", "settings_auto", "notifications", "auto_trade"}:
+            return text, build_settings_menu()
+        if normalized_action in {"settings_risk"}:
+            return text, build_risk_level_menu()
+        if normalized_action in {"settings_mode", "mode"}:
+            target_mode = "PAPER" if self._mode.upper() == "LIVE" else "LIVE"
+            return text, build_mode_confirm_menu(target_mode)
+        if normalized_action == "control":
+            current_state = self._state.state.value
+            return text, build_control_menu(current_state)
+        return text, build_main_menu()
 
     # ── Dispatch table ─────────────────────────────────────────────────────────
 
@@ -443,6 +464,12 @@ class CallbackRouter:
             "market",
             "markets",
             "summary",
+            "settings",
+            "settings_risk",
+            "settings_mode",
+            "settings_notify",
+            "settings_auto",
+            "control",
         }
         if action in normalized_actions:
             return await self._render_normalized_callback(action)
@@ -506,16 +533,63 @@ class CallbackRouter:
             return await handle_control(state_manager=self._state)
 
         if action == "control_pause":
-            return await handle_pause(state_manager=self._state)
+            _, _ = await handle_pause(state_manager=self._state)
+            payload = self._build_normalized_payload("control")
+            payload.update(
+                {
+                    "mode_label": self._mode.upper(),
+                    "control_action": "paused",
+                    "decision": "System paused via control menu",
+                    "operator_note": "Resume when safety checks pass",
+                    "insight": "Control actions use the same renderer as all operator menus",
+                }
+            )
+            text = await render_view("control", payload)
+            return text, build_control_menu(self._state.state.value)
 
         if action == "control_resume":
-            return await handle_resume(state_manager=self._state)
+            _, _ = await handle_resume(state_manager=self._state)
+            payload = self._build_normalized_payload("control")
+            payload.update(
+                {
+                    "mode_label": self._mode.upper(),
+                    "control_action": "resumed",
+                    "decision": "System resumed via control menu",
+                    "operator_note": "Monitor status and exposure after resume",
+                    "insight": "Control actions use the same renderer as all operator menus",
+                }
+            )
+            text = await render_view("control", payload)
+            return text, build_control_menu(self._state.state.value)
 
         if action == "control_stop_confirm":
-            return control_stop_confirm_screen(), build_stop_confirm_menu()
+            payload = self._build_normalized_payload("control")
+            payload.update(
+                {
+                    "mode_label": self._mode.upper(),
+                    "control_action": "confirm stop",
+                    "decision": "Stop requested — confirmation required",
+                    "operator_note": "Stop triggers halt and requires manual restart",
+                    "insight": "Use confirmation to prevent accidental halts",
+                }
+            )
+            text = await render_view("control", payload)
+            return text, build_stop_confirm_menu()
 
         if action == "control_stop_execute":
-            return await handle_kill(state_manager=self._state)
+            _, _ = await handle_kill(state_manager=self._state)
+            payload = self._build_normalized_payload("control")
+            payload.update(
+                {
+                    "mode_label": self._mode.upper(),
+                    "control_action": "halted",
+                    "decision": "System halted from control menu",
+                    "operator_note": "Manual restart required before trading can resume",
+                    "insight": "Kill-switch state is now rendered in the unified menu format",
+                }
+            )
+            text = await render_view("control", payload)
+            return text, build_control_menu(self._state.state.value)
 
         if action == "noop":
             return noop_screen(), []


### PR DESCRIPTION
### Motivation
- Address founder-reported live Telegram menu correctness issues including Position/Market card bleed, inconsistent settings/utility rendering, raw market-id primary labels, and callback/command parity gaps.
- Ensure every operator-facing menu uses the single final renderer grammar and that market labels are human-readable first with raw ids as reference-only.
- Keep the change strictly UI/menu-surface only with no changes to strategy, risk, execution, infra, or async behavior.

### Description
- Extended the final formatter in `projects/polymarket/polyquantbot/interface/ui_formatter.py` with new VIEW modes (e.g., `system`, `settings`, `notifications`, `auto_trade`, `mode`, `control`), adjusted market-label resolution to prefer `market_title` → `market_question` → `market_name` → context name and changed the fallback to `Untitled market (ref <id>)`, and gated Position/Market card rendering so they only appear in context-relevant modes.
- Updated `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to normalize action aliases, add payload fields required for settings/control rendering (`mode_label`, `target_mode`, `mode_guard`, `auto_trade_state`, etc.), and added explicit render branches for `system`, `settings`, `notifications`, `auto_trade`, `mode`, and `control` to guarantee command/callback/edit parity.
- Normalized callback routing in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` by enriching the normalized payload, routing settings/control actions through the single renderer path, returning context-appropriate keyboards, and converting control actions (`pause`, `resume`, `stop_confirm`, `stop_execute`) to final-rendered feedback instead of mixed legacy blocks; also removed unused legacy screen imports.
- Added the required FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_full_menu_fix_20260406.md` and updated `PROJECT_STATE.md` to reflect completion and next steps (SENTINEL validation); all changes committed in a single batch on branch `feature/telegram-full-menu-fix-20260406`.

### Testing
- Compiled modified modules successfully with `python -m py_compile projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` (no syntax errors).
- Ran an in-process render sweep script exercising operator-facing actions (`start`, `home/system/status`, `wallet`, `positions`, `trade`, `pnl`, `performance`, `exposure`, `risk`, `strategy`, `settings` and settings_* callbacks, `control`, `market(s)`, `refresh`) and verified Position/Market card isolation, unified rendering grammar, and command/callback parity as expected.
- Observed network reachability warnings from `get_market_context` during local checks (external endpoint unreachable in this environment), but safe fallback labels and rendering behavior were validated; no non-UI domains were modified. }

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e653ef60832e831cab00cf8d4125)