### PR TITLE
Fix Telegram Trade Menu MVP Portfolio routing contract and add routing-proof tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 05:31
-- Status        : FORGE-X Phase 0 blockers cleared for telegram_trade_menu_mvp_20260407; prior validation remained blocked pending missing forge report/test artifacts; SENTINEL revalidation now queued
+- Last Updated  : 2026-04-07 07:49
+- Status        : FORGE-X final routing-contract fix pass completed for telegram_trade_menu_mvp_20260407; previous block was routing mismatch risk under Portfolio→Trade path; SENTINEL revalidation required before merge
 
 ---
 
@@ -29,14 +29,15 @@
 - Telegram premium navigation / UX consolidation pass (2026-04-07): enforced two-layer Telegram navigation with persistent 5-item reply-keyboard root and contextual inline section actions; removed duplicated inline root menu; added active-root cue and compact button layout polish while preserving approved scope-control semantics.
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
+- Telegram Trade Menu MVP final fix pass (2026-04-07): added Portfolio `⚡ Trade`, created dedicated 4-action Trade submenu, and corrected callback routing contract so trade actions stay in Trade context without Home fallback.
 
 ---
 
 ## 🚧 IN PROGRESS
 
 ### Telegram trade menu MVP blocker-clear handoff
-- Previous SENTINEL validation for `telegram_trade_menu_mvp_20260407` was blocked due to missing FORGE report/test artifacts.
-- FORGE-X has now added the missing report + target test and produced pre-SENTINEL proof (py_compile + pytest pass).
+- Previous validation line for `telegram_trade_menu_mvp_20260407` was blocked due to routing-contract mismatch risk (trade actions could collapse to Home context instead of Trade context).
+- FORGE-X final pass implemented explicit Trade submenu routing and added routing-proof tests (`test_telegram_trade_menu_routing_mvp.py`) with py_compile + pytest evidence.
 - SENTINEL revalidation is now required for `telegram_trade_menu_mvp_20260407`.
 
 ### Telegram post-approval UX consolidation handoff
@@ -58,12 +59,13 @@
 
 - SENTINEL revalidation required for telegram_trade_menu_mvp_20260407 before merge.
 - Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
+- Tier: STANDARD
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
-- Previous validation for `telegram_trade_menu_mvp_20260407` was blocked at Phase 0 before this FORGE-X blocker-clear pass; SENTINEL must re-run validation with the new artifacts.
+- Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
@@ -1,36 +1,54 @@
 # FORGE-X REPORT — telegram_trade_menu_mvp_20260407
 
 ## 1. What was built
-- Added the requested FORGE report at the exact required path for the `telegram_trade_menu_mvp_20260407` blocker-clear task.
-- Added the requested target test file at the exact required path.
-- Implemented a focused Phase-0 safety test asserting the MVP trade menu callback contract in `build_paper_wallet_menu()`.
-- Updated `PROJECT_STATE.md` to acknowledge blocked validation context and queue SENTINEL revalidation as the next priority.
+- Implemented the final narrow routing-contract fix for Telegram Trade Menu MVP under Portfolio context.
+- Added `⚡ Trade` to the Portfolio submenu and implemented a dedicated Trade submenu with exactly 4 approved actions.
+- Wired callback routing so `portfolio_trade`, `trade_signal`, `trade_paper_execute`, `trade_kill_switch`, and `trade_status` resolve to intended views and remain in Trade submenu context (no Home fallback).
+- Added/updated focused MVP tests, including the required routing-proof artifact.
+- Validation Tier: STANDARD
+- Validation Target: Telegram menu/routing contract for Portfolio → Trade MVP path (`keyboard.py`, `callback_router.py`, and the two MVP tests).
+- Not in Scope: root 5-item reply keyboard redesign, strategy/risk/execution engine behavior changes, live-wallet behavior changes, unrelated Telegram views.
 
 ## 2. Current system architecture
