### PR TITLE
sentinel: validate paper_trade_hardening_p0_20260407 (BLOCKED)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/paper_trade_hardening_p0_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/paper_trade_hardening_p0_validation_20260407.md
@@ -1,0 +1,179 @@
+# SENTINEL VALIDATION REPORT — paper_trade_hardening_p0_20260407
+
+## 1. Target
+- Intent: validate `paper_trade_hardening_p0_20260407` on `feature/harden-paper-trade-execution-path-2026-04-06`.
+- Requested validation set:
+  - `/workspace/walker-ai-team/PROJECT_STATE.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+  - Runtime/code targets listed by COMMANDER.
+
+## 2. Score
+- **Total: 34 / 100**
+- Architecture: 8/20
+- Functional: 10/20
+- Failure modes: 6/20
+- Risk compliance: 4/20
+- Infra/Telegram: 4/10
+- Latency: 2/10
+
+## 3. Findings by phase
+
+### Phase 0 — Preconditions
+- **FAIL (hard blocker): missing FORGE report artifact**
+  - Expected: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+  - Actual: file not present.
+- **FAIL (hard blocker): missing target test harness**
+  - Expected: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+  - Actual: file not present.
+- `PROJECT_STATE.md` is not aligned to a completed hardening pass; it still states FORGE hardening pending and SENTINEL re-validation pending.
+
+System drift detected:
+- component: forge hardening artifact linkage
+- expected: paper trade hardening forge report exists at requested path and is validation source
+- actual: requested forge report path does not exist
+
+System drift detected:
+- component: P0 hardening test evidence
+- expected: deterministic test file `test_paper_trade_hardening_p0_20260407.py` exists and runs
+- actual: requested test file path does not exist
+
+### Phase 1 — Static evidence
+1) **Active trading loop formal RiskGuard enforcement before execution**: **FAIL**
+- `trading_loop.py` still executes `PaperEngine` and `execute_trade` paths without `RiskGuard` import/use and without passing authoritative kill-switch state into `execute_trade`.
+- `execute_trade(... kill_switch_active=False)` default remains unused by trading loop call site.
+
+2) **Authoritative kill-switch propagation**: **FAIL (partial capability exists in executor only)**
+- `executor.execute_trade` supports `kill_switch_active`, but trading loop call path does not pass it.
+
+3) **Durable trade_intent reservation/persistence**: **FAIL**
+- No `trade_intent` persistence or reservation API located in target modules.
+
+4) **PaperEngine dedup hydration from durable storage**: **FAIL**
+- `PaperEngine` dedup set (`_processed_trade_ids`) is in-memory only; no DB hydration path found.
+
+5) **Wallet restore semantics corrected in engine router/container**: **FAIL (critical)**
+- `EngineContainer.restore_from_db` calls `await self.wallet.restore_from_db(db)` where `restore_from_db` is a classmethod returning a new `WalletEngine`; return value is ignored, so active container wallet is unchanged.
+
+6) **Silent exception swallowing removed from audited paths**: **FAIL**
+- Explicit swallow remains in audited runtime paths, including `except RuntimeError: pass` and additional `except Exception: pass` blocks in trading loop close paths.
+
+7) **No unintended unrelated edits**: **UNVERIFIED / PARTIAL**
+- Available local history does not contain a forge hardening commit on this worktree; could not verify branch-target diff for requested feature branch.
+
+### Phase 2 — Runtime proof
+- **RiskGuard-blocked execution path**: **FAIL / not proven on trading loop path**
+  - No formal RiskGuard call in active `run_trading_loop` execution path.
+- **Kill-switch-blocked execution path**: **PARTIAL**
+  - `execute_trade` blocks when `kill_switch_active=True` (direct harness).
+  - But trading loop does not propagate authoritative kill-switch flag.
+- **Allowed execution path**: **PASS (executor direct harness)**
+- **Durable dedup restart replay behavior**: **FAIL**
+  - Duplicate protection works only within same `PaperEngine` instance; replay on new instance re-executes same trade id.
+- **Wallet restore / engine rebinding after restore**: **FAIL (critical)**
+  - Runtime simulation shows wallet state restored in a newly constructed engine object, while active container wallet remains stale.
+- **Partial downstream observability**: **PARTIAL**
+  - Logging exists, but audited close/projection paths still contain swallowed exceptions.
+
+### Phase 3 — Test and harness validation
+- `py_compile` on requested runtime modules: PASS.
+- Targeted pytest requested by COMMANDER: FAIL (file not found).
+- Requested hardening tests therefore cannot be used as evidence.
+
+### Phase 4 — Failure-mode break attempts
+- Break attempt: bypass formal risk gate in active loop -> **succeeds** (no formal RiskGuard enforcement in loop).
+- Break attempt: kill-switch bypass at loop level -> **succeeds** (not passed through loop to executor).
+- Break attempt: duplicate replay after restart/re-init -> **succeeds** (new `PaperEngine` instance reprocesses same trade ID).
+- Break attempt: wallet restore stale active object -> **succeeds**.
+- Break attempt: silent failure visibility -> **fails expectation** (silent swallow remains in audited paths).
+
+### Phase 5 — Regression scope check
+- Could not validate intended feature-branch-only delta in this worktree because target branch content/commits are unavailable locally.
+- Local latest commit remains prior SENTINEL audit commit, not FORGE hardening implementation.
+
+## 4. Evidence
+
+### Commands executed
+1. Existence checks:
+```bash
+for f in PROJECT_STATE.md ...; do [ -f "$f" ] && echo "OK $f" || echo "MISSING $f"; done
+```
+Output highlights:
+- `MISSING projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+- `MISSING projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+
+2. Compile sanity:
+```bash
+python -m py_compile projects/polymarket/polyquantbot/core/pipeline/trading_loop.py ... projects/polymarket/polyquantbot/infra/db/database.py
+```
+Output: `py_compile_ok`
+
+3. Targeted pytest:
+```bash
+pytest -q projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
+```
+Output: `ERROR: file or directory not found`
+
+4. Static search (risk gating in loop):
+```bash
+rg -n "RiskGuard|kill_switch_active=.*risk|execute_trade\(" projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+```
+Output highlights:
+- `1154: result = await execute_trade(`
+- no RiskGuard evidence in active execution segment.
+
+5. Runtime harness — kill-switch + allowed path (executor direct):
+```bash
+python - <<'PY'
+... execute_trade(... kill_switch_active=True/False) ...
+PY
+```
+Output highlights:
+- `kill_block False kill_switch_active`
+- `allowed True partial_fill ...`
+- `duplicate False duplicate`
+
+6. Runtime harness — dedup restart replay:
+```bash
+python - <<'PY'
+... PaperEngine instance A then new instance B with same trade_id ...
+PY
+```
+Output highlights:
+- `same_instance_second FILLED duplicate_trade_id`
+- `new_instance_replay PARTIAL partial_fill`
+
+7. Runtime harness — wallet restore semantics:
+```bash
+python - <<'PY'
+... EngineContainer.restore_from_db(FakeDB) ...
+PY
+```
+Output highlights:
+- restore logs show wallet restored to `cash=321.0`
+- active wallet remains unchanged:
+  - `before WalletState(cash=10000.0, locked=0.0, equity=10000.0)`
+  - `after WalletState(cash=10000.0, locked=0.0, equity=10000.0)`
+
+### Static code references (critical)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py:1154-1158`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/execution/executor.py:170-179`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py:96-99`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/wallet_engine.py:365-387`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/portfolio/pnl.py:110-112`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py:1508-1509`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py:1595-1596`
+
+## 5. Critical issues
+1. Missing FORGE report artifact at required path (Phase 0 blocker).
+2. Missing requested hardening test file (Phase 0 blocker).
+3. Active loop still lacks formal RiskGuard enforcement before execution.
+4. Kill-switch not authoritatively propagated through active loop execution path.
+5. Wallet restore bug remains (class method return value ignored in container restore path).
+6. Dedup durability across restart/re-init not implemented.
+7. Silent exception swallowing remains in audited paths.
+
+## 6. Verdict
+**BLOCKED**
+
+Rationale:
+- Multiple critical blockers remain, including missing prerequisite artifacts and unresolved runtime-safety gaps directly tied to the audited P0 objective.


### PR DESCRIPTION
### Motivation
- Provide an independent SENTINEL validation for the claimed P0 paper-trade hardening and produce an evidence-backed verdict for `paper_trade_hardening_p0_20260407`.
- Surface any critical safety regressions that would prevent enabling real-wallet mode until FORGE-X fixes are delivered.

### Description
- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/paper_trade_hardening_p0_validation_20260407.md` containing phase-by-phase findings, evidence, a numeric score, and the final verdict `BLOCKED`.
- The report documents missing required artifacts (`projects/.../reports/forge/paper_trade_hardening_p0_20260407.md` and the test harness `projects/.../tests/test_paper_trade_hardening_p0_20260407.py`) and remaining code-level issues (no RiskGuard enforcement in `trading_loop.py`, kill-switch not propagated, wallet restore return ignored by `EngineContainer.restore_from_db`, in-memory-only dedup, and remaining silent `except: pass` paths).

### Testing
- Ran `python -m py_compile` on the touched runtime modules which succeeded and returned `py_compile_ok`.
- Attempted `pytest -q projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py` which failed with `file or directory not found` because the test artifact is missing.
- Performed static searches and line inspections (`rg` / `nl`) confirming `execute_trade` call site in `trading_loop.py` lacks `RiskGuard` wiring and that `EngineContainer.restore_from_db` ignores the `WalletEngine.restore_from_db` return value, and executed small runtime harnesses that demonstrated `execute_trade` honors `kill_switch_active` when called directly but the trading loop does not propagate it, PaperEngine dedup is instance-scoped (replay on new instance re-executes), and engine restore leaves the active container wallet stale.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d449324a9c832ea5448d9a499bb14d)