### PR TITLE
sentinel: block telegram_trade_menu_mvp validation (missing required artifacts)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
@@ -1,0 +1,59 @@
+# 1. Target
+- Validation task: `telegram_trade_menu_mvp_20260407`
+- Requested branch context: `feature/add-telegram-trade-submenu-mvp-2026-04-07`
+- Required artifacts checked:
+  - `/workspace/walker-ai-team/PROJECT_STATE.md` (FOUND)
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md` (MISSING)
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py` (MISSING)
+  - Remaining listed code files (FOUND)
+
+System drift detected:
+- component: forge report artifact
+- expected: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+- actual: artifact not present; nearest dated forge reports are `telegram_menu_scope_hardening_20260407.md` and `telegram_premium_nav_ux_20260407.md`
+
+System drift detected:
+- component: targeted MVP test artifact
+- expected: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py`
+- actual: file not present in repository
+
+# 2. Score
+- Architecture: 0/20 (Phase 0 gate not satisfied)
+- Functional: 0/20 (not executed due missing required artifacts)
+- Failure Modes: 0/20 (not executed due missing required artifacts)
+- Risk Compliance: 0/20 (not executed due missing required artifacts)
+- Infra + Telegram: 0/10 (not executed due missing required artifacts)
+- Latency: 0/10 (not executed; no measurements)
+- **Total: 0/100**
+
+# 3. Findings by phase
+- **Phase 0 — Preconditions: BLOCKED**
+  - Required forge report file is missing.
+  - Required targeted test file is missing.
+  - Per task instruction, validation must stop when required artifact is missing.
+- **Phase 1 — Static evidence:** Not executed (blocked at Phase 0).
+- **Phase 2 — Runtime proof:** Not executed (blocked at Phase 0).
+- **Phase 3 — Test/harness validation:** Not executed (blocked at Phase 0).
+- **Phase 4 — Safety/break checks:** Not executed (blocked at Phase 0).
+- **Phase 5 — Regression scope:** Not executed (blocked at Phase 0).
+
+# 4. Evidence
+- Artifact existence command:
+  - `for f in /workspace/walker-ai-team/PROJECT_STATE.md /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py; do if [ -f "$f" ]; then echo "FOUND $f"; else echo "MISSING $f"; fi; done`
+- Output excerpt:
+  - `MISSING /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+  - `MISSING /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py`
+- Repository forge report listing command:
+  - `rg --files /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge | rg 'trade_menu|telegram.*trade|20260407'`
+- Output excerpt:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_menu_scope_hardening_20260407.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_premium_nav_ux_20260407.md`
+
+# 5. Critical issues
+- Missing required forge report for this validation target:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+- Missing required targeted test file for this validation target:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py`
+
+# 6. Verdict
+**BLOCKED**


### PR DESCRIPTION
### Motivation
- Run SENTINEL validation for `telegram_trade_menu_mvp_20260407` on branch `feature/add-telegram-trade-submenu-mvp-2026-04-07` and surface Phase 0 blockers preventing further testing. 

### Description
- Added SENTINEL validation report `projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md` documenting missing required artifacts and system drift. 
- Report records that the forge report `projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md` and the targeted test `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py` are absent, and therefore validation must stop at Phase 0. 
- Committed the report with commit message `sentinel: telegram_trade_menu_mvp_validation_20260407 — BLOCKED` and opened this PR to communicate the BLOCKED verdict.

### Testing
- Ran artifact existence check via the shell command used in the report (presence check for `PROJECT_STATE.md`, target forge report, UI files, and tests), which found the two missing artifacts and succeeded in detecting drift. 
- Ran `rg` to list nearby forge reports and confirmed only related reports (`telegram_menu_scope_hardening_20260407.md`, `telegram_premium_nav_ux_20260407.md`) exist; this check succeeded. 
- `python -m py_compile` and the targeted `pytest` command were intentionally not run because Phase 0 preconditions failed and the validation contract requires stopping on missing required artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d494903aa0832e92f80c0ed4706bdd)