### PR TITLE
SENTINEL: validate execution-boundary capital guardrails (P3)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p3_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p3_validation_20260407.md
@@ -1,0 +1,107 @@
+## 1. Target
+- Task: `trade_system_hardening_p3_20260407`
+- Requested branch context: `feature/implement-execution-safety-guardrails-2026-04-07` (Codex worktree HEAD is `work`, validated per Codex worktree rule).
+- Validation scope (explicit):
+  - `/workspace/walker-ai-team/PROJECT_STATE.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p3_20260407.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/capital_guard.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine_router.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py`
+- Objective: prove execution-boundary capital guardrails are authoritative and prevent order execution when breached, while allowed execution remains functional.
+
+## 2. Score
+- **96 / 100**
+- Rationale:
+  - Authoritative execution-boundary guardrails are implemented before order placement and return structured blocked outcomes with explicit reasons.
+  - Runtime and targeted pytest evidence both confirm all required blocked paths.
+  - Allowed execution path remains functional under passing guardrails.
+  - Minor deduction only for pytest config warning (`Unknown config option: asyncio_mode`) not directly blocking this task objective.
+
+## 3. Findings by phase
+### Phase 0 — Preconditions
+- PASS: Required forge report exists at expected path.
+- PASS: Required target test exists at expected path.
+- PASS: All target files exist.
+- PASS: `PROJECT_STATE.md` aligns with declared status (P3 implemented, SENTINEL validation pending).
+- PASS: Scope is limited to declared P3 guardrail targets (`git show --name-only --pretty=format: HEAD` lists only P3 files + state/report).
+
+### Phase 1 — Static evidence
+1) Execution-boundary guardrail checks before order placement: **PASS**
+- `EngineContainer._wire_execution_guardrails()` wraps `paper_engine.execute_order` and evaluates guardrails first (`violation = self.capital_guard.evaluate(order)`), only delegating to original execute path when no violation exists.
+
+2) Explicit structured block reasons: **PASS**
+- Guardrail reasons are explicit and structured in `GuardrailViolation` with `outcome`, `reason`, `details`.
+- Required reasons found:
+  - `capital_insufficient`
+  - `exposure_limit`
+  - `max_positions_reached`
+  - `drawdown_limit`
+
+3) No bypass path in touched scope: **PASS**
+- In touched execution boundary code, every `paper_engine.execute_order` call is routed through wrapped `_guarded_execute_order`; blocked path returns `PaperOrderResult(status=REJECTED, reason=...)` without calling underlying order placement.
+
+4) Runtime-evaluated guardrail logic: **PASS**
+- Exposure and position capacity are computed at execution time via `_current_exposure()` and `get_all_open()`.
+- Daily loss / drawdown evaluated from current wallet state and UTC-day ledger aggregation each call.
+
+5) Failures authoritative (not logs-only): **PASS**
+- Guardrail failures return concrete `PaperOrderResult` rejections with explicit reason, not only logging.
+
+6) No silent fallback execution in touched paths: **PASS**
+- Guardrail violation returns early and prevents delegation to original execute function.
+
+### Phase 2 — Runtime proof
+- PASS: Insufficient capital blocks execution (`reason=capital_insufficient`, no ledger growth).
+- PASS: Exposure overflow blocks execution (`reason=exposure_limit`, no ledger growth).
+- PASS: Max open positions blocks execution (`reason=max_positions_reached`, no ledger growth).
+- PASS: Daily loss/drawdown breach blocks execution (`reason=drawdown_limit`, no extra execution ledger entry).
+- PASS: Allowed execution path works when guardrails pass (order processed with non-rejected status and ledger increment).
+- PASS: Blocked paths emit structured outcomes (warning logs with `outcome=blocked`, explicit `reason`, and guardrail details).
+
+### Phase 3 — Test proof
+- PASS: `python -m py_compile` for both execution files succeeded.
+- PASS: targeted pytest succeeded (`4 passed`).
+
+### Phase 4 — Failure-mode checks
+- PASS: Active break attempts for each guarded condition did not bypass guardrails.
+- PASS: No ambiguous blocked reason observed in tested paths.
+- PASS: No accidental bypass detected in touched execution boundary scope.
+
+### Phase 5 — Regression scope check
+- PASS: No unintended changes observed in telegram/UI/strategy/infra/websocket/async or wallet-enable surfaces in the validated change set.
+- Note: Verified via HEAD file list for this task commit scope.
+
+## 4. Evidence
+- Preconditions/file existence command:
+  - `for f in PROJECT_STATE.md projects/polymarket/polyquantbot/reports/forge/trade_system_hardening_p3_20260407.md projects/polymarket/polyquantbot/execution/capital_guard.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py; do if [ -f "$f" ]; then echo "FOUND $f"; else echo "MISSING $f"; fi; done`
+  - Output: all `FOUND`.
+- Static proof references:
+  - `projects/polymarket/polyquantbot/execution/engine_router.py`: guardrail wrapper + early rejection return.
+  - `projects/polymarket/polyquantbot/execution/capital_guard.py`: runtime guardrail evaluation and explicit reasons.
+  - `projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py`: targeted negative-path tests.
+- Compile proof:
+  - `python -m py_compile projects/polymarket/polyquantbot/execution/capital_guard.py projects/polymarket/polyquantbot/execution/engine_router.py`
+  - Output: `py_compile_ok`.
+- Targeted pytest proof:
+  - `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py`
+  - Output snippet: `.... [100%]` and `4 passed, 1 warning in 0.07s`.
+- Runtime break-attempt proof command:
+  - `python - <<'PY' ... PY` (custom harness executing five scenarios).
+  - Output snippets:
+    - `{"case": "capital_insufficient", "status": "REJECTED", "reason": "capital_insufficient", "ledger_before": 0, "ledger_after": 0}`
+    - `{"case": "exposure_limit", "status": "REJECTED", "reason": "exposure_limit", "ledger_before": 0, "ledger_after": 0}`
+    - `{"case": "max_positions_reached", "status": "REJECTED", "reason": "max_positions_reached", "ledger_before": 0, "ledger_after": 0}`
+    - `{"case": "drawdown_limit", "status": "REJECTED", "reason": "drawdown_limit", "ledger_before": 1, "ledger_after": 1}`
+    - `{"case": "allowed", "status": "PARTIAL", "reason": "partial_fill", "ledger_before": 0, "ledger_after": 1}`
+- Regression-scope command:
+  - `git show --name-only --pretty=format: HEAD | sed '/^$/d'`
+  - Output: only P3 guardrail target files + forge report + `PROJECT_STATE.md`.
+
+## 5. Critical issues
+- None in validated scope.
+- Non-blocking note: pytest emitted config warning (`Unknown config option: asyncio_mode`), unrelated to guardrail authority objective.
+
+## 6. Verdict
+**APPROVED**
+
+Guardrails are authoritative at execution boundary, required blocked reasons are explicit/structured, tested blocked paths do not execute trades, and allowed path remains functional.


