### PR TITLE
FORGE-X: fix paper_trade_hardening_p0 blockers from SENTINEL PR #234

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-06 22:40
-- Status        : SENTINEL trade-system truth audit complete (paper-path decision map delivered); premium-nav and trade-hardening merge sequence awaiting COMMANDER direction
+- Last Updated  : 2026-04-07 23:10
+- Status        : FORGE-X blocker-fix v2 complete for paper_trade_hardening_p0_20260407; PR #234 blocked findings addressed and line prepared for SENTINEL revalidation
 
 ---
 
@@ -29,6 +29,7 @@
 - Telegram premium navigation / UX consolidation pass (2026-04-07): enforced two-layer Telegram navigation with persistent 5-item reply-keyboard root and contextual inline section actions; removed duplicated inline root menu; added active-root cue and compact button layout polish while preserving approved scope-control semantics.
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
+- Paper-trade hardening blocker-fix v2 (2026-04-07): created required target test artifact, enforced formal RiskGuard gate on active trading loop before execution, propagated kill-switch blocking on paper path, fixed wallet restore runtime rebinding, added durable dedup seed-on-restore, and removed explicit silent exception swallowing from audited close-alert paths.
 
 ---
 
@@ -39,7 +40,7 @@
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
 ### Trade-system hardening handoff
-- FORGE-X hardening pending for risk-gate unification, reconciliation ownership, restart recovery correctness, and silent-failure removal before any real-wallet enablement.
+- SENTINEL revalidation pending for `paper_trade_hardening_p0_20260407` after blocker-fix v2.
 
 ---
 
@@ -51,9 +52,8 @@
 
 ## 🎯 NEXT PRIORITY
 
-- FORGE-X hardening required for trade-system readiness before any real-wallet enablement.
-- Source: projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md
-- SENTINEL re-validation required after hardening pass; COMMANDER merge/enablement decision only after that validation.
+- SENTINEL validation required for paper_trade_hardening_p0_20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
 
 ---
 
@@ -62,5 +62,4 @@
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
-- Trading-loop execution path currently bypasses formal `RiskGuard` kill-switch/daily-loss/drawdown gating and must be hardened before real-wallet mode.
-- Startup wallet restore path in engine container may not apply persisted wallet state correctly (class-method return value is not assigned), creating restart reconciliation risk.
+- Remaining P1 gap: broader multi-store reconciliation ownership/atomicity across PaperEngine wallet/positions/ledger and loop-side DB/portfolio overlays still requires dedicated follow-up hardening.

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -88,6 +88,7 @@ from ...monitoring.metrics_engine import MetricsEngine
 from ...monitoring.validation_engine import ValidationEngine, ValidationState
 from ...monitoring.snapshot_engine import SnapshotEngine
 from ...strategy.market_intelligence import MarketIntelligenceEngine
