### PR TITLE
harden: persist Telegram market-scope state & improve category inference

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 02:15
-- Status        : SENTINEL validation complete — Telegram menu structure + market scope control pass is CONDITIONAL (96/100), no critical blockers, with persistence and category-inference hardening still required before merge decision
+- Last Updated  : 2026-04-06 19:36
+- Status        : FORGE-X hardening pass complete for telegram-menu-scope-hardening-20260407 — market-scope persistence and category-inference fallback hardening implemented; awaiting SENTINEL revalidation before merge decision
 
 ---
 
@@ -19,41 +19,37 @@
 - SENTINEL confirmed root menu structure, markets controls, dashboard scope summary, callback routing, and trading-loop scope gate behavior all pass for the target task.
 - SENTINEL confirmed blocked-scope behavior prevents downstream ingest/signals when no category is active and All Markets is OFF.
 - No CRITICAL blockers found for this task objective.
+- Telegram scope hardening pass (2026-04-07): persisted Telegram market-scope state (`all_markets_enabled` + enabled categories + selection type) to local scope-state file and restored it on module/router re-init.
+- Category inference hardening applied for weak-metadata and uncategorized markets: deterministic inference order plus fallback inclusion path under category mode to reduce avoidable exclusions while preserving blocked-scope behavior when no categories are active.
 
 ---
 
 ## 🚧 IN PROGRESS
 
 ### Phase 10.4 — 24H Live Paper Run
-- Persistence hardening for Telegram market-scope selection across restart/re-init.
-- Category inference hardening for uncategorized / weak-metadata markets when All Markets is OFF.
 - Final on-device Telegram visual confirmation in live-network environment.
 - Merge decision preparation based on CONDITIONAL validation result.
+- SENTINEL revalidation preparation for `telegram-menu-scope-hardening-20260407`.
 
 ---
 
 ## ❌ NOT STARTED
 
-- Persistent storage implementation for Telegram market-scope state.
-- Post-hardening SENTINEL revalidation after persistence/category work is completed.
 - BRIEFER packaging/reporting for this increment if COMMANDER wants downstream communication artifact.
 
 ---
 
 ## 🎯 NEXT PRIORITY
 
-- FORGE-X hardening pass for `telegram-menu-structure-20260406`:
-  1. Persist market-scope selection across restart
-  2. Improve category inference / fallback handling for uncategorized markets
-  3. Re-run SENTINEL after hardening pass
-  4. If validation remains clean, move to BRIEFER or COMMANDER merge decision
+- SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+- If validation remains clean, move to BRIEFER or COMMANDER merge decision.
 - Merge to main is not yet automatic; COMMANDER decides after the hardening follow-up or explicit acceptance of current CONDITIONAL verdict.
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
-- Market scope state currently persists in-process only and resets after bot restart/re-init.
-- Category inference is metadata/keyword-based; uncategorized markets are excluded when All Markets is OFF.
+- Weak-metadata fallback may still include some uncategorized markets that operators may prefer to classify explicitly; monitor category hit quality during live-paper usage.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.

--- a/projects/polymarket/polyquantbot/core/market_scope.py
+++ b/projects/polymarket/polyquantbot/core/market_scope.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+from pathlib import Path
 from typing import Any, Mapping