-- Trade-menu MVP verification remains a unit-test level contract check in the Telegram UI keyboard layer.
-- The new test validates callback payload integrity for paper-wallet trade menu actions:
-  - `action:trade`
-  - `action:exposure`
-  - `action:wallet`
-  - `action:back_main`
-- Repository state tracking remains centralized in `/workspace/walker-ai-team/PROJECT_STATE.md` and has been synchronized for this task.
+- Reply keyboard remains the authoritative 5-item root navigation contract.
+- Portfolio inline menu now includes:
+  - Wallet
+  - Positions
+  - Exposure
+  - PnL
+  - Performance
+  - `⚡ Trade` entrypoint (`action:portfolio_trade`)
+- Trade submenu is an explicit contextual layer with exactly:
+  - `action:trade_signal`
+  - `action:trade_paper_execute`
+  - `action:trade_kill_switch`
+  - `action:trade_status`
+- CallbackRouter normalized action mapping now routes those actions to trade/status/control render targets while retaining Trade submenu keyboard context.
 
 ## 3. Files created / modified (full paths)
-- /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
 - /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
 - /workspace/walker-ai-team/PROJECT_STATE.md
 
 ## 4. What is working
-- Required FORGE report file exists at the exact requested path.
-- Required target test file exists at the exact requested path.
-- `py_compile` passes for the new test module.
-- `pytest` passes for the new test module.
-- `PROJECT_STATE.md` now reflects blocked validation context and SENTINEL revalidation handoff for this task.
+- Root 5-item reply keyboard contract remains unchanged.
+- Portfolio submenu contains `⚡ Trade`.
+- `⚡ Trade` resolves to the real Trade submenu with only the 4 approved actions.
+- Required routing actions resolve to intended targets and do not fall back to Home.
+- Required tests pass:
+  - `test_telegram_trade_menu_mvp.py`
+  - `test_telegram_trade_menu_routing_mvp.py`
+- `py_compile` passes for touched Telegram files.
 
 ## 5. Known issues
-- This change set is scoped strictly to Phase-0 blocker clearance artifacts and does not include broader Telegram runtime/UI integration revalidation.
-- External Telegram live-device screenshot validation remains unavailable in this container environment.
+- Latest blocked SENTINEL report specifically named for `telegram_trade_menu_mvp_20260407` was not present in `projects/polymarket/polyquantbot/reports/sentinel/` during this FORGE-X pass; task used `PROJECT_STATE.md` blocked context + current forge/sentinel repo state as available source truth.
+- Live Telegram device screenshot proof remains unavailable in this container environment.
 
 ## 6. What is next
-- SENTINEL validation required for telegram_trade_menu_mvp_20260407 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
+- SENTINEL validation requested for telegram_trade_menu_mvp_20260407. Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md. Tier: STANDARD
+- Suggested Next Step:
+  - Codex code review baseline complete for changed files
+  - SENTINEL revalidation (explicitly requested by COMMANDER) before merge

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -29,6 +29,7 @@ import structlog
 from ..ui.keyboard import (
     build_dashboard_menu,
     build_portfolio_menu,
+    build_trade_menu,
     build_markets_menu,
     build_help_menu,
     build_market_categories_menu,
@@ -364,7 +365,7 @@ class CallbackRouter:
     @staticmethod
     def _active_root_for_action(action: str) -> str:
         """Resolve active root section for contextual inline keyboard rendering."""
-        if action.startswith("portfolio_") or action in {"portfolio", "wallet", "positions", "pnl", "performance", "exposure"}:
+        if action.startswith("portfolio_") or action.startswith("trade_") or action in {"portfolio", "wallet", "positions", "pnl", "performance", "exposure"}:
             return "portfolio"
         if action.startswith("markets_") or action in {"markets", "market", "active_scope"}:
             return "markets"
@@ -465,6 +466,11 @@ class CallbackRouter:
             "portfolio_exposure": "exposure",
             "portfolio_pnl": "pnl",
             "portfolio_performance": "performance",
+            "portfolio_trade": "trade",
+            "trade_signal": "trade",
+            "trade_paper_execute": "trade",
+            "trade_kill_switch": "control",
+            "trade_status": "system",
             "markets_overview": "markets",
             "markets_refresh_all": "refresh",
         }
