### PR TITLE
Enforce truthful execution outcomes for rejected/partial-fill (execution safety P1 addendum)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 07:49
-- Status        : FORGE-X final routing-contract fix pass completed for telegram_trade_menu_mvp_20260407; previous block was routing mismatch risk under Portfolio→Trade path; SENTINEL revalidation required before merge
+- Last Updated  : 2026-04-07 08:25
+- Status        : FORGE-X execution safety enforcement p1 review-fix addendum completed; execution outcomes are now explicit/auditable and line is prepared for SENTINEL validation
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Execution safety enforcement p1 review-fix addendum (2026-04-07): hardened callback status handling so rejected/block/failed statuses cannot be interpreted as success, added explicit partial-fill semantics, added execution outcome classifier (`executed`/`blocked`/`rejected`/`partial_fill`/`failed`), added trading-loop `execution_audit` outcome logging, and added focused safety tests in `test_execution_safety_p1_20260407.py`.
 - Telegram live coverage fix pass (2026-04-06) normalized core callback/menu render paths but left remaining utility/control menu correctness gaps.
 - Telegram full menu fix pass (2026-04-06): completed full operator-facing menu correctness coverage across home/system/status, wallet, positions, trade, pnl, performance, exposure, risk, strategy, settings, notifications, auto-trade, mode, control, market/markets, and refresh callback/edit/send paths.
 - Enforced strict view isolation so Position/Market blocks render only in context-relevant menus; removed cross-menu bleed from unrelated utility/system/settings/control menus.
@@ -35,6 +36,10 @@
 
 ## 🚧 IN PROGRESS
 
+### Execution safety enforcement p1 handoff
+- FORGE-X addendum fixes are implemented for rejected-order truth, partial-fill explicit handling, callback status semantics, and execution audit labeling.
+- SENTINEL validation is required before merge due to MAJOR execution/runtime impact.
+
 ### Telegram trade menu MVP blocker-clear handoff
 - Previous validation line for `telegram_trade_menu_mvp_20260407` was blocked due to routing-contract mismatch risk (trade actions could collapse to Home context instead of Trade context).
 - FORGE-X final pass implemented explicit Trade submenu routing and added routing-proof tests (`test_telegram_trade_menu_routing_mvp.py`) with py_compile + pytest evidence.
@@ -57,14 +62,15 @@
 
 ## 🎯 NEXT PRIORITY
 
-- SENTINEL revalidation required for telegram_trade_menu_mvp_20260407 before merge.
-- Source: projects/polymarket/polyquantbot/reports/forge/telegram_trade_menu_mvp_20260407.md
-- Tier: STANDARD
+- SENTINEL validation required for execution_safety_enforcement_p1_20260407 before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
+- Tier: MAJOR
 
 ---
 
 ## ⚠️ KNOWN ISSUES
 
+- Execution outcomes are now explicitly classified, but integrated SENTINEL verification is still pending before merge approval.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.

--- a/projects/polymarket/polyquantbot/core/execution/executor.py
+++ b/projects/polymarket/polyquantbot/core/execution/executor.py
@@ -140,6 +140,31 @@ class TradeResult:
     extra: dict[str, Any] = field(default_factory=dict)
 
 
+def classify_trade_result_outcome(result: TradeResult) -> str:
+    """Classify a :class:`TradeResult` into an auditable outcome label."""
+    if result.success:
+        return "partial_fill" if result.partial_fill else "executed"
+
+    reason = (result.reason or "").lower()
+    if "rejected" in reason:
+        return "rejected"
+
+    blocked_reasons = {
+        "duplicate",
+        "kill_switch_active",
+        "edge_non_positive",
+        "edge_below_threshold",
+        "size_exceeds_max_position",
+        "insufficient_liquidity",
+        "max_concurrent_reached",
+        "live_mode_not_enabled",
+    }
+    if reason in blocked_reasons:
+        return "blocked"
+
+    return "failed"
+
+
 # ── Module-level dedup set ─────────────────────────────────────────────────────
 # Stores signal_ids that have already been submitted.  Cleared on process restart
 # (intentional — prevents stale dedup state across restarts).