+
+import structlog
 
 MARKET_SCOPE_CATEGORIES: tuple[str, ...] = (
     "Breaking",
@@ -44,10 +49,15 @@ _CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
 _lock = asyncio.Lock()
 _all_markets_enabled: bool = True
 _enabled_categories: set[str] = set()
-
-
-def _category_set() -> set[str]:
-    return set(MARKET_SCOPE_CATEGORIES)
+_scope_state_loaded: bool = False
+_log = structlog.get_logger(__name__)
+_UNCATEGORIZED_FALLBACK_LABEL: str = "Weak-metadata markets are included as fallback while category mode is active."
+_SCOPE_STATE_FILE: Path = Path(
+    os.getenv(
+        "POLYQUANT_MARKET_SCOPE_STATE_FILE",
+        "projects/polymarket/polyquantbot/infra/market_scope_state.json",
+    )
+)
 
 
 def _normalize_category(name: str) -> str:
@@ -64,31 +74,143 @@ def _as_text(value: object) -> str:
     return str(value).strip()
 
 
+def _normalize_text_blob(value: object) -> str:
+    return _as_text(value).lower()
+
+
+def _metadata_tokens(market: Mapping[str, Any]) -> list[str]:
+    tokens: list[str] = []
+    base_keys = ("question", "title", "name", "description", "slug", "seriesSlug", "eventSlug")
+    for key in base_keys:
+        raw = _normalize_text_blob(market.get(key))
+        if raw:
+            tokens.append(raw)
+
+    tags = market.get("tags")
+    if isinstance(tags, list):
+        for tag in tags:
+            value = _normalize_text_blob(tag)
+            if value:
+                tokens.append(value)
+
+    events = market.get("events")
+    if isinstance(events, list):
+        for event in events:
+            if not isinstance(event, Mapping):
+                continue
+            for key in ("title", "slug", "name"):
+                value = _normalize_text_blob(event.get(key))
+                if value:
+                    tokens.append(value)
+
+    return tokens
+
+
 def _infer_category(market: Mapping[str, Any]) -> str:
+    """Deterministic category inference order.
+
+    1) explicit ``category`` field
+    2) direct category name in tag list
+    3) keyword scoring across title/question/description/tags/slug/event metadata
+    4) tie/no-signal => uncategorized (empty string)
+    """
     explicit_category = _normalize_category(_as_text(market.get("category")))
     if explicit_category:
         return explicit_category
 
-    searchable_parts: list[str] = []
-    for key in ("question", "title", "name", "description"):
-        searchable_parts.append(_as_text(market.get(key)))
-
     tags = market.get("tags")
     if isinstance(tags, list):
-        searchable_parts.extend(_as_text(tag) for tag in tags)
+        for tag in tags:
+            tag_category = _normalize_category(_as_text(tag))
+            if tag_category:
+                return tag_category
 
-    searchable = " ".join(part.lower() for part in searchable_parts if part)
+    searchable = " ".join(_metadata_tokens(market))
     if not searchable:
         return ""
 
+    category_scores: dict[str, int] = {}
     for category, keywords in _CATEGORY_KEYWORDS.items():
-        if any(keyword in searchable for keyword in keywords):
-            return category
+        hits = sum(1 for keyword in keywords if keyword in searchable)
+        if hits:
+            category_scores[category] = hits
 
-    return ""
+    if not category_scores:
+        return ""
+
+    ranked = sorted(
+        category_scores.items(),
+        key=lambda item: (-item[1], MARKET_SCOPE_CATEGORIES.index(item[0])),
+    )
+    top_category, top_hits = ranked[0]
+    if len(ranked) > 1 and ranked[1][1] == top_hits:
+        # Ambiguous metadata: leave uncategorized so fallback policy remains explicit.
+        return ""
+    return top_category
+
+
+def _is_weak_metadata_market(market: Mapping[str, Any]) -> bool:
+    explicit_signals = 0
+    for key in ("category", "question", "title", "name", "description", "slug", "seriesSlug", "eventSlug"):
+        if _as_text(market.get(key)):
+            explicit_signals += 1
+    tags = market.get("tags")
+    if isinstance(tags, list) and any(_as_text(tag) for tag in tags):
+        explicit_signals += 1
+    return explicit_signals <= 2
+
+
+def _ensure_scope_state_loaded() -> None:
+    global _scope_state_loaded  # noqa: PLW0603
+    if _scope_state_loaded:
+        return
+    _scope_state_loaded = True
+
+    if not _SCOPE_STATE_FILE.exists():
+        return
+
+    try:
+        raw = _SCOPE_STATE_FILE.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("market_scope_state_load_failed", error=str(exc), state_file=str(_SCOPE_STATE_FILE))
+        return
+
+    all_markets = payload.get("all_markets_enabled")
+    categories = payload.get("enabled_categories")
+    if isinstance(all_markets, bool):
+        global _all_markets_enabled  # noqa: PLW0603
+        _all_markets_enabled = all_markets
+    if isinstance(categories, list):
+        global _enabled_categories  # noqa: PLW0603
+        _enabled_categories = {name for name in (_normalize_category(_as_text(item)) for item in categories) if name}
+
+    _log.info(
+        "market_scope_state_restored",
+        all_markets_enabled=_all_markets_enabled,
+        enabled_categories=sorted(_enabled_categories),
+        state_file=str(_SCOPE_STATE_FILE),
+    )
+
+
+def _persist_scope_state() -> None:
+    payload = {
+        "all_markets_enabled": _all_markets_enabled,
+        "enabled_categories": sorted(_enabled_categories),
+        "selection_type": "All Markets" if _all_markets_enabled else "Categories",
+    }
+    try:
+        _SCOPE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _SCOPE_STATE_FILE.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("market_scope_state_persist_failed", error=str(exc), state_file=str(_SCOPE_STATE_FILE))
 
 
 def get_market_scope_snapshot() -> dict[str, Any]:
+    _ensure_scope_state_loaded()
+
     enabled = sorted(_enabled_categories)
     selection_type = "All Markets" if _all_markets_enabled else "Categories"
     if _all_markets_enabled:
@@ -109,18 +231,25 @@ def get_market_scope_snapshot() -> dict[str, Any]:
         "scope_label": scope_label,
         "can_trade": _all_markets_enabled or bool(enabled),
         "supported_categories": list(MARKET_SCOPE_CATEGORIES),
+        "fallback_policy": _UNCATEGORIZED_FALLBACK_LABEL,
+        "scope_state_file": str(_SCOPE_STATE_FILE),
     }
 
 
 async def toggle_all_markets() -> dict[str, Any]:
     global _all_markets_enabled  # noqa: PLW0603
