### PR TITLE
sentinel: corrected revalidation for telegram_trade_menu_mvp_20260407

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md
@@ -1,0 +1,111 @@
+## 1. Target
+- Task: corrected revalidation for `telegram_trade_menu_mvp_20260407` after routing-test artifact confirmation.
+- Requested branch: `feature/fix-routing-contract-for-telegram-trade-menu-2026-04-07`.
+- Runtime validation context observed in Codex worktree: `work` (detached/worktree-normal per CODEX WORKTREE RULE).
+- Validation scope (confirmed present):
+  - `PROJECT_STATE.md`
+  - `projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md`
+  - `projects/polymarket/polyquantbot/telegram/ui/keyboard.py`
+  - `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py`
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py`
+
+## 2. Score
+- Overall score: **93/100**
+- Phase 0 (preconditions): 20/20
+- Phase 1 (static evidence): 27/30
+- Phase 2 (runtime proof): 26/30
+- Phase 3 (test proof): 20/20
+- Phase 4 (safety/break checks): pass with non-blocking environment warning
+
+## 3. Findings by phase
+### Phase 0 — Preconditions
+- Forge report exists at required path.
+- All required test artifacts exist, including confirmed routing artifact `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`.
+- All requested target files exist in current validation source tree.
+- `PROJECT_STATE.md` aligns with corrected revalidation context: it explicitly states previous block was routing mismatch and now requests SENTINEL revalidation for this exact task.
+- Branch naming mismatch (requested branch not locally materialized) did **not** block validation because task/file/report association is explicit and consistent with CODEX worktree rule.
+
+### Phase 1 — Static evidence
+1. Root Telegram menu remains unchanged at 5 items:
+   - `REPLY_MENU_MAP` maps exactly dashboard/portfolio/markets/settings/help.
+   - Persistent keyboard is still rendered as 3 rows containing these same 5 labels.
+2. Portfolio submenu includes `⚡ Trade` via `action:portfolio_trade`.
+3. `⚡ Trade` opens a real Trade submenu through explicit routing branch (`portfolio_trade -> build_trade_menu()`).
+4. Trade submenu is constrained to exactly:
+   - `📡 Signal` (`trade_signal`)
+   - `🧪 Paper Execute` (`trade_paper_execute`)
+   - `🛑 Kill Switch` (`trade_kill_switch`)
+   - `📊 Trade Status` (`trade_status`)
+5. `portfolio_trade` and `trade_*` routes remain in Trade context; dispatch keyboard return paths are explicit and no longer Home-fallback based.
+6. Paper Execute is textually constrained to paper-only intent in payload decision/operator-note copy.
+7. No unrelated root-menu structure refactor detected in validated files.
+
+### Phase 2 — Runtime proof
+- Runtime dispatch of `portfolio_trade`, `trade_signal`, `trade_paper_execute`, `trade_kill_switch`, and `trade_status` succeeded without crash.
+- All new Trade routes rendered titles consistent with intent (`🎯 Trade Detail`, `🎛️ Control`, `🧠 System Status`) and all returned the Trade submenu keyboard callbacks.
+- Home fallback negative check passed (`"🏠 Home Command" not in text`) for each new Trade action.
+- Paper Execute route behavior remained non-executing/paper-labeled in route payload design and runtime output contract.
+- Kill Switch route rendered control view without crash.
+- Trade Status rendered with safe fallback despite missing external market data.
+
+### Phase 3 — Test proof
+- `python -m py_compile` passed for touched Telegram/UI routing/view files.
+- Targeted pytest set passed: 9 passed, 0 failed (1 non-blocking pytest config warning).
+- Routing-contract test confirms the anti-fallback guarantee and expected contextual titles.
+
+### Phase 4 — Safety / break checks
+Break attempts executed:
+- Attempted to detect accidental root mutation: failed to break (root contract intact at 5 items).
+- Attempted to detect Trade leak into root: failed to break (Trade only in Portfolio submenu).
+- Attempted to force Home fallback on trade routes: failed to break (`🏠 Home Command` absent).
+- Attempted to detect unsafe live-wallet implication in paper execute path: failed to break (paper-only messaging present).
+- Attempted kill-switch/status crash under sparse runtime data: failed to break (views rendered).
+
+Non-blocking warning:
+- External market context call to `clob.polymarket.com` is unreachable in this container; runtime paths still degraded safely and produced valid fallback output.
+
+## 4. Evidence
+### Static evidence (file + line)
+- Root 5-item contract and reply keyboard rows:
+  - `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py:8-28,35-42`
+- Portfolio includes `⚡ Trade`, Trade submenu exactly 4 actions:
+  - `projects/polymarket/polyquantbot/telegram/ui/keyboard.py:65-79`
+- Routing aliases and contextual submenu return paths (no Home fallback for trade actions):
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py:457-474,517-525`
+- Paper-only route intent text:
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py:491-494`
+- Targeted anti-fallback contract tests:
+  - `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py:25-45`
+- Root/portfolio/trade scope contract tests:
+  - `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py:11-26`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py:18-38`
+
+### Runtime / command evidence
+1. Preconditions:
+   - `for f in ...; do [ -f "$f" ] ...; done` → all target artifacts found.
+2. Compile validation:
+   - `python -m py_compile projects/polymarket/polyquantbot/telegram/ui/keyboard.py projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py`
+   - Output: success (no errors).
+3. Targeted tests:
+   - `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py`
+   - Output snippet: `9 passed, 1 warning in 0.90s`.
+4. Runtime dispatch probe (behavioral):
+   - Command: inline Python dispatching `portfolio_trade`, `trade_signal`, `trade_paper_execute`, `trade_kill_switch`, `trade_status`.
+   - Output snippet confirms:
+     - `HAS_HOME_COMMAND False` for each action
+     - `TITLE_LINE 🎯 Trade Detail` / `🎛️ Control` / `🧠 System Status`
+     - `CALLBACKS ['action:trade_kill_switch', 'action:trade_paper_execute', 'action:trade_signal', 'action:trade_status']`
+
+## 5. Critical issues
+- No critical implementation blocker found for the requested Telegram Trade Menu MVP routing objective.
+- Non-blocking environment limitation:
+  - External `clob.polymarket.com` network access is unavailable in this container, producing warning logs during market-context fetch; fallback rendering remained safe and deterministic.
+- Process note (non-blocking): requested branch name could not be checked out locally because only Codex worktree `work` exists in this environment; validation proceeded on matching task-associated state per repo artifacts.
+
+## 6. Verdict
+**APPROVED**


### PR DESCRIPTION
### Motivation
- Re-run SENTINEL validation for the Telegram Trade Menu MVP now that the missing routing-test artifact is present, to verify Portfolio → Trade routing no longer falls back to Home and to produce an authoritative verdict for merge readiness.

### Description
- Add a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_validation_20260407.md` documenting phase-based findings and the final verdict `APPROVED`, and record that the validation covered the forge report and target files such as `projects/polymarket/polyquantbot/telegram/ui/keyboard.py`, `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`, `projects/polymarket/polyquantbot/telegram/ui/reply_keyboard.py`, `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`, `projects/polymarket/polyquantbot/interface/ui_formatter.py`, and the test artifacts under `projects/polymarket/polyquantbot/tests/`.

### Testing
- Static and runtime checks were performed including `python -m py_compile` on the touched Telegram/UI and view files (passed), targeted pytest run `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_premium_nav_ux.py` (result: `9 passed, 1 warning`), and an explicit runtime dispatch probe that confirmed `portfolio_trade` and all `trade_*` routes render the Trade submenu without falling back to Home (non-blocking network warning for `clob.polymarket.com` was observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c18eb098832ea6db86a1e8e1acdb)