### PR TITLE
fix: resolve paper_trade_hardening_p0 blocked findings (2026-04-07)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 22:40
-- Status        : SENTINEL trade-system truth audit complete (paper-path decision map delivered); premium-nav and trade-hardening merge sequence awaiting COMMANDER direction
+- Last Updated  : 2026-04-07 00:34
+- Status        : FORGE-X blocker-fix pass complete for paper_trade_hardening_p0_20260407; line ready for SENTINEL revalidation, with founder priority remaining trade-system hardening
 
 ---
 
@@ -29,6 +29,7 @@
 - Telegram premium navigation / UX consolidation pass (2026-04-07): enforced two-layer Telegram navigation with persistent 5-item reply-keyboard root and contextual inline section actions; removed duplicated inline root menu; added active-root cue and compact button layout polish while preserving approved scope-control semantics.
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
+- FORGE-X blocker-fix pass complete for `paper_trade_hardening_p0_20260407` (2026-04-07): required forge/test artifacts added, formal `RiskGuard` wired into active trading-loop execution path, kill-switch propagation enforced on execution fallback path, wallet restore runtime assignment fixed in engine container, restart dedup rehydration added for paper execution, and audited silent `except ...: pass` close-alert paths removed.
 
 ---
 
@@ -39,7 +40,7 @@
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
 ### Trade-system hardening handoff
-- FORGE-X hardening pending for risk-gate unification, reconciliation ownership, restart recovery correctness, and silent-failure removal before any real-wallet enablement.
+- SENTINEL revalidation pending for `paper_trade_hardening_p0_20260407` blocker-fix pass before merge.
 
 ---
 
@@ -51,9 +52,9 @@
 
 ## 🎯 NEXT PRIORITY
 
-- FORGE-X hardening required for trade-system readiness before any real-wallet enablement.
-- Source: projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md
-- SENTINEL re-validation required after hardening pass; COMMANDER merge/enablement decision only after that validation.
+- SENTINEL validation required for paper_trade_hardening_p0_20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+- Founder priority remains trade-system hardening; remaining P1 gaps include reconciliation ownership hardening and broader paper/live parity validation.
 
 ---
 
@@ -62,5 +63,4 @@
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
-- Trading-loop execution path currently bypasses formal `RiskGuard` kill-switch/daily-loss/drawdown gating and must be hardened before real-wallet mode.
-- Startup wallet restore path in engine container may not apply persisted wallet state correctly (class-method return value is not assigned), creating restart reconciliation risk.
+- Post-P0 remaining gaps persist for full readiness: multi-store reconciliation ownership and broader paper/live lifecycle parity validation are still pending.

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -99,6 +99,7 @@ from ...interface.ui.views import (
     render_wallet_view,
 )
 from ..validation_state import ValidationStateStore