+    _ensure_scope_state_loaded()
+
     async with _lock:
         _all_markets_enabled = not _all_markets_enabled
+        _persist_scope_state()
         return get_market_scope_snapshot()
 
 
 async def toggle_category(category: str) -> dict[str, Any]:
     global _all_markets_enabled  # noqa: PLW0603
+    _ensure_scope_state_loaded()
+
     normalized = _normalize_category(category)
     if not normalized:
         return get_market_scope_snapshot()
@@ -131,6 +260,7 @@ async def toggle_category(category: str) -> dict[str, Any]:
         else:
             _enabled_categories.add(normalized)
         _all_markets_enabled = False
+        _persist_scope_state()
         return get_market_scope_snapshot()
 
 
@@ -143,5 +273,26 @@ async def apply_market_scope(markets: list[dict[str, Any]]) -> tuple[list[dict[s
     if not enabled:
         return [], snapshot
 
-    filtered = [market for market in markets if _infer_category(market) in enabled]
+    filtered: list[dict[str, Any]] = []
+    uncategorized_fallback_count = 0
+
+    for market in markets:
+        inferred_category = _infer_category(market)
+        if inferred_category in enabled:
+            filtered.append(market)
+            continue
+        if inferred_category:
+            continue
+        if _is_weak_metadata_market(market):
+            filtered.append(market)
+            uncategorized_fallback_count += 1
+
+    if uncategorized_fallback_count > 0:
+        snapshot = dict(snapshot)
+        snapshot["fallback_applied_count"] = uncategorized_fallback_count
+        snapshot["trading_scope_summary"] = (
+            f"{snapshot['trading_scope_summary']} "
+            f"{uncategorized_fallback_count} weak-metadata market(s) included via fallback."
+        )
+
     return filtered, snapshot

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -829,6 +829,7 @@ async def run_trading_loop(
                     scoped_count=len(scoped_markets),
                     selection_type=scope_snapshot.get("selection_type", "All Markets"),
                     active_categories=scope_snapshot.get("enabled_categories", []),
+                    fallback_applied_count=scope_snapshot.get("fallback_applied_count", 0),
                 )
 
                 if not scoped_markets:

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -134,6 +134,8 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "enabled_categories": payload.get("enabled_categories", []),
         "trading_scope_summary": payload.get("trading_scope_summary", "Trading scope: all allowed markets."),
         "scope_warning": payload.get("scope_warning", ""),
+        "scope_fallback_policy": payload.get("scope_fallback_policy", ""),
+        "scope_state_file": payload.get("scope_state_file", ""),
     }
 
 

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -336,6 +336,8 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
                 ("Active Categories", _safe_int(payload.get("active_categories_count"))),
                 ("Enabled", _compact_text(", ".join(payload.get("enabled_categories", [])) or "None", max_len=86)),
                 ("Summary", _compact_text(payload.get("trading_scope_summary"), "Trading scope: all allowed markets.", max_len=86)),
+                ("Fallback Rule", _compact_text(payload.get("scope_fallback_policy"), "Disabled", max_len=86)),
+                ("Persistence", "Scope restored after restart/re-init"),
             ],
         ),
         "help": (

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
@@ -1,0 +1,57 @@
+# telegram_menu_scope_hardening_20260407
+
+## 1. What was built
+- Added persistent Telegram market-scope state handling so market scope survives process restart/re-init:
+  - Persists `all_markets_enabled`, `enabled_categories`, and `selection_type` into `projects/polymarket/polyquantbot/infra/market_scope_state.json` (configurable via `POLYQUANT_MARKET_SCOPE_STATE_FILE`).
+  - Restores persisted state on scope module load and during callback-router re-init via snapshot hydration.
+- Hardened category inference for weak/uncategorized market metadata when `All Markets` is OFF:
+  - Deterministic inference order now covers explicit category, direct tag category match, then keyword scoring across question/title/name/description/slug/event metadata.
+  - Ambiguous/tie cases are treated as uncategorized instead of making non-deterministic assignments.
+  - Weak-metadata uncategorized markets are included through an explicit fallback rule to reduce avoidable scope exclusion.
+- Preserved runtime scope gate behavior in trading loop and surfaced fallback usage telemetry via `fallback_applied_count` in market-feed logs.
+- Preserved Telegram menu structure behavior (5-item root, Markets controls, Active Scope path) while adding explicit fallback-policy visibility in Active Scope view.
+
+## 2. Design principles
+- **Minimal integration only:** scope hardening was limited to market-scope core logic and its direct UI/runtime integration points; no architecture rewrite.
+- **State truth over session memory:** scope settings are now explicit persisted state, not implicit in-process memory.
+- **Deterministic inference:** category assignment uses an ordered rule path; ambiguity intentionally falls back to uncategorized handling instead of guessing.
+- **Operator honesty:** Active Scope UI now includes fallback-policy communication so category-mode behavior is transparent.
+- **No logic-layer drift:** strategy/risk/capital/order placement paths were not modified.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/market_scope.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- **Persistence gap (before → after)**
+  - Before: scope state lived in-memory and reset after restart/re-init.
+  - After: scope state is persisted to file and restored at initialization, preserving All Markets/category selection and selection type.
+- **Restart/re-init restoration (before → after)**
+  - Before: Active Scope and dashboard scope label reverted to defaults after restart.
+  - After: restored snapshot feeds callback payload/render path, so Dashboard/Home scope summary and Active Scope reflect last persisted selection.
+- **Category fallback behavior (before → after)**
+  - Before: only simple metadata/keyword mapping; uncategorized markets were dropped when All Markets OFF.
+  - After: deterministic multi-source inference + weak-metadata fallback include path reduces false exclusion while keeping behavior explicit.
+- **Uncategorizable market treatment (before → after)**
+  - Before: uncategorizable markets were excluded.
+  - After: if metadata is weak/insufficient, market can be retained via fallback in category mode and summary indicates fallback count.
+- **Blocked-scope protection (before → after)**
+  - Before: blocked when All Markets OFF and no categories selected.
+  - After: unchanged and preserved; still returns blocked scope and stops downstream scan/trade path.
+- **Menu-truth regression check (before → after)**
+  - Before: validated menu truth from previous pass.
+  - After: no root/menu structure redesign or cross-menu behavior change introduced in this hardening pass.
+
+## 5. Issues
+- Weak-metadata fallback is intentionally permissive to avoid hard false-negative exclusion; some operators may still prefer tighter category constraints in future tuning.
+- External live-network Telegram screenshot validation remains unavailable in this container environment.
+- External market-context endpoint connectivity warnings may still appear in this environment and were not part of this targeted hardening scope.
+
+## 6. Next
+- SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -122,11 +122,14 @@ class CallbackRouter:
 
         # ── Propagate mode + state to all handlers at init ────────────────────
         self._propagate_mode_and_state()
+        restored_scope = get_market_scope_snapshot()
 
         log.info(
             "callback_router_initialized",
             mode=mode,
             api_base=tg_api[:40] + "…" if len(tg_api) > 40 else tg_api,
+            all_markets_enabled=restored_scope.get("all_markets_enabled", True),
+            enabled_categories=restored_scope.get("enabled_categories", []),
         )
 
     def _propagate_mode_and_state(self) -> None:
@@ -396,6 +399,8 @@ class CallbackRouter:
             "trading_scope_summary": scope_snapshot.get("trading_scope_summary", "Trading scope: all allowed markets."),
             "scope_label": scope_snapshot.get("scope_label", "All Markets"),
             "scope_warning": scope_warning,
+            "scope_fallback_policy": scope_snapshot.get("fallback_policy", ""),
+            "scope_state_file": scope_snapshot.get("scope_state_file", ""),
         }
 
         if action in {"strategy"}:


