### PR TITLE
paper trade hardening P0: enforce RiskGuard + durable dedup + restore fix

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 22:40
-- Status        : SENTINEL trade-system truth audit complete (paper-path decision map delivered); premium-nav and trade-hardening merge sequence awaiting COMMANDER direction
+- Last Updated  : 2026-04-06 23:35
+- Status        : FORGE-X paper-trade hardening P0 completed from SENTINEL trade-system truth audit; paper path safety improved and restart consistency hardened, but real-wallet readiness remains blocked pending SENTINEL re-validation
 
 ---
 
@@ -30,6 +30,8 @@
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
 
+- Paper trade hardening P0 (2026-04-06): enforced formal RiskGuard gating on active trading loop before every execution attempt, propagated kill-switch state into execution calls, fixed EngineContainer wallet restore assignment semantics, removed silent close-alert exception swallowing, introduced durable trade-intent reservation for restart-safe dedup, and bounded projection-layer partial-failure observability with explicit logs.
+
 ---
 
 ## 🚧 IN PROGRESS
@@ -38,8 +40,8 @@
 - SENTINEL validation pending for `telegram-premium-nav-ux-20260407` (two-layer nav + premium UX consolidation).
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
-### Trade-system hardening handoff
-- FORGE-X hardening pending for risk-gate unification, reconciliation ownership, restart recovery correctness, and silent-failure removal before any real-wallet enablement.
+### Trade-system hardening validation handoff
+- SENTINEL validation pending for `paper_trade_hardening_p0_20260407` before merge and before any real-wallet readiness promotion.
 
 ---
 
@@ -51,9 +53,9 @@
 
 ## 🎯 NEXT PRIORITY
 
-- FORGE-X hardening required for trade-system readiness before any real-wallet enablement.
-- Source: projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md
-- SENTINEL re-validation required after hardening pass; COMMANDER merge/enablement decision only after that validation.
+- SENTINEL validation required for paper_trade_hardening_p0_20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+- Real-wallet enablement remains blocked until SENTINEL approves this hardening increment and remaining P1 reconciliation/parity work.
 
 ---
 
@@ -62,5 +64,5 @@
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
-- Trading-loop execution path currently bypasses formal `RiskGuard` kill-switch/daily-loss/drawdown gating and must be hardened before real-wallet mode.
-- Startup wallet restore path in engine container may not apply persisted wallet state correctly (class-method return value is not assigned), creating restart reconciliation risk.
+- Paper path is materially safer after P0 hardening, but real-wallet readiness is still blocked on P1 parity/reconciliation follow-up and SENTINEL validation evidence.
+- P1 gap: execution projection writes (DB + overlays) are now bounded/observable but still non-transactional across all stores; further reconciliation unification is required before real-wallet enablement.

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -99,6 +99,7 @@ from ...interface.ui.views import (
     render_wallet_view,
 )
 from ..validation_state import ValidationStateStore
