### PR TITLE
feat: redesign Telegram menu and enforce market scope controls

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
 Last Updated  : 2026-04-06
-Status        : FORGE-X Telegram menu truth fix pass complete (pending SENTINEL validation)
+Status        : FORGE-X Telegram menu structure + market scope control pass complete (pending SENTINEL validation)
 COMPLETED     :
 - Telegram live coverage fix pass (2026-04-06) normalized core callback/menu render paths but left remaining utility/control menu correctness gaps.
 - Telegram full menu fix pass (2026-04-06): completed full operator-facing menu correctness coverage across home/system/status, wallet, positions, trade, pnl, performance, exposure, risk, strategy, settings, notifications, auto-trade, mode, control, market/markets, and refresh callback/edit/send paths.
@@ -8,15 +8,17 @@ COMPLETED     :
 - Updated market label resolution to title/question/name-first with raw market id only as fallback reference metadata.
 - Telegram menu truth fix pass (2026-04-06): separated positions vs exposure and pnl vs performance menu contracts, removed trade/wallet exposure bleed, fixed callback payload binding for active-position pnl movement, and added per-card ref dedup behavior in market/position cards.
 - Confirmed previous full-menu/live-coverage passes still left menu-truth and data/view-mapping gaps that required this targeted correctness pass.
+- Telegram menu structure + market scope control pass (2026-04-06): simplified root/submenu architecture to Dashboard/Portfolio/Markets/Settings/❓ Help, standardized Refresh All actions, added All Markets + category toggle + Active Scope Telegram controls, surfaced scope summary in Dashboard/Home, and wired market-scope enforcement into runtime market scanning/trading path.
 
 IN PROGRESS   :
 - N/A
 
 NEXT PRIORITY :
-- SENTINEL validation required for telegram-menu-truth-fix-20260406 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_truth_fix_20260406.md
+- SENTINEL validation required for telegram-menu-structure-20260406 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md
 
 KNOWN ISSUES  :
 - Real Telegram screenshot capture is not available in this Codex environment; visual verification used formatter/callback render outputs.
 - External market-context endpoint is unreachable from this container, so live context fetches produce warning logs and fallback labels during local checks.
 - Final on-device Telegram visual confirmation still requires external SENTINEL/live run because network-restricted local checks use fallback market-context fetch paths.
+- Market scope state currently persists in-process only and must be reselected after bot restart.