### PR DESCRIPTION
### Motivation
- Ensure Telegram market-scope selections survive process restart/re-init so operator choices persist and Dashboard/Active Scope reflect the last saved selection.
- Reduce avoidable market exclusions when `All Markets` is OFF by hardening category inference and adding an explainable fallback for weak/uncategorized metadata.
- Keep the previously validated 5-item Telegram menu and runtime scope-gate behavior unchanged while adding minimal persistence and observability.

### Description
- Added file-backed scope persistence in `projects/polymarket/polyquantbot/core/market_scope.py` with a configurable state file (`POLYQUANT_MARKET_SCOPE_STATE_FILE`) and restore on module/load, and made `toggle_all_markets` / `toggle_category` persist the state.  
- Hardened category inference with a deterministic order (explicit category -> tag category match -> keyword scoring across richer metadata) and tie-handling that returns uncategorized; introduced `_is_weak_metadata_market` and a controlled weak-metadata fallback that can include such markets under category mode.  
- Updated `apply_market_scope` to include fallback-included markets and to attach `fallback_applied_count` and an updated `trading_scope_summary` in the returned snapshot.  
- Surface persistence/fallback state to Telegram UI and routing by hydrating scope on `CallbackRouter` init and adding `scope_fallback_policy` / `scope_state_file` to the normalized payload in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` and `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`.  
- Updated UI text to communicate the fallback rule and persistence line in `projects/polymarket/polyquantbot/interface/ui_formatter.py` while preserving the validated menu layout in `projects/polymarket/polyquantbot/telegram/ui/keyboard.py` (no menu redesign).  
- Added lightweight observability: `fallback_applied_count` is logged in the trading-loop market feed (`projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`).  
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md` and updated `PROJECT_STATE.md` to reflect hardening completion and next-step (SENTINEL revalidation).  

