### PR TITLE
fix: harden /start numeric placeholder coercion in telegram dashboard path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 19:36
-- Status        : FORGE-X hardening pass complete for telegram-menu-scope-hardening-20260407 — market-scope persistence and category-inference fallback hardening implemented; awaiting SENTINEL revalidation before merge decision
+- Last Updated  : 2026-04-06 19:39
+- Status        : FORGE-X hardening addendum applied for telegram-menu-scope-hardening-20260407 — /start numeric placeholder crash path patched with safe normalization; awaiting SENTINEL revalidation before merge decision
 
 ---
 
@@ -21,6 +21,7 @@
 - No CRITICAL blockers found for this task objective.
 - Telegram scope hardening pass (2026-04-07): persisted Telegram market-scope state (`all_markets_enabled` + enabled categories + selection type) to local scope-state file and restored it on module/router re-init.
 - Category inference hardening applied for weak-metadata and uncategorized markets: deterministic inference order plus fallback inclusion path under category mode to reduce avoidable exclusions while preserving blocked-scope behavior when no categories are active.
+- Telegram /start numeric placeholder blocker patch (2026-04-06): hardened Telegram-facing numeric normalization in view/callback payload paths so `"N/A"`, `None`, empty, missing, and malformed numeric values no longer hard-crash dashboard/menu render.
 
 ---
 
@@ -43,6 +44,7 @@
 
 - SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
 Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+- SENTINEL must include explicit `/start` placeholder regression validation (`"N/A"`, `None`, sparse payload, missing portfolio/performance fields) and confirm no CRITICAL ERROR card for this class.
 - If validation remains clean, move to BRIEFER or COMMANDER merge decision.
 - Merge to main is not yet automatic; COMMANDER decides after the hardening follow-up or explicit acceptance of current CONDITIONAL verdict.
 

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -51,6 +51,24 @@ def _first_present(payload: Mapping[str, Any], *keys: str, default: Any = None) 
     return default
 
 