+from ...risk.risk_guard import RiskGuard
 from ..logging.logger import (
     log_market_metadata_used,
     log_position_updated,
@@ -444,6 +445,7 @@ async def run_trading_loop(
     position_manager: Optional[Any] = None,
     pnl_tracker: Optional[Any] = None,
     paper_engine: Optional[Any] = None,
+    risk_guard: Optional[RiskGuard] = None,
     tp_pct: float = _DEFAULT_TP_PCT,
     sl_pct: float = _DEFAULT_SL_PCT,
 ) -> None:
@@ -487,12 +489,21 @@ async def run_trading_loop(
                             fill is forwarded to ``PaperEngine.execute_order()`` so
                             the wallet, paper positions, and trade ledger are kept
                             in sync with real execution state.
+        risk_guard:         Mandatory risk authority used to enforce
+                            kill-switch, daily-loss, drawdown, and exposure
+                            checks before execution.
     """
     # ── Enforce database — no silent fallback ─────────────────────────────────
     if db is None:
         raise RuntimeError(
             "Database required — db must not be None. "
             "Inject a connected DatabaseClient before starting the trading loop."
+        )
+    if risk_guard is None:
+        risk_guard = RiskGuard()
+        log.warning(
+            "risk_guard_missing_injected_default",
+            hint="Inject shared RiskGuard instance for authoritative kill-switch propagation.",
         )
 
     _interval = (
@@ -524,6 +535,20 @@ async def run_trading_loop(
 
     # ── Loop state ────────────────────────────────────────────────────────────
     _tick: int = 0
+    _risk_peak_equity: float = max(_bankroll, 1.0)
+
+    async def _reserve_trade_intent(trade_id: str, market_id: str, side: str) -> bool:
+        if hasattr(db, "reserve_trade_intent"):
+            return await db.reserve_trade_intent(trade_id, market_id, side)
+        return True
+
+    async def _set_trade_intent_status(
+        trade_id: str,
+        status: str,
+        last_error: Optional[str] = None,
+    ) -> None:
+        if hasattr(db, "update_trade_intent_status"):
+            await db.update_trade_intent_status(trade_id, status, last_error)
 
     # ── Validation Engine singletons (initialized once, shared across ticks) ──
     _performance_tracker = PerformanceTracker()
@@ -1064,6 +1089,91 @@ async def run_trading_loop(
                                 error=str(meta_exc),
                             )
 
+                    _reserved_trade_intent = await _reserve_trade_intent(
+                        signal.signal_id,
+                        signal.market_id,
+                        signal.side,
+                    )
+                    if not _reserved_trade_intent:
+                        log.info(
+                            "signal_skipped_duplicate_persistent",
+                            trade_id=signal.signal_id,
+                            market_id=signal.market_id,
+                        )
+                        continue
+
+                    try:
+                        if risk_guard.disabled:
+                            await _set_trade_intent_status(
+                                signal.signal_id,
+                                "blocked_risk",
+                                "kill_switch_active",
+                            )
+                            log.info(
+                                "signal_blocked_risk_guard",
+                                trade_id=signal.signal_id,
+                                market_id=signal.market_id,
+                                reason="kill_switch_active",
+                            )
+                            continue
+
+                        _risk_positions = await db.get_positions(_user_id)
+                        _risk_trades = await db.get_recent_trades(limit=500)
+                        _risk_realized = PnLCalculator.calculate_realized_pnl(_risk_trades)
+                        _risk_unrealized = PnLCalculator.calculate_unrealized_pnl(
+                            _risk_positions, market_prices
+                        )
+                        _risk_total_pnl = _risk_realized + _risk_unrealized
+                        _risk_equity = _bankroll + _risk_total_pnl
+                        if _mode == "PAPER" and paper_engine is not None:
+                            try:
+                                _risk_equity = float(paper_engine._wallet.get_state().equity)  # type: ignore[attr-defined]
+                            except Exception as wallet_exc:  # noqa: BLE001
+                                log.warning(
+                                    "risk_guard_wallet_state_read_failed",
+                                    error=str(wallet_exc),
+                                )
+                        _risk_peak_equity = max(_risk_peak_equity, _risk_equity)
+                        _risk_exposure = sum(float(p.get("size", 0.0)) for p in _risk_positions)
+
+                        await risk_guard.check_daily_loss(_risk_total_pnl)
+                        await risk_guard.check_drawdown(
+                            peak_balance=max(_risk_peak_equity, 1.0),
+                            current_balance=max(_risk_equity, 0.0),
+                        )
+                        await risk_guard.check_exposure(
+                            total_exposure=_risk_exposure,
+                            balance=max(_risk_equity, 1.0),
+                        )
+                    except Exception as risk_exc:  # noqa: BLE001
+                        await _set_trade_intent_status(
+                            signal.signal_id,
+                            "blocked_risk",
+                            f"risk_guard_error:{risk_exc}",
+                        )
+                        log.error(
+                            "risk_guard_check_failed",
+                            trade_id=signal.signal_id,
+                            market_id=signal.market_id,
+                            error=str(risk_exc),
+                            exc_info=True,
+                        )
+                        continue
+
+                    if risk_guard.disabled:
+                        await _set_trade_intent_status(
+                            signal.signal_id,
+                            "blocked_risk",
+                            "risk_guard_disabled_after_checks",
+                        )
+                        log.info(
+                            "signal_blocked_risk_guard",
+                            trade_id=signal.signal_id,
+                            market_id=signal.market_id,
+                            reason="risk_guard_disabled_after_checks",
+                        )
+                        continue
+
                     # ── 4d. UNIFIED EXECUTION ────────────────────────────────
                     # PAPER mode with PaperEngine: PaperEngine is the single
                     # source of truth.  Bypass execute_trade() fill simulation.
@@ -1087,6 +1197,11 @@ async def run_trading_loop(
                                 "trade_id": signal.signal_id,
                             })
                         except Exception as _pe_exc:
+                            await _set_trade_intent_status(
+                                signal.signal_id,
+                                "execution_failed",
+                                str(_pe_exc),
+                            )
                             log.error(
                                 "execution_failed",
                                 trade_id=signal.signal_id,
@@ -1099,6 +1214,11 @@ async def run_trading_loop(
                         _pe_success = _paper_order.status in (_OS.FILLED, _OS.PARTIAL)
 
                         if not _pe_success:
+                            await _set_trade_intent_status(
+                                signal.signal_id,
+                                "execution_failed",
+                                str(_paper_order.reason),
+                            )
                             log.info(
                                 "execution_failed",
                                 trade_id=signal.signal_id,
@@ -1134,6 +1254,7 @@ async def run_trading_loop(
                             fill_price=round(result.fill_price, 6),
                             mode=result.mode,
                         )
+                        await _set_trade_intent_status(signal.signal_id, "executed")
 
                         # ── Persist ledger entry ──────────────────────────────
                         if db is not None and paper_engine is not None:
@@ -1155,8 +1276,14 @@ async def run_trading_loop(
                             signal,
                             mode=_mode,
                             executor_callback=executor_callback,
+                            kill_switch_active=risk_guard.disabled,
                         )
                         if not result.success:
+                            await _set_trade_intent_status(
+                                signal.signal_id,
+                                "execution_failed",
+                                result.reason,
+                            )
                             log.info(
                                 "execution_failed",
                                 trade_id=result.trade_id,
@@ -1164,6 +1291,7 @@ async def run_trading_loop(
                                 reason=result.reason,
                             )
                             continue
+                        await _set_trade_intent_status(signal.signal_id, "executed")
                         log.info(
                             "execution_success",
                             trade_id=result.trade_id,
@@ -1212,34 +1340,53 @@ async def run_trading_loop(
                         _market_last_trade[signal.market_id] = _now_trade
                         _last_trade_time = _now_trade  # reset force-trade fallback counter
 
+                        _projection_errors: list[str] = []
+
                         # ── 4e. Persist position (db is always present) ───────────
                         if result.fill_price > 0.0:
-                            await db.upsert_position({
-                                "user_id": _user_id,
-                                "market_id": result.market_id,
-                                "avg_price": result.fill_price,
-                                "size": result.filled_size_usd,
-                            })
+                            try:
+                                await db.upsert_position({
+                                    "user_id": _user_id,
+                                    "market_id": result.market_id,
+                                    "avg_price": result.fill_price,
+                                    "size": result.filled_size_usd,
+                                })
+                            except Exception as db_pos_exc:  # noqa: BLE001
+                                _projection_errors.append(f"db_position:{db_pos_exc}")
+                                log.error(
+                                    "projection_db_position_failed",
+                                    trade_id=result.trade_id,
+                                    market_id=result.market_id,
+                                    error=str(db_pos_exc),
+                                )
 
                             # ── 4f. Record trade in DB and set status ─────────────
-                            await db.insert_trade({
-                                "trade_id": result.trade_id,
-                                "user_id": _user_id,
-                                "strategy_id": signal.extra.get("strategy_id", ""),
-                                "market_id": result.market_id,
-                                "side": result.side,
-                                "size_usd": result.filled_size_usd,
-                                "price": result.fill_price,
-                                "entry_price": result.fill_price,
-                                "expected_ev": signal.ev,
-                                "pnl": 0.0,
-                                "won": False,
-                                "status": "open",
-                                "mode": result.mode,
-                                "executed_at": time.time(),
-                            })
-
-                            await db.update_trade_status(result.trade_id, "open")
+                            try:
+                                await db.insert_trade({
+                                    "trade_id": result.trade_id,
+                                    "user_id": _user_id,
+                                    "strategy_id": signal.extra.get("strategy_id", ""),
+                                    "market_id": result.market_id,
+                                    "side": result.side,
+                                    "size_usd": result.filled_size_usd,
+                                    "price": result.fill_price,
+                                    "entry_price": result.fill_price,
+                                    "expected_ev": signal.ev,
+                                    "pnl": 0.0,
+                                    "won": False,
+                                    "status": "open",
+                                    "mode": result.mode,
+                                    "executed_at": time.time(),
+                                })
+                                await db.update_trade_status(result.trade_id, "open")
+                            except Exception as db_trade_exc:  # noqa: BLE001
+                                _projection_errors.append(f"db_trade:{db_trade_exc}")
+                                log.error(
+                                    "projection_db_trade_failed",
+                                    trade_id=result.trade_id,
+                                    market_id=result.market_id,
+                                    error=str(db_trade_exc),
+                                )
 
                         # ── 4g. Update in-memory PositionManager ──────────────────
                         _pos_realized: float = 0.0
@@ -1267,6 +1414,7 @@ async def run_trading_loop(
                                     result.market_id, _mark_price
                                 )
                             except Exception as pos_exc:  # noqa: BLE001
+                                _projection_errors.append(f"position_manager:{pos_exc}")
                                 log.warning(
                                     "position_manager_update_failed",
                                     market_id=result.market_id,
@@ -1287,6 +1435,7 @@ async def run_trading_loop(
                                     total=pnl_rec.realized + pnl_rec.unrealized,
                                 )
                             except Exception as pnl_exc:  # noqa: BLE001
+                                _projection_errors.append(f"pnl_tracker:{pnl_exc}")
                                 log.warning(
                                     "pnl_tracker_update_failed",
                                     market_id=result.market_id,
@@ -1335,6 +1484,7 @@ async def run_trading_loop(
                                     unrealized_pnl=_pos_unrealized,
                                 )
                             except Exception as tg_exc:  # noqa: BLE001
+                                _projection_errors.append(f"telegram:{tg_exc}")
                                 log.warning(
                                     "telegram_trade_alert_failed",
                                     trade_id=result.trade_id,
@@ -1360,6 +1510,14 @@ async def run_trading_loop(
                             }
                             asyncio.create_task(
                                 _run_validation_hook(_val_trade, telegram_callback)
+                            )
+                        if _projection_errors:
+                            log.warning(
+                                "execution_projection_partial_failure",
+                                trade_id=result.trade_id,
+                                market_id=result.market_id,
+                                projection_errors=_projection_errors,
+                                projection_error_count=len(_projection_errors),
                             )
 
                 # ── 5. Compute and log PnL metrics (db always present) ───────────
@@ -1505,8 +1663,13 @@ async def run_trading_loop(
                                                 f"Entry: {_pos.entry_price:.4f}"
                                             )
                                             await telegram_sender.send(_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as tg_close_exc:  # noqa: BLE001
+                                            log.warning(
+                                                "telegram_close_alert_failed",
+                                                trade_id=_close_trade_id,
+                                                market_id=_pos.market_id,
+                                                error=str(tg_close_exc),
+                                            )
                                 except Exception as _close_exc:
                                     log.error(
                                         "close_order_failed",
@@ -1592,8 +1755,13 @@ async def run_trading_loop(
                                                 f"Entry: {_lpos.avg_price:.4f}"
                                             )
                                             await telegram_sender.send(_live_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as tg_live_close_exc:  # noqa: BLE001
+                                            log.warning(
+                                                "telegram_live_close_alert_failed",
+                                                trade_id=_live_close_id,
+                                                market_id=_lpos.market_id,
+                                                error=str(tg_live_close_exc),
+                                            )
                                 except Exception as _live_close_exc:
                                     log.error(
                                         "live_close_order_failed",

--- a/projects/polymarket/polyquantbot/execution/engine_router.py
+++ b/projects/polymarket/polyquantbot/execution/engine_router.py
@@ -94,7 +94,13 @@ class EngineContainer:
         """
         log.info("engine_container_restore_start")
         try:
-            await self.wallet.restore_from_db(db)  # type: ignore[arg-type]
+            restored_wallet = await WalletEngine.restore_from_db(db)  # type: ignore[arg-type]
+            self.wallet = restored_wallet
+            self.paper_engine = PaperEngine(
+                wallet=self.wallet,
+                positions=self.positions,
+                ledger=self.ledger,
+            )
         except Exception as exc:
             log.warning("engine_container_wallet_restore_error", error=str(exc))
 
@@ -107,6 +113,11 @@ class EngineContainer:
             await self.ledger.load_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_ledger_restore_error", error=str(exc))
+
+        try:
+            await self.paper_engine.hydrate_processed_trade_ids(db)  # type: ignore[arg-type]
+        except Exception as exc:
+            log.warning("engine_container_dedup_restore_error", error=str(exc))
 
         log.info("engine_container_restore_complete")
 

--- a/projects/polymarket/polyquantbot/execution/paper_engine.py
+++ b/projects/polymarket/polyquantbot/execution/paper_engine.py
@@ -516,6 +516,30 @@ class PaperEngine:
             reason="",
         )
 
+    async def hydrate_processed_trade_ids(self, db: object) -> None:
+        """Restore processed trade IDs from durable DB state.
+
+        This reduces restart replay risk by rebuilding dedup memory from
+        persisted trade-intent records.
+        """
+        try:
+            trade_ids = await db.load_reserved_trade_ids()  # type: ignore[attr-defined]
+            restored = 0
+            for trade_id in trade_ids:
+                if trade_id and trade_id not in self._processed_trade_ids:
+                    self._processed_trade_ids.add(trade_id)
+                    restored += 1
+            log.info(
+                "paper_engine_dedup_state_hydrated",
+                restored=restored,
+                total_seen=len(self._processed_trade_ids),
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "paper_engine_dedup_state_hydrate_failed",
+                error=str(exc),
+            )
+
     # ── Internal helpers ──────────────────────────────────────────────────────
 
     @staticmethod

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -175,6 +175,18 @@ CREATE TABLE IF NOT EXISTS trade_ledger (
 );
 """
 
+_DDL_TRADE_INTENTS = """
+CREATE TABLE IF NOT EXISTS trade_intents (
+    trade_id        TEXT        PRIMARY KEY,
+    market_id       TEXT        NOT NULL,
+    side            TEXT        NOT NULL,
+    status          TEXT        NOT NULL DEFAULT 'reserved',
+    created_at      DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at      DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    last_error      TEXT
+);
+"""
+
 
 # ── DatabaseClient ─────────────────────────────────────────────────────────────
 
@@ -322,6 +334,7 @@ class DatabaseClient:
             await conn.execute(_DDL_WALLET_STATE)
             await conn.execute(_DDL_PAPER_POSITIONS)
             await conn.execute(_DDL_TRADE_LEDGER)
+            await conn.execute(_DDL_TRADE_INTENTS)
         log.info("db_schema_applied")
 
     # ── Trades ────────────────────────────────────────────────────────────────
@@ -429,6 +442,62 @@ class DatabaseClient:
             )
         sql = "UPDATE trades SET status = $2 WHERE trade_id = $1"
         return await self._execute(sql, trade_id, status, op_label="update_trade_status")
+
+    async def reserve_trade_intent(self, trade_id: str, market_id: str, side: str) -> bool:
+        """Reserve a trade intent ID durably.
+
+        Returns:
+            True when reservation succeeds (new intent row inserted),
+            False when trade_id was already reserved before.
+        """
+        sql = """
+            INSERT INTO trade_intents (trade_id, market_id, side, status, created_at, updated_at)
+            VALUES ($1, $2, $3, 'reserved', $4, $5)
+            ON CONFLICT (trade_id) DO NOTHING
+            RETURNING trade_id
+        """
+        now = time.time()
+        rows = await self._fetch(
+            sql,
+            str(trade_id),
+            str(market_id),
+            str(side),
+            now,
+            now,
+            op_label="reserve_trade_intent",
+        )
+        return bool(rows)
+
+    async def update_trade_intent_status(
+        self,
+        trade_id: str,
+        status: str,
+        last_error: Optional[str] = None,
+    ) -> bool:
+        """Update a reserved trade intent status."""
+        sql = """
+            UPDATE trade_intents
+            SET status = $2, updated_at = $3, last_error = $4
+            WHERE trade_id = $1
+        """
+        return await self._execute(
+            sql,
+            str(trade_id),
+            str(status),
+            time.time(),
+            last_error,
+            op_label="update_trade_intent_status",
+        )
+
+    async def load_reserved_trade_ids(self, limit: int = 5000) -> List[str]:
+        """Load recent trade IDs from durable intent storage."""
+        sql = """
+            SELECT trade_id FROM trade_intents
+            WHERE status IN ('reserved', 'executed')
+            ORDER BY created_at DESC LIMIT $1
+        """
+        rows = await self._fetch(sql, limit, op_label="load_reserved_trade_ids")
+        return [str(row.get("trade_id", "")) for row in rows if row.get("trade_id")]
 
     # ── Positions ─────────────────────────────────────────────────────────────
 

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -728,6 +728,7 @@ async def main() -> None:
                 position_manager=position_manager,
                 pnl_tracker=pnl_tracker,
                 paper_engine=engine_container.paper_engine,
+                risk_guard=risk_guard,
             ),
             name="trading_loop",
         )

--- a/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
@@ -1,0 +1,65 @@
+## 1. What was built
+- Hardened active paper-trade execution in `core/pipeline/trading_loop.py` with mandatory formal RiskGuard gate checks before every execution attempt.
+- Added durable execution-intent reservation and status tracking in `infra/db/database.py` via new `trade_intents` table and related DB methods.
+- Fixed `EngineContainer.restore_from_db()` to actually assign restored wallet state into runtime and rebind `PaperEngine` to restored wallet.
+- Added `PaperEngine.hydrate_processed_trade_ids()` to rebuild dedup memory from durable DB state and reduce restart replay risk.
+- Replaced silent close-alert exception swallowing (`except Exception: pass`) with explicit warning logs in paper and live close paths.
+- Added deterministic hardening tests in `tests/test_paper_trade_hardening_p0_20260407.py` for risk-blocking, kill-switch propagation, wallet restore semantics, dedup hydration, and silent-swallow regression guard.
+
+## 2. Design principles
+- Risk-before-execution is mandatory: execution cannot proceed unless formal RiskGuard checks pass.
+- Fail-closed behavior: kill-switch active state blocks execution and records blocked intent state.
+- Durable idempotency first: process-memory dedup is now supplemented by persisted trade-intent reservation and replay-state hydration.
+- Runtime source-of-truth contract clarified:
+  - authoritative: `PaperEngine` wallet + paper positions + ledger
+  - projection: DB trade/position rows + PositionManager + PnLTracker overlays
+  - projection failures are bounded and explicitly logged.
+- Minimal-scope hardening only: no real-wallet enablement and no Telegram UX redesign.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/database.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/paper_engine.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+
+## 4. Before/after improvement summary
+- Risk bypass before vs after:
+  - Before: trading loop executed paper orders without formal RiskGuard gate.
+  - After: every execution attempt reserves intent and runs RiskGuard daily-loss/drawdown/exposure/kill-switch checks first; blocked paths do not execute.
+- Kill-switch propagation before vs after:
+  - Before: active trading loop path did not propagate authoritative kill-switch to execution.
+  - After: kill-switch state is checked pre-execution and also propagated to fallback `execute_trade(... kill_switch_active=...)` path.
+- Wallet restore bug before vs after:
+  - Before: `WalletEngine.restore_from_db()` returned a new object that was ignored in `EngineContainer`.
+  - After: returned wallet is assigned to container runtime and `PaperEngine` is rebound to the restored wallet instance.
+- Silent failure path before vs after:
+  - Before: close-alert code had explicit `except Exception: pass` swallowing.
+  - After: both close paths now log explicit `telegram_close_alert_failed` warning events with context.
+- Dedup/idempotency before vs after:
+  - Before: dedup for active path relied on in-memory sets only.
+  - After: durable `trade_intents` reservation blocks replayed trade IDs across restart/re-init and PaperEngine restores processed IDs from DB.
+- Reconciliation contract before vs after:
+  - Before: mixed state writes without explicit ownership contract.
+  - After: contract is explicit in trading loop comments and logs; PaperEngine is authoritative, projection-layer partial failures are bounded and observable.
+- Deterministic tests added:
+  - Risk block no mutation
+  - Kill-switch propagation block
+  - EngineContainer wallet restore assignment
+  - PaperEngine dedup hydration replay block
+  - Silent exception swallow regression guard
+- No unintended logic-layer drift:
+  - Strategy generation logic and Telegram UX navigation were not redesigned in this pass.
+
+## 5. Issues
+- Test environment lacks async pytest plugin (`pytest-asyncio`), so legacy async-native suites cannot be executed directly in this container without plugin availability.
+- Projection writes remain non-transactional across all stores (improved observability but not full atomic reconciliation).
+- Real-wallet readiness is still blocked; this pass is paper-path P0 hardening only.
+
+## 6. Next
+- SENTINEL validation required for paper_trade_hardening_p0_20260407 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+- P1 follow-up should target deeper reconciliation unification and parity validation before any real-wallet enablement work.

--- a/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from projects.polymarket.polyquantbot.core.pipeline.trading_loop import run_trading_loop
+from projects.polymarket.polyquantbot.execution.engine_router import EngineContainer
+from projects.polymarket.polyquantbot.execution.paper_engine import PaperEngine
+from projects.polymarket.polyquantbot.core.wallet_engine import WalletEngine
+from projects.polymarket.polyquantbot.core.positions import PaperPositionManager
+from projects.polymarket.polyquantbot.core.ledger import TradeLedger
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
+
+
+class _RiskGuardStub:
+    def __init__(self, *, disabled: bool = False, disable_on_check: bool = False) -> None:
+        self.disabled = disabled
+        self._disable_on_check = disable_on_check
+
+    async def check_daily_loss(self, current_pnl: float) -> None:
+        if self._disable_on_check:
+            self.disabled = True
+
+    async def check_drawdown(self, peak_balance: float, current_balance: float) -> None:
+        return None
+
+    async def check_exposure(self, total_exposure: float, balance: float) -> None:
+        return None
+
+
+class _DBMock:
+    def __init__(self) -> None:
+        self.upsert_position = AsyncMock(return_value=True)
+        self.insert_trade = AsyncMock(return_value=True)
+        self.update_trade_status = AsyncMock(return_value=True)
+        self.get_positions = AsyncMock(return_value=[])
+        self.get_recent_trades = AsyncMock(return_value=[])
+        self.reserve_trade_intent = AsyncMock(return_value=True)
+        self.update_trade_intent_status = AsyncMock(return_value=True)
+
+
+def _signal() -> SignalResult:
+    return SignalResult(
+        signal_id="sig-hardening-1",
+        market_id="mkt-hardening-1",
+        side="YES",
+        p_market=0.40,
+        p_model=0.65,
+        edge=0.25,
+        ev=0.40,
+        kelly_f=0.25,
+        size_usd=50.0,
+        liquidity_usd=100_000.0,
+    )
+
+
+def test_risk_guard_block_prevents_execution_mutation() -> None:
+    stop = asyncio.Event()
+
+    async def fake_sleep(_: float) -> None:
+        stop.set()
+
+    db = _DBMock()
+    risk_guard = _RiskGuardStub(disabled=True)
+    execute_mock = AsyncMock()
+    paper_engine = SimpleNamespace(execute_order=AsyncMock())
+
+    with (
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.get_active_markets",
+            new=AsyncMock(return_value=[{"market_id": "mkt-hardening-1", "p_market": 0.4}]),
+        ),
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.generate_signals",
+            new=AsyncMock(return_value=[_signal()]),
+        ),
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.execute_trade",
+            new=execute_mock,
+        ),
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.asyncio.sleep",
+            new=fake_sleep,
+        ),
+    ):
+        asyncio.run(run_trading_loop(
+            loop_interval_s=0,
+            bankroll=1000.0,
+            mode="PAPER",
+            stop_event=stop,
+            db=db,
+            paper_engine=paper_engine,
+            risk_guard=risk_guard,
+        ))
+
+    paper_engine.execute_order.assert_not_awaited()
+    execute_mock.assert_not_awaited()
+    db.upsert_position.assert_not_awaited()
+    db.insert_trade.assert_not_awaited()
+
+
+def test_kill_switch_flip_during_risk_check_blocks_execution() -> None:
+    stop = asyncio.Event()
+
+    async def fake_sleep(_: float) -> None:
+        stop.set()
+
+    db = _DBMock()
+    risk_guard = _RiskGuardStub(disable_on_check=True)
+    paper_engine = SimpleNamespace(execute_order=AsyncMock())
+
+    with (
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.get_active_markets",
+            new=AsyncMock(return_value=[{"market_id": "mkt-hardening-1", "p_market": 0.4}]),
+        ),
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.generate_signals",
+            new=AsyncMock(return_value=[_signal()]),
+        ),
+        patch(
+            "projects.polymarket.polyquantbot.core.pipeline.trading_loop.asyncio.sleep",
+            new=fake_sleep,
+        ),
+    ):
+        asyncio.run(run_trading_loop(
+            loop_interval_s=0,
+            bankroll=1000.0,
+            mode="PAPER",
+            stop_event=stop,
+            db=db,
+            paper_engine=paper_engine,
+            risk_guard=risk_guard,
+        ))
+
+    paper_engine.execute_order.assert_not_awaited()
+    db.update_trade_intent_status.assert_awaited()
+
+
+def test_engine_container_restore_assigns_restored_wallet() -> None:
+    container = EngineContainer()
+    restored_wallet = WalletEngine(initial_balance=2222.0)
+    db = object()
+
+    with (
+        patch(
+            "projects.polymarket.polyquantbot.execution.engine_router.WalletEngine.restore_from_db",
+            new=AsyncMock(return_value=restored_wallet),
+        ),
+        patch.object(container.positions, "load_from_db", new=AsyncMock(return_value=None)),
+        patch.object(container.ledger, "load_from_db", new=AsyncMock(return_value=None)),
+        patch.object(PaperEngine, "hydrate_processed_trade_ids", new=AsyncMock(return_value=None)),
+    ):
+        asyncio.run(container.restore_from_db(db))
+
+    assert container.wallet is restored_wallet
+    assert container.paper_engine._wallet is restored_wallet
+
+
+def test_paper_engine_hydrates_dedup_ids_and_blocks_replay() -> None:
+    wallet = WalletEngine(initial_balance=5000.0)
+    positions = PaperPositionManager()
+    ledger = TradeLedger()
+    engine = PaperEngine(wallet=wallet, positions=positions, ledger=ledger, random_seed=1)
+
+    class _DedupDB:
+        async def load_reserved_trade_ids(self, limit: int = 5000) -> list[str]:
+            return ["dup-intent-1"]
+
+    asyncio.run(engine.hydrate_processed_trade_ids(_DedupDB()))
+    result = asyncio.run(engine.execute_order(
+        {
+            "trade_id": "dup-intent-1",
+            "market_id": "mkt-dup",
+            "side": "YES",
+            "price": 0.5,
+            "size": 10.0,
+        }
+    ))
+
+    assert result.reason == "duplicate_trade_id"
+
+
+def test_no_silent_exception_swallow_in_close_alert_paths() -> None:
+    target_file = "projects/polymarket/polyquantbot/core/pipeline/trading_loop.py"
+    with open(target_file, encoding="utf-8") as handle:
+        content = handle.read()
+    assert "except Exception:\n                                            pass" not in content


### PR DESCRIPTION
### Motivation
- Address critical findings from the SENTINEL trade-system truth audit (risk bypass on `run_trading_loop`, silent exception swallowing, wallet restore bug, dual state ownership drift, and in-memory-only dedup replay risk). 
- Deliver a narrow P0 hardening pass to make the active paper-trade path materially safer and more restart-consistent while preserving paper-only behavior and avoiding real-wallet enablement.

### Description
- Enforce formal risk-before-execution in the active loop by reserving intents and running `RiskGuard` (kill-switch, daily-loss, drawdown, exposure) prior to any execution attempt in `core/pipeline/trading_loop.py`, and propagate authoritative kill-switch state into execution calls via `kill_switch_active`.
- Add durable dedup/idempotency via a new `trade_intents` schema and DB APIs (`reserve_trade_intent`, `update_trade_intent_status`, `load_reserved_trade_ids`) in `infra/db/database.py`, and hydrate `PaperEngine` in-memory dedup set from DB on startup with `PaperEngine.hydrate_processed_trade_ids()`.
- Fix wallet restore semantics in `execution/engine_router.py` by assigning the `WalletEngine.restore_from_db()` return value into the container wallet and rebinding `PaperEngine` to the restored wallet, and call dedup hydration during container restore.
- Replace silent `except Exception: pass` swallowing in close-alert paths with explicit warning logs to ensure alert failures are observable, and add bounded projection-layer error logging for DB/overlay writes so partial downstream failures are visible and contained.
- Add deterministic hardening tests `projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`, create the FORGE report `projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`, and update `PROJECT_STATE.md` to reflect the priority shift and P0 completion handoff to SENTINEL.

### Testing
- Ran the new deterministic unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py -q` and observed all tests in that file passed (`5 passed`).
- Static sanity: `python -m py_compile` was executed against the touched Python modules (`core/pipeline/trading_loop.py`, `execution/engine_router.py`, `execution/paper_engine.py`, `infra/db/database.py`, `main.py`, and the new test file`) with success.
- Integration / environment note: running broader async integration suites in this container hit an environment limitation (missing `pytest-asyncio` plugin) causing unrelated async test harness failures; this is a test harness limitation and not a functional regression of the implemented P0 changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43a867b3c832eb3cf70157f71c8e5)