### PR TITLE
Enforce execution safety authority and audit trail (P1 2026-04-07)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 07:49
-- Status        : FORGE-X final routing-contract fix pass completed for telegram_trade_menu_mvp_20260407; previous block was routing mismatch risk under Portfolio→Trade path; SENTINEL revalidation required before merge
+- Last Updated  : 2026-04-07 09:05
+- Status        : FORGE-X execution safety enforcement phase 1 completed for execution_safety_enforcement_p1_20260407; SENTINEL validation required before merge
 
 ---
 
@@ -23,15 +23,14 @@
 - Category inference hardening applied for weak-metadata and uncategorized markets: deterministic inference order plus fallback inclusion path under category mode to reduce avoidable exclusions while preserving blocked-scope behavior when no categories are active.
 - Telegram /start numeric placeholder blocker patch (2026-04-06): hardened Telegram-facing numeric normalization in view/callback payload paths so `"N/A"`, `None`, empty, missing, and malformed numeric values no longer hard-crash dashboard/menu render.
 - Telegram Home live blocker addendum (2026-04-06): hardened callback Home payload hydration against malformed shared-state payloads, unified Home↔`/start` safe numeric normalization policy, and added callback render fallback so degraded Home payloads do not hard-crash.
-- Telegram live-path blocker fix (2026-04-06): removed root-menu divergence by aligning reply keyboard with 5-item root contract, forced `/start` to emit authoritative inline main menu payload, and hardened shared portfolio normalization path that could still execute `float(\"N/A\")`.
+- Telegram live-path blocker fix (2026-04-06): removed root-menu divergence by aligning reply keyboard with 5-item root contract, forced `/start` to emit authoritative inline main menu payload, and hardened shared portfolio normalization path that could still execute `float("N/A")`.
 - SENTINEL validation complete for `telegram-menu-scope-hardening-20260407` with verdict **APPROVED** (score **88/100**) and **no critical issues**.
 - BRIEFER handoff completed for `telegram-menu-scope-hardening-20260407`.
 - Telegram premium navigation / UX consolidation pass (2026-04-07): enforced two-layer Telegram navigation with persistent 5-item reply-keyboard root and contextual inline section actions; removed duplicated inline root menu; added active-root cue and compact button layout polish while preserving approved scope-control semantics.
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
 - Telegram Trade Menu MVP final fix pass (2026-04-07): added Portfolio `⚡ Trade`, created dedicated 4-action Trade submenu, and corrected callback routing contract so trade actions stay in Trade context without Home fallback.
-
----
+- Execution safety enforcement phase 1 (2026-04-07): centralized execution authority in `executor.py`, added mode/kill-switch hard gates plus execution audit trail, and removed trading-loop direct execution bypass path via executor callback enforcement.
 
 ## 🚧 IN PROGRESS
 
@@ -47,7 +46,8 @@
 ### Trade-system hardening handoff
 - FORGE-X hardening pending for risk-gate unification, reconciliation ownership, restart recovery correctness, and silent-failure removal before any real-wallet enablement.
 
----
+### Execution safety enforcement handoff
+- SENTINEL validation required for `execution_safety_enforcement_p1_20260407` before merge.
 
 ## ❌ NOT STARTED
 
@@ -57,11 +57,9 @@
 
 ## 🎯 NEXT PRIORITY
 
-- SENTINEL revalidation required for telegram_trade_menu_mvp_20260407 before merge.
-- Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
-- Tier: STANDARD
-
----
+- SENTINEL validation required for execution_safety_enforcement_p1_20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
+- Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
@@ -71,3 +69,4 @@
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - Trading-loop execution path currently bypasses formal `RiskGuard` kill-switch/daily-loss/drawdown gating and must be hardened before real-wallet mode.
 - Startup wallet restore path in engine container may not apply persisted wallet state correctly (class-method return value is not assigned), creating restart reconciliation risk.
+- Execution safety phase 1 enforces executor authority/mode/kill-switch/audit at path level; broader risk-layer unification remains pending.