--- a/projects/polymarket/polyquantbot/core/market_scope.py
+++ b/projects/polymarket/polyquantbot/core/market_scope.py
@@ -1,0 +1,147 @@
+"""Telegram-controlled market scope state and filtering helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping
+
+MARKET_SCOPE_CATEGORIES: tuple[str, ...] = (
+    "Breaking",
+    "Politics",
+    "Trump",
+    "Crypto",
+    "Sports",
+    "Elections",
+    "World",
+    "Business",
+    "Geopolitics",
+    "Finance",
+    "Tech",
+    "Culture",
+    "Economy",
+    "Climate",
+    "Bonds",
+)
+
+_CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "Breaking": ("breaking", "urgent", "live now"),
+    "Politics": ("politic", "senate", "congress", "government"),
+    "Trump": ("trump",),
+    "Crypto": ("crypto", "bitcoin", "btc", "ethereum", "eth", "solana", "token"),
+    "Sports": ("sport", "nba", "nfl", "mlb", "nhl", "soccer", "football", "ufc"),
+    "Elections": ("election", "primary", "ballot", "vote"),
+    "World": ("world", "global", "international"),
+    "Business": ("business", "company", "corporate", "earnings", "ceo"),
+    "Geopolitics": ("geopolit", "war", "conflict", "nato", "diplomac"),
+    "Finance": ("finance", "fed", "interest rate", "stocks", "market cap", "nasdaq"),
+    "Tech": ("tech", "ai", "openai", "apple", "google", "microsoft", "meta"),
+    "Culture": ("culture", "movie", "music", "hollywood", "celebrity"),
+    "Economy": ("economy", "gdp", "inflation", "recession", "jobs"),
+    "Climate": ("climate", "weather", "temperature", "co2", "emissions"),
+    "Bonds": ("bond", "treasury", "yield curve", "10y", "2y"),
+}
+
+_lock = asyncio.Lock()
+_all_markets_enabled: bool = True
+_enabled_categories: set[str] = set()
+
+
+def _category_set() -> set[str]:
+    return set(MARKET_SCOPE_CATEGORIES)
+
+
+def _normalize_category(name: str) -> str:
+    lowered = name.strip().lower()
+    for category in MARKET_SCOPE_CATEGORIES:
+        if lowered == category.lower():
+            return category
+    return ""
+
+
+def _as_text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _infer_category(market: Mapping[str, Any]) -> str:
+    explicit_category = _normalize_category(_as_text(market.get("category")))
+    if explicit_category:
+        return explicit_category
+
+    searchable_parts: list[str] = []
+    for key in ("question", "title", "name", "description"):
+        searchable_parts.append(_as_text(market.get(key)))
+
+    tags = market.get("tags")
+    if isinstance(tags, list):
+        searchable_parts.extend(_as_text(tag) for tag in tags)
+
+    searchable = " ".join(part.lower() for part in searchable_parts if part)
+    if not searchable:
+        return ""
+
+    for category, keywords in _CATEGORY_KEYWORDS.items():
+        if any(keyword in searchable for keyword in keywords):
+            return category
+
+    return ""
+
+
+def get_market_scope_snapshot() -> dict[str, Any]:
+    enabled = sorted(_enabled_categories)
+    selection_type = "All Markets" if _all_markets_enabled else "Categories"
+    if _all_markets_enabled:
+        summary = "Trading scope: all allowed markets."
+        scope_label = "All Markets"
+    elif enabled:
+        summary = f"Trading scope: {len(enabled)} selected categories only."
+        scope_label = f"Categories ({len(enabled)})"
+    else:
+        summary = "Trading scope: blocked — no active categories selected."
+        scope_label = "No Active Categories"
+    return {
+        "all_markets_enabled": _all_markets_enabled,
+        "enabled_categories": enabled,
+        "selection_type": selection_type,
+        "active_categories_count": len(enabled),
+        "trading_scope_summary": summary,
+        "scope_label": scope_label,
+        "can_trade": _all_markets_enabled or bool(enabled),
+        "supported_categories": list(MARKET_SCOPE_CATEGORIES),
+    }
+
+
+async def toggle_all_markets() -> dict[str, Any]:
+    global _all_markets_enabled  # noqa: PLW0603
+    async with _lock:
+        _all_markets_enabled = not _all_markets_enabled
+        return get_market_scope_snapshot()
+
+
+async def toggle_category(category: str) -> dict[str, Any]:
+    global _all_markets_enabled  # noqa: PLW0603
+    normalized = _normalize_category(category)
+    if not normalized:
+        return get_market_scope_snapshot()
+
+    async with _lock:
+        if normalized in _enabled_categories:
+            _enabled_categories.remove(normalized)
+        else:
+            _enabled_categories.add(normalized)
+        _all_markets_enabled = False
+        return get_market_scope_snapshot()
+
+
+async def apply_market_scope(markets: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    snapshot = get_market_scope_snapshot()
+    if snapshot["all_markets_enabled"]:
+        return markets, snapshot
+
+    enabled = set(snapshot["enabled_categories"])
+    if not enabled:
+        return [], snapshot
+
+    filtered = [market for market in markets if _infer_category(market) in enabled]
+    return filtered, snapshot

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -77,6 +77,7 @@ from typing import Any, Callable, Awaitable, Optional
 import structlog
 
 from ..market.market_client import get_active_markets, extract_market_data
+from ..market_scope import apply_market_scope
 from ..market.ingest import ingest_markets
 from ..signal.signal_engine import generate_signals, generate_synthetic_signals
 from ..signal.alpha_model import ProbabilisticAlphaModel
@@ -821,15 +822,31 @@ async def run_trading_loop(
                     )
                     break
 
-                log.info("market_feed", count=len(markets))
+                scoped_markets, scope_snapshot = await apply_market_scope(markets)
+                log.info(
+                    "market_feed",
+                    count=len(markets),
+                    scoped_count=len(scoped_markets),
+                    selection_type=scope_snapshot.get("selection_type", "All Markets"),
+                    active_categories=scope_snapshot.get("enabled_categories", []),
+                )
+
+                if not scoped_markets:
+                    log.warning(
+                        "trading_loop_scope_blocked",
+                        all_markets=scope_snapshot.get("all_markets_enabled", True),
+                        active_categories=scope_snapshot.get("enabled_categories", []),
+                        guidance="Enable All Markets or at least one category in Telegram > Markets > Categories",
+                    )
+                    break
 
                 # ── 1a. Debug: log first 3 raw markets (temp) ─────────────────────
                 # TODO: remove once production data structure is confirmed stable
-                for _raw in markets[:3]:
+                for _raw in scoped_markets[:3]:
                     log.info("market_raw_sample", data=_raw)
 
                 # ── 1b. Parse and normalise markets ───────────────────────────────
-                normalised_markets = ingest_markets(markets)
+                normalised_markets = ingest_markets(scoped_markets)
                 for m in normalised_markets:
                     log.info(
                         "market_valid",

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -18,6 +18,21 @@ _ACTION_ALIAS: dict[str, str] = {
     "settings_auto": "auto_trade",
     "settings_mode": "mode",
     "settings_risk": "risk",
+    "dashboard_home": "home",
+    "dashboard_system": "system",
+    "dashboard_refresh_all": "refresh",
+    "portfolio_wallet": "wallet",
+    "portfolio_positions": "positions",
+    "portfolio_exposure": "exposure",
+    "portfolio_pnl": "pnl",
+    "portfolio_performance": "performance",
+    "markets_overview": "markets",
+    "markets_categories": "markets",
+    "markets_refresh_all": "refresh",
+    "markets_active_scope": "active_scope",
+    "help": "help",
+    "help_guidance": "guidance",
+    "help_bot_info": "bot_info",
 }
 
 
@@ -113,6 +128,12 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "control_action": payload.get("control_action", "standby"),
         "winrate": payload.get("winrate", 0),
         "trades": payload.get("trades", payload.get("total_trades", 0)),
+        "scope_label": payload.get("scope_label", "All Markets"),
+        "selection_type": payload.get("selection_type", "All Markets"),
+        "active_categories_count": payload.get("active_categories_count", 0),
+        "enabled_categories": payload.get("enabled_categories", []),
+        "trading_scope_summary": payload.get("trading_scope_summary", "Trading scope: all allowed markets."),
+        "scope_warning": payload.get("scope_warning", ""),
     }
 
 
@@ -228,6 +249,17 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
         )
         return await render_dashboard(dashboard_payload)
 
+    if action == "active_scope":
+        dashboard_payload = _base_payload("active_scope", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Scope controls exactly what the bot can scan and trade"),
+                "operator_note": safe_payload.get("operator_note", "Use All Markets or category toggles to define market universe"),
+                "insight": safe_payload.get("insight", "Active scope is enforced in the trading loop before signal generation"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
     if action in {"refresh", "summary"}:
         dashboard_payload = _base_payload("refresh", safe_payload)
         dashboard_payload.update(
@@ -257,6 +289,39 @@ async def render_view(name: str, payload: Mapping[str, Any]) -> str:
                 "decision": safe_payload.get("decision", "Adjust runtime preferences with guardrails enabled"),
                 "operator_note": safe_payload.get("operator_note", "Settings menus now follow the same renderer grammar"),
                 "insight": safe_payload.get("insight", "Configuration context is isolated from market and position cards"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "help":
+        dashboard_payload = _base_payload("help", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Use Guidance and Bot Info for quick operational clarity"),
+                "operator_note": safe_payload.get("operator_note", "Help is informational and does not change runtime state"),
+                "insight": safe_payload.get("insight", "Reference surface stays concise for mobile navigation"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "guidance":
+        dashboard_payload = _base_payload("guidance", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Navigate Dashboard, Portfolio, Markets, and Settings from the main menu"),
+                "operator_note": safe_payload.get("operator_note", "If scope is blocked, enable All Markets or at least one category"),
+                "insight": safe_payload.get("insight", "Market scope controls are in Markets → All Markets / Categories / Active Scope"),
+            }
+        )
+        return await render_dashboard(dashboard_payload)
+
+    if action == "bot_info":
+        dashboard_payload = _base_payload("bot_info", safe_payload)
+        dashboard_payload.update(
+            {
+                "decision": safe_payload.get("decision", "Bot enforces risk before execution and follows selected market scope"),
+                "operator_note": safe_payload.get("operator_note", "Scope selection changes scan/trade universe immediately"),
+                "insight": safe_payload.get("insight", "Use Active Scope to verify what is currently tradable"),
             }
         )
         return await render_dashboard(dashboard_payload)

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -26,6 +26,10 @@ VIEW_TITLE = {
     "auto_trade": "🤖 Auto Trade",
     "mode": "🔀 Mode",
     "control": "🎛️ Control",
+    "active_scope": "✅ Active Scope",
+    "help": "❓ Help",
+    "guidance": "🧭 Guidance",
+    "bot_info": "ℹ️ Bot Info",
 }
 
 
@@ -184,6 +188,7 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
                 ("Total Value", _fmt_currency(payload.get("equity"))),
                 ("Exposure", _fmt_percent(payload.get("exposure"))),
                 ("Open Positions", _safe_int(payload.get("positions"))),
+                ("Scope", _safe_text(payload.get("scope_label"), "All Markets")),
             ],
         ),
         "system": (
@@ -271,7 +276,9 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
             [
                 ("Scanned", _safe_int(payload.get("markets_total"))),
                 ("Active", _safe_int(payload.get("markets_active"))),
-                ("Focus", _compact_text(payload.get("decision"), "Scan for asymmetric opportunity", max_len=56)),
+                ("Selection", _safe_text(payload.get("selection_type"), "All Markets")),
+                ("Categories", _safe_int(payload.get("active_categories_count"))),
+                ("Focus", _compact_text(payload.get("trading_scope_summary"), "Scan for asymmetric opportunity", max_len=56)),
             ],
         ),
         "refresh": (
@@ -320,6 +327,39 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
                 ("State", _safe_text(payload.get("state"), "running").upper()),
                 ("Action", _safe_text(payload.get("control_action"), "standby")),
                 ("Kill Switch", "Armed"),
+            ],
+        ),
+        "active_scope": (
+            "✅ Trading Scope",
+            [
+                ("Selection Type", _safe_text(payload.get("selection_type"), "All Markets")),
+                ("Active Categories", _safe_int(payload.get("active_categories_count"))),
+                ("Enabled", _compact_text(", ".join(payload.get("enabled_categories", [])) or "None", max_len=86)),
+                ("Summary", _compact_text(payload.get("trading_scope_summary"), "Trading scope: all allowed markets.", max_len=86)),
+            ],
+        ),
+        "help": (
+            "❓ Help Center",
+            [
+                ("Guidance", "How to use menus and scope controls"),
+                ("Bot Info", "Runtime behavior and control surfaces"),
+                ("Style", "Concise and mobile-first"),
+            ],
+        ),
+        "guidance": (
+            "🧭 Operator Guidance",
+            [
+                ("Main Menu", "Dashboard · Portfolio · Markets · Settings · Help"),
+                ("Scope Control", "Markets → All Markets / Categories / Active Scope"),
+                ("Refresh", "Use Refresh All in Dashboard or Markets"),
+            ],
+        ),
+        "bot_info": (
+            "ℹ️ Bot Runtime",
+            [
+                ("Pipeline", "DATA → STRATEGY → INTELLIGENCE → RISK → EXECUTION → MONITORING"),
+                ("Risk", "Risk checks remain enforced before execution"),
+                ("Scope", _compact_text(payload.get("trading_scope_summary"), "Trading scope: all allowed markets.", max_len=86)),
             ],
         ),
     }
@@ -403,6 +443,13 @@ def _render_performance_card(payload: Mapping[str, Any]) -> str:
 def _render_operator_note(payload: Mapping[str, Any]) -> str:
     note = _compact_text(payload.get("operator_note"), "Monitoring with current safeguards.", max_len=100)
     return _section("💡 Operator Note", _tree_group([("Guidance", note)]))
+
+
+def _render_scope_warning(payload: Mapping[str, Any]) -> str:
+    warning = _safe_text(payload.get("scope_warning"), "")
+    if not warning:
+        return ""
+    return _section("⚠️ Scope Warning", _tree_group([("Action Required", warning)]))
 
 
 def _render_empty_state(mode: str, payload: Mapping[str, Any]) -> str:
@@ -524,6 +571,9 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
     empty_state = _render_empty_state(mode, normalized)
     if empty_state:
         blocks.append(empty_state)
+    scope_warning = _render_scope_warning(normalized)
+    if scope_warning:
+        blocks.append(scope_warning)
     blocks.append(_render_operator_note(normalized))
     blocks.append(_render_meta(normalized))
 

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md
@@ -1,0 +1,64 @@
+# telegram_menu_structure_20260406
+
+## 1. What was built
+- Replaced the Telegram root menu with the founder-approved 5-item structure: `📊 Dashboard`, `💼 Portfolio`, `🎯 Markets`, `⚙️ Settings`, and `❓ Help`.
+- Implemented strict submenu architecture for Dashboard, Portfolio, Markets, Settings, and Help, including `Refresh All` simplification in Dashboard/Markets.
+- Added market-scope control surface in Telegram:
+  - `🌍 All Markets` ON/OFF toggle
+  - `🗂 Categories` per-category toggle UX (`✅/⬜`) with save action
+  - `✅ Active Scope` view showing selection type, active count, enabled list, and trading scope summary
+- Added Dashboard/Home scope-at-a-glance display so operators always see active trading universe.
+- Added runtime market-scope enforcement in the trading loop so scan/signal/trade path only uses Telegram-selected scope.
+
+## 2. Design principles
+- **Menu truth first:** each top-level menu owns only context-correct sub-actions; no cross-menu bleed.
+- **Single refresh intent:** user-facing refresh collapsed to `Refresh All` for cleaner UX.
+- **Scope as real control, not cosmetic:** Telegram scope state is wired into runtime market filtering before signal generation.
+- **Mobile-first premium readability:** concise inline rows, strategy-like toggles, and summary-first scope language.
+- **Backward-safe routing:** legacy action names still normalize to current views where needed, while new menu paths are explicit.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/market_scope.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- **Root menu simplification**
+  - Before: root emphasized legacy Status/Wallet/Settings/Control split.
+  - After: root is simplified to the required 5-item hierarchy with `❓ Help` icon replacement.
+- **Refresh simplification**
+  - Before: mixed `Refresh` naming in multiple contexts.
+  - After: user-facing refresh in redesigned flows is standardized to `Refresh All`.
+- **Markets redesign**
+  - Before: markets actions were broad and not a full scope-control surface.
+  - After: Markets contains Overview + All Markets toggle + Categories toggles + Active Scope + Refresh All.
+- **Category toggle flow**
+  - Before: no category-level market universe control in Telegram.
+  - After: strategy-style category toggles (✅/⬜) with persisted in-process state and save path.
+- **Active scope visibility**
+  - Before: no explicit screen summarizing selection type/count/list/scope summary.
+  - After: Active Scope view provides all required scope fields and warning guidance when scope is blocked.
+- **Dashboard scope visibility**
+  - Before: Home screen did not show scope summary.
+  - After: Home card includes scope label at-a-glance.
+- **Scope-control behavior linkage**
+  - Before: scan universe not controlled by Telegram scope selection.
+  - After: trading loop filters fetched markets via scope gate before normalization/signal generation; no enabled scope means no market scan/trade path proceeds.
+- **Menu-truth regression guard**
+  - Kept prior menu-truth fixes intact (no reintroduction of positions/exposure duplication, pnl/performance duplication, or cross-context block bleed).
+- **Logic-layer drift guard**
+  - Only minimal runtime integration added for scope enforcement (`core/market_scope.py` + narrow trading loop filter call); no strategy/risk/capital/order logic changes.
+
+## 5. Issues
+- Telegram screenshot capture is unavailable in this Codex environment.
+- Category inference for runtime scope filtering currently uses market metadata/keyword matching; uncategorized markets are excluded when All Markets is OFF.
+- Scope state is currently in-process (runtime memory) and does not yet persist across bot restarts.
+
+## 6. Next
+- SENTINEL validation required for telegram-menu-structure-20260406 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -28,6 +28,11 @@ import structlog
 
 from ..ui.keyboard import (
     build_main_menu,
+    build_dashboard_menu,
+    build_portfolio_menu,
+    build_markets_menu,
+    build_help_menu,
+    build_market_categories_menu,
     build_settings_menu,
     build_risk_level_menu,
     build_stop_confirm_menu,
@@ -42,6 +47,12 @@ from ..ui.screens import (
 )
 from ..ui.components import render_kv_line, render_insight, SEP
 from ...interface.telegram.view_handler import render_view
+from ...core.market_scope import (
+    MARKET_SCOPE_CATEGORIES,
+    get_market_scope_snapshot,
+    toggle_all_markets,
+    toggle_category,
+)
 from .portfolio_service import get_portfolio_service
 
 if TYPE_CHECKING:
@@ -57,6 +68,7 @@ if TYPE_CHECKING:
     from ...execution.paper_engine import PaperEngine
 
 _STRATEGY_TOGGLE_PREFIX = "strategy_toggle:"
+_MARKET_CATEGORY_TOGGLE_PREFIX = "markets_category_toggle:"
 
 log = structlog.get_logger(__name__)
 
@@ -347,6 +359,10 @@ class CallbackRouter:
         ]
         strategy_states = self._strategy_states()
         active_strategy = [name for name, enabled in strategy_states.items() if bool(enabled)]
+        scope_snapshot = get_market_scope_snapshot()
+        scope_warning = ""
+        if not bool(scope_snapshot.get("can_trade", True)):
+            scope_warning = "All Markets is OFF and no categories are enabled. Bot scanning/trading is blocked."
 
         payload: dict[str, object] = {
             "status": state_snapshot.get("state", "RUNNING"),
@@ -374,6 +390,12 @@ class CallbackRouter:
             "updated_at": state_snapshot.get("timestamp") or state_snapshot.get("updated_at"),
             "markets_total": 0,
             "markets_active": 0,
+            "selection_type": scope_snapshot.get("selection_type", "All Markets"),
+            "active_categories_count": scope_snapshot.get("active_categories_count", 0),
+            "enabled_categories": scope_snapshot.get("enabled_categories", []),
+            "trading_scope_summary": scope_snapshot.get("trading_scope_summary", "Trading scope: all allowed markets."),
+            "scope_label": scope_snapshot.get("scope_label", "All Markets"),
+            "scope_warning": scope_warning,
         }
 
         if action in {"strategy"}:
@@ -382,7 +404,6 @@ class CallbackRouter:
 
     async def _render_normalized_callback(self, action: str) -> tuple[str, list]:
         from ..ui.keyboard import (
-            build_status_menu,
             build_mode_confirm_menu,
             build_control_menu,
             build_main_menu,
@@ -390,7 +411,23 @@ class CallbackRouter:
             build_risk_level_menu,
         )  # noqa: PLC0415
 
-        normalized_action = "home" if action in {"back_main", "back", "start", "menu", "home"} else action
+        action_aliases = {
+            "dashboard": "dashboard_home",
+            "portfolio": "portfolio_wallet",
+            "markets": "markets_overview",
+            "dashboard_home": "home",
+            "dashboard_system": "system",
+            "dashboard_refresh_all": "refresh",
+            "portfolio_wallet": "wallet",
+            "portfolio_positions": "positions",
+            "portfolio_exposure": "exposure",
+            "portfolio_pnl": "pnl",
+            "portfolio_performance": "performance",
+            "markets_overview": "markets",
+            "markets_refresh_all": "refresh",
+        }
+        base_action = "home" if action in {"back_main", "back", "start", "menu", "home"} else action
+        normalized_action = action_aliases.get(base_action, base_action)
         payload = self._build_normalized_payload(normalized_action)
         payload["mode_label"] = self._mode.upper()
         if normalized_action == "settings_mode":
@@ -401,10 +438,27 @@ class CallbackRouter:
 
         text = await render_view(normalized_action, payload)
 
+        scope_snapshot = get_market_scope_snapshot()
+        enabled_categories = set(scope_snapshot.get("enabled_categories", []))
+
+        if base_action == "dashboard" or normalized_action in {"home", "system", "refresh"} and base_action.startswith("dashboard"):
+            return text, build_dashboard_menu()
+        if base_action == "portfolio" or base_action.startswith("portfolio_"):
+            return text, build_portfolio_menu()
+        if base_action == "markets_categories":
+            return text, build_market_categories_menu(
+                categories=list(MARKET_SCOPE_CATEGORIES),
+                enabled_categories=enabled_categories,
+            )
+        if base_action == "markets" or base_action.startswith("markets_"):
+            return text, build_markets_menu(bool(scope_snapshot.get("all_markets_enabled", True)))
+        if base_action == "help" or base_action.startswith("help_"):
+            return text, build_help_menu()
+
         if normalized_action == "home":
             return text, build_main_menu()
         if normalized_action in {"status", "system", "refresh", "positions", "trade", "pnl", "performance", "exposure", "risk"}:
-            return text, build_status_menu()
+            return text, build_dashboard_menu()
         if normalized_action == "wallet":
             if self._mode == "PAPER" and self._paper_wallet_engine is not None:
                 from ..ui.keyboard import build_paper_wallet_menu  # noqa: PLC0415
@@ -463,6 +517,23 @@ class CallbackRouter:
             "start",
             "menu",
             "home",
+            "dashboard",
+            "dashboard_home",
+            "dashboard_system",
+            "dashboard_refresh_all",
+            "portfolio",
+            "portfolio_wallet",
+            "portfolio_positions",
+            "portfolio_exposure",
+            "portfolio_pnl",
+            "portfolio_performance",
+            "markets_overview",
+            "markets_categories",
+            "markets_active_scope",
+            "markets_refresh_all",
+            "help",
+            "help_guidance",
+            "help_bot_info",
             "status",
             "refresh",
             "wallet",
@@ -485,6 +556,26 @@ class CallbackRouter:
         }
         if action in normalized_actions:
             return await self._render_normalized_callback(action)
+
+        if action == "markets_all_toggle":
+            await toggle_all_markets()
+            payload = self._build_normalized_payload("markets")
+            if bool(payload.get("scope_warning")):
+                payload["decision"] = "Scope blocked until at least one category is enabled or All Markets is turned ON"
+                payload["operator_note"] = "Use Markets → Categories to enable categories"
+            else:
+                payload["decision"] = "All Markets scope updated"
+            payload["insight"] = "Scope updates apply to market scanning and execution eligibility"
+            text = await render_view("markets", payload)
+            scope_snapshot = get_market_scope_snapshot()
+            return text, build_markets_menu(bool(scope_snapshot.get("all_markets_enabled", True)))
+
+        if action == "markets_categories_save":
+            payload = self._build_normalized_payload("active_scope")
+            payload["decision"] = "Category selection saved"
+            payload["operator_note"] = "Active scope now controls allowed scan/trade universe"
+            text = await render_view("active_scope", payload)
+            return text, build_markets_menu(bool(get_market_scope_snapshot().get("all_markets_enabled", True)))
 
         if action == "wallet_balance":
             return await handle_wallet_balance(user_id=user_id)
@@ -682,6 +773,20 @@ class CallbackRouter:
                     )
             await handle_strategy_toggle(strategy_name)
             return await self._render_normalized_callback("strategy")
+
+        if action.startswith(_MARKET_CATEGORY_TOGGLE_PREFIX):
+            category_name = action.removeprefix(_MARKET_CATEGORY_TOGGLE_PREFIX)
+            await toggle_category(category_name)
+            payload = self._build_normalized_payload("markets")
+            payload["decision"] = f"Category toggled: {category_name}"
+            payload["operator_note"] = "Category scope is now active because All Markets is OFF"
+            payload["insight"] = "Tap categories to enable/disable; use Active Scope to verify final trading universe"
+            text = await render_view("markets", payload)
+            scope_snapshot = get_market_scope_snapshot()
+            return text, build_market_categories_menu(
+                categories=list(MARKET_SCOPE_CATEGORIES),
+                enabled_categories=set(scope_snapshot.get("enabled_categories", [])),
+            )
 
         # ── Unknown ────────────────────────────────────────────────────────
         log.warning("callback_unknown_action", action=action)

--- a/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
+++ b/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
@@ -39,8 +39,11 @@ def build_main_menu() -> InlineKeyboard:
         [⚙️ Settings]  [▶  Control ]
     """
     return [
-        [_btn("📊 Status",    "status"),   _btn("💰 Wallet",  "wallet")],
-        [_btn("⚙️ Settings", "settings"),  _btn("▶ Control", "control")],
+        [_btn("📊 Dashboard", "dashboard")],
+        [_btn("💼 Portfolio", "portfolio")],
+        [_btn("🎯 Markets", "markets")],
+        [_btn("⚙️ Settings", "settings")],
+        [_btn("❓ Help", "help")],
     ]
 
 
