### PR TITLE
forge: emit explicit restore_failure outcome in engine restore path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 10:07
-- Status        : FORGE-X telegram UI text leakage audit fix pass completed for telegram_ui_text_leakage_audit_20260407; user-facing fallback/internal leakage cleaned; COMMANDER review for STANDARD-tier validation decision
+- Last Updated  : 2026-04-07 10:45
+- Status        : FORGE-X restore_failure observability addendum completed for trade_system_hardening_p2_20260407 after SENTINEL #262 CONDITIONAL caveat; awaiting SENTINEL rerun before merge
 
 ---
 
@@ -32,6 +32,8 @@
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
 - Telegram Trade Menu MVP final fix pass (2026-04-07): added Portfolio `⚡ Trade`, created dedicated 4-action Trade submenu, and corrected callback routing contract so trade actions stay in Trade context without Home fallback.
+- Trade-system hardening P2 restore_failure observability addendum (2026-04-07): added explicit structured restore outcome emission (`restore_failure`/`restore_success`) in engine restore path and added focused proof test `test_trade_system_hardening_p2_20260407.py`.
+- SENTINEL #262 for trade-system hardening P2 is currently **CONDITIONAL (84/100)** pending explicit restore-failure observability confirmation rerun.
 
 ---
 
@@ -50,7 +52,7 @@
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
 ### Trade-system hardening handoff
-- FORGE-X hardening pending for risk-gate unification, reconciliation ownership, restart recovery correctness, and silent-failure removal before any real-wallet enablement.
+- restore_failure observability addendum is complete; SENTINEL rerun pending for `trade_system_hardening_p2_20260407` before merge.
 
 ---
 
@@ -62,10 +64,11 @@
 
 ## 🎯 NEXT PRIORITY
 