@@ -259,6 +284,26 @@ async def execute_trade(
             mode=_mode,
             attempted_size=signal.size_usd,
             reason="kill_switch_active",
+        )
+
+    # ── LIVE mode guard ───────────────────────────────────────────────────────
+    if _mode == "LIVE" and not _env_bool("ENABLE_LIVE_TRADING", False):
+        log.info(
+            "trade_skipped",
+            trade_id=trade_id,
+            signal_id=signal.signal_id,
+            market_id=signal.market_id,
+            reason="live_mode_not_enabled",
+        )
+        return TradeResult(
+            trade_id=trade_id,
+            signal_id=signal.signal_id,
+            market_id=signal.market_id,
+            side=signal.side,
+            success=False,
+            mode=_mode,
+            attempted_size=signal.size_usd,
+            reason="live_mode_not_enabled",
         )
 
     # ── Risk re-validation ────────────────────────────────────────────────────
@@ -510,9 +555,43 @@ async def _attempt_execution(
                 size_usd=signal.size_usd,
                 trade_id=trade_id,
             )
+            callback_status = str(raw.get("status", "FILLED")).strip().upper()
             latency_ms = (time.time() - t_start) * 1_000.0
             filled = float(raw.get("filled_size", signal.size_usd))
             fill_price = float(raw.get("fill_price", signal.p_market))
