### PR TITLE
fix: harden Telegram Home render path against degraded payloads

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 19:39
-- Status        : FORGE-X hardening addendum applied for telegram-menu-scope-hardening-20260407 — /start numeric placeholder crash path patched with safe normalization; awaiting SENTINEL revalidation before merge decision
+- Last Updated  : 2026-04-06 19:57
+- Status        : FORGE-X hardening addendum applied for telegram-menu-scope-hardening-20260407 — live Telegram Home blocker patched with unified safe normalization/hydration fallback; awaiting SENTINEL revalidation before merge decision
 
 ---
 
@@ -22,6 +22,7 @@
 - Telegram scope hardening pass (2026-04-07): persisted Telegram market-scope state (`all_markets_enabled` + enabled categories + selection type) to local scope-state file and restored it on module/router re-init.
 - Category inference hardening applied for weak-metadata and uncategorized markets: deterministic inference order plus fallback inclusion path under category mode to reduce avoidable exclusions while preserving blocked-scope behavior when no categories are active.
 - Telegram /start numeric placeholder blocker patch (2026-04-06): hardened Telegram-facing numeric normalization in view/callback payload paths so `"N/A"`, `None`, empty, missing, and malformed numeric values no longer hard-crash dashboard/menu render.
+- Telegram Home live blocker addendum (2026-04-06): hardened callback Home payload hydration against malformed shared-state payloads, unified Home↔`/start` safe numeric normalization policy, and added callback render fallback so degraded Home payloads do not hard-crash.
 
 ---
 
@@ -44,7 +45,7 @@
 
 - SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
 Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
-- SENTINEL must include explicit `/start` placeholder regression validation (`"N/A"`, `None`, sparse payload, missing portfolio/performance fields) and confirm no CRITICAL ERROR card for this class.
+- SENTINEL must include explicit `/start` + Home placeholder regression validation (`"N/A"`, `None`, empty, malformed numerics, sparse payload, missing portfolio/performance fields, persisted scope restore) and confirm no CRITICAL ERROR card for this class.
 - If validation remains clean, move to BRIEFER or COMMANDER merge decision.
 - Merge to main is not yet automatic; COMMANDER decides after the hardening follow-up or explicit acceptance of current CONDITIONAL verdict.
 

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -51,7 +51,7 @@ def _first_present(payload: Mapping[str, Any], *keys: str, default: Any = None) 
     return default
 
 
-def _safe_number(value: Any, default: float = 0.0) -> float:
+def safe_number(value: Any, default: float = 0.0) -> float:
     if value is None:
         return default
     if isinstance(value, str):