Files changed (key):
- `projects/polymarket/polyquantbot/core/market_scope.py` (persistence + inference + fallback)
- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (log fallback count)
- `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` (restore scope on init + payload fields)
- `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` (accept new payload fields)
- `projects/polymarket/polyquantbot/interface/ui_formatter.py` (Active Scope shows fallback/persistence)
- `projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md` (FORGE report)
- `PROJECT_STATE.md` (status update)

Report: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md

### Testing
- Ran `python -m py_compile` on modified modules and it completed successfully.  
- Persistence simulation: set `POLYQUANT_MARKET_SCOPE_STATE_FILE` to a temp file, toggled `All Markets` and categories, reloaded the module with `importlib.reload`, and verified the saved `selection_type` / `all_markets_enabled` / `enabled_categories` were restored (success).  
- Category fallback tests: executed `apply_market_scope` on sample market dicts including explicit, tag-matching, and weak/empty metadata cases and verified weak-metadata markets can be retained by fallback while zero-category state remains blocked (success).  
- UI/render checks: rendered `active_scope` view with fallback/persistence payload and verified the Active Scope card shows the fallback rule and persistence line (success).  
- Trading-loop integration: ran a one-tick harness that exercised `apply_market_scope` and verified `market_feed` logs include `fallback_applied_count` and blocked-scope still prevents downstream ingest/signals (success).  
- Note: a network reachability warning to external market/context endpoint (`clob.polymarket.com`) was observed in this container environment but did not block the targeted hardening tests (warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4097d662c832e95416dbaa05effea)