--- a/projects/polymarket/polyquantbot/core/execution/executor.py
+++ b/projects/polymarket/polyquantbot/core/execution/executor.py
@@ -125,6 +125,7 @@ class TradeResult:
     """
 
     trade_id: str
+    execution_id: str
     signal_id: str
     market_id: str
     side: str
@@ -177,6 +178,7 @@ async def execute_trade(
     min_liquidity_usd: float | None = None,
     kill_switch_active: bool = False,
     executor_callback: Optional[Callable[..., Awaitable[dict[str, Any]]]] = None,
+    paper_executor_callback: Optional[Callable[..., Awaitable[dict[str, Any]]]] = None,
     telegram_callback: Optional[Callable[[str], Awaitable[None]]] = None,
 ) -> TradeResult:
     """Validate and execute (or simulate) a single trading signal.
@@ -195,8 +197,9 @@ async def execute_trade(
         kill_switch_active: When True, all trades are blocked immediately.
         executor_callback:  Async callable
                             ``(market_id, side, price, size_usd, trade_id)
-                            -> dict`` invoked in LIVE mode.  When None in LIVE
-                            mode, the call falls back to paper simulation.
+                            -> dict`` invoked in LIVE mode.
+        paper_executor_callback: Optional async callable for PAPER mode
+                            engine execution.
         telegram_callback:  Optional async callable ``(message: str)`` for
                             trade-executed notifications.
 
@@ -220,18 +223,46 @@ async def execute_trade(
     )
 
     trade_id = f"trade-{uuid.uuid4().hex[:12]}"
+    execution_id = f"exec-{uuid.uuid4().hex[:12]}"
+
+    log.info(
+        "execution_audit",
+        execution_id=execution_id,
+        trade_id=trade_id,
+        signal_id=signal.signal_id,
+        market_id=signal.market_id,
+        intent="execute_trade",
+        mode=_mode,
+        result="attempt",
+        reason="received",
+    )
+    def _audit(result: str, reason: str) -> None:
+        log.info(
+            "execution_audit",
+            execution_id=execution_id,
+            trade_id=trade_id,
+            signal_id=signal.signal_id,
+            market_id=signal.market_id,
+            intent="execute_trade",
+            mode=_mode,
+            result=result,
+            reason=reason,
+        )
 
     # ── Duplicate check ───────────────────────────────────────────────────────
     if signal.signal_id in _submitted_ids:
+        _audit("blocked", "duplicate")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="duplicate",
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -243,15 +274,18 @@ async def execute_trade(
 
     # ── Kill switch ───────────────────────────────────────────────────────────
     if kill_switch_active:
+        _audit("blocked", "kill_switch_active")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="kill_switch_active",
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -263,9 +297,11 @@ async def execute_trade(
 
     # ── Risk re-validation ────────────────────────────────────────────────────
     if signal.edge <= 0 and not signal.force_mode:
+        _audit("blocked", "edge_non_positive")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="edge_non_positive",
@@ -273,6 +309,7 @@ async def execute_trade(
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -283,9 +320,11 @@ async def execute_trade(
         )
 
     if signal.edge < _min_e:
+        _audit("blocked", "edge_below_threshold")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="edge_below_threshold",
@@ -294,6 +333,7 @@ async def execute_trade(
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -304,9 +344,11 @@ async def execute_trade(
         )
 
     if signal.size_usd > _max_p:
+        _audit("blocked", "size_exceeds_max_position")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="size_exceeds_max_position",
@@ -315,6 +357,7 @@ async def execute_trade(
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -327,9 +370,11 @@ async def execute_trade(
     # ── Liquidity check ───────────────────────────────────────────────────────
     liquidity_usd: float = float(getattr(signal, "liquidity_usd", 0.0) or 0.0)
     if _min_liq > 0 and liquidity_usd < _min_liq:
+        _audit("blocked", "insufficient_liquidity")
         log.info(
             "trade_skipped",
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             reason="insufficient_liquidity",
@@ -338,6 +383,7 @@ async def execute_trade(
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,
@@ -349,9 +395,11 @@ async def execute_trade(
     lock = _get_lock()
     async with lock:
         if _open_trade_count >= _max_c:
+            _audit("blocked", "max_concurrent_reached")
             log.info(
                 "trade_skipped",
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 reason="max_concurrent_reached",
@@ -360,6 +408,7 @@ async def execute_trade(
             )
             return TradeResult(
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 side=signal.side,
@@ -391,6 +440,8 @@ async def execute_trade(
         trade_id=trade_id,
         mode=_mode,
         executor_callback=executor_callback,
+        paper_executor_callback=paper_executor_callback,
+        execution_id=execution_id,
     )
 
     if not result.success:
@@ -402,9 +453,12 @@ async def execute_trade(
             trade_id=trade_id,
             mode=_mode,
             executor_callback=executor_callback,
+            paper_executor_callback=paper_executor_callback,
+            execution_id=execution_id,
         )
         if not result.success:
             log.info("trade_skipped", trade_id=trade_id, reason=f"retry_failed:{result.reason}")
+            _audit("blocked", f"retry_failed:{result.reason}")
             async with lock:
                 _open_trade_count = max(0, _open_trade_count - 1)
             return result
@@ -472,6 +526,7 @@ async def execute_trade(
                 error=str(tg_exc),
             )
 
+    _audit("executed", result.reason or "executed")
     return result
 
 
@@ -483,6 +538,8 @@ async def _attempt_execution(
     trade_id: str,
     mode: str,
     executor_callback: Optional[Callable[..., Awaitable[dict[str, Any]]]],
+    paper_executor_callback: Optional[Callable[..., Awaitable[dict[str, Any]]]],
+    execution_id: str,
 ) -> TradeResult:
     """Single execution attempt (paper or live).
 
@@ -493,6 +550,7 @@ async def _attempt_execution(
     try:
         log.info(
             "order_sent",
+            execution_id=execution_id,
             trade_id=trade_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
@@ -501,6 +559,27 @@ async def _attempt_execution(
             size_usd=round(signal.size_usd, 4),
             mode=mode,
         )
+
+        if mode == "LIVE" and executor_callback is None:
+            return TradeResult(
+                trade_id=trade_id,
+                execution_id=execution_id,
+                signal_id=signal.signal_id,
+                market_id=signal.market_id,
+                side=signal.side,
+                success=False,
+                mode=mode,
+                attempted_size=signal.size_usd,
+                reason="live_executor_callback_required",
+            )
+
+        if mode != "LIVE" and executor_callback is not None:
+            log.warning(
+                "execution_mode_guard_blocked_live_callback",
+                execution_id=execution_id,
+                trade_id=trade_id,
+                mode=mode,
+            )
 
         if mode == "LIVE" and executor_callback is not None:
             raw = await executor_callback(
@@ -516,6 +595,7 @@ async def _attempt_execution(
             log.info(
                 "order_filled",
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 side=signal.side,
@@ -526,6 +606,7 @@ async def _attempt_execution(
             )
             return TradeResult(
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 side=signal.side,
@@ -539,7 +620,37 @@ async def _attempt_execution(
                 extra=raw,
             )
         else:
-            # ── Realistic paper simulation ────────────────────────────────
+            # ── PAPER path (authoritative) ───────────────────────────────
+            if paper_executor_callback is not None:
+                raw = await paper_executor_callback(
+                    market_id=signal.market_id,
+                    side=signal.side,
+                    price=signal.p_market,
+                    size_usd=signal.size_usd,
+                    trade_id=trade_id,
+                    execution_id=execution_id,
+                )
+                latency_ms = (time.time() - t_start) * 1_000.0
+                filled = float(raw.get("filled_size", signal.size_usd))
+                fill_price = float(raw.get("fill_price", signal.p_market))
+                partial_fill = bool(raw.get("partial_fill", False))
+                return TradeResult(
+                    trade_id=trade_id,
+                    execution_id=execution_id,
+                    signal_id=signal.signal_id,
+                    market_id=signal.market_id,
+                    side=signal.side,
+                    success=True,
+                    mode="PAPER",
+                    attempted_size=signal.size_usd,
+                    filled_size_usd=round(filled, 4),
+                    fill_price=round(fill_price, 6),
+                    latency_ms=round(latency_ms, 2),
+                    partial_fill=partial_fill,
+                    reason=str(raw.get("reason", "paper_engine_executed")),
+                    extra=raw,
+                )
+
             # 1. Simulated latency: random value in [100 ms, 500 ms]
             sim_latency_s = random.uniform(
                 _PAPER_LATENCY_MIN_MS / 1_000.0,
@@ -585,6 +696,7 @@ async def _attempt_execution(
             log.info(
                 "order_filled",
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 side=signal.side,
@@ -598,6 +710,7 @@ async def _attempt_execution(
             reason = "partial_fill" if partial_fill else "paper_simulated"
             return TradeResult(
                 trade_id=trade_id,
+                execution_id=execution_id,
                 signal_id=signal.signal_id,
                 market_id=signal.market_id,
                 side=signal.side,
@@ -622,6 +735,7 @@ async def _attempt_execution(
         )
         return TradeResult(
             trade_id=trade_id,
+            execution_id=execution_id,
             signal_id=signal.signal_id,
             market_id=signal.market_id,
             side=signal.side,

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -1064,10 +1064,7 @@ async def run_trading_loop(
                                 error=str(meta_exc),
                             )
 
-                    # ── 4d. UNIFIED EXECUTION ────────────────────────────────
-                    # PAPER mode with PaperEngine: PaperEngine is the single
-                    # source of truth.  Bypass execute_trade() fill simulation.
-                    # LIVE mode: use execute_trade() with executor_callback.
+                    # ── 4d. UNIFIED EXECUTION (executor authority) ───────────
                     log.info(
                         "execution_start",
                         trade_id=signal.signal_id,
@@ -1076,103 +1073,69 @@ async def run_trading_loop(
                         mode=_mode,
                     )
 
-                    if _mode == "PAPER" and paper_engine is not None:
-                        # ── PAPER path: PaperEngine is sole authority ─────────
-                        try:
-                            _paper_order = await paper_engine.execute_order({
-                                "market_id": signal.market_id,
-                                "side": signal.side,
-                                "price": signal.p_market,
-                                "size": signal.size_usd,
-                                "trade_id": signal.signal_id,
-                            })
-                        except Exception as _pe_exc:
-                            log.error(
-                                "execution_failed",
-                                trade_id=signal.signal_id,
-                                market_id=signal.market_id,
-                                error=str(_pe_exc),
-                            )
-                            continue
-
+                    async def _paper_executor_callback(**kwargs: Any) -> dict[str, Any]:
+                        if paper_engine is None:
+                            raise RuntimeError("paper_engine_not_available")
+                        _paper_order = await paper_engine.execute_order(
+                            {
+                                "market_id": kwargs["market_id"],
+                                "side": kwargs["side"],
+                                "price": kwargs["price"],
+                                "size": kwargs["size_usd"],
+                                "trade_id": kwargs["trade_id"],
+                            }
+                        )
                         from ...execution.paper_engine import OrderStatus as _OS  # noqa: PLC0415
-                        _pe_success = _paper_order.status in (_OS.FILLED, _OS.PARTIAL)
+                        if _paper_order.status not in (_OS.FILLED, _OS.PARTIAL):
+                            raise RuntimeError(f"paper_engine_blocked:{_paper_order.reason}")
+                        return {
+                            "filled_size": _paper_order.filled_size,
+                            "fill_price": _paper_order.fill_price,
+                            "partial_fill": _paper_order.status == _OS.PARTIAL,
+                            "reason": _paper_order.reason,
+                            "status": str(_paper_order.status),
+                        }
 
-                        if not _pe_success:
-                            log.info(
-                                "execution_failed",
-                                trade_id=signal.signal_id,
-                                market_id=signal.market_id,
-                                reason=_paper_order.reason,
-                                status=_paper_order.status,
-                            )
-                            continue
-
-                        # Build a synthetic TradeResult from PaperOrderResult
-                        from ..execution.executor import TradeResult  # noqa: PLC0415
-                        result = TradeResult(
-                            trade_id=_paper_order.trade_id,
-                            signal_id=signal.signal_id,
-                            market_id=_paper_order.market_id,
-                            side=_paper_order.side,
-                            success=True,
-                            mode="PAPER",
-                            attempted_size=_paper_order.requested_size,
-                            filled_size_usd=_paper_order.filled_size,
-                            fill_price=_paper_order.fill_price,
-                            latency_ms=0.0,
-                            slippage_pct=0.0,
-                            partial_fill=_paper_order.status == _OS.PARTIAL,
-                            reason=_paper_order.reason,
-                        )
+                    result = await execute_trade(
+                        signal,
+                        mode=_mode,
+                        kill_switch_active=bool(stop_event is not None and stop_event.is_set()),
+                        executor_callback=executor_callback,
+                        paper_executor_callback=(
+                            _paper_executor_callback if _mode != "LIVE" and paper_engine is not None else None
+                        ),
+                    )
+                    if not result.success:
                         log.info(
-                            "execution_success",
+                            "execution_failed",
                             trade_id=result.trade_id,
                             market_id=result.market_id,
-                            side=result.side,
-                            filled_size_usd=round(result.filled_size_usd, 4),
-                            fill_price=round(result.fill_price, 6),
-                            mode=result.mode,
+                            reason=result.reason,
+                            execution_id=result.execution_id,
                         )
+                        continue
+                    log.info(
+                        "execution_success",
+                        trade_id=result.trade_id,
+                        market_id=result.market_id,
+                        side=result.side,
+                        filled_size_usd=round(result.filled_size_usd or 0.0, 4),
+                        fill_price=round(result.fill_price or 0.0, 6),
+                        mode=result.mode,
+                        execution_id=result.execution_id,
+                    )
 
-                        # ── Persist ledger entry ──────────────────────────────
-                        if db is not None and paper_engine is not None:
-                            try:
-                                # Persist wallet state after every execution
-                                await paper_engine._wallet.persist(db)  # type: ignore[attr-defined]
-                                # Persist positions
-                                await paper_engine._positions.save_to_db(db)  # type: ignore[attr-defined]
-                            except Exception as _persist_exc:
-                                log.error(
-                                    "persistence_write_failed",
-                                    trade_id=result.trade_id,
-                                    error=str(_persist_exc),
-                                )
-
-                    else:
-                        # ── LIVE path (or PAPER fallback): use execute_trade ──
-                        result = await execute_trade(
-                            signal,
-                            mode=_mode,
-                            executor_callback=executor_callback,
-                        )
-                        if not result.success:
-                            log.info(
-                                "execution_failed",
+                    # ── Persist ledger entry ──────────────────────────────────
+                    if db is not None and paper_engine is not None and result.mode == "PAPER":
+                        try:
+                            await paper_engine._wallet.persist(db)  # type: ignore[attr-defined]
+                            await paper_engine._positions.save_to_db(db)  # type: ignore[attr-defined]
+                        except Exception as _persist_exc:
+                            log.error(
+                                "persistence_write_failed",
                                 trade_id=result.trade_id,
-                                market_id=result.market_id,
-                                reason=result.reason,
+                                error=str(_persist_exc),
                             )
-                            continue
-                        log.info(
-                            "execution_success",
-                            trade_id=result.trade_id,
-                            market_id=result.market_id,
-                            side=result.side,
-                            filled_size_usd=round(result.filled_size_usd or 0.0, 4),
-                            fill_price=round(result.fill_price or 0.0, 6),
-                            mode=result.mode,
-                        )
 
                     if result.success:
                         _trades_this_tick += 1

--- a/projects/polymarket/polyquantbot/execution/engine_router.py
+++ b/projects/polymarket/polyquantbot/execution/engine_router.py
@@ -26,7 +26,7 @@ Design:
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import structlog
 
@@ -180,3 +180,31 @@ def get_engine_container() -> EngineContainer:
     else:
         log.debug("engine_container_singleton_reused")
     return _container
+
+
+def build_paper_executor_callback() -> Callable[..., Awaitable[dict[str, Any]]]:
+    """Return an executor-compatible PAPER callback backed by EngineContainer.
+
+    This enforces a single execution authority by exposing PaperEngine through
+    the core executor callback contract instead of allowing ad-hoc direct calls.
+    """
+    container = get_engine_container()
+
+    async def _paper_executor_callback(**kwargs: object) -> dict[str, object]:
+        order = {
+            "market_id": kwargs["market_id"],
+            "side": kwargs["side"],
+            "price": kwargs["price"],
+            "size": kwargs["size_usd"],
+            "trade_id": kwargs["trade_id"],
+        }
+        result = await container.paper_engine.execute_order(order)
+        return {
+            "filled_size": result.filled_size,
+            "fill_price": result.fill_price,
+            "partial_fill": bool(getattr(result, "partial_fill", False)),
+            "reason": result.reason,
+            "status": str(result.status),
+        }
+
+    return _paper_executor_callback

--- a/projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
@@ -1,0 +1,65 @@
+# FORGE REPORT — execution_safety_enforcement_p1_20260407
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Validation Target: `projects/polymarket/polyquantbot/core/execution/executor.py`, `projects/polymarket/polyquantbot/execution/engine_router.py`, `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`, `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+- Not in Scope: `telegram/`, `ui/`, `strategy/`, and any risk-model logic changes beyond execution enforcement hooks
+
+## 1. Target
+Enforce a single, authoritative, auditable execution path so every execution attempt is routed through `core/execution/executor.py`, with explicit mode guards, kill-switch enforcement, and observable failure behavior.
+
+## 2. Changes made
+- Added authoritative execution audit trail in `executor.execute_trade()`:
+  - unique `execution_id` generation for every attempt
+  - `execution_audit` logs with intent/mode/result/reason lifecycle
+  - `TradeResult` now carries `execution_id`
+- Added explicit mode enforcement:
+  - LIVE requires `executor_callback`; no implicit fallback to paper
+  - non-LIVE blocks live callback usage and enforces paper path
+- Added paper execution enforcement hook:
+  - `paper_executor_callback` support in executor path
+- Removed trading-loop direct execution bypass:
+  - trading loop now always calls `execute_trade(...)`
+  - PaperEngine execution is delegated via executor callback contract
+- Added `engine_router.build_paper_executor_callback()` helper for callback-style paper delegation
+- Added focused execution safety test suite:
+  - `tests/test_execution_safety_p1_20260407.py`
+
+## 3. Enforcement points added
+- **Single authority:** `trading_loop` delegates all execution through `execute_trade()`.
+- **Mode guard:** `_attempt_execution()` blocks LIVE without live executor callback.
+- **Kill-switch authority:** `trading_loop` forwards kill-switch state (`stop_event.is_set()`) into executor; executor blocks immediately.
+- **Auditability:** every attempt emits `execution_audit` with result transitions (`attempt`, `blocked`, `executed`).
+- **No silent failures:** execution exceptions are logged with `execution_error`; failed retries are explicitly logged and returned.
+
+## 4. Execution flow before vs after
+### Before
+- Trading loop had a PAPER branch that could directly call `paper_engine.execute_order(...)` before executor, creating a bypass path.
+- LIVE without callback could silently drift into paper simulation fallback.
+- Audit metadata was not normalized around a dedicated `execution_id` per attempt.
+
+### After
+- Trading loop uses one execution authority: `execute_trade()` for PAPER and LIVE.
+- PAPER engine access is callback-driven under executor control.
+- LIVE mode explicitly requires live callback; otherwise blocked.
+- Every attempt has a generated `execution_id` and explicit audit/result logs.
+
+## 5. Test coverage
+Added `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` covering:
+1. execution blocked from real/live callback path when mode != LIVE
+2. execution blocked when kill-switch is active
+3. execution allowed in PAPER mode through paper-engine callback path
+4. trading-loop execution contract references executor authority
+5. audit event emitted on every execution attempt
+6. forced exception path logs error and returns observable failure (no silent fail)
+
+Commands run:
+- `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+- `pytest -q projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+
+## 6. Known limitations
+- Existing repository-wide legacy `phase*` references outside this scoped task remain and were not modified per strict scope gate.
+- This phase enforces mode/kill-switch/audit guarantees in execution path but does not perform broader risk logic refactor.
+- Test environment emits a pre-existing pytest config warning (`Unknown config option: asyncio_mode`) unrelated to this patch.
+
+Report: projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md

--- a/projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from projects.polymarket.polyquantbot.core.execution import executor
+from projects.polymarket.polyquantbot.core.pipeline import trading_loop
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
+
+
+def _signal(signal_id: str = "sig-safety-1") -> SignalResult:
+    return SignalResult(
+        signal_id=signal_id,
+        market_id="mkt-safety",
+        side="YES",
+        p_market=0.45,
+        p_model=0.6,
+        edge=0.15,
+        ev=0.1,
+        kelly_f=0.2,
+        size_usd=50.0,
+        liquidity_usd=50_000.0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor_state() -> None:
+    executor.reset_state()
+    yield
+    executor.reset_state()
+
+
+def test_execution_blocked_when_mode_not_live_for_real_executor() -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _run() -> executor.TradeResult:
+        async def _live_executor(**kwargs: Any) -> dict[str, Any]:
+            calls.append(kwargs)
+            return {"filled_size": 50.0, "fill_price": 0.45}
+
+        return await executor.execute_trade(_signal(), mode="PAPER", executor_callback=_live_executor)
+
+    result = asyncio.run(_run())
+    assert result.success
+    assert result.mode == "PAPER"
+    assert calls == []
+
+
+def test_execution_blocked_when_kill_switch_active() -> None:
+    result = asyncio.run(executor.execute_trade(_signal(), mode="LIVE", kill_switch_active=True))
+    assert not result.success
+    assert result.reason == "kill_switch_active"
+
+
+def test_execution_allowed_in_paper_mode_via_paper_engine_only() -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _run() -> executor.TradeResult:
+        async def _paper_executor(**kwargs: Any) -> dict[str, Any]:
+            calls.append(kwargs)
+            return {
+                "filled_size": kwargs["size_usd"],
+                "fill_price": kwargs["price"],
+                "partial_fill": False,
+                "reason": "paper_engine_executed",
+            }
+
+        return await executor.execute_trade(
+            _signal(),
+            mode="PAPER",
+            paper_executor_callback=_paper_executor,
+        )
+
+    result = asyncio.run(_run())
+    assert result.success
+    assert result.mode == "PAPER"
+    assert len(calls) == 1
+
+
+def test_execution_always_routed_through_executor() -> None:
+    source = Path(trading_loop.__file__).read_text()
+    assert "result = await execute_trade(" in source
+    assert "paper_executor_callback=" in source
+    assert "Bypass execute_trade() fill simulation." not in source
+
+
+def test_audit_log_generated_for_every_execution_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    def _capture(event: str, **kwargs: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(executor.log, "info", _capture)
+    asyncio.run(executor.execute_trade(_signal("sig-audit"), mode="PAPER"))
+    assert "execution_audit" in events
+
+
+def test_no_silent_failure_on_forced_exception_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    errors: list[str] = []
+
+    def _capture_error(event: str, **kwargs: Any) -> None:
+        errors.append(event)
+
+    async def _boom(**kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("forced_exception")
+
+    monkeypatch.setattr(executor.log, "error", _capture_error)
+
+    result = asyncio.run(
+        executor.execute_trade(
+            _signal("sig-exception"),
+            mode="PAPER",
+            paper_executor_callback=_boom,
+        )
+    )
+
+    assert not result.success
+    assert "execution_exception" in result.reason
+    assert "execution_error" in errors


### PR DESCRIPTION
### Motivation
- Centralize and harden trade execution so no path can bypass the authoritative executor, ensuring mode/gating/kill-switch rules are enforced and every attempt is auditable. 
- Prevent accidental LIVE execution when not permitted and remove silent fallback behaviors that could enable unsafe real-wallet actions. 

### Description
- Enforced single execution authority by routing the trading loop through `projects/polymarket/polyquantbot/core/execution/executor.py` and delegating PAPER execution via a callback contract instead of direct `PaperEngine` calls. 
- Added `execution_id` and per-attempt `execution_audit` logs and embedded audit lifecycle calls for `attempt`, `blocked`, and `executed` outcomes in `projects/polymarket/polyquantbot/core/execution/executor.py`. 
- Added explicit mode guards so LIVE requires an `executor_callback` and non-LIVE mode blocks any live callback usage, and introduced `kill_switch_active` enforcement to block executions authoritatively. 
- Added `paper_executor_callback` support to `execute_trade()` and a helper `build_paper_executor_callback()` in `projects/polymarket/polyquantbot/execution/engine_router.py` to expose PaperEngine via the executor contract; updated `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` to pass the paper callback and forward kill-switch state. 
- Tests and a FORGE report were added and `PROJECT_STATE.md` was updated to reflect this MAJOR validation-tier change (SENTINEL validation required). 

### Testing
- Ran `python -m py_compile` against the modified modules and the new test file and the compile step passed. 
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` and all tests passed (`6 passed`, 1 pytest config warning unrelated to this change). 
- Tests cover: mode blocking when not LIVE, kill-switch blocking, PAPER-mode execution via paper callback, enforcement that trading loop routes via `execute_trade()`, audit event emission per attempt, and observable error logging on forced exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c68689ec832eb8472e2e5bf619fb)