### PR TITLE
sentinel: block P2 quick rerun on missing #263 branch context

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p2_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p2_validation_20260407.md
@@ -1,0 +1,59 @@
+## 1. Target
+- Task: corrected quick rerun validation for `trade_system_hardening_p2_20260407` after restore-failure observability addendum #263.
+- Requested target branch: `feature/add-restore_failure-outcome-emission-2026-04-07`.
+- Validation scope requested by COMMANDER:
+  - `/workspace/walker-ai-team/PROJECT_STATE.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p2_20260407.py`
+- Validation mode: corrected quick rerun, narrow scope only (no broad re-audit).
+
+## 2. Score
+- Score: **0/100**
+- Status: **CONTEXT FAILURE**
+- Rationale: Mandatory pre-validation hard checks failed before static/runtime/test phases could start.
+
+## 3. Findings by phase
+- Phase 0 (Pre-validation hard checks): **FAILED**
+  - Could not confirm remote branch existence because no `origin` remote exists in this repository clone.
+  - Could not confirm required files on target branch because target branch context is unavailable.
+  - Current checked-out context (`work`) does not contain required forge report path for this task.
+- Phase 1 (Static evidence): **NOT RUN** (blocked by Phase 0 failure).
+- Phase 2 (Runtime/behavior proof): **NOT RUN** (blocked by Phase 0 failure).
+- Phase 3 (Test proof): **NOT RUN** (blocked by Phase 0 failure; per instruction, no `py_compile`/`pytest` executed).
+
+## 4. Evidence
+- Command run:
+  - `git remote -v && git branch -a | sed -n '1,120p' && git ls-remote --heads origin feature/add-restore_failure-outcome-emission-2026-04-07`
+- Output snippet:
+  - `fatal: 'origin' does not appear to be a git repository`
+  - `fatal: Could not read from remote repository.`
+- Command run:
+  - `sed -n '1,260p' projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md`
+- Output snippet:
+  - `sed: can't read projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md: No such file or directory`
+- Command run:
+  - `git status --short --branch`
+- Output snippet:
+  - `## work`
+
+## 5. Critical issues
+- Critical issue 1:
+  - Type: Context failure
+  - Expected: remote branch `feature/add-restore_failure-outcome-emission-2026-04-07` must be verifiable.
+  - Actual: repository has no configured `origin`, so remote branch existence cannot be validated.
+- Critical issue 2:
+  - Type: Artifact availability failure in current context
+  - Expected: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md` must be openable on target branch.
+  - Actual: path is absent in current context and target branch could not be resolved.
+- Critical issue 3:
+  - Type: Mandatory gate enforcement
+  - Per task instruction, pre-validation hard-check failure requires immediate stop and prohibits `py_compile`/`pytest` progression.
+
+## 6. Verdict
+- **BLOCKED**
+- Classification: **CONTEXT FAILURE**
+- Reason: Mandatory branch/context/artifact pre-checks failed, so validation cannot proceed safely against the required #263 branch.
+- Required unblock action:
+  1. Provide repository context with a configured remote that exposes `feature/add-restore_failure-outcome-emission-2026-04-07`, or provide an equivalent local branch containing the exact #263 artifacts.
+  2. Re-run SENTINEL quick rerun after branch and artifact checks pass.


### PR DESCRIPTION
### Motivation
- Record a SENTINEL quick-rerun validation attempt for `trade_system_hardening_p2_20260407` and halt validation because the required `feature/add-restore_failure-outcome-emission-2026-04-07` branch and its forge artifact could not be verified in the current repo context.

### Description
- Add a SENTINEL report at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p2_validation_20260407.md` that documents a **BLOCKED** verdict classified as **CONTEXT FAILURE**, lists the missing artifacts and pre-validation gate failures, and prescribes unblock actions.

### Testing
- Ran prevalidation checks: `git remote -v && git branch -a | sed -n '1,120p' && git ls-remote --heads origin feature/add-restore_failure-outcome-emission-2026-04-07` which failed due to no configured `origin` remote, and `sed -n '1,260p' projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p2_20260407.md` which failed because the forge report path was not present in the current context; both failures prevented further phases.
- Ran `git status --short --branch` which succeeded and was recorded as evidence; `python -m py_compile ...` and `PYTHONPATH=... pytest -q ...` were intentionally not run due to the Phase 0 stop condition per task instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53705f8c8832eb8d3118f49d54a62)