+
+            if callback_status in {"REJECTED", "BLOCKED", "FAILED", "ERROR"}:
+                reason = str(raw.get("reason") or callback_status.lower())
+                return TradeResult(
+                    trade_id=trade_id,
+                    signal_id=signal.signal_id,
+                    market_id=signal.market_id,
+                    side=signal.side,
+                    success=False,
+                    mode=mode,
+                    attempted_size=signal.size_usd,
+                    filled_size_usd=0.0,
+                    fill_price=0.0,
+                    latency_ms=round(latency_ms, 2),
+                    reason=f"callback_rejected:{reason}",
+                    extra=raw,
+                )
+
+            partial_fill = callback_status in {"PARTIAL", "PARTIAL_FILL"}
+            if partial_fill and filled <= 0.0:
+                return TradeResult(
+                    trade_id=trade_id,
+                    signal_id=signal.signal_id,
+                    market_id=signal.market_id,
+                    side=signal.side,
+                    success=False,
+                    mode=mode,
+                    attempted_size=signal.size_usd,
+                    latency_ms=round(latency_ms, 2),
+                    reason="callback_partial_fill_invalid",
+                    extra=raw,
+                )
+
             log.info(
                 "order_filled",
                 trade_id=trade_id,
@@ -522,6 +601,7 @@ async def _attempt_execution(
                 filled_size_usd=round(filled, 4),
                 fill_price=round(fill_price, 6),
                 latency_ms=round(latency_ms, 2),
+                partial_fill=partial_fill,
                 mode=mode,
             )
             return TradeResult(
@@ -535,7 +615,8 @@ async def _attempt_execution(
                 filled_size_usd=round(filled, 4),
                 fill_price=round(fill_price, 6),
                 latency_ms=round(latency_ms, 2),
-                reason="live_executed",
+                partial_fill=partial_fill,
+                reason="partial_fill" if partial_fill else "live_executed",
                 extra=raw,
             )
         else:

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -81,7 +81,7 @@ from ..market_scope import apply_market_scope
 from ..market.ingest import ingest_markets
 from ..signal.signal_engine import generate_signals, generate_synthetic_signals
 from ..signal.alpha_model import ProbabilisticAlphaModel
-from ..execution.executor import execute_trade
+from ..execution.executor import execute_trade, classify_trade_result_outcome
 from ...monitoring.pnl_calculator import PnLCalculator
 from ...monitoring.performance_tracker import PerformanceTracker
 from ...monitoring.metrics_engine import MetricsEngine
@@ -1096,47 +1096,53 @@ async def run_trading_loop(
                             continue
 
                         from ...execution.paper_engine import OrderStatus as _OS  # noqa: PLC0415
-                        _pe_success = _paper_order.status in (_OS.FILLED, _OS.PARTIAL)
+                        _is_partial = _paper_order.status == _OS.PARTIAL
+                        _is_filled = _paper_order.status == _OS.FILLED
+                        _is_rejected = _paper_order.status == _OS.REJECTED
 
-                        if not _pe_success:
-                            log.info(
-                                "execution_failed",
-                                trade_id=signal.signal_id,
-                                market_id=signal.market_id,
-                                reason=_paper_order.reason,
-                                status=_paper_order.status,
-                            )
-                            continue
-
-                        # Build a synthetic TradeResult from PaperOrderResult
-                        from ..execution.executor import TradeResult  # noqa: PLC0415
                         result = TradeResult(
                             trade_id=_paper_order.trade_id,
                             signal_id=signal.signal_id,
                             market_id=_paper_order.market_id,
                             side=_paper_order.side,
-                            success=True,
+                            success=_is_filled or _is_partial,
                             mode="PAPER",
                             attempted_size=_paper_order.requested_size,
                             filled_size_usd=_paper_order.filled_size,
                             fill_price=_paper_order.fill_price,
                             latency_ms=0.0,
                             slippage_pct=0.0,
-                            partial_fill=_paper_order.status == _OS.PARTIAL,
-                            reason=_paper_order.reason,
-                        )
-                        log.info(
-                            "execution_success",
-                            trade_id=result.trade_id,
-                            market_id=result.market_id,
-                            side=result.side,
-                            filled_size_usd=round(result.filled_size_usd, 4),
-                            fill_price=round(result.fill_price, 6),
-                            mode=result.mode,
+                            partial_fill=_is_partial,
+                            reason=(
+                                f"paper_engine_rejected:{_paper_order.reason}"
+                                if _is_rejected
+                                else (_paper_order.reason or ("partial_fill" if _is_partial else "paper_filled"))
+                            ),
+                            extra={"paper_status": str(_paper_order.status)},
                         )
 
+                        if not result.success:
+                            log.info(
+                                "execution_failed",
+                                trade_id=result.trade_id,
+                                market_id=result.market_id,
+                                reason=result.reason,
+                                status=str(_paper_order.status),
+                            )
+                        else:
+                            log.info(
+                                "execution_success",
+                                trade_id=result.trade_id,
+                                market_id=result.market_id,
+                                side=result.side,
+                                filled_size_usd=round(result.filled_size_usd, 4),
+                                fill_price=round(result.fill_price, 6),
+                                mode=result.mode,
+                                partial_fill=result.partial_fill,
+                            )
+
                         # ── Persist ledger entry ──────────────────────────────
-                        if db is not None and paper_engine is not None:
+                        if result.success and db is not None and paper_engine is not None:
                             try:
                                 # Persist wallet state after every execution
                                 await paper_engine._wallet.persist(db)  # type: ignore[attr-defined]
@@ -1163,16 +1169,36 @@ async def run_trading_loop(
                                 market_id=result.market_id,
                                 reason=result.reason,
                             )
-                            continue
-                        log.info(
-                            "execution_success",
-                            trade_id=result.trade_id,
-                            market_id=result.market_id,
-                            side=result.side,
-                            filled_size_usd=round(result.filled_size_usd or 0.0, 4),
-                            fill_price=round(result.fill_price or 0.0, 6),
-                            mode=result.mode,
-                        )
+                        else:
+                            log.info(
+                                "execution_success",
+                                trade_id=result.trade_id,
+                                market_id=result.market_id,
+                                side=result.side,
+                                filled_size_usd=round(result.filled_size_usd or 0.0, 4),
+                                fill_price=round(result.fill_price or 0.0, 6),
+                                mode=result.mode,
+                                partial_fill=result.partial_fill,
+                            )
+
+                    _execution_outcome = classify_trade_result_outcome(result)
+                    log.info(
+                        "execution_audit",
+                        trade_id=result.trade_id,
+                        signal_id=signal.signal_id,
+                        market_id=result.market_id,
+                        side=result.side,
+                        mode=result.mode,
+                        outcome=_execution_outcome,
+                        reason=result.reason,
+                        attempted_size=round(result.attempted_size or 0.0, 4),
+                        filled_size=round(result.filled_size_usd or 0.0, 4),
+                        fill_price=round(result.fill_price or 0.0, 6),
+                        partial_fill=result.partial_fill,
+                    )
+
+                    if not result.success:
+                        continue
 
                     if result.success:
                         _trades_this_tick += 1

--- a/projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md
@@ -1,0 +1,49 @@
+# execution_safety_enforcement_p1_20260407
+
+Validation Tier: MAJOR  
+Validation Target: `projects/polymarket/polyquantbot/core/execution/executor.py`, `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`, and `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` execution-outcome semantics (`executed`, `blocked`, `rejected`, `partial_fill`, `failed`) and callback handling paths only.  
+Not in Scope: Telegram/UI/strategy/risk model refactors, real-wallet enablement, websocket/infra redesign, unrelated pipeline behavior.
+
+## 1. What was built
+- Added explicit execution-outcome classifier in executor (`classify_trade_result_outcome`) to enforce auditable labels: `executed`, `blocked`, `rejected`, `partial_fill`, `failed`.
+- Hardened LIVE callback handling in `execute_trade()` so callback statuses `REJECTED/BLOCKED/FAILED/ERROR` return explicit failure (`success=False`, `reason=callback_rejected:*`) rather than being treated as success.
+- Added explicit partial-fill callback semantics (`status=PARTIAL/PARTIAL_FILL`) with preserved `partial_fill=True` and explicit `reason=partial_fill`.
+- Added LIVE mode guard in executor (`live_mode_not_enabled`) when `ENABLE_LIVE_TRADING` is not explicitly enabled.
+- Updated trading loop paper-engine path to construct explicit `TradeResult` for `FILLED/PARTIAL/REJECTED` statuses and avoid success logging for rejected paper-engine orders.
+- Added `execution_audit` structured log event in trading loop for every execution attempt with truthful outcome+reason fields.
+- Added focused test suite `test_execution_safety_p1_20260407.py` for rejected handling, partial fills, kill-switch block, mode-guard block, and outcome truth table.
+
+## 2. Current system architecture
+- Signal generation remains unchanged.
+- Execution routing:
+  - PAPER + `paper_engine` path in trading loop: `PaperOrderResult` is converted into `TradeResult` with explicit success/failure and preserved status semantics.
+  - LIVE path: `execute_trade()` delegates to callback but now validates callback status before marking success.
+- Outcome/audit layer:
+  - `classify_trade_result_outcome()` is the normalization layer used by trading loop to emit `execution_audit` outcome records.
+  - Rejected and blocked paths are no longer ambiguous “success”.
+- Persistence behavior remains scoped:
+  - DB position/trade persistence only happens for successful execution paths, while non-success paths still emit explicit audit events.
+
+## 3. Files created / modified (full paths)
+- `projects/polymarket/polyquantbot/core/execution/executor.py` (modified)
+- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` (modified)
+- `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` (created)
+- `projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md` (created)
+- `PROJECT_STATE.md` (modified)
+
+## 4. What is working
+- Rejected callback responses are surfaced as execution failure and classified as `rejected`.
+- Partial-fill callback responses preserve explicit partial semantics and are classified as `partial_fill`.
+- Kill-switch result remains blocked and is classified as `blocked`.
+- LIVE mode guard blocks unsafe live execution by default unless explicitly enabled.
+- Trading loop now emits explicit `execution_audit` records with outcome+reason for both success and failure paths.
+- New targeted tests pass for required review-fix addendum coverage.
+
+## 5. Known issues
+- This addendum does not add DB persistence for failed/blocked/rejected attempts; audit truth is currently via structured `execution_audit` logs and explicit `TradeResult` semantics.
+- End-to-end SENTINEL validation is still required before merge because this is a MAJOR execution-safety surface.
+
+## 6. What is next
+- Run SENTINEL validation for execution safety enforcement addendum before merge.
+- Validate rejected/blocked/partial/executed/failed outcomes in integrated runtime checks.
+- Confirm no regression in broader execution/trading-loop integration tests.

--- a/projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py
@@ -1,0 +1,149 @@
+"""Execution safety addendum tests for rejected/blocked/partial-fill semantics."""
+from __future__ import annotations
+
+import os
+import asyncio
+from unittest.mock import patch
+
+from projects.polymarket.polyquantbot.core.execution.executor import (
+    TradeResult,
+    classify_trade_result_outcome,
+    execute_trade,
+    reset_state,
+)
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
+
+
+def _signal(signal_id: str = "sig-p1-001") -> SignalResult:
+    return SignalResult(
+        signal_id=signal_id,
+        market_id="mkt-p1",
+        side="YES",
+        p_market=0.41,
+        p_model=0.62,
+        edge=0.21,
+        ev=0.22,
+        kelly_f=0.25,
+        size_usd=40.0,
+        liquidity_usd=20_000.0,
+    )
+
+
+def test_rejected_callback_not_treated_as_executed() -> None:
+    """Rejected callback response must produce non-success + rejected outcome."""
+    reset_state()
+
+    async def _rejected_callback(**_: object) -> dict[str, object]:
+        return {"status": "REJECTED", "reason": "risk_reject", "filled_size": 0.0}
+
+    with patch.dict(os.environ, {"ENABLE_LIVE_TRADING": "true"}):
+        result = asyncio.run(
+            execute_trade(
+                _signal(),
+                mode="LIVE",
+                executor_callback=_rejected_callback,
+            )
+        )
+
+    assert result.success is False
+    assert "callback_rejected" in result.reason
+    assert classify_trade_result_outcome(result) == "rejected"
+
+
+def test_partial_fill_callback_is_explicit_and_auditable() -> None:
+    """Partial fill callback must remain success with explicit partial semantics."""
+    reset_state()
+
+    async def _partial_callback(**_: object) -> dict[str, object]:
+        return {
+            "status": "PARTIAL",
+            "reason": "partial_fill",
+            "filled_size": 10.0,
+            "fill_price": 0.43,
+        }
+
+    with patch.dict(os.environ, {"ENABLE_LIVE_TRADING": "true"}):
+        result = asyncio.run(
+            execute_trade(
+                _signal("sig-p1-002"),
+                mode="LIVE",
+                executor_callback=_partial_callback,
+            )
+        )
+
+    assert result.success is True
+    assert result.partial_fill is True
+    assert result.reason == "partial_fill"
+    assert classify_trade_result_outcome(result) == "partial_fill"
+
+
+def test_kill_switch_block_still_blocks() -> None:
+    """Kill switch remains an explicit blocked outcome."""
+    reset_state()
+    result = asyncio.run(
+        execute_trade(_signal("sig-p1-003"), mode="PAPER", kill_switch_active=True)
+    )
+    assert result.success is False
+    assert result.reason == "kill_switch_active"
+    assert classify_trade_result_outcome(result) == "blocked"
+
+
+def test_live_mode_guard_blocks_without_enable_flag() -> None:
+    """LIVE mode is blocked unless ENABLE_LIVE_TRADING is true."""
+    reset_state()
+    with patch.dict(os.environ, {"ENABLE_LIVE_TRADING": "false"}):
+        result = asyncio.run(execute_trade(_signal("sig-p1-004"), mode="LIVE"))
+    assert result.success is False
+    assert result.reason == "live_mode_not_enabled"
+    assert classify_trade_result_outcome(result) == "blocked"
+
+
+def test_execution_outcome_classification_truth_table() -> None:
+    """Audit outcome classification differentiates executed/blocked/rejected/failed."""
+    executed = TradeResult(
+        trade_id="t1",
+        signal_id="s1",
+        market_id="m1",
+        side="YES",
+        success=True,
+        mode="PAPER",
+        attempted_size=10.0,
+        filled_size_usd=10.0,
+        fill_price=0.5,
+        reason="paper_filled",
+    )
+    blocked = TradeResult(
+        trade_id="t2",
+        signal_id="s2",
+        market_id="m2",
+        side="YES",
+        success=False,
+        mode="PAPER",
+        attempted_size=10.0,
+        reason="kill_switch_active",
+    )
+    rejected = TradeResult(
+        trade_id="t3",
+        signal_id="s3",
+        market_id="m3",
+        side="YES",
+        success=False,
+        mode="LIVE",
+        attempted_size=10.0,
+        reason="callback_rejected:insufficient_funds",
+    )
+    failed = TradeResult(
+        trade_id="t4",
+        signal_id="s4",
+        market_id="m4",
+        side="YES",
+        success=False,
+        mode="LIVE",
+        attempted_size=10.0,
+        reason="execution_exception:timeout",
+    )
+
+    assert classify_trade_result_outcome(executed) == "executed"
+    assert classify_trade_result_outcome(blocked) == "blocked"
+    assert classify_trade_result_outcome(rejected) == "rejected"
+    assert classify_trade_result_outcome(failed) == "failed"


### PR DESCRIPTION
### Motivation
- Fix critical execution-safety review findings so rejected or blocked orders are never interpreted as successful executions and partial-fill semantics are explicit and auditable. 
- Ensure callback placement/handling and trading-loop construction produce a clear, auditable outcome for every execution attempt before handing the line to SENTINEL. 

### Description
- Added `classify_trade_result_outcome(result: TradeResult) -> str` in `projects/polymarket/polyquantbot/core/execution/executor.py` to normalize auditable outcome labels: `executed`, `blocked`, `rejected`, `partial_fill`, and `failed`.
- Hardened LIVE callback handling in `execute_trade()` so callback statuses `REJECTED/BLOCKED/FAILED/ERROR` return explicit failure `TradeResult` (with `reason=callback_rejected:*`) and partial-fill callback responses preserve `partial_fill=True` and an explicit `reason` rather than being collapsed into ambiguous success.
- Added a LIVE mode guard that blocks LIVE execution unless `ENABLE_LIVE_TRADING` is explicitly enabled to prevent accidental real-wallet behavior.
- Updated `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` PAPER path to convert `PaperOrderResult` statuses (`FILLED`, `PARTIAL`, `REJECTED`) into explicit `TradeResult` semantics, emit an `execution_audit` structured log for every attempt, and restrict DB persistence to true success paths only.
- Added a focused test suite `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` and created the required FORGE report at `projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md`, and updated `PROJECT_STATE.md` to reflect the addendum and MAJOR-tier SENTINEL handoff.

### Testing
- Static/compile checks: ran `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` and it passed.
- Unit tests: ran `export PYTHONPATH=. && pytest -q projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` and all tests passed (`5 passed`, `1 warning` about pytest config option).
- Test coverage targeted and validated the acceptance criteria: rejected callback treated as non-executed, partial-fill semantics explicit and auditable, kill-switch blocking still works, LIVE mode guard blocks without the enable flag, and audit outcome classification truth table verifies auditable labels.

Files modified/added: `projects/polymarket/polyquantbot/core/execution/executor.py`, `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`, `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` (new), `projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md` (new), and `PROJECT_STATE.md` (updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d407b75c832e85274b7fe1b45e0a)