@@ -65,8 +65,8 @@ def _safe_number(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def _safe_count(value: Any, default: int = 0) -> int:
-    return int(_safe_number(value, float(default)))
+def safe_count(value: Any, default: int = 0) -> int:
+    return int(safe_number(value, float(default)))
 
 
 def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -81,25 +81,25 @@ def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     rows = _position_rows(payload)
     primary = _as_mapping(rows[0]) if rows else {}
     unrealized_total = sum(
-        _safe_number(_as_mapping(row).get("unrealized_pnl", _as_mapping(row).get("pnl", 0.0)))
+        safe_number(_as_mapping(row).get("unrealized_pnl", _as_mapping(row).get("pnl", 0.0)))
         for row in rows
     )
     largest_position_size = max(
-        (_safe_number(_as_mapping(row).get("size", 0.0)) for row in rows),
+        (safe_number(_as_mapping(row).get("size", 0.0)) for row in rows),
         default=0.0,
     )
     realized = _first_present(payload, "realized_pnl", "realized", default=0.0)
     total_pnl = _first_present(payload, "pnl", default=None)
     if total_pnl is None:
-        total_pnl = _safe_number(realized, 0.0) + unrealized_total
+        total_pnl = safe_number(realized, 0.0) + unrealized_total
     return {
         "rows": rows,
         "primary": primary,
-        "positions_count": _safe_count(payload.get("positions_count"), len(rows)),
+        "positions_count": safe_count(payload.get("positions_count"), len(rows)),
         "unrealized_total": unrealized_total,
         "largest_position_size": largest_position_size,
-        "realized_pnl": _safe_number(realized, 0.0),
-        "total_pnl": _safe_number(total_pnl, 0.0),
+        "realized_pnl": safe_number(realized, 0.0),
+        "total_pnl": safe_number(total_pnl, 0.0),
     }
 
 

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -59,6 +59,12 @@ def _compact_text(value: object, default: str = "N/A", max_len: int = 72) -> str
     return text if len(text) <= max_len else f"{text[: max_len - 1]}…"
 
 
+def _as_text_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [_safe_text(item, "").strip() for item in value if _safe_text(item, "").strip()]
+    return []
+
+
 def _fmt_currency(value: object) -> str:
     return f"${_safe_float(value):,.2f}"
 
@@ -334,7 +340,7 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
             [
                 ("Selection Type", _safe_text(payload.get("selection_type"), "All Markets")),
                 ("Active Categories", _safe_int(payload.get("active_categories_count"))),
-                ("Enabled", _compact_text(", ".join(payload.get("enabled_categories", [])) or "None", max_len=86)),
+                ("Enabled", _compact_text(", ".join(_as_text_list(payload.get("enabled_categories"))) or "None", max_len=86)),
                 ("Summary", _compact_text(payload.get("trading_scope_summary"), "Trading scope: all allowed markets.", max_len=86)),
                 ("Fallback Rule", _compact_text(payload.get("scope_fallback_policy"), "Disabled", max_len=86)),
                 ("Persistence", "Scope restored after restart/re-init"),

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
@@ -1,6 +1,12 @@
 # telegram_menu_scope_hardening_20260407
 
 ## 1. What was built
+- **FORGE-X addendum (Home live blocker) applied in the same hardening pass:**
+  - Audited Home render path (`action:home`/dashboard/menu callbacks) versus `/start` alias flow and identified divergence in callback payload hydration robustness.
+  - Unified numeric normalization usage between Home callback payload hydration and `/start`-safe render policy by reusing shared Telegram `safe_number`/`safe_count` normalization.
+  - Hardened callback Home payload builder against malformed/shared-state portfolio payload shapes (dict/object/None, malformed numeric strings, missing keys).
+  - Added Home render fallback in callback router so degraded payload render errors are recovered to safe Home output instead of surfacing a hard failure.
+  - Hardened Active Scope text rendering for malformed restored category payload types.
 - Patched `/start` dashboard/menu numeric coercion blocker so placeholder values no longer crash Telegram render flow:
   - Added explicit numeric placeholder normalization in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` for Telegram-facing dashboard payload derivation.
   - Added callback payload numeric hardening in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` so portfolio values such as `"N/A"`, `None`, `""`, and malformed strings are coerced safely before render.
@@ -31,10 +37,28 @@
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`
 - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md`
 - `/workspace/walker-ai-team/PROJECT_STATE.md`
 
 ## 4. Before/after improvement summary
+- **Home callback live blocker path (before → after)**
+  - Before: Home callback payload normalization assumed object-style portfolio fields and could break under malformed/shared-state restored payload shapes.
+  - After: Home payload hydration safely normalizes dict/object/None portfolio states, malformed numerics (`"N/A"`, `None`, `""`, non-numeric strings), and missing keys without hard crash.
+- **Home vs `/start` normalization divergence (before → after)**
+  - Before: callback Home normalization duplicated logic and could drift from `/start`-safe behavior.
+  - After: callback Home path reuses shared Telegram-safe numeric normalization (`safe_number`/`safe_count`) aligned with `/start` safety policy.
+- **Callback-driven Home hard failure behavior (before → after)**
+  - Before: render exception in callback path bubbled to error screen flow.
+  - After: callback router now recovers to safe Home fallback render with operator note instead of hard-failing menu flow.
+- **Persisted scope restore + Home render (before → after)**
+  - Before: malformed restored category payload types could produce inconsistent category render behavior.
+  - After: scope category display path now enforces list-to-text normalization so restored sparse/malformed values cannot break Home/Scope rendering.
+- **Regression evidence added for Home blocker**
+  - Added/extended tests for:
+    - Home render with malformed portfolio dict payload and placeholder numerics.
+    - callback `/start` → Home transition with sparse payload.
+    - Home render after persisted scope-state restore containing sparse/malformed category entries.
 - **`/start` numeric placeholder crash (before → after)**
   - Before: `/start` render path could execute `float("N/A")` during dashboard payload derivation, producing `ValueError` and CRITICAL ERROR card (`command_handler:/start` context).
   - After: all Telegram-facing numeric coercion on `/start` path routes through explicit safe normalization (`_safe_number`, `_safe_count`) with truthful defaults for degraded input.
@@ -79,4 +103,4 @@
 ## 6. Next
 - SENTINEL validation required for telegram-menu-scope-hardening-20260407 before merge.
 Source: projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md
-- SENTINEL should validate `/start` placeholder regression path explicitly (including `"N/A"`, `None`, sparse/missing numeric fields) and confirm no CRITICAL ERROR card for this class.
+- SENTINEL should validate both `/start` and callback-driven Home placeholder regression paths explicitly (including `"N/A"`, `None`, empty, malformed numerics, sparse/missing fields, and persisted scope restore path) and confirm no CRITICAL ERROR card for this class.

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -46,7 +46,7 @@ from ..ui.screens import (
     noop_screen,
 )
 from ..ui.components import render_kv_line, render_insight, SEP
-from ...interface.telegram.view_handler import render_view
+from ...interface.telegram.view_handler import render_view, safe_number, safe_count
 from ...core.market_scope import (
     MARKET_SCOPE_CATEGORIES,
     get_market_scope_snapshot,
@@ -333,52 +333,59 @@ class CallbackRouter:
             return {}
 
     @staticmethod
-    def _safe_number(value: object, default: float = 0.0) -> float:
-        if value is None:
-            return default
-        if isinstance(value, str):
-            text = value.strip()
-            if not text or text.lower() in {"n/a", "na", "none", "null", "nan", "-"}:
-                return default
-            value = text
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return default
+    def _extract_field(container: object, key: str, default: object = None) -> object:
+        if isinstance(container, dict):
+            return container.get(key, default)
+        return getattr(container, key, default)
+
+    def _normalize_positions(self, raw_positions: object) -> list[dict[str, object]]:
+        if not isinstance(raw_positions, list | tuple):
+            return []
+        normalized: list[dict[str, object]] = []
+        for pos in raw_positions:
+            normalized.append(
+                {
+                    "market_id": str(self._extract_field(pos, "market_id", "") or ""),
+                    "side": str(self._extract_field(pos, "side", "flat") or "flat"),
+                    "entry_price": safe_number(
+                        self._extract_field(
+                            pos,
+                            "avg_price",
+                            self._extract_field(pos, "entry_price", 0.0),
+                        )
+                    ),
+                    "size": safe_number(self._extract_field(pos, "size", 0.0)),
+                    "unrealized_pnl": safe_number(
+                        self._extract_field(pos, "unrealized_pnl", self._extract_field(pos, "pnl", 0.0))
+                    ),
+                }
+            )
+        return normalized
 
     def _build_normalized_payload(self, action: str) -> dict[str, object]:
         state_snapshot = self._state.snapshot()
         config_snapshot = self._config.snapshot()
         portfolio = get_portfolio_service().get_state()
 
-        positions = []
+        positions: list[dict[str, object]] = []
         equity = 0.0
         cash = 0.0
         pnl = 0.0
         if portfolio is not None:
-            positions = list(portfolio.positions)
-            equity = self._safe_number(getattr(portfolio, "equity", 0.0))
-            cash = self._safe_number(getattr(portfolio, "cash", 0.0))
-            pnl = self._safe_number(getattr(portfolio, "pnl", 0.0))
+            positions = self._normalize_positions(self._extract_field(portfolio, "positions", []))
+            equity = safe_number(self._extract_field(portfolio, "equity", 0.0))
+            cash = safe_number(self._extract_field(portfolio, "cash", 0.0))
+            pnl = safe_number(self._extract_field(portfolio, "pnl", 0.0))
 
         primary = positions[0] if positions else None
         exposure = (
-            sum(self._safe_number(getattr(pos, "size", 0.0)) for pos in positions) / equity
+            sum(safe_number(pos.get("size", 0.0)) for pos in positions) / equity
         ) if equity > 0 else 0.0
         unrealized_total = sum(
-            self._safe_number(getattr(pos, "unrealized_pnl", 0.0))
+            safe_number(pos.get("unrealized_pnl", 0.0))
             for pos in positions
         )
-        open_positions = [
-            {
-                "market_id": getattr(pos, "market_id", ""),
-                "side": getattr(pos, "side", "flat"),
-                "entry_price": self._safe_number(getattr(pos, "avg_price", 0.0)),
-                "size": self._safe_number(getattr(pos, "size", 0.0)),
-                "unrealized_pnl": self._safe_number(getattr(pos, "unrealized_pnl", 0.0)),
-            }
-            for pos in positions
-        ]
+        open_positions = positions
         strategy_states = self._strategy_states()
         active_strategy = [name for name, enabled in strategy_states.items() if bool(enabled)]
         scope_snapshot = get_market_scope_snapshot()
@@ -396,17 +403,17 @@ class CallbackRouter:
             "equity": equity,
             "balance": cash,
             "available_balance": cash,
-            "positions_count": len(positions),
+            "positions_count": safe_count(len(positions), 0),
             "positions": open_positions,
             "pnl": pnl,
             "realized_pnl": 0.0,
             "unrealized_pnl": unrealized_total,
             "exposure": exposure,
-            "market_id": getattr(primary, "market_id", ""),
+            "market_id": (primary or {}).get("market_id", ""),
             "market_title": "",
-            "side": getattr(primary, "side", "flat"),
-            "entry": self._safe_number(getattr(primary, "avg_price", 0.0)),
-            "size": self._safe_number(getattr(primary, "size", 0.0)),
+            "side": (primary or {}).get("side", "flat"),
+            "entry": safe_number((primary or {}).get("entry_price", 0.0)),
+            "size": safe_number((primary or {}).get("size", 0.0)),
             "strategy_mode": "enabled" if active_strategy else "monitoring",
             "signal_state": f"{len(active_strategy)} active",
             "updated_at": state_snapshot.get("timestamp") or state_snapshot.get("updated_at"),
@@ -460,7 +467,15 @@ class CallbackRouter:
         if normalized_action == "control":
             payload["control_action"] = "standby"
 
-        text = await render_view(normalized_action, payload)
+        try:
+            text = await render_view(normalized_action, payload)
+        except Exception as exc:  # noqa: BLE001
+            log.error("callback_render_fallback", action=normalized_action, error=str(exc), exc_info=True)
+            fallback_payload = self._build_normalized_payload("home")
+            fallback_payload["decision"] = "Telemetry payload degraded — rendered with safe defaults"
+            fallback_payload["operator_note"] = "Home recovered from malformed input without interruption"
+            fallback_payload["insight"] = "Normalization parity with /start keeps home resilient"
+            text = await render_view("home", fallback_payload)
 
         scope_snapshot = get_market_scope_snapshot()
         enabled_categories = set(scope_snapshot.get("enabled_categories", []))

--- a/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
@@ -4,7 +4,10 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core import market_scope
 from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
 from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
 from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
@@ -65,3 +68,88 @@ def test_callback_router_normalized_payload_tolerates_portfolio_na_values() -> N
     assert payload["positions_count"] == 1
     assert payload["entry"] == 0.0
     assert payload["size"] == 0.0
+
+
+def test_callback_router_home_render_tolerates_malformed_portfolio_payload() -> None:
+    cmd_handler = MagicMock()
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    router = CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+    malformed_portfolio_state = {
+        "positions": [
+            {"market_id": "m1", "side": "YES", "entry_price": "N/A", "size": "N/A", "unrealized_pnl": ""},
+            {"market_id": None, "side": None, "entry_price": "bad-value", "size": None},
+        ],
+        "equity": "N/A",
+        "cash": "",
+        "pnl": "broken-number",
+    }
+    portfolio_service = MagicMock()
+    portfolio_service.get_state.return_value = malformed_portfolio_state
+
+    with patch(
+        "projects.polymarket.polyquantbot.telegram.handlers.callback_router.get_portfolio_service",
+        return_value=portfolio_service,
+    ):
+        text, _ = asyncio.run(router._render_normalized_callback("home"))
+
+    assert "🏠 Home Command" in text
+    assert "Open Positions: 2" in text
+    assert "Total Value: $0.00" in text
+
+
+def test_callback_router_start_to_home_transition_safe_with_sparse_payload() -> None:
+    cmd_handler = MagicMock()
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    router = CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+    portfolio_service = MagicMock()
+    portfolio_service.get_state.return_value = {"positions": None, "equity": None, "cash": None, "pnl": None}
+
+    with patch(
+        "projects.polymarket.polyquantbot.telegram.handlers.callback_router.get_portfolio_service",
+        return_value=portfolio_service,
+    ):
+        text, _ = asyncio.run(router._render_normalized_callback("start"))
+
+    assert "🏠 Home Command" in text
+    assert "Open Positions: 0" in text
+
+
+def test_home_render_after_scope_state_restore_tolerates_sparse_file(tmp_path) -> None:
+    state_file = tmp_path / "market_scope_state.json"
+    state_file.write_text(
+        '{"all_markets_enabled": false, "enabled_categories": ["Crypto", null, "", 42]}',
+        encoding="utf-8",
+    )
+
+    original_file = market_scope._SCOPE_STATE_FILE
+    original_loaded = market_scope._scope_state_loaded
+    original_all = market_scope._all_markets_enabled
+    original_categories = set(market_scope._enabled_categories)
+    try:
+        market_scope._SCOPE_STATE_FILE = state_file
+        market_scope._scope_state_loaded = False
+        market_scope._all_markets_enabled = True
+        market_scope._enabled_categories = set()
+
+        text = asyncio.run(render_view("home", market_scope.get_market_scope_snapshot()))
+        assert "🏠 Home Command" in text
+        assert "Scope: Categories (1)" in text
+    finally:
+        market_scope._SCOPE_STATE_FILE = original_file
+        market_scope._scope_state_loaded = original_loaded
+        market_scope._all_markets_enabled = original_all
+        market_scope._enabled_categories = original_categories


### PR DESCRIPTION
### Motivation
- Fix a live Telegram Home crash that occurred when callback-driven or restored/shared-state payloads contained placeholders, malformed numeric strings, or missing keys. 
- Ensure Home and `/start` share the same safe normalization rules so numeric coercion parity prevents divergent hard failures.
- Preserve existing menu structure and scope gating while preventing Home from hard-crashing under degraded inputs.

### Description
- Introduced shared safe normalization helpers by promoting `safe_number` / `safe_count` in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` and reusing them across Home/callback paths. 
- Hardened callback payload hydration in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` by adding `_extract_field`, `_normalize_positions`, safe extraction of portfolio fields, and replacing ad-hoc conversions with `safe_number`/`safe_count`. 
- Added a render fallback in the callback router so `render_view` exceptions recover to a safe Home output instead of causing a hard failure. 
- Hardened Active Scope UI formatting in `projects/polymarket/polyquantbot/interface/ui_formatter.py` by coercing restored `enabled_categories` to a safe text list before joining for display. 
- Extended and added regression tests in `projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py` covering malformed/missing numeric placeholders, callback `/start -> home` transition with sparse payloads, and persisted scope-state restore with malformed category entries. 
- Updated the FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md` and synchronized `PROJECT_STATE.md` to document the Home live-fix addendum and required SENTINEL follow-up.

### Testing
- Ran the targeted test module with environment set: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`, and all tests passed (`6 passed`).
- An initial `pytest` run without `PYTHONPATH` failed to import the package due to environment path setup, and this was resolved by running with `PYTHONPATH=.` to exercise the tests in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40f95cff4832e92f1c861530b3e5b)