### PR TITLE
sentinel: block telegram trade menu MVP revalidation (missing routing test artifact)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 05:31
-- Status        : FORGE-X Phase 0 blockers cleared for telegram_trade_menu_mvp_20260407; prior validation remained blocked pending missing forge report/test artifacts; SENTINEL revalidation now queued
+- Last Updated  : 2026-04-07 06:10
+- Status        : SENTINEL revalidation executed for telegram_trade_menu_mvp_20260407; Phase 0 blocked due to missing required routing test artifact; contract validation remains blocked pending FORGE-X artifact fix
 
 ---
 
@@ -35,6 +35,7 @@
 ## 🚧 IN PROGRESS
 
 ### Telegram trade menu MVP blocker-clear handoff
+- Phase 0 failed because required target test artifact is missing: `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`.
 - Previous SENTINEL validation for `telegram_trade_menu_mvp_20260407` was blocked due to missing FORGE report/test artifacts.
 - FORGE-X has now added the missing report + target test and produced pre-SENTINEL proof (py_compile + pytest pass).
 - SENTINEL revalidation is now required for `telegram_trade_menu_mvp_20260407`.
@@ -56,14 +57,15 @@
 
 ## 🎯 NEXT PRIORITY
 
-- SENTINEL revalidation required for telegram_trade_menu_mvp_20260407 before merge.
-- Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
+- FORGE-X artifact fix required: add missing `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` before SENTINEL can continue telegram_trade_menu_mvp_20260407 validation.
+- Source: projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
 - Previous validation for `telegram_trade_menu_mvp_20260407` was blocked at Phase 0 before this FORGE-X blocker-clear pass; SENTINEL must re-run validation with the new artifacts.
+- SENTINEL revalidation run on 2026-04-07 is BLOCKED at Phase 0 because required target file `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` is missing.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.

--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
@@ -1,0 +1,62 @@
+# SENTINEL VALIDATION — telegram_trade_menu_mvp_20260407 (Revalidation after FORGE-X #249)
+
+## 1) Task context
+- Role: **SENTINEL**
+- Intent: **revalidate telegram_trade_menu_mvp_20260407 after contract fix #249**
+- Target branch context: `feature/fix-telegram_trade_menu_mvp-contract-mismatch-2026-04-07` (Codex worktree HEAD reports `work`, treated as normal per Codex worktree rule)
+- Validation timestamp (UTC): **2026-04-07**
+
+## 2) Inputs loaded
+- `/workspace/walker-ai-team/PROJECT_STATE.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+- Required validation-target paths from COMMANDER task prompt
+
+## 3) Phase 0 — Preconditions (authoritative gate)
+
+### 3.1 Required forge report
+- ✅ Present:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+
+### 3.2 Required target tests
+- ✅ Present:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py`
+- ❌ Missing:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+
+### 3.3 Required target files
+- ✅ Present:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+
+### 3.4 Gate decision
+Per COMMANDER instruction:
+- If required artifact is missing → **stop** → verdict = **BLOCKED**.
+
+Result:
+- **Phase 0 FAILED** due to missing required test artifact:
+  - `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+
+## 4) Phase 1–4 execution status
+Because Phase 0 failed and stop-condition is mandatory:
+- Phase 1 (static evidence): **NOT EXECUTED**
+- Phase 2 (runtime proof): **NOT EXECUTED**
+- Phase 3 (py_compile + targeted pytest): **NOT EXECUTED**
+- Phase 4 (safety/break checks): **NOT EXECUTED**
+
+## 5) PROJECT_STATE alignment
+- `PROJECT_STATE.md` currently states SENTINEL revalidation is queued, but does not yet reflect this specific **Phase-0 artifact-missing blocker outcome** from this run.
+- This report records the new blocker truth for synchronization.
+
+## 6) Verdict
+## **BLOCKED**
+
+### Blocking reason
+Missing required artifact declared by COMMANDER validation target:
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+
+### Required unblocking action
+FORGE-X must add (or restore) the missing target test at the exact path above. After that, rerun full SENTINEL validation phases 1–4.


### PR DESCRIPTION
### Motivation
- Record the SENTINEL revalidation attempt for `telegram_trade_menu_mvp_20260407` and block further validation because a required routing test artifact is missing. 

### Description
- Added the SENTINEL report at `projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md` and updated `PROJECT_STATE.md` (timestamp/status/next-priority) to reflect the Phase‑0 blocker and handoff to FORGE‑X to restore the missing test. 

### Testing
- Ran Phase‑0 precondition checks (file existence checks and `rg` scans) which confirmed `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` is missing, so `py_compile`/`pytest` were not executed for this SENTINEL run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b241de18832e8cbcc8cceec1bf73)