+from ...risk.risk_guard import RiskGuard
 from ...telegram.utils import telegram_sender
 from ...interface.ui.views import (
     render_exposure_view,
@@ -444,6 +445,7 @@ async def run_trading_loop(
     position_manager: Optional[Any] = None,
     pnl_tracker: Optional[Any] = None,
     paper_engine: Optional[Any] = None,
+    risk_guard: Optional[RiskGuard] = None,
     tp_pct: float = _DEFAULT_TP_PCT,
     sl_pct: float = _DEFAULT_SL_PCT,
 ) -> None:
@@ -545,6 +547,8 @@ async def run_trading_loop(
     _last_market_intel_payload: dict[str, Any] = {}
     _trade_type_distribution: dict[str, int] = {}
     _market_type_by_id: dict[str, str] = {}
+    _risk_guard: RiskGuard = risk_guard or RiskGuard()
+    _risk_peak_balance: float = _bankroll
 
     def _to_float(value: Any) -> float:
         """Return float-safe value for Telegram formatting."""
@@ -986,6 +990,44 @@ async def run_trading_loop(
                 # ── 4. Execute each signal and update positions ───────────────────
                 _trades_this_tick: int = 0
                 for signal in signals:
+                    try:
+                        _risk_trades = await db.get_recent_trades(limit=500)
+                        _realized_pnl = PnLCalculator.calculate_realized_pnl(_risk_trades)
+                    except Exception as _risk_trade_exc:  # noqa: BLE001
+                        log.warning(
+                            "risk_gate_trade_scan_failed",
+                            error=str(_risk_trade_exc),
+                        )
+                        _realized_pnl = 0.0
+
+                    try:
+                        if _mode == "PAPER" and paper_engine is not None:
+                            _wallet_state = paper_engine._wallet.get_state()  # type: ignore[attr-defined]
+                            _current_balance = float(_wallet_state.equity)
+                        else:
+                            _current_balance = _bankroll + float(_realized_pnl)
+                        _risk_peak_balance = max(_risk_peak_balance, _current_balance)
+                        await _risk_guard.check_daily_loss(float(_realized_pnl))
+                        await _risk_guard.check_drawdown(_risk_peak_balance, _current_balance)
+                    except Exception as _risk_guard_exc:  # noqa: BLE001
+                        log.error(
+                            "risk_guard_check_failed",
+                            market_id=signal.market_id,
+                            error=str(_risk_guard_exc),
+                            exc_info=True,
+                        )
+                        continue
+
+                    _kill_switch_active = _risk_guard.disabled
+                    if _kill_switch_active:
+                        log.warning(
+                            "risk_guard_blocked_execution",
+                            market_id=signal.market_id,
+                            signal_id=signal.signal_id,
+                            reason=_risk_guard.kill_switch_reason,
+                        )
+                        continue
+
                     # ── 4a. Force signal mode: max 1 trade per loop ───────────────
                     if _active_force and _trades_this_tick >= 1:
                         log.info(
@@ -1154,6 +1196,7 @@ async def run_trading_loop(
                         result = await execute_trade(
                             signal,
                             mode=_mode,
+                            kill_switch_active=_kill_switch_active,
                             executor_callback=executor_callback,
                         )
                         if not result.success:
@@ -1505,8 +1548,13 @@ async def run_trading_loop(
                                                 f"Entry: {_pos.entry_price:.4f}"
                                             )
                                             await telegram_sender.send(_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as _close_tg_exc:
+                                            log.warning(
+                                                "close_alert_send_failed",
+                                                trade_id=_close_trade_id,
+                                                market_id=_pos.market_id,
+                                                error=str(_close_tg_exc),
+                                            )
                                 except Exception as _close_exc:
                                     log.error(
                                         "close_order_failed",
@@ -1592,8 +1640,13 @@ async def run_trading_loop(
                                                 f"Entry: {_lpos.avg_price:.4f}"
                                             )
                                             await telegram_sender.send(_live_close_msg)
-                                        except Exception:
-                                            pass
+                                        except Exception as _live_close_tg_exc:
+                                            log.warning(
+                                                "live_close_alert_send_failed",
+                                                trade_id=_live_close_id,
+                                                market_id=_lpos.market_id,
+                                                error=str(_live_close_tg_exc),
+                                            )
                                 except Exception as _live_close_exc:
                                     log.error(
                                         "live_close_order_failed",

--- a/projects/polymarket/polyquantbot/execution/engine_router.py
+++ b/projects/polymarket/polyquantbot/execution/engine_router.py
@@ -94,7 +94,13 @@ class EngineContainer:
         """
         log.info("engine_container_restore_start")
         try:
-            await self.wallet.restore_from_db(db)  # type: ignore[arg-type]
+            restored_wallet = await WalletEngine.restore_from_db(db)  # type: ignore[arg-type]
+            self.wallet = restored_wallet
+            self.paper_engine = PaperEngine(
+                wallet=self.wallet,
+                positions=self.positions,
+                ledger=self.ledger,
+            )
         except Exception as exc:
             log.warning("engine_container_wallet_restore_error", error=str(exc))
 
@@ -107,6 +113,13 @@ class EngineContainer:
             await self.ledger.load_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_ledger_restore_error", error=str(exc))
+
+        try:
+            if hasattr(db, "load_processed_trade_ids"):
+                trade_ids = await db.load_processed_trade_ids()  # type: ignore[attr-defined]
+                self.paper_engine.seed_processed_trade_ids(set(trade_ids))
+        except Exception as exc:
+            log.warning("engine_container_dedup_seed_error", error=str(exc))
 
         log.info("engine_container_restore_complete")
 

--- a/projects/polymarket/polyquantbot/execution/paper_engine.py
+++ b/projects/polymarket/polyquantbot/execution/paper_engine.py
@@ -135,6 +135,25 @@ class PaperEngine:
 
         log.info("paper_engine_initialized", seeded=random_seed is not None)
 
+    def seed_processed_trade_ids(self, trade_ids: set[str]) -> int:
+        """Seed idempotency cache from durable storage on restart/re-init.
+
+        Args:
+            trade_ids: Trade IDs that have already been processed.
+
+        Returns:
+            Number of IDs newly added to the in-memory cache.
+        """
+        before = len(self._processed_trade_ids)
+        self._processed_trade_ids.update({tid for tid in trade_ids if tid})
+        added = len(self._processed_trade_ids) - before
+        log.info(
+            "paper_engine_dedup_seeded",
+            added=added,
+            total=len(self._processed_trade_ids),
+        )
+        return added
+
     # ── Public API ────────────────────────────────────────────────────────────
 
     async def execute_order(self, order: dict) -> PaperOrderResult:

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -737,6 +737,37 @@ class DatabaseClient:
         sql = "SELECT * FROM trade_ledger ORDER BY inserted_at ASC LIMIT $1"
         return await self._fetch(sql, limit, op_label="load_ledger_entries")
 
+    async def load_processed_trade_ids(self, limit: int = 5000) -> List[str]:
+        """Load durable trade IDs for restart-safe dedup seeding.
+
+        Trade IDs are collected from both ``trades`` and ``trade_ledger`` so
+        paper execution replay can be blocked after process restart.
+
+        Args:
+            limit: Max IDs loaded from each source table.
+
+        Returns:
+            List of unique trade IDs.
+        """
+        trade_rows = await self._fetch(
+            "SELECT trade_id FROM trades ORDER BY inserted_at DESC LIMIT $1",
+            limit,
+            op_label="load_processed_trade_ids_trades",
+        )
+        ledger_rows = await self._fetch(
+            "SELECT trade_id FROM trade_ledger ORDER BY inserted_at DESC LIMIT $1",
+            limit,
+            op_label="load_processed_trade_ids_ledger",
+        )
+        merged: set[str] = set()
+        for row in trade_rows + ledger_rows:
+            trade_id = str(row.get("trade_id", "")).strip()
+            if trade_id:
+                merged.add(trade_id)
+        ids = list(merged)
+        log.info("load_processed_trade_ids_ok", count=len(ids))
+        return ids
+
     # ── Strategy toggle state ─────────────────────────────────────────────────
 
     async def load_strategy_state(self) -> Dict[str, bool]:

--- a/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md
@@ -1,0 +1,74 @@
+# FORGE-X REPORT — paper_trade_hardening_p0_20260407
+
+## 1. What was built
+- Resolved missing required artifact by adding deterministic target test suite at:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+- Hardened active paper-trade execution path in `trading_loop.py` by enforcing formal `RiskGuard` checks before each execution attempt:
+  - `check_daily_loss(...)`
+  - `check_drawdown(...)`
+  - authoritative `kill_switch` block path before any paper execution mutation.
+- Added explicit kill-switch propagation into `execute_trade(...)` call path.
+- Fixed wallet restore/re-init binding bug in `EngineContainer.restore_from_db(...)`:
+  - now assigns restored wallet object to active runtime container
+  - rebuilds `paper_engine` with restored wallet reference.
+- Added durable dedup restart safety:
+  - `DatabaseClient.load_processed_trade_ids(...)` loads persisted IDs from trades + ledger.
+  - `PaperEngine.seed_processed_trade_ids(...)` seeds in-memory dedup set on restore/re-init.
+- Removed explicit silent exception swallowing in audited close-alert paths in `trading_loop.py` and replaced with structured warning logs.
+
+Before/after evidence summary:
+- Missing artifact before: test file absent.
+- After: required test file added at exact blocker path.
+- RiskGuard before: active trading loop executed directly without formal guard.
+- After: active loop executes risk checks and blocks on kill-switch before execution call.
+- Kill-switch before: not authoritatively propagated on active paper path.
+- After: kill-switch state blocks paper execution path and is forwarded to executor path.
+- Wallet restore before: classmethod return value ignored.
+- After: restored wallet instance is rebound to container + paper engine.
+- Dedup before: process-memory only.
+- After: dedup seeds from durable persisted trade IDs on restore.
+- Silent failure before: explicit `except Exception: pass` in close-alert paths.
+- After: explicit warning logs emitted on close-alert send failures.
+
+## 2. Current system architecture
+- Active paper path remains:
+  - `DATA -> STRATEGY -> INTELLIGENCE -> RISK -> EXECUTION -> MONITORING`
+- `RISK` is now formalized on the active loop by requiring `RiskGuard` checks before execution.
+- `EXECUTION` remains paper-mode safe (no real-wallet enablement).
+- Restart/re-init now restores wallet state into active runtime object and seeds dedup from durable data.
+- No Telegram UX/navigation flow changes were introduced.
+
+## 3. Files created / modified (full paths)
+- Created:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md`
+- Modified:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/paper_engine.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/database.py`
+  - `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required blocker artifact exists at exact required path.
+- Active loop enforces formal `RiskGuard` gate before execution.
+- Kill-switch blocks execution on active loop path (paper path no mutation when blocked).
+- Allowed paper mode execution still works under non-blocked risk state.
+- Wallet restore now applies restored runtime wallet object to active container/paper engine.
+- Restart dedup protection is materially improved via durable seed from DB records.
+- Explicit silent exception swallowing removed from audited close-alert code paths.
+- Deterministic tests for blocker coverage were added.
+
+## 5. Known issues
+- This pass is scoped to P0 blocker fixes only; broader reconciliation unification remains outside this narrow blocker-fix v2 task.
+- External network-dependent validations (e.g., live endpoint reachability) remain environment-dependent and unchanged.
+
+## 6. What is next
+- SENTINEL revalidation required for paper_trade_hardening_p0_20260407 before merge.
+- Focus SENTINEL checks on:
+  - formal RiskGuard gate behavior on active loop,
+  - kill-switch non-bypass execution blocking,
+  - wallet restore runtime rebinding,
+  - durable dedup replay safety,
+  - silent failure removal observability,
+  - deterministic target test execution results.

--- a/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from projects.polymarket.polyquantbot.core.pipeline.trading_loop import run_trading_loop
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
+from projects.polymarket.polyquantbot.execution.engine_router import EngineContainer
+from projects.polymarket.polyquantbot.execution.paper_engine import OrderStatus
+from projects.polymarket.polyquantbot.risk.risk_guard import RiskGuard
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self._trades: list[dict] = []
+
+    async def get_positions(self, _user_id: str):
+        return []
+
+    async def get_recent_trades(self, limit: int = 500):
+        return self._trades[:limit]
+
+    async def upsert_position(self, _position: dict):
+        return True
+
+    async def insert_trade(self, trade: dict):
+        self._trades.append(trade)
+        return True
+
+    async def update_trade_status(self, *_args, **_kwargs):
+        return True
+
+
+class _AllowRiskGuard(RiskGuard):
+    async def check_daily_loss(self, current_pnl: float) -> None:
+        return None
+
+    async def check_drawdown(self, peak_balance: float, current_balance: float) -> None:
+        return None
+
+
+class _BlockRiskGuard(RiskGuard):
+    async def check_daily_loss(self, current_pnl: float) -> None:
+        await self.trigger_kill_switch("test_block")
+
+
+def test_risk_guard_blocks_active_paper_loop_execution(monkeypatch) -> None:
+    stop_event = asyncio.Event()
+    db = _FakeDB()
+    paper_engine = SimpleNamespace(
+        execute_order=AsyncMock(),
+        _wallet=SimpleNamespace(get_state=lambda: SimpleNamespace(equity=10_000.0)),
+        _positions=SimpleNamespace(update_price=lambda *_args, **_kwargs: None, get_all_open=lambda: []),
+    )
+
+    signal = SignalResult(
+        signal_id="sig-risk-block",
+        market_id="m1",
+        side="YES",
+        p_market=0.45,
+        p_model=0.60,
+        edge=0.15,
+        ev=0.1,
+        kelly_f=0.1,
+        size_usd=10.0,
+        liquidity_usd=20_000.0,
+    )
+
+    async def _stop_sleep(_seconds: float) -> None:
+        stop_event.set()
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.get_active_markets",
+        AsyncMock(return_value=[{"id": "m1"}]),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.apply_market_scope",
+        AsyncMock(return_value=([{"id": "m1"}], {"enabled_categories": [], "selection_type": "All"})),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.ingest_markets",
+        lambda _markets: [{"market_id": "m1", "p_market": 0.45}],
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.generate_signals",
+        AsyncMock(return_value=[signal]),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.asyncio.sleep",
+        _stop_sleep,
+    )
+
+    asyncio.run(
+        run_trading_loop(
+            mode="PAPER",
+            db=db,
+            stop_event=stop_event,
+            paper_engine=paper_engine,
+            risk_guard=_BlockRiskGuard(),
+        )
+    )
+
+    paper_engine.execute_order.assert_not_called()
+
+
+def test_allowed_path_still_executes_in_paper_mode(monkeypatch) -> None:
+    stop_event = asyncio.Event()
+    db = _FakeDB()
+
+    async def _exec_order(_order: dict):
+        return SimpleNamespace(
+            status=OrderStatus.FILLED,
+            trade_id="t-allowed",
+            market_id="m-allowed",
+            side="YES",
+            requested_size=10.0,
+            filled_size=10.0,
+            fill_price=0.5,
+            reason="ok",
+        )
+
+    paper_engine = SimpleNamespace(
+        execute_order=AsyncMock(side_effect=_exec_order),
+        _wallet=SimpleNamespace(
+            get_state=lambda: SimpleNamespace(equity=10_000.0),
+            persist=AsyncMock(),
+        ),
+        _positions=SimpleNamespace(
+            update_price=lambda *_args, **_kwargs: None,
+            get_all_open=lambda: [],
+            save_to_db=AsyncMock(),
+        ),
+    )
+
+    signal = SignalResult(
+        signal_id="sig-allowed",
+        market_id="m-allowed",
+        side="YES",
+        p_market=0.45,
+        p_model=0.60,
+        edge=0.15,
+        ev=0.1,
+        kelly_f=0.1,
+        size_usd=10.0,
+        liquidity_usd=20_000.0,
+    )
+
+    async def _stop_sleep(_seconds: float) -> None:
+        stop_event.set()
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.get_active_markets",
+        AsyncMock(return_value=[{"id": "m-allowed"}]),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.apply_market_scope",
+        AsyncMock(return_value=([{"id": "m-allowed"}], {"enabled_categories": [], "selection_type": "All"})),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.ingest_markets",
+        lambda _markets: [{"market_id": "m-allowed", "p_market": 0.45}],
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.generate_signals",
+        AsyncMock(return_value=[signal]),
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.pipeline.trading_loop.asyncio.sleep",
+        _stop_sleep,
+    )
+
+    asyncio.run(
+        run_trading_loop(
+            mode="PAPER",
+            db=db,
+            stop_event=stop_event,
+            paper_engine=paper_engine,
+            risk_guard=_AllowRiskGuard(),
+        )
+    )
+
+    paper_engine.execute_order.assert_called_once()
+
+
+def test_wallet_restore_rebinds_runtime_wallet_and_dedup_seed() -> None:
+    container = EngineContainer()
+
+    restored_wallet = SimpleNamespace(marker="restored")
+
+    async def _restore(_cls, _db):
+        return restored_wallet
+
+    db = SimpleNamespace(
+        load_processed_trade_ids=AsyncMock(return_value=["persisted-trade-id"]),
+        load_open_paper_positions=AsyncMock(return_value=[]),
+        load_ledger_entries=AsyncMock(return_value=[]),
+    )
+
+    from projects.polymarket.polyquantbot.execution import engine_router as router_module
+
+    original_restore = router_module.WalletEngine.restore_from_db
+    router_module.WalletEngine.restore_from_db = classmethod(_restore)  # type: ignore[assignment]
+    try:
+        asyncio.run(container.restore_from_db(db))
+    finally:
+        router_module.WalletEngine.restore_from_db = original_restore  # type: ignore[assignment]
+
+    assert container.wallet is restored_wallet
+    assert container.paper_engine._wallet is restored_wallet
+    duplicate = asyncio.run(
+        container.paper_engine.execute_order(
+            {
+                "trade_id": "persisted-trade-id",
+                "market_id": "m1",
+                "side": "YES",
+                "price": 0.5,
+                "size": 10.0,
+            }
+        )
+    )
+    assert duplicate.reason == "duplicate_trade_id"
+
+
+def test_trading_loop_no_silent_exception_swallow_for_close_alerts() -> None:
+    from pathlib import Path
+
+    source = Path(
+        "/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "except Exception:\n                                            pass" not in source


### PR DESCRIPTION
### Motivation
- Clear the critical blockers raised by SENTINEL PR #234 that prevent safe paper-trade hardening: missing target tests, RiskGuard bypass on the active trading-loop path, wallet restore rebinding bug, in-memory-only dedup (restart replay risk), and silent exception swallowing in close-alerts. 
- Deliver a narrowly-scoped P0 blocker-fix so the line can be handed back to SENTINEL for revalidation without expanding scope or enabling real-wallet behavior.

### Description
- Added deterministic target test suite at `projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py` covering RiskGuard blocking, kill-switch behavior, allowed paper execution, wallet restore rebinding, dedup replay protection, and silent-exception removal. 
- Enforced formal `RiskGuard` checks in the active trading loop (`core/pipeline/trading_loop.py`) by running `check_daily_loss` and `check_drawdown` before each execution attempt and blocking when the kill-switch is active; kill-switch state is propagated into execution paths. 
- Replaced explicit silent `except: pass` swallowing in close-alert sends with structured warning logs to preserve observability and prevent silent failures. 
- Fixed wallet restore/rebind in the engine container (`execution/engine_router.py`) by assigning the restored `WalletEngine` instance to the runtime container and rebuilding `PaperEngine` with the restored wallet. 
- Added durable dedup seeding on restart: `DatabaseClient.load_processed_trade_ids(...)` (reads persisted `trades` + `trade_ledger`) and `PaperEngine.seed_processed_trade_ids(...)` to populate in-memory dedup cache after restore. 
- Created the required FORGE report at `projects/polymarket/polyquantbot/reports/forge/paper_trade_hardening_p0_20260407.md` and updated `PROJECT_STATE.md` to reflect blocker-fix v2 completion and SENTINEL revalidation handoff. 

### Testing
- Ran the new targeted test module with repository on PYTHONPATH: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_paper_trade_hardening_p0_20260407.py` and observed final outcome: **4 passed**. 
- During iteration encountered and fixed test-import and async execution issues (missing PYTHONPATH at first run, then adjusted tests to run synchronously with `asyncio.run` for this environment), after which the deterministic tests passed. 
- No broader test-suite runs were performed; validation focused on the deterministic P0 target tests added for the blocked findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47590c714832e84a4c83a4c6b8933)