@@ -56,11 +59,65 @@ def build_status_menu() -> InlineKeyboard:
         [📊 Performance] [📉 Exposure     ]
         [🔄 Refresh    ] [🏠 Main Menu    ]
     """
+    return build_dashboard_menu()
+
+
+def build_dashboard_menu() -> InlineKeyboard:
+    """Dashboard sub-menu."""
     return [
-        [_btn("📈 Positions", "positions"), _btn("💹 PnL",          "pnl")],
-        [_btn("📊 Performance", "performance"), _btn("📉 Exposure", "exposure")],
-        [_btn("🔄 Refresh", "refresh"),     _btn("🏠 Main Menu",    "back_main")],
+        [_btn("Home", "dashboard_home"), _btn("System", "dashboard_system")],
+        [_btn("Refresh All", "dashboard_refresh_all")],
+        [_btn("🏠 Main Menu", "back_main")],
     ]
+
+
+def build_portfolio_menu() -> InlineKeyboard:
+    """Portfolio sub-menu."""
+    return [
+        [_btn("Wallet", "portfolio_wallet"), _btn("Positions", "portfolio_positions")],
+        [_btn("Exposure", "portfolio_exposure"), _btn("PnL", "portfolio_pnl")],
+        [_btn("Performance", "portfolio_performance")],
+        [_btn("🏠 Main Menu", "back_main")],
+    ]
+
+
+def build_markets_menu(all_markets_enabled: bool) -> InlineKeyboard:
+    """Markets sub-menu with All Markets scope state."""
+    all_markets_label = "🌍 All Markets ✅" if all_markets_enabled else "🌍 All Markets ⬜"
+    return [
+        [_btn("Overview", "markets_overview")],
+        [_btn(all_markets_label, "markets_all_toggle")],
+        [_btn("🗂 Categories", "markets_categories")],
+        [_btn("✅ Active Scope", "markets_active_scope")],
+        [_btn("🔄 Refresh All", "markets_refresh_all")],
+        [_btn("🏠 Main Menu", "back_main")],
+    ]
+
+
+def build_help_menu() -> InlineKeyboard:
+    """Help sub-menu."""
+    return [
+        [_btn("Guidance", "help_guidance")],
+        [_btn("Bot Info", "help_bot_info")],
+        [_btn("🏠 Main Menu", "back_main")],
+    ]
+
+
+def build_market_categories_menu(
+    categories: list[str],
+    enabled_categories: set[str],
+) -> InlineKeyboard:
+    """Category toggle menu with strategy-like checkbox rows."""
+    rows: InlineKeyboard = []
+    for idx in range(0, len(categories), 2):
+        row: list[dict[str, str]] = []
+        for name in categories[idx : idx + 2]:
+            marker = "✅" if name in enabled_categories else "⬜"
+            row.append(_btn(f"{marker} {name}", f"markets_category_toggle:{name}"))
+        rows.append(row)
+    rows.append([_btn("💾 Save Selection", "markets_categories_save")])
+    rows.append([_btn("🔙 Back", "markets")])
+    return rows
 
 
 # ── Wallet sub-menu ────────────────────────────────────────────────────────────
@@ -95,9 +152,10 @@ def build_paper_wallet_menu() -> InlineKeyboard:
 def build_settings_menu() -> InlineKeyboard:
     """Settings sub-menu."""
     return [
-        [_btn("⚠️ Risk Level",    "settings_risk"),    _btn("🔀 Mode",           "settings_mode")],
-        [_btn("📐 Strategy",       "settings_strategy"), _btn("🔔 Notifications",  "settings_notify")],
-        [_btn("🤖 Auto Trade",     "settings_auto"),     _btn("🏠 Main Menu",      "back_main")],
+        [_btn("Mode", "settings_mode"), _btn("Control", "control")],
+        [_btn("Risk Level", "settings_risk"), _btn("Strategy", "settings_strategy")],
+        [_btn("Notifications", "settings_notify"), _btn("Auto Trade", "settings_auto")],
+        [_btn("🏠 Main Menu", "back_main")],
     ]
 
 


### PR DESCRIPTION
### Motivation
- Simplify the Telegram operator UI to a founder-approved 5-item root menu and make refresh a single, consistent user action (`Refresh All`).
- Provide explicit market-universe control from Telegram so operators can select `All Markets` or enable/disable categories and immediately affect what the bot may scan and trade. 
- Enforce the selected market scope in the runtime pipeline so scope selection is a real control surface (not cosmetic) that gates scanning/signal/trade behavior.

### Description
- Reworked top-level and submenus in the inline keyboard builders in `projects/polymarket/polyquantbot/telegram/ui/keyboard.py` to provide the exact root menu (`📊 Dashboard`, `💼 Portfolio`, `🎯 Markets`, `⚙️ Settings`, `❓ Help`) and required submenus including `Refresh All`, category toggle grid and help menus. 
- Extended UI rendering and view adapters in `projects/polymarket/polyquantbot/interface/ui_formatter.py` and `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` to surface scope fields (`selection_type`, `active_categories_count`, `enabled_categories`, `trading_scope_summary`, `scope_warning`), add `Active Scope`/`Help`/`Guidance`/`Bot Info` views, and show scope summary on Dashboard/Home. 
- Updated callback routing in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` to support new actions (`markets_all_toggle`, category toggles, `markets_categories_save`, dashboard/portfolio/markets/help navigation), persist in-process scope state into view payloads, and render appropriate menus after toggles. 
- Implemented runtime scope state and filtering via a new module `projects/polymarket/polyquantbot/core/market_scope.py` and wired it into the trading pipeline by filtering `get_active_markets()` output in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` so the trading loop only proceeds on scoped markets (and logs/warns when scope blocks scanning). 
- Added the required FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_menu_structure_20260406.md` and updated `PROJECT_STATE.md` to record completion and next priority (SENTINEL validation). 

### Testing
- Ran Python byte-compile across the modified modules with `python -m compileall <files>` which completed successfully. 
- Performed keyboard/menu sanity checks via a small render script that printed `build_main_menu()` and `build_markets_menu()` labels, which produced the expected layout and `All Markets` ON/OFF labels. 
- Executed a scope-behavior smoke test script that exercised `get_market_scope_snapshot()`, `toggle_all_markets()`, `toggle_category()` and `apply_market_scope()` in-process (All Markets ON → blocked when OFF with no categories → category-only filter behavior), which passed all assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f4e659e0832e953286b1679a5d84)