### PR TITLE
feat(telegram): consolidate premium two-layer navigation UX

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 21:44
-- Status        : SENTINEL validation complete for telegram-menu-scope-hardening-20260407 — verdict APPROVED, score 88/100, critical blockers none; BRIEFER handoff completed; awaiting COMMANDER merge decision
+- Last Updated  : 2026-04-06 22:15
+- Status        : FORGE-X telegram-premium-nav-ux-20260407 build pass complete (post-approval UX consolidation); awaiting SENTINEL validation before COMMANDER merge decision
 
 ---
 
@@ -26,15 +26,15 @@
 - Telegram live-path blocker fix (2026-04-06): removed root-menu divergence by aligning reply keyboard with 5-item root contract, forced `/start` to emit authoritative inline main menu payload, and hardened shared portfolio normalization path that could still execute `float(\"N/A\")`.
 - SENTINEL validation complete for `telegram-menu-scope-hardening-20260407` with verdict **APPROVED** (score **88/100**) and **no critical issues**.
 - BRIEFER handoff completed for `telegram-menu-scope-hardening-20260407`.
+- Telegram premium navigation / UX consolidation pass (2026-04-07): enforced two-layer Telegram navigation with persistent 5-item reply-keyboard root and contextual inline section actions; removed duplicated inline root menu; added active-root cue and compact button layout polish while preserving approved scope-control semantics.
 
 ---
 
 ## 🚧 IN PROGRESS
 
-### Phase 10.4 — 24H Live Paper Run
-- Final on-device Telegram visual confirmation in live-network environment.
-- Operational follow-up monitoring for external Railway/live deployment confirmation status.
-- COMMANDER merge-decision preparation based on APPROVED validation result (88/100, no critical issues) and completed BRIEFER handoff.
+### Telegram post-approval UX consolidation handoff
+- SENTINEL validation pending for `telegram-premium-nav-ux-20260407` (two-layer nav + premium UX consolidation).
+- Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
 ---
 
@@ -46,9 +46,9 @@
 
 ## 🎯 NEXT PRIORITY
 
-- COMMANDER merge decision for `telegram-menu-scope-hardening-20260407`.
-- Continue external Railway/live confirmation monitoring as operational follow-up until fully confirmed.
-- Merge to main remains a COMMANDER-only decision.
+- SENTINEL validation required for telegram-premium-nav-ux-20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md
+- COMMANDER merge decision after SENTINEL verdict.
 
 ---
 
@@ -56,3 +56,4 @@
 
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
+- External live Telegram device screenshot proof is still unavailable in this container environment.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -103,6 +103,18 @@ def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _resolve_active_root(mode: str) -> str:
+    if mode in {"wallet", "positions", "pnl", "performance", "exposure", "portfolio"}:
+        return "portfolio"
+    if mode in {"market", "markets", "active_scope"}:
+        return "markets"
+    if mode in {"settings", "notifications", "auto_trade", "mode", "risk", "strategy", "control"}:
+        return "settings"
+    if mode in {"help", "guidance", "bot_info"}:
+        return "help"
+    return "dashboard"
+
+
 def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
     metrics = _derive_position_metrics(payload)
     primary = metrics["primary"]
@@ -160,6 +172,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "scope_warning": payload.get("scope_warning", ""),
         "scope_fallback_policy": payload.get("scope_fallback_policy", ""),
         "scope_state_file": payload.get("scope_state_file", ""),
+        "active_root": payload.get("active_root", _resolve_active_root(mode)),
     }
 
 

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -32,6 +32,14 @@ VIEW_TITLE = {
     "bot_info": "ℹ️ Bot Info",
 }
 
+ROOT_LABELS: dict[str, str] = {
+    "dashboard": "📊 Dashboard",
+    "portfolio": "💼 Portfolio",
+    "markets": "🎯 Markets",
+    "settings": "⚙️ Settings",
+    "help": "❓ Help",
+}
+
 
 def _safe_float(value: object, default: float = 0.0) -> float:
     try:
@@ -174,10 +182,13 @@ def _hero_block(mode: str, payload: Mapping[str, Any]) -> str:
     status = _safe_text(payload.get("state"), "waiting").upper()
     decision = _compact_text(payload.get("decision"), "Await qualified signal", max_len=84)
     risk_state = _compact_text(payload.get("risk_state"), "within limits", max_len=56)
+    active_root = _safe_text(payload.get("active_root"), "dashboard").lower()
+    active_label = ROOT_LABELS.get(active_root, ROOT_LABELS["dashboard"])
     return _section(
         VIEW_TITLE.get(mode, VIEW_TITLE["home"]),
         _tree_group(
             [
+                ("Section", f"● {active_label}"),
                 ("Status", status),
                 ("Now", decision),
                 ("Risk", risk_state),

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md
@@ -1,0 +1,65 @@
+## 1. What was built
+- Refactored Telegram navigation into a strict two-layer UX model:
+  - **Layer 1 (persistent root):** reply keyboard remains the sole 5-item root navigation (`📊 Dashboard`, `💼 Portfolio`, `🎯 Markets`, `⚙️ Settings`, `❓ Help`).
+  - **Layer 2 (contextual inline):** inline keyboards now show section-only actions and no longer render a duplicated 5-item root menu.
+- Consolidated inline button grammar for a cleaner premium layout:
+  - standardized two-column grouping where semantically appropriate,
+  - reduced one-button-per-row heaviness,
+  - removed redundant `Main Menu` buttons from root section inline submenus.
+- Added active-root clarity cues in rendered cards by surfacing a compact `Section` marker in the hero block.
+- Preserved approved behavior for market-scope controls and callback semantics while improving UX composition only.
+
+### Before vs After evidence
+- **Duplicated root navigation (before):** `build_main_menu()` produced the same root stack inline while reply keyboard also contained root nav.
+- **No duplication (after):** `build_main_menu()` now resolves to dashboard contextual actions only, and callback fallbacks return contextual section menus.
+- **Context isolation (after):**
+  - Portfolio inline actions: Wallet/Positions/Exposure/PnL/Performance only.
+  - Markets inline actions: Overview/All Markets/Categories/Active Scope/Refresh All only.
+  - Settings inline actions: Mode/Control/Risk Level/Strategy/Notifications/Auto Trade only.
+  - Help inline actions: Guidance/Bot Info only.
+- **Vertical-space reduction (after):** compact two-column rows replace stacked one-column root duplication.
+
+## 2. Current system architecture
+- **Root layer (persistent):**
+  - `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py`
+  - Authoritative bottom keyboard with only 5 root sections.
+- **Section layer (contextual):**
+  - `projects/polymarket/polyquantbot/telegram/ui/keyboard.py`
+  - Dashboard/Portfolio/Markets/Settings/Help inline builders expose section-local actions only.
+- **Routing and keyboard selection:**
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - Added active-root resolver and normalized callback behavior so fallback/edit paths stay contextual.
+- **View composition + active-state cue:**
+  - `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - Payload now carries `active_root`; hero block displays concise section marker.
+- **/start parity:**
+  - `projects/polymarket/polyquantbot/telegram/command_handler.py`
+  - `/start` inline payload now uses dashboard contextual menu rather than duplicate root inline menu.
+
+## 3. Files created / modified (full paths)
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md
+- /workspace/walker-ai-team/PROJECT_STATE.md
+
+## 4. What is working
+- Reply keyboard remains the only full root navigation layer (5-item contract intact).
+- Inline keyboards no longer render a duplicated root menu; they render contextual section actions only.
+- Dashboard, Portfolio, Markets, Settings, and Help each map to isolated inline action sets.
+- Markets controls (`All Markets`, `Categories`, `Active Scope`, `Refresh All`) remain intact semantically, with cleaner grouping.
+- Callback normalization and fallback rendering retain approved functionality without reopening strategy/risk/execution layers.
+- Active section cue now appears in message hero (`Section: ● <root>`), improving root/submenu hierarchy clarity.
+- Added focused tests asserting two-layer nav separation and context-only submenu discipline.
+
+## 5. Known issues
+- Real Telegram device visual confirmation (true end-user screenshot proof) is not available in this container-only environment.
+- Legacy broad callback-router test suite still includes historical expectations from older menu contracts and should be re-baselined in a dedicated validation pass.
+
+## 6. What is next
+- SENTINEL validation required for telegram-premium-nav-ux-20260407 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -12,7 +12,7 @@ from ..core.system_state import SystemState, SystemStateManager
 from ..interface.telegram.view_handler import render_view, safe_count, safe_number
 from ..execution.engine import export_execution_payload, get_execution_engine
 from ..execution.strategy_trigger import StrategyConfig, StrategyTrigger
-from .ui.keyboard import build_main_menu
+from .ui.keyboard import build_dashboard_menu
 from .handlers.portfolio_service import get_portfolio_service
 from .message_formatter import (
     format_capital_allocation_report,
@@ -451,7 +451,7 @@ class CommandHandler:
             "positions": safe_count(metrics.get("open_positions", metrics.get("positions", 0)), 0),
             "unrealized": safe_number(metrics.get("unrealized_pnl", metrics.get("unreal", 0.0)), 0.0),
             "realized": safe_number(metrics.get("pnl", metrics.get("realized", 0.0)), 0.0),
-            "_keyboard": build_main_menu(),
+            "_keyboard": build_dashboard_menu(),
             "insight": (
                 f"Risk {risk_multiplier:.2f} • Max Pos {max_position:.2f}"
             ),

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -27,7 +27,6 @@ from typing import Optional, TYPE_CHECKING
 import structlog
 
 from ..ui.keyboard import (
-    build_main_menu,
     build_dashboard_menu,
     build_portfolio_menu,
     build_markets_menu,
@@ -288,7 +287,7 @@ class CallbackRouter:
                 exc_info=True,
             )
             text = error_screen(context=action, error=str(exc))
-            keyboard = build_main_menu()
+            keyboard = build_dashboard_menu()
 
         # noop — no message update needed
         if not text:
@@ -361,6 +360,19 @@ class CallbackRouter:
                 }
             )
         return normalized
+
+    @staticmethod
+    def _active_root_for_action(action: str) -> str:
+        """Resolve active root section for contextual inline keyboard rendering."""
+        if action.startswith("portfolio_") or action in {"portfolio", "wallet", "positions", "pnl", "performance", "exposure"}:
+            return "portfolio"
+        if action.startswith("markets_") or action in {"markets", "market", "active_scope"}:
+            return "markets"
+        if action.startswith("settings_") or action.startswith("mode_confirm_") or action in {"settings", "risk", "strategy", "control", "notifications", "auto_trade"}:
+            return "settings"
+        if action.startswith("help_") or action in {"help", "guidance", "bot_info"}:
+            return "help"
+        return "dashboard"
 
     def _build_normalized_payload(self, action: str) -> dict[str, object]:
         state_snapshot = self._state.snapshot()
@@ -437,7 +449,6 @@ class CallbackRouter:
         from ..ui.keyboard import (
             build_mode_confirm_menu,
             build_control_menu,
-            build_main_menu,
             build_settings_menu,
             build_risk_level_menu,
         )  # noqa: PLC0415
@@ -457,9 +468,10 @@ class CallbackRouter:
             "markets_overview": "markets",
             "markets_refresh_all": "refresh",
         }
-        base_action = "home" if action in {"back_main", "back", "start", "menu", "home"} else action
+        base_action = "dashboard_home" if action in {"back_main", "back", "start", "menu", "home"} else action
         normalized_action = action_aliases.get(base_action, base_action)
         payload = self._build_normalized_payload(normalized_action)
+        payload["active_root"] = self._active_root_for_action(base_action)
         payload["mode_label"] = self._mode.upper()
         if normalized_action == "settings_mode":
             payload["target_mode"] = "PAPER" if self._mode.upper() == "LIVE" else "LIVE"
@@ -495,7 +507,7 @@ class CallbackRouter:
             return text, build_help_menu()
 
         if normalized_action == "home":
-            return text, build_main_menu()
+            return text, build_dashboard_menu()
         if normalized_action in {"status", "system", "refresh", "positions", "trade", "pnl", "performance", "exposure", "risk"}:
             return text, build_dashboard_menu()
         if normalized_action == "wallet":
@@ -520,7 +532,7 @@ class CallbackRouter:
         if normalized_action == "control":
             current_state = self._state.state.value
             return text, build_control_menu(current_state)
-        return text, build_main_menu()
+        return text, build_dashboard_menu()
 
     # ── Dispatch table ─────────────────────────────────────────────────────────
 
@@ -599,6 +611,7 @@ class CallbackRouter:
         if action == "markets_all_toggle":
             await toggle_all_markets()
             payload = self._build_normalized_payload("markets")
+            payload["active_root"] = "markets"
             if bool(payload.get("scope_warning")):
                 payload["decision"] = "Scope blocked until at least one category is enabled or All Markets is turned ON"
                 payload["operator_note"] = "Use Markets → Categories to enable categories"
@@ -611,6 +624,7 @@ class CallbackRouter:
 
         if action == "markets_categories_save":
             payload = self._build_normalized_payload("active_scope")
+            payload["active_root"] = "markets"
             payload["decision"] = "Category selection saved"
             payload["operator_note"] = "Active scope now controls allowed scan/trade universe"
             text = await render_view("active_scope", payload)
@@ -679,6 +693,7 @@ class CallbackRouter:
             payload = self._build_normalized_payload("control")
             payload.update(
                 {
+                    "active_root": "settings",
                     "mode_label": self._mode.upper(),
                     "control_action": "paused",
                     "decision": "System paused via control menu",
@@ -694,6 +709,7 @@ class CallbackRouter:
             payload = self._build_normalized_payload("control")
             payload.update(
                 {
+                    "active_root": "settings",
                     "mode_label": self._mode.upper(),
                     "control_action": "resumed",
                     "decision": "System resumed via control menu",
@@ -708,6 +724,7 @@ class CallbackRouter:
             payload = self._build_normalized_payload("control")
             payload.update(
                 {
+                    "active_root": "settings",
                     "mode_label": self._mode.upper(),
                     "control_action": "confirm stop",
                     "decision": "Stop requested — confirmation required",
@@ -723,6 +740,7 @@ class CallbackRouter:
             payload = self._build_normalized_payload("control")
             payload.update(
                 {
+                    "active_root": "settings",
                     "mode_label": self._mode.upper(),
                     "control_action": "halted",
                     "decision": "System halted from control menu",
@@ -820,6 +838,7 @@ class CallbackRouter:
             payload["decision"] = f"Category toggled: {category_name}"
             payload["operator_note"] = "Category scope is now active because All Markets is OFF"
             payload["insight"] = "Tap categories to enable/disable; use Active Scope to verify final trading universe"
+            payload["active_root"] = "markets"
             text = await render_view("markets", payload)
             scope_snapshot = get_market_scope_snapshot()
             return text, build_market_categories_menu(
@@ -840,7 +859,7 @@ class CallbackRouter:
                 main_screen(mode=self._mode, state=snap.get("state", "UNKNOWN")),
                 render_insight("Unexpected action — returning to main menu"),
             ]),
-            build_main_menu(),
+            build_dashboard_menu(),
         )
 
     # ── Telegram API helpers ───────────────────────────────────────────────────

--- a/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
+++ b/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
@@ -31,20 +31,12 @@ def _btn(text: str, action: str) -> dict[str, str]:
 
 
 def build_main_menu() -> InlineKeyboard:
-    """Top-level navigation menu.
+    """Legacy compatibility entry-point.
 
-    Layout::
-
-        [📊 Status]    [💰 Wallet  ]
-        [⚙️ Settings]  [▶  Control ]
+    The persistent reply keyboard is now the only root navigation layer, so
+    inline callbacks default to Dashboard contextual actions.
     """
-    return [
-        [_btn("📊 Dashboard", "dashboard")],
-        [_btn("💼 Portfolio", "portfolio")],
-        [_btn("🎯 Markets", "markets")],
-        [_btn("⚙️ Settings", "settings")],
-        [_btn("❓ Help", "help")],
-    ]
+    return build_dashboard_menu()
 
 
 # ── Status sub-menu ────────────────────────────────────────────────────────────
@@ -63,43 +55,36 @@ def build_status_menu() -> InlineKeyboard:
 
 
 def build_dashboard_menu() -> InlineKeyboard:
-    """Dashboard sub-menu."""
+    """Dashboard contextual menu (two-layer model)."""
     return [
-        [_btn("Home", "dashboard_home"), _btn("System", "dashboard_system")],
-        [_btn("Refresh All", "dashboard_refresh_all")],
-        [_btn("🏠 Main Menu", "back_main")],
+        [_btn("🏠 Home", "dashboard_home"), _btn("🧠 System", "dashboard_system")],
+        [_btn("🔄 Refresh All", "dashboard_refresh_all")],
     ]
 
 
 def build_portfolio_menu() -> InlineKeyboard:
-    """Portfolio sub-menu."""
+    """Portfolio contextual menu."""
     return [
-        [_btn("Wallet", "portfolio_wallet"), _btn("Positions", "portfolio_positions")],
-        [_btn("Exposure", "portfolio_exposure"), _btn("PnL", "portfolio_pnl")],
-        [_btn("Performance", "portfolio_performance")],
-        [_btn("🏠 Main Menu", "back_main")],
+        [_btn("💰 Wallet", "portfolio_wallet"), _btn("📈 Positions", "portfolio_positions")],
+        [_btn("📊 Exposure", "portfolio_exposure"), _btn("💹 PnL", "portfolio_pnl")],
+        [_btn("🏁 Performance", "portfolio_performance")],
     ]
 
 
 def build_markets_menu(all_markets_enabled: bool) -> InlineKeyboard:
-    """Markets sub-menu with All Markets scope state."""
+    """Markets contextual menu with compact control grouping."""
     all_markets_label = "🌍 All Markets ✅" if all_markets_enabled else "🌍 All Markets ⬜"
     return [
-        [_btn("Overview", "markets_overview")],
-        [_btn(all_markets_label, "markets_all_toggle")],
-        [_btn("🗂 Categories", "markets_categories")],
-        [_btn("✅ Active Scope", "markets_active_scope")],
+        [_btn("📡 Overview", "markets_overview"), _btn(all_markets_label, "markets_all_toggle")],
+        [_btn("🗂 Categories", "markets_categories"), _btn("✅ Active Scope", "markets_active_scope")],
         [_btn("🔄 Refresh All", "markets_refresh_all")],
-        [_btn("🏠 Main Menu", "back_main")],
     ]
 
 
 def build_help_menu() -> InlineKeyboard:
-    """Help sub-menu."""
+    """Help contextual menu."""
     return [
-        [_btn("Guidance", "help_guidance")],
-        [_btn("Bot Info", "help_bot_info")],
-        [_btn("🏠 Main Menu", "back_main")],
+        [_btn("🧭 Guidance", "help_guidance"), _btn("ℹ️ Bot Info", "help_bot_info")],
     ]
 
 
@@ -150,12 +135,11 @@ def build_paper_wallet_menu() -> InlineKeyboard:
 
 
 def build_settings_menu() -> InlineKeyboard:
-    """Settings sub-menu."""
+    """Settings contextual menu."""
     return [
-        [_btn("Mode", "settings_mode"), _btn("Control", "control")],
-        [_btn("Risk Level", "settings_risk"), _btn("Strategy", "settings_strategy")],
-        [_btn("Notifications", "settings_notify"), _btn("Auto Trade", "settings_auto")],
-        [_btn("🏠 Main Menu", "back_main")],
+        [_btn("🔀 Mode", "settings_mode"), _btn("🎛️ Control", "control")],
+        [_btn("🛡️ Risk Level", "settings_risk"), _btn("🧠 Strategy", "settings_strategy")],
+        [_btn("🔔 Notifications", "settings_notify"), _btn("🤖 Auto Trade", "settings_auto")],
     ]
 
 

--- a/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.telegram.ui.keyboard import (
+    build_dashboard_menu,
+    build_help_menu,
+    build_main_menu,
+    build_markets_menu,
+    build_portfolio_menu,
+    build_settings_menu,
+)
+from projects.polymarket.polyquantbot.telegram.ui.reply_keyboard import REPLY_MENU_MAP
+
+
+def _callback_values(keyboard: list[list[dict[str, str]]]) -> set[str]:
+    return {btn["callback_data"] for row in keyboard for btn in row}
+
+
+def test_reply_keyboard_is_authoritative_five_root_sections() -> None:
+    assert set(REPLY_MENU_MAP.values()) == {"dashboard", "portfolio", "markets", "settings", "help"}
+
+
+def test_main_menu_alias_returns_dashboard_context_only() -> None:
+    assert _callback_values(build_main_menu()) == {
+        "action:dashboard_home",
+        "action:dashboard_system",
+        "action:dashboard_refresh_all",
+    }
+
+
+def test_portfolio_menu_has_only_contextual_actions() -> None:
+    assert _callback_values(build_portfolio_menu()) == {
+        "action:portfolio_wallet",
+        "action:portfolio_positions",
+        "action:portfolio_exposure",
+        "action:portfolio_pnl",
+        "action:portfolio_performance",
+    }
+
+
+def test_markets_menu_keeps_scope_controls_without_root_duplication() -> None:
+    actions = _callback_values(build_markets_menu(all_markets_enabled=True))
+    assert actions == {
+        "action:markets_overview",
+        "action:markets_all_toggle",
+        "action:markets_categories",
+        "action:markets_active_scope",
+        "action:markets_refresh_all",
+    }
+
+
+def test_settings_and_help_menus_are_contextual_only() -> None:
+    assert "action:back_main" not in _callback_values(build_settings_menu())
+    assert "action:back_main" not in _callback_values(build_help_menu())


### PR DESCRIPTION
### Motivation
- Founder-requested UX consolidation to remove duplicated root navigation and deliver a premium two-layer tab-style experience while preserving all approved menu/hardening behavior. 
- Improve visual weight, spacing, and hierarchy so reply keyboard is authoritative root and inline keyboards are contextual section actions only.

### Description
- Implemented two-layer navigation: reply keyboard remains the persistent 5-item root (`📊 Dashboard`, `💼 Portfolio`, `🎯 Markets`, `⚙️ Settings`, `❓ Help`) and inline keyboards were refactored to contain only contextual submenu actions (Dashboard/Portfolio/Markets/Settings/Help). 
- Changed inline/menu builders and routing so `build_main_menu()` now aliases to the Dashboard contextual menu and callback routing returns section-only inline keyboards (no duplicated inline root stack); added `_active_root_for_action` and propagate `active_root` in payloads. 
- Added active-root visual cue in the hero block (`Section: ● <root>`) and polished button layouts to compact two-column/grouped rows for reduced vertical space and premium rhythm. 
- Files updated and new artifacts: `projects/polymarket/polyquantbot/telegram/ui/keyboard.py`, `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`, `projects/polymarket/polyquantbot/interface/ui_formatter.py`, `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`, `projects/polymarket/polyquantbot/telegram/command_handler.py`, new focused tests `projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py`, and forge report `projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md`; `PROJECT_STATE.md` was updated to reflect this build pass. 

### Testing
- Ran `python -m pytest projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py -q` and all tests passed (5 passed). 
- Re-ran existing numeric-safety suite with `python -m pytest projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py -q` and it passed (9 passed). 
- Confirmed phase-folder guard (`rg --files | rg '/phase[0-9]+'`) returned no phase folders. 
- Note: real-device Telegram screenshot verification is not available in this environment (visual confirmation recommended during SENTINEL/live device validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d42fb1f50c832e8f860129af1dab14)