+def _safe_number(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        text = value.strip()
+        if not text or text.lower() in {"n/a", "na", "none", "null", "nan", "-"}:
+            return default
+        value = text
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_count(value: Any, default: int = 0) -> int:
+    return int(_safe_number(value, float(default)))
+
+
 def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     rows = _as_list(payload.get("positions"))
     if rows and isinstance(rows[0], Mapping):
@@ -62,20 +80,26 @@ def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
 def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     rows = _position_rows(payload)
     primary = _as_mapping(rows[0]) if rows else {}
-    unrealized_total = sum(float(_as_mapping(row).get("unrealized_pnl", _as_mapping(row).get("pnl", 0.0)) or 0.0) for row in rows)
-    largest_position_size = max((float(_as_mapping(row).get("size", 0.0) or 0.0) for row in rows), default=0.0)
+    unrealized_total = sum(
+        _safe_number(_as_mapping(row).get("unrealized_pnl", _as_mapping(row).get("pnl", 0.0)))
+        for row in rows
+    )
+    largest_position_size = max(
+        (_safe_number(_as_mapping(row).get("size", 0.0)) for row in rows),
+        default=0.0,
+    )
     realized = _first_present(payload, "realized_pnl", "realized", default=0.0)
     total_pnl = _first_present(payload, "pnl", default=None)
     if total_pnl is None:
-        total_pnl = float(realized or 0.0) + unrealized_total
+        total_pnl = _safe_number(realized, 0.0) + unrealized_total
     return {
         "rows": rows,
         "primary": primary,
-        "positions_count": payload.get("positions_count", len(rows)),
+        "positions_count": _safe_count(payload.get("positions_count"), len(rows)),
         "unrealized_total": unrealized_total,
         "largest_position_size": largest_position_size,
-        "realized_pnl": realized,
-        "total_pnl": total_pnl,
+        "realized_pnl": _safe_number(realized, 0.0),
+        "total_pnl": _safe_number(total_pnl, 0.0),
     }
 
 

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
@@ -1,6 +1,10 @@
 # telegram_menu_scope_hardening_20260407
 
 ## 1. What was built
+- Patched `/start` dashboard/menu numeric coercion blocker so placeholder values no longer crash Telegram render flow:
+  - Added explicit numeric placeholder normalization in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` for Telegram-facing dashboard payload derivation.
+  - Added callback payload numeric hardening in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` so portfolio values such as `"N/A"`, `None`, `""`, and malformed strings are coerced safely before render.
+  - Added regression tests for placeholder-heavy and sparse payload render paths in `projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`.
 - Added persistent Telegram market-scope state handling so market scope survives process restart/re-init:
   - Persists `all_markets_enabled`, `enabled_categories`, and `selection_type` into `projects/polymarket/polyquantbot/infra/market_scope_state.json` (configurable via `POLYQUANT_MARKET_SCOPE_STATE_FILE`).
   - Restores persisted state on scope module load and during callback-router re-init via snapshot hydration.
@@ -19,6 +23,9 @@
 - **No logic-layer drift:** strategy/risk/capital/order placement paths were not modified.
 
 ## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/market_scope.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
@@ -28,6 +35,22 @@
 - `/workspace/walker-ai-team/PROJECT_STATE.md`
 
 ## 4. Before/after improvement summary
+- **`/start` numeric placeholder crash (before → after)**
+  - Before: `/start` render path could execute `float("N/A")` during dashboard payload derivation, producing `ValueError` and CRITICAL ERROR card (`command_handler:/start` context).
+  - After: all Telegram-facing numeric coercion on `/start` path routes through explicit safe normalization (`_safe_number`, `_safe_count`) with truthful defaults for degraded input.
+- **Dashboard/menu sparse payload behavior (before → after)**
+  - Before: sparse payload with placeholder/missing numeric fields could trigger hard failure in position metrics derivation.
+  - After: sparse and mixed placeholder payloads render valid premium dashboard output with safe defaults (`0`, `0.0`) and no hard-crash.
+- **Callback payload safety (before → after)**
+  - Before: callback router normalization used direct `float(...)` conversion on portfolio and position values.
+  - After: callback router normalizes all portfolio/position numeric fields via safe conversion to prevent placeholder coercion failure from shared state injection.
+- **Regression proof for this blocker**
+  - Added tests covering:
+    - `"N/A"` numeric placeholders
+    - `None` / empty string placeholders
+    - sparse `/start`-equivalent payload
+    - callback payload normalization with malformed portfolio numbers
+  - Added runtime render check script proving home/start render succeeds and does not emit CRITICAL ERROR marker for the placeholder class.
 - **Persistence gap (before → after)**
   - Before: scope state lived in-memory and reset after restart/re-init.
   - After: scope state is persisted to file and restored at initialization, preserving All Markets/category selection and selection type.
@@ -48,6 +71,7 @@
   - After: no root/menu structure redesign or cross-menu behavior change introduced in this hardening pass.
 
 ## 5. Issues
+- This patch intentionally uses safe numeric defaults for degraded Telegram payloads to preserve runtime safety; semantic data quality still depends on upstream producers.
 - Weak-metadata fallback is intentionally permissive to avoid hard false-negative exclusion; some operators may still prefer tighter category constraints in future tuning.
 - External live-network Telegram screenshot validation remains unavailable in this container environment.
 - External market-context endpoint connectivity warnings may still appear in this environment and were not part of this targeted hardening scope.
@@ -55,3 +79,4 @@
 ## 6. Next
 - SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
 Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+- SENTINEL should validate `/start` placeholder regression path explicitly (including `"N/A"`, `None`, sparse/missing numeric fields) and confirm no CRITICAL ERROR card for this class.

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -332,6 +332,20 @@ class CallbackRouter:
             log.warning("callback_strategy_state_unavailable", error=str(exc))
             return {}
 
+    @staticmethod
+    def _safe_number(value: object, default: float = 0.0) -> float:
+        if value is None:
+            return default
+        if isinstance(value, str):
+            text = value.strip()
+            if not text or text.lower() in {"n/a", "na", "none", "null", "nan", "-"}:
+                return default
+            value = text
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
     def _build_normalized_payload(self, action: str) -> dict[str, object]:
         state_snapshot = self._state.snapshot()
         config_snapshot = self._config.snapshot()
@@ -343,20 +357,25 @@ class CallbackRouter:
         pnl = 0.0
         if portfolio is not None:
             positions = list(portfolio.positions)
-            equity = float(portfolio.equity)
-            cash = float(portfolio.cash)
-            pnl = float(portfolio.pnl)
+            equity = self._safe_number(getattr(portfolio, "equity", 0.0))
+            cash = self._safe_number(getattr(portfolio, "cash", 0.0))
+            pnl = self._safe_number(getattr(portfolio, "pnl", 0.0))
 
         primary = positions[0] if positions else None
-        exposure = (sum(float(getattr(pos, "size", 0.0)) for pos in positions) / equity) if equity > 0 else 0.0
-        unrealized_total = sum(float(getattr(pos, "unrealized_pnl", 0.0)) for pos in positions)
+        exposure = (
+            sum(self._safe_number(getattr(pos, "size", 0.0)) for pos in positions) / equity
+        ) if equity > 0 else 0.0
+        unrealized_total = sum(
+            self._safe_number(getattr(pos, "unrealized_pnl", 0.0))
+            for pos in positions
+        )
         open_positions = [
             {
                 "market_id": getattr(pos, "market_id", ""),
                 "side": getattr(pos, "side", "flat"),
-                "entry_price": getattr(pos, "avg_price", 0.0),
-                "size": getattr(pos, "size", 0.0),
-                "unrealized_pnl": getattr(pos, "unrealized_pnl", 0.0),
+                "entry_price": self._safe_number(getattr(pos, "avg_price", 0.0)),
+                "size": self._safe_number(getattr(pos, "size", 0.0)),
+                "unrealized_pnl": self._safe_number(getattr(pos, "unrealized_pnl", 0.0)),
             }
             for pos in positions
         ]
@@ -386,8 +405,8 @@ class CallbackRouter:
             "market_id": getattr(primary, "market_id", ""),
             "market_title": "",
             "side": getattr(primary, "side", "flat"),
-            "entry": getattr(primary, "avg_price", 0.0),
-            "size": getattr(primary, "size", 0.0),
+            "entry": self._safe_number(getattr(primary, "avg_price", 0.0)),
+            "size": self._safe_number(getattr(primary, "size", 0.0)),
             "strategy_mode": "enabled" if active_strategy else "monitoring",
             "signal_state": f"{len(active_strategy)} active",
             "updated_at": state_snapshot.get("timestamp") or state_snapshot.get("updated_at"),

--- a/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+def test_render_view_home_tolerates_na_numeric_placeholders() -> None:
+    payload = {
+        "status": "RUNNING",
+        "equity": "N/A",
+        "balance": None,
+        "positions": "",
+        "realized": "N/A",
+        "unrealized_pnl": "N/A",
+        "winrate": "N/A",
+        "trades": "N/A",
+    }
+    text = asyncio.run(render_view("home", payload))
+    assert "🏠 Home Command" in text
+    assert "💡 Operator Note" in text
+
+
+def test_render_view_home_tolerates_sparse_payload() -> None:
+    text = asyncio.run(render_view("start", {"status": "RUNNING"}))
+    assert "🏠 Home Command" in text
+    assert "Open Positions: 0" in text
+
+
+def test_callback_router_normalized_payload_tolerates_portfolio_na_values() -> None:
+    cmd_handler = MagicMock()
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    router = CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+
+    portfolio_state = SimpleNamespace(
+        positions=[SimpleNamespace(market_id="m1", side="yes", avg_price="N/A", size="N/A", unrealized_pnl=None)],
+        equity="N/A",
+        cash=None,
+        pnl="",
+    )
+    portfolio_service = MagicMock()
+    portfolio_service.get_state.return_value = portfolio_state
+
+    with patch(
+        "projects.polymarket.polyquantbot.telegram.handlers.callback_router.get_portfolio_service",
+        return_value=portfolio_service,
+    ):
+        payload = router._build_normalized_payload("home")
+
+    assert payload["equity"] == 0.0
+    assert payload["available_balance"] == 0.0
+    assert payload["pnl"] == 0.0
+    assert payload["positions_count"] == 1
+    assert payload["entry"] == 0.0
+    assert payload["size"] == 0.0


### PR DESCRIPTION
### Motivation
- The live Telegram `/start` path was crashing with numeric coercion errors when payload fields contained placeholders like "N/A", `None`, empty strings, or missing values. 
- The change is narrowly scoped to prevent `float()`/`int()` from receiving non-numeric placeholders and to ensure the dashboard/menu always renders a usable premium view under degraded inputs. 
- Preserve the existing menu structure and market-scope hardening work while removing this runtime blocker. 

### Description
- Added a narrow numeric normalization layer (`_safe_number`, `_safe_count`) to `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` and routed derived position/PnL metrics through it to avoid `float()` on placeholder strings. 
- Added `CallbackRouter._safe_number` and replaced unsafe `float()` conversions for portfolio and per-position fields (equity, cash, pnl, entry, size, unrealized_pnl, exposure) in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`. 
- Added focused regression tests `projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py` covering `"N/A"`, `None`, empty/malformed fields, and sparse payloads. 
- Updated the FORGE report addendum at `projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md` and `PROJECT_STATE.md` to record the blocker patch and request SENTINEL follow-up. 

### Testing
- Ran the new unit/regression tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py` which passed (3 tests). 
- Performed a smoke render run using `asyncio.run(render_view(...))` across placeholder/sparse/missing-portfolio cases which produced dashboard text with no CRITICAL ERROR marker. 
- A targeted subset of existing callback-router tests (`test_telegram_callback_router.py -k

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40b3ea33c832e9cbcc4e34bc807f8)