### PR DESCRIPTION
### Motivation
- Enforce authoritative capital/exposure guardrails at the execution boundary so no trade can execute when configured risk limits are breached. 
- Make blocked outcomes deterministic and structured with explicit reasons (`capital_insufficient`, `exposure_limit`, `max_positions_reached`, `drawdown_limit`).
- Provide targeted tests and evidence for SENTINEL validation prior to merge (MAJOR tier change to execution safety). 

### Description
- Added a new guard module `projects/polymarket/polyquantbot/execution/capital_guard.py` implementing runtime checks and a `GuardrailViolation` structured result. 
- Wired guardrails into the execution boundary by modifying `projects/polymarket/polyquantbot/execution/engine_router.py` to wrap `paper_engine.execute_order` with an early-evaluating `_guarded_execute_order` that returns a rejected `PaperOrderResult` when a violation occurs. 
- Added targeted tests at `projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py` covering all blocked paths and an allowed-path case. 
- Added SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_hardening_p3_validation_20260407.md` and updated `PROJECT_STATE.md` to reflect P3 implementation status. 

### Testing
- Ran static compile: `python -m py_compile projects/polymarket/polyquantbot/execution/capital_guard.py projects/polymarket/polyquantbot/execution/engine_router.py` — result: `py_compile_ok`. 
- Ran targeted unit tests: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_hardening_p3_20260407.py` — result: `4 passed` (one non-blocking pytest config warning). 
- Executed a custom runtime harness exercising the negative and positive paths (insufficient capital, exposure overflow, max positions reached, drawdown breach, allowed execution) and observed structured rejected outcomes for each blocked case and successful/partial execution when guardrails passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5808b5d68832e91d916c28ed982a2)