### PR TITLE
sentinel: validate execution safety enforcement p1 addendum

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/execution_safety_enforcement_p1_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/execution_safety_enforcement_p1_validation_20260407.md
@@ -1,0 +1,109 @@
+# execution_safety_enforcement_p1_validation_20260407
+
+- Role: SENTINEL
+- Task: validate `execution_safety_enforcement_p1_20260407` after review-fix addendum #255
+- Branch Context: `feature/fix-critical-review-findings-for-execution-safety-2026-04-07` (Codex worktree `work` accepted per policy)
+- Date (UTC): 2026-04-07
+- Verdict: **APPROVED**
+
+## Phase 0 — Preconditions
+
+Status: **PASS**
+
+Required artifacts verified present:
+- `PROJECT_STATE.md`
+- `projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md`
+- `projects/polymarket/polyquantbot/core/execution/executor.py`
+- `projects/polymarket/polyquantbot/execution/engine_router.py`
+- `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+
+PROJECT_STATE alignment check:
+- `PROJECT_STATE.md` status/next-priority explicitly states this exact line is awaiting SENTINEL validation.
+- No contradiction between state file and forge report objective.
+
+## Phase 1 — Static Evidence
+
+Status: **PASS**
+
+1) Execution still routes through executor authority
+- `trading_loop.py` imports and calls `execute_trade(...)` on non-paper-engine path.
+- `trading_loop.py` paper-engine path still creates canonical `TradeResult` object used for unified outcome handling.
+
+2) Rejected callback results are not interpreted as success
+- `executor.py` `_attempt_execution(...)` maps callback statuses `REJECTED/BLOCKED/FAILED/ERROR` to `TradeResult(success=False, reason="callback_rejected:...")`.
+
+3) partial_fill handling is explicit and auditable
+- `executor.py` marks callback statuses `PARTIAL/PARTIAL_FILL` as `partial_fill=True` and returns explicit reason `partial_fill`.
+- Invalid partial fill payload (`filled<=0`) is hard-failed with reason `callback_partial_fill_invalid`.
+
+4) LIVE mode requires explicit enablement
+- `executor.py` blocks LIVE mode unless `ENABLE_LIVE_TRADING=true`, returning `success=False` with reason `live_mode_not_enabled`.
+
+5) Audit outcome labels are differentiated
+- `classify_trade_result_outcome(...)` returns explicit labels: `executed`, `partial_fill`, `blocked`, `rejected`, `failed`.
+
+6) No silent execution-path swallowing in touched path
+- Touched paths emit explicit result objects and logs for failed/blocked/rejected branches; no `except: pass` or silent drop in evaluated execution branches.
+
+## Phase 2 — Runtime Proof
+
+Status: **PASS**
+
+Executed targeted runtime script (async) against `execute_trade` + `classify_trade_result_outcome`:
+
+Observed outputs:
+- rejected callback: `success=False`, reason includes `callback_rejected:...`, classified `rejected`
+- partial callback: `success=True`, `partial_fill=True`, reason `partial_fill`, classified `partial_fill`
+- kill-switch: `success=False`, reason `kill_switch_active`, classified `blocked`
+- LIVE without enable flag: `success=False`, reason `live_mode_not_enabled`, classified `blocked`
+- PAPER path: successful auditable `TradeResult` generated and classified (`executed`/`partial_fill` depending simulated fill)
+
+Required runtime outcomes:
+- rejected != executed ✅
+- blocked != executed ✅
+- partial_fill not collapsed to plain success label ✅
+- live execution blocked when enable flag is off ✅
+- result-to-outcome semantics remain truthful ✅
+
+Execution-audit trail proof:
+- `trading_loop.py` emits `execution_audit` event for each execution attempt using `classify_trade_result_outcome(result)` and includes `outcome`, `reason`, `partial_fill`, attempted/filled sizes.
+- This ties audit label directly to canonical `TradeResult` semantics.
+
+## Phase 3 — Test Proof
+
+Status: **PASS**
+
+Commands run:
+1. `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+   - Result: PASS
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`
+   - Result: PASS (`5 passed`)
+   - Warning: `PytestConfigWarning: Unknown config option: asyncio_mode` (non-blocking for this targeted scope)
+
+## Phase 4 — Failure-Mode Break Attempts
+
+Status: **PASS**
+
+Break attempt outcomes:
+- Force callback `REJECTED` and verify system cannot classify as executed: **failed to break** (safe)
+- Force callback `PARTIAL` and verify semantics collapse to executed label: **failed to break** (safe; remains `partial_fill`)
+- Try kill-switch bypass by setting `kill_switch_active=True`: **failed to break** (blocked)
+- Attempt LIVE execution with `ENABLE_LIVE_TRADING=false`: **failed to break** (blocked)
+- Attempt audit ambiguity: classification table continues to separate blocked/rejected/failed paths: **failed to break** (safe)
+
+## Findings Summary
+
+- Execution safety P1 addendum now enforces truthful non-success handling for callback rejection/block/failure paths.
+- Partial-fill semantics are explicit and preserved in result + outcome label.
+- LIVE guard prevents accidental live execution unless explicitly enabled.
+- Audit outcome mapping is explicit and materially auditable in trading loop.
+
+## Score
+
+- 97 / 100
+- Deduction (minor): warning-only pytest config noise (`asyncio_mode` option) unrelated to execution semantics.
+
+## Final Verdict
+
+**APPROVED** — execution safety enforcement P1 is truthful, authoritative, and auditable for the validated target scope.


### PR DESCRIPTION
### Motivation

- Provide SENTINEL-level validation of the FORGE-X addendum that hardens execution outcome semantics (auditable labels, rejected/blocked handling, explicit partial-fill, and LIVE-mode guard) before merging this MAJOR change.

### Description

- Add SENTINEL validation report `projects/polymarket/polyquantbot/reports/sentinel/execution_safety_enforcement_p1_validation_20260407.md` documenting static analysis, runtime proofs, negative/break attempts, findings, score, and final verdict **APPROVED**.
- Verified and exercised the modified execution surfaces and supporting artifacts: `PROJECT_STATE.md`, `projects/polymarket/polyquantbot/reports/forge/execution_safety_enforcement_p1_20260407.md`, `projects/polymarket/polyquantbot/core/execution/executor.py`, `projects/polymarket/polyquantbot/execution/engine_router.py`, `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`, and `projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py`.
- Recorded that the trading loop emits `execution_audit` derived from the canonical `TradeResult` via `classify_trade_result_outcome(...)`, and that rejected/blocked/partial/failed outcomes are differentiated and auditable.

### Testing

- Ran `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` which passed.
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_execution_safety_p1_20260407.py` which passed (`5 passed`) with one non-blocking `PytestConfigWarning` about `asyncio_mode`.
- Executed a targeted runtime script invoking `execute_trade` with mocked callbacks to validate rejected/partial/kill-switch/LIVE-guard behavior and negative break attempts; observed expected outcomes (rejected != executed, blocked != executed, partial_fill preserved, live execution blocked when `ENABLE_LIVE_TRADING` is not set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d77e9da4832e838f09e81c52131f)