+from ...risk.risk_guard import RiskGuard
 from ..logging.logger import (
     log_market_metadata_used,
     log_position_updated,
@@ -444,6 +445,7 @@ async def run_trading_loop(
     position_manager: Optional[Any] = None,
     pnl_tracker: Optional[Any] = None,
     paper_engine: Optional[Any] = None,
+    risk_guard: Optional[RiskGuard] = None,
     tp_pct: float = _DEFAULT_TP_PCT,
     sl_pct: float = _DEFAULT_SL_PCT,
 ) -> None:
@@ -521,6 +523,53 @@ async def run_trading_loop(
     # When no trade fires for _NO_TRADE_FALLBACK_S (30 min), we lower edge
     # threshold and activate synthetic signal mode for 1 pass.
     _last_trade_time: float = time.time()
+    _risk_peak_balance: float = _bankroll
+
+    async def _enforce_formal_risk_guard() -> bool:
+        """Enforce RiskGuard checks before any execution attempt."""
+        nonlocal _risk_peak_balance
+        if risk_guard is None:
+            return True
+
+        if risk_guard.disabled:
+            log.warning(
+                "risk_guard_blocked",
+                reason=risk_guard.kill_switch_reason or "kill_switch_active",
+            )
+            return False
+
+        current_balance = _bankroll
+        current_pnl = 0.0
+        try:
+            if paper_engine is not None:
+                wallet_state = paper_engine._wallet.get_state()  # type: ignore[attr-defined]
+                current_balance = float(wallet_state.equity)
+                current_pnl = current_balance - _bankroll
+            else:
+                positions = await db.get_positions(_user_id)
+                trades = await db.get_recent_trades(limit=500)
+                realized = PnLCalculator.calculate_realized_pnl(trades)
+                unrealized = PnLCalculator.calculate_unrealized_pnl(positions, {})
+                current_pnl = float(realized + unrealized)
+                current_balance = float(_bankroll + current_pnl)
+        except Exception as risk_exc:  # noqa: BLE001
+            log.error("risk_guard_snapshot_failed", error=str(risk_exc))
+            return False
+
+        _risk_peak_balance = max(_risk_peak_balance, current_balance)
+        await risk_guard.check_daily_loss(current_pnl)
+        await risk_guard.check_drawdown(_risk_peak_balance, current_balance)
+
+        if risk_guard.disabled:
+            log.warning(
+                "risk_guard_blocked",
+                reason=risk_guard.kill_switch_reason or "risk_guard_triggered",
+                current_pnl=current_pnl,
+                current_balance=current_balance,
+                peak_balance=_risk_peak_balance,
+            )
+            return False
+        return True
 
     # ── Loop state ────────────────────────────────────────────────────────────
     _tick: int = 0
@@ -986,6 +1035,9 @@ async def run_trading_loop(
                 # ── 4. Execute each signal and update positions ───────────────────
                 _trades_this_tick: int = 0
                 for signal in signals:
+                    if not await _enforce_formal_risk_guard():
+                        continue
+
                     # ── 4a. Force signal mode: max 1 trade per loop ───────────────
                     if _active_force and _trades_this_tick >= 1:
                         log.info(
@@ -1154,6 +1206,7 @@ async def run_trading_loop(
                         result = await execute_trade(
                             signal,
                             mode=_mode,
+                            kill_switch_active=bool(risk_guard.disabled) if risk_guard else False,
                             executor_callback=executor_callback,
                         )
                         if not result.success:
@@ -1505,8 +1558,13 @@ async def run_trading_loop(
                                                 f"Entry: {_pos.entry_price:.4f}"
                                             )
                                             await telegram_sender.send(_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as close_tg_exc:  # noqa: BLE001
+                                            log.warning(
+                                                "telegram_close_alert_failed",
+                                                trade_id=_close_trade_id,
+                                                market_id=_pos.market_id,
+                                                error=str(close_tg_exc),
+                                            )
                                 except Exception as _close_exc:
                                     log.error(
                                         "close_order_failed",
@@ -1592,8 +1650,13 @@ async def run_trading_loop(
                                                 f"Entry: {_lpos.avg_price:.4f}"
                                             )
                                             await telegram_sender.send(_live_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as live_close_tg_exc:  # noqa: BLE001
+                                            log.warning(
+                                                "telegram_live_close_alert_failed",
+                                                trade_id=_live_close_id,
+                                                market_id=_lpos.market_id,
+                                                error=str(live_close_tg_exc),
+                                            )
                                 except Exception as _live_close_exc:
                                     log.error(
                                         "live_close_order_failed",

--- a/projects/polymarket/polyquantbot/execution/engine_router.py
+++ b/projects/polymarket/polyquantbot/execution/engine_router.py
@@ -94,7 +94,12 @@ class EngineContainer:
         """
         log.info("engine_container_restore_start")
         try:
-            await self.wallet.restore_from_db(db)  # type: ignore[arg-type]
+            self.wallet = await WalletEngine.restore_from_db(db)  # type: ignore[arg-type]
+            self.paper_engine = PaperEngine(
+                wallet=self.wallet,
+                positions=self.positions,
+                ledger=self.ledger,
+            )
         except Exception as exc:
             log.warning("engine_container_wallet_restore_error", error=str(exc))
 
@@ -107,6 +112,11 @@ class EngineContainer:
             await self.ledger.load_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_ledger_restore_error", error=str(exc))
+
+        try:
+            await self.paper_engine.restore_dedup_state(db)  # type: ignore[arg-type]
+        except Exception as exc:
+            log.warning("engine_container_dedup_restore_error", error=str(exc))
 
         log.info("engine_container_restore_complete")
 

--- a/projects/polymarket/polyquantbot/execution/paper_engine.py
+++ b/projects/polymarket/polyquantbot/execution/paper_engine.py
@@ -135,6 +135,38 @@ class PaperEngine:
 
         log.info("paper_engine_initialized", seeded=random_seed is not None)
 
+    async def restore_dedup_state(self, db: object, limit: int = 5000) -> None:
+        """Rehydrate processed trade IDs from durable storage on restart.
+
+        Args:
+            db: Database client exposing ``load_recent_trade_ids``.
+            limit: Maximum number of IDs to hydrate.
+        """
+        try:
+            trade_ids = await db.load_recent_trade_ids(limit=limit)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "paper_engine_dedup_restore_failed",
+                error=str(exc),
+                limit=limit,
+            )
+            return
+
+        restored = 0
+        for trade_id in trade_ids:
+            tid = str(trade_id).strip()
+            if not tid:
+                continue
+            if tid not in self._processed_trade_ids:
+                self._processed_trade_ids.add(tid)
+                restored += 1
+        log.info(
+            "paper_engine_dedup_restored",
+            restored=restored,
+            total_cached=len(self._processed_trade_ids),
+            limit=limit,
+        )
+
     # ── Public API ────────────────────────────────────────────────────────────
 
     async def execute_order(self, order: dict) -> PaperOrderResult:

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -398,6 +398,22 @@ class DatabaseClient:
         sql = "SELECT * FROM trades ORDER BY executed_at DESC LIMIT $1"
         return await self._fetch(sql, limit, op_label="get_recent_trades")
 
+    async def load_recent_trade_ids(self, limit: int = 5000) -> List[str]:
+        """Load recent trade identifiers for restart-safe dedup rehydration.
+
+        Args:
+            limit: Maximum number of trade IDs to return.
+
+        Returns:
+            List of non-empty trade IDs (newest first).
+        """
+        sql = """
+            SELECT trade_id FROM trades
+            ORDER BY executed_at DESC LIMIT $1
+        """
+        rows = await self._fetch(sql, limit, op_label="load_recent_trade_ids")
+        return [str(row.get("trade_id", "")).strip() for row in rows if row.get("trade_id")]
+
     async def update_trade_status(
         self, trade_id: str, status: str, pnl: Optional[float] = None, won: Optional[bool] = None
     ) -> bool:

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -728,6 +728,7 @@ async def main() -> None:
                 position_manager=position_manager,
                 pnl_tracker=pnl_tracker,
                 paper_engine=engine_container.paper_engine,
+                risk_guard=risk_guard,
             ),
             name="trading_loop",
         )

--- a/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
@@ -1,0 +1,59 @@
+## 1. What was built
+- Added the required FORGE artifact at `projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`.
+- Added the required deterministic blocker-target test artifact at `projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`.
+- Hardened active trading-loop execution so formal `RiskGuard` checks are executed before each trade attempt and execution is skipped when blocked.
+- Propagated authoritative kill-switch state to execution fallback via `kill_switch_active` in `execute_trade` calls.
+- Fixed `EngineContainer.restore_from_db` so restored wallet state is assigned to the runtime wallet used by `PaperEngine` (instead of ignoring the classmethod return).
+- Added durable dedup rehydration support:
+  - `DatabaseClient.load_recent_trade_ids()` for restart-safe dedup seed loading.
+  - `PaperEngine.restore_dedup_state()` to rehydrate processed trade IDs from DB.
+  - `EngineContainer.restore_from_db()` now calls dedup rehydration after state restore.
+- Removed audited silent exception swallowing in active trading-loop close-alert paths and replaced with explicit warning logs.
+
+## 2. Design principles
+- Blocker-fix pass only: changes were limited strictly to items raised by SENTINEL PR #232.
+- Fail-closed risk behavior: if formal risk snapshot computation fails, execution is blocked for that signal.
+- Keep paper mode operable: no real-wallet enablement was introduced.
+- Minimal durable dedup: added only the narrow DB-backed trade-id rehydrate path needed to reduce replay risk on restart/re-init.
+- Zero silent failures in audited path: explicit logging on close-alert exceptions.
+
+## 3. Files changed
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/paper_engine.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/database.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. Before/after improvement summary
+- Missing artifact gap:
+  - Before: required forge and test artifacts absent.
+  - After: both required files exist at exact validator-target paths.
+- Formal RiskGuard enforcement:
+  - Before: trading loop could execute without formal `RiskGuard` checks.
+  - After: each signal path runs `_enforce_formal_risk_guard()` before execution and blocks when guard is disabled or limits trigger.
+- Kill-switch propagation:
+  - Before: `execute_trade` invocation used default kill-switch argument in loop fallback path.
+  - After: loop now passes `kill_switch_active=bool(risk_guard.disabled)`.
+- Wallet restore bug:
+  - Before: `EngineContainer.restore_from_db()` called wallet classmethod-style restore but ignored returned engine, leaving runtime wallet stale.
+  - After: restored wallet is assigned to `self.wallet`, and `PaperEngine` is rebuilt to use restored runtime wallet.
+- Dedup durability:
+  - Before: replay protection was instance-scoped in engine process memory.
+  - After: `PaperEngine` rehydrates processed trade IDs from durable DB recent-trades history on restore.
+- Silent failure handling:
+  - Before: audited close-alert paths used `except Exception: pass`.
+  - After: those paths emit explicit warning logs (`telegram_close_alert_failed`, `telegram_live_close_alert_failed`).
+- Deterministic test coverage:
+  - Added targeted tests for RiskGuard block, allowed paper execution path, runtime wallet restore, restart dedup replay blocking, and silent-path removal assertion.
+
+## 5. Issues
+- Test harness uses lightweight stubs/monkeypatch to isolate blocker behavior and avoid unrelated infrastructure dependencies.
+- No Telegram UX/menu behavior was changed in this pass.
+- No real-wallet enablement changes were introduced.
+
+## 6. Next
+- SENTINEL revalidation required for `paper_trade_hardening_p0_20260407` before merge.
+- Source: `projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`.

--- a/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.core.pipeline import trading_loop
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
+from projects.polymarket.polyquantbot.execution.engine_router import EngineContainer
+from projects.polymarket.polyquantbot.execution.paper_engine import PaperEngine, OrderStatus
+from projects.polymarket.polyquantbot.risk.risk_guard import RiskGuard
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.trades: list[dict] = []
+        self.positions: list[dict] = []
+
+    async def get_positions(self, user_id: str | None = None):
+        return list(self.positions)
+
+    async def get_recent_trades(self, limit: int = 500):
+        return list(self.trades)
+
+    async def upsert_position(self, position: dict):
+        self.positions.append(position)
+        return True
+
+    async def insert_trade(self, trade: dict):
+        self.trades.append(trade)
+        return True
+
+    async def update_trade_status(self, trade_id: str, status: str, pnl: float | None = None, won: bool | None = None):
+        return True
+
+    async def load_latest_wallet_state(self):
+        return {"cash": 777.0, "locked": 123.0, "equity": 900.0}
+
+    async def load_open_paper_positions(self):
+        return []
+
+    async def load_ledger_entries(self, market_id: str | None = None, limit: int = 1000):
+        return []
+
+    async def load_recent_trade_ids(self, limit: int = 5000):
+        return ["dup-1"]
+
+
+class _PaperEngineStub:
+    def __init__(self) -> None:
+        self.calls = 0
+        self._wallet = type(
+            "Wallet",
+            (),
+            {
+                "get_state": lambda _self: type("State", (), {"equity": 1000.0})(),
+                "persist": lambda _self, db: asyncio.sleep(0),
+            },
+        )()
+        self._positions = type(
+            "Positions",
+            (),
+            {
+                "update_price": lambda _self, market_id, price: None,
+                "get_all_open": lambda _self: [],
+                "save_closed_to_db": lambda _self, db, market_id: asyncio.sleep(0),
+            },
+        )()
+
+    async def execute_order(self, order: dict):
+        self.calls += 1
+        return type("Order", (), {
+            "trade_id": order["trade_id"],
+            "market_id": order["market_id"],
+            "side": order["side"],
+            "requested_size": order["size"],
+            "filled_size": order["size"],
+            "fill_price": order["price"],
+            "reason": "filled",
+            "status": OrderStatus.FILLED,
+        })()
+
+
+def _signal() -> SignalResult:
+    return SignalResult(
+        signal_id="sig-1",
+        market_id="mkt-1",
+        side="YES",
+        p_market=0.45,
+        p_model=0.55,
+        edge=0.10,
+        ev=0.12,
+        kelly_f=0.2,
+        size_usd=20.0,
+        liquidity_usd=20_000.0,
+        extra={"strategy_id": "test"},
+    )
+
+
+def _patch_single_tick(monkeypatch, stop_event: asyncio.Event) -> None:
+    async def _sleep(_: float):
+        stop_event.set()
+
+    async def _markets():
+        return [{"condition_id": "mkt-1", "question": "q", "outcomes": ["YES", "NO"], "best_ask": 0.45, "liquidity": 20000}]
+
+    async def _scope(markets):
+        return markets, {"selection_type": "All", "enabled_categories": [], "all_markets_enabled": True, "fallback_applied_count": 0}
+
+    def _ingest(markets):
+        return [{"market_id": "mkt-1", "p_market": 0.45, "liquidity_usd": 20000.0}]
+
+    async def _signals(*args, **kwargs):
+        return [_signal()]
+
+    monkeypatch.setattr(trading_loop, "get_active_markets", _markets)
+    monkeypatch.setattr(trading_loop, "apply_market_scope", _scope)
+    monkeypatch.setattr(trading_loop, "ingest_markets", _ingest)
+    monkeypatch.setattr(trading_loop, "generate_signals", _signals)
+    monkeypatch.setattr(trading_loop.asyncio, "sleep", _sleep)
+
+
+def test_risk_guard_blocks_active_loop_execution(monkeypatch):
+    async def _run() -> None:
+        stop_event = asyncio.Event()
+        db = _FakeDB()
+        paper = _PaperEngineStub()
+        risk = RiskGuard()
+        await risk.trigger_kill_switch("test")
+        _patch_single_tick(monkeypatch, stop_event)
+
+        await trading_loop.run_trading_loop(
+            loop_interval_s=0.01,
+            mode="PAPER",
+            db=db,
+            stop_event=stop_event,
+            paper_engine=paper,
+            risk_guard=risk,
+        )
+        assert paper.calls == 0
+
+    asyncio.run(_run())
+
+
+def test_allowed_path_runs_in_paper_mode(monkeypatch):
+    async def _run() -> None:
+        stop_event = asyncio.Event()
+        db = _FakeDB()
+        paper = _PaperEngineStub()
+        risk = RiskGuard()
+        _patch_single_tick(monkeypatch, stop_event)
+
+        await trading_loop.run_trading_loop(
+            loop_interval_s=0.01,
+            mode="PAPER",
+            db=db,
+            stop_event=stop_event,
+            paper_engine=paper,
+            risk_guard=risk,
+        )
+        assert paper.calls == 1
+
+    asyncio.run(_run())
+
+
+def test_wallet_restore_updates_active_runtime_wallet_and_dedup():
+    async def _run() -> None:
+        db = _FakeDB()
+        container = EngineContainer()
+        old_wallet = container.wallet
+        await container.restore_from_db(db)
+
+        assert container.wallet is not old_wallet
+        assert container.paper_engine._wallet is container.wallet
+        assert container.wallet.get_state().cash == 777.0
+
+    asyncio.run(_run())
+
+
+def test_duplicate_replay_blocked_after_restart_rehydrate(monkeypatch):
+    async def _run() -> None:
+        db = _FakeDB()
+        container = EngineContainer()
+        engine = PaperEngine(
+            wallet=container.wallet,
+            positions=container.positions,
+            ledger=container.ledger,
+            random_seed=42,
+        )
+
+        async def _sleep(_: float):
+            return None
+
+        monkeypatch.setattr("projects.polymarket.polyquantbot.execution.paper_engine.asyncio.sleep", _sleep)
+        await engine.restore_dedup_state(db)
+        result = await engine.execute_order(
+            {"trade_id": "dup-1", "market_id": "mkt-1", "side": "YES", "price": 0.5, "size": 10.0}
+        )
+        assert result.reason == "duplicate_trade_id"
+
+    asyncio.run(_run())
+
+
+def test_audited_silent_failure_path_removed():
+    content = open(
+        "projects/polymarket/polyquantbot/core/pipeline/trading_loop.py",
+        "r",
+        encoding="utf-8",
+    ).read()
+    assert "except Exception:\n                                            pass" not in content


### PR DESCRIPTION
### Motivation
- Address SENTINEL PR #232 P0 blockers preventing paper-trade hardening and revalidation, specifically missing artifacts, RiskGuard bypass, kill-switch propagation, wallet restore mismatch, restart dedup risk, and silent exception swallowing. 
- Make the minimal, scope-limited changes required so the paper execution path remains operable while enforcing formal pre-execution risk controls.

### Description
- Enforced formal `RiskGuard` in the active trading loop by adding a `risk_guard` parameter to `run_trading_loop` and running fail-closed checks (`check_daily_loss` + `check_drawdown` + kill-switch fast-path) before each execution attempt. 
- Propagated authoritative kill-switch state into execution fallbacks by passing `kill_switch_active=bool(risk_guard.disabled)` to `execute_trade`. 
- Fixed engine wallet restore semantics in `EngineContainer.restore_from_db` so the returned `WalletEngine` is assigned to `self.wallet` and `PaperEngine` is re-created to use the restored wallet, and added a call to rehydrate paper dedup state. 
- Improved dedup durability by adding `DatabaseClient.load_recent_trade_ids()` and `PaperEngine.restore_dedup_state()` so processed trade IDs are rehydrated from DB on restore. 
- Removed audited silent `except ...: pass` paths in the trading-loop close-alert branches and replaced them with explicit structured `log.warning(...)` entries. 
- Added required artifacts: `projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md` and deterministic test module `projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`, and updated `PROJECT_STATE.md` to reflect blocker-fix completion and SENTINEL revalidation handoff.

### Testing
- Ran the new targeted test suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py` and observed `5 passed` (one pytest config warning unrelated to changes). 
- Verified git state and committed all changes (single commit includes code + tests + forge report + `PROJECT_STATE.md`). 
- Smoke-checked that no `phase*/` folders were introduced and that trading-loop now consults `RiskGuard` before execution (static inspection and unit test evidence).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4501eb81c832ea1aee7655e02ff4f)