-- Codex code review required. COMMANDER review for validation decision. Source: projects/polymarket/polyquantbot/reports/forge/telegram_ui_text_leakage_audit_20260407.md. Tier: STANDARD
+- SENTINEL validation required for trade_system_hardening_p2_20260407 before merge. Source: projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- SENTINEL #262 remains CONDITIONAL (84/100) until rerun confirms explicit `restore_failure` outcome observability in runtime artifacts.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/execution/engine_router.py
+++ b/projects/polymarket/polyquantbot/execution/engine_router.py
@@ -93,20 +93,37 @@ class EngineContainer:
             db: :class:`~infra.db.database.DatabaseClient` connected instance.
         """
         log.info("engine_container_restore_start")
+        failed_components: list[str] = []
         try:
             await self.wallet.restore_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_wallet_restore_error", error=str(exc))
+            failed_components.append("wallet")
 
         try:
             await self.positions.load_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_positions_restore_error", error=str(exc))
+            failed_components.append("positions")
 
         try:
             await self.ledger.load_from_db(db)  # type: ignore[arg-type]
         except Exception as exc:
             log.warning("engine_container_ledger_restore_error", error=str(exc))
+            failed_components.append("ledger")
+
+        if failed_components:
+            log.warning(
+                "engine_container_restore_outcome",
+                outcome="restore_failure",
+                failed_components=failed_components,
+            )
+        else:
+            log.info(
+                "engine_container_restore_outcome",
+                outcome="restore_success",
+                failed_components=[],
+            )
 
         log.info("engine_container_restore_complete")
 

--- a/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md
@@ -1,0 +1,37 @@
+# trade_system_hardening_p2_20260407 — restore_failure observability addendum
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Validation Target: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py` restore/recovery path outcome emission and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` focused restore-failure proof.
+- Not in Scope: Telegram/UI changes, strategy/risk logic changes, execution behavior changes, real-wallet behavior changes.
+
+## 1) What was built
+- Added explicit restore outcome emission in `EngineContainer.restore_from_db` so recovery failures now emit a structured `outcome="restore_failure"` category.
+- Added focused test coverage proving restore failure produces explicit `restore_failure` outcome with failed component attribution.
+
+## 2) Current system architecture
+- Startup restore remains centralized in `EngineContainer.restore_from_db`.
+- Wallet/positions/ledger restore calls still run independently with non-fatal error handling.
+- New observability layer now emits one explicit restore outcome event:
+  - success path: `engine_container_restore_outcome` with `outcome="restore_success"`
+  - failure path: `engine_container_restore_outcome` with `outcome="restore_failure"` plus `failed_components` list.
+
+## 3) Files created / modified (full paths)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py` (modified)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` (created)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md` (created)
+- `/workspace/walker-ai-team/PROJECT_STATE.md` (updated)
+
+## 4) What is working
+- Restore/recovery failures now produce explicit `restore_failure` outcome category in structured logging payload.
+- Successful restore path emits explicit `restore_success` outcome category.
+- Focused pytest confirms failure path behavior and failed-component payload.
+- py_compile and target pytest pass in this environment.
+
+## 5) Known issues
+- SENTINEL #262 remains CONDITIONAL until rerun confirms this addendum resolves the observability caveat.
+- This addendum intentionally does not alter Telegram notifications/UI behavior or runtime execution semantics.
+
+## 6) What is next
+- SENTINEL rerun required for `trade_system_hardening_p2_20260407` before merge to close CONDITIONAL observability caveat.
+- COMMANDER to review rerun verdict and decide merge readiness.

--- a/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.execution import engine_router
+
+
+class _FailingWallet:
+    async def restore_from_db(self, db: object) -> None:
+        raise RuntimeError("wallet restore broke")
+
+
+class _OkPositions:
+    async def load_from_db(self, db: object) -> None:
+        return None
+
+
+class _OkLedger:
+    async def load_from_db(self, db: object) -> None:
+        return None
+
+
+class _CaptureLog:
+    def __init__(self) -> None:
+        self.warning_events: list[tuple[str, dict[str, object]]] = []
+        self.info_events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_events.append((event, kwargs))
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.info_events.append((event, kwargs))
+
+
+def test_restore_failure_emits_explicit_restore_failure_outcome() -> None:
+    container = engine_router.EngineContainer()
+    container.wallet = _FailingWallet()  # type: ignore[assignment]
+    container.positions = _OkPositions()  # type: ignore[assignment]
+    container.ledger = _OkLedger()  # type: ignore[assignment]
+
+    capture_log = _CaptureLog()
+    original_log = engine_router.log
+    engine_router.log = capture_log  # type: ignore[assignment]
+    try:
+        asyncio.run(container.restore_from_db(db=object()))
+    finally:
+        engine_router.log = original_log
+
+    restore_outcomes = [
+        payload
+        for event, payload in capture_log.warning_events
+        if event == "engine_container_restore_outcome"
+    ]
+    assert restore_outcomes, "restore outcome warning was not emitted"
+    assert restore_outcomes[0]["outcome"] == "restore_failure"
+    assert restore_outcomes[0]["failed_components"] == ["wallet"]


### PR DESCRIPTION
### Motivation
- SENTINEL #262 reported a CONDITIONAL caveat: restore/recovery failures relied on warning logs and did not emit an explicit runtime `restore_failure` outcome, reducing observability and structured reporting.
- The change is a focused micro-fix to make restore failures observable in structured logs and outcome reporting without changing Telegram/UI, strategy, risk logic, or real-wallet behavior.

### Description
- Engine restore path: `EngineContainer.restore_from_db` now accumulates `failed_components` and emits a structured `engine_container_restore_outcome` event with `outcome="restore_failure"` and `failed_components` when any component restore fails, or `outcome="restore_success"` when none fail (file modified: `projects/polymarket/polyquantbot/execution/engine_router.py`).
- Tests: added a focused unit test `projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` that injects a failing wallet, captures structured log calls, and asserts the `restore_failure` outcome and failed-component attribution are emitted.
- Reporting/state: added the FORGE report at `projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md` and updated `PROJECT_STATE.md` to record the addendum, note SENTINEL #262 as CONDITIONAL (84/100), and set next priority to a SENTINEL rerun before merge.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` — PASS.
- `pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` (without repo PYTHONPATH) — FAIL during collection due to module import resolution in this environment (expected environment invocation issue).
- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py` — PASS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5022326d0832e8bb3a36fcd37630a)