@@ -478,6 +484,22 @@ class CallbackRouter:
             payload["mode_guard"] = "ENABLE_LIVE_TRADING=true required for LIVE"
         if normalized_action == "control":
             payload["control_action"] = "standby"
+        if base_action == "trade_signal":
+            payload["decision"] = "Signal view is active — safe fallback values render when data is missing"
+            payload["operator_note"] = "No live order placement in this menu path"
+            payload["insight"] = "Signal summary remains informational unless explicitly executed in paper mode"
+        if base_action == "trade_paper_execute":
+            payload["decision"] = "Paper execution only — no live-wallet action is performed"
+            payload["operator_note"] = "Use this route to simulate execution safely"
+            payload["insight"] = "Paper execution keeps wallet isolation intact"
+        if base_action == "trade_kill_switch":
+            payload["decision"] = "Kill switch reflects current control state"
+            payload["operator_note"] = "State is reported honestly from the control manager"
+            payload["insight"] = "Use control menu for full halt/resume actions"
+        if base_action == "trade_status":
+            payload["decision"] = "Trade status view active — safe defaults shown when runtime data is missing"
+            payload["operator_note"] = "Status panel is read-only in this route"
+            payload["insight"] = "No execution side effects in status route"
 
         try:
             text = await render_view(normalized_action, payload)
@@ -495,7 +517,11 @@ class CallbackRouter:
         if base_action == "dashboard" or normalized_action in {"home", "system", "refresh"} and base_action.startswith("dashboard"):
             return text, build_dashboard_menu()
         if base_action == "portfolio" or base_action.startswith("portfolio_"):
+            if base_action == "portfolio_trade":
+                return text, build_trade_menu()
             return text, build_portfolio_menu()
+        if base_action.startswith("trade_"):
+            return text, build_trade_menu()
         if base_action == "markets_categories":
             return text, build_market_categories_menu(
                 categories=list(MARKET_SCOPE_CATEGORIES),
@@ -578,6 +604,11 @@ class CallbackRouter:
             "portfolio_exposure",
             "portfolio_pnl",
             "portfolio_performance",
+            "portfolio_trade",
+            "trade_signal",
+            "trade_paper_execute",
+            "trade_kill_switch",
+            "trade_status",
             "markets_overview",
             "markets_categories",
             "markets_active_scope",

--- a/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
+++ b/projects/polymarket/polyquantbot/telegram/ui/keyboard.py
@@ -67,7 +67,15 @@ def build_portfolio_menu() -> InlineKeyboard:
     return [
         [_btn("💰 Wallet", "portfolio_wallet"), _btn("📈 Positions", "portfolio_positions")],
         [_btn("📊 Exposure", "portfolio_exposure"), _btn("💹 PnL", "portfolio_pnl")],
-        [_btn("🏁 Performance", "portfolio_performance")],
+        [_btn("🏁 Performance", "portfolio_performance"), _btn("⚡ Trade", "portfolio_trade")],
+    ]
+
+
+def build_trade_menu() -> InlineKeyboard:
+    """Trade contextual submenu for Portfolio -> ⚡ Trade."""
+    return [
+        [_btn("📡 Signal", "trade_signal"), _btn("🧪 Paper Execute", "trade_paper_execute")],
+        [_btn("🛑 Kill Switch", "trade_kill_switch"), _btn("📊 Trade Status", "trade_status")],
     ]
 
 

--- a/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py
@@ -34,6 +34,7 @@ def test_portfolio_menu_has_only_contextual_actions() -> None:
         "action:portfolio_exposure",
         "action:portfolio_pnl",
         "action:portfolio_performance",
+        "action:portfolio_trade",
     }
 
 

--- a/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-
-from projects.polymarket.polyquantbot.telegram.ui.keyboard import build_paper_wallet_menu
+from projects.polymarket.polyquantbot.telegram.ui.keyboard import build_portfolio_menu, build_trade_menu
+from projects.polymarket.polyquantbot.telegram.ui.reply_keyboard import REPLY_MENU_MAP
 
 
 def _callback_values(keyboard: list[list[dict[str, str]]]) -> set[str]:
     return {button["callback_data"] for row in keyboard for button in row}
 
 
-def test_trade_menu_mvp_contains_expected_trade_actions() -> None:
-    """Phase-0 guard: ensure the paper wallet trade menu contract is present."""
-    assert _callback_values(build_paper_wallet_menu()) == {
-        "action:trade",
-        "action:exposure",
-        "action:wallet",
-        "action:back_main",
+def test_trade_menu_mvp_root_reply_keyboard_keeps_approved_five_item_contract() -> None:
+    assert set(REPLY_MENU_MAP.values()) == {"dashboard", "portfolio", "markets", "settings", "help"}
+
+
+def test_trade_menu_mvp_portfolio_contains_trade_entry() -> None:
+    actions = _callback_values(build_portfolio_menu())
+    assert "action:portfolio_trade" in actions
+
+
+def test_trade_menu_mvp_trade_submenu_contains_only_approved_actions() -> None:
+    assert _callback_values(build_trade_menu()) == {
+        "action:trade_signal",
+        "action:trade_paper_execute",
+        "action:trade_kill_switch",
+        "action:trade_status",
     }

--- a/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+def _callback_values(keyboard: list[list[dict[str, str]]]) -> set[str]:
+    return {button["callback_data"] for row in keyboard for button in row}
+
+
+def _make_router() -> CallbackRouter:
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=MagicMock(),
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def test_trade_menu_routing_contract_routes_without_home_fallback() -> None:
+    router = _make_router()
+    expected_trade_keyboard = {
+        "action:trade_signal",
+        "action:trade_paper_execute",
+        "action:trade_kill_switch",
+        "action:trade_status",
+    }
+    routes = {
+        "portfolio_trade": "🎯 Trade Detail",
+        "trade_signal": "🎯 Trade Detail",
+        "trade_paper_execute": "🎯 Trade Detail",
+        "trade_kill_switch": "🎛️ Control",
+        "trade_status": "🧠 System Status",
+    }
+
+    for action, expected_title in routes.items():
+        text, keyboard = asyncio.run(router._dispatch(action))
+        assert "🏠 Home Command" not in text
+        assert expected_title in text
+        assert _callback_values(keyboard) == expected_trade_keyboard


### PR DESCRIPTION
### Motivation
- The Portfolio→Trade routing previously allowed trade actions to fall back to Home instead of remaining in a dedicated Trade submenu, blocking MVP completion. 
- The change narrows scope to routing correctness only and provides provable test artifacts required for SENTINEL revalidation. 
- Preserve the authoritative 5-item root reply keyboard while making the Trade entrypoint and submenu first-class and non-destructive. 

### Description
- Added `⚡ Trade` entry to the Portfolio inline menu and implemented a dedicated `build_trade_menu()` with exactly the four approved actions (`trade_signal`, `trade_paper_execute`, `trade_kill_switch`, `trade_status`) in `projects/polymarket/polyquantbot/telegram/ui/keyboard.py`.
- Wired normalized aliases and routing in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` so `portfolio_trade`, `trade_signal`, `trade_paper_execute`, `trade_kill_switch`, and `trade_status` resolve to intended view targets and return the Trade submenu keyboard instead of falling back to Home.
- Added the required routing-proof test `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` and updated/rewrote `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py` and `projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py` to reflect the new Portfolio→Trade contract.
- Published the FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md` and updated `PROJECT_STATE.md` to record the final routing-fix pass and request SENTINEL revalidation (Validation Tier: `STANDARD`).

### Testing
- `python -m py_compile` was run against touched Telegram modules (`projects/polymarket/polyquantbot/telegram/ui/keyboard.py`, `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py`, `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`, `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`, `projects/polymarket/polyquantbot/interface/ui_formatter.py`) and returned `PASS`.
- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` executed and returned `PASS` (4 tests passed for those files).
- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py` executed and returned `PASS` (5 tests passed), confirming root reply-keyboard invariants remain intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b64dd3e0832eb8e88ece5b366414)