### PR TITLE
sentinel: blocked validation for P4 observability artifacts (2026-04-07)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md
@@ -1,0 +1,93 @@
+## 1. Target
+- Task: validate `trade_system_reliability_observability_p4_20260407` on branch `feature/implement-trade-system-reliability-observability-p4-2026-04-07`.
+- Validation target set provided by COMMANDER:
+  - `PROJECT_STATE.md`
+  - `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+  - `projects/polymarket/polyquantbot/execution/trace_context.py`
+  - `projects/polymarket/polyquantbot/execution/event_logger.py`
+  - `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+  - `projects/polymarket/polyquantbot/core/execution/executor.py`
+  - `projects/polymarket/polyquantbot/execution/engine_router.py`
+  - `projects/polymarket/polyquantbot/core/portfolio/position_manager.py`
+  - `projects/polymarket/polyquantbot/core/portfolio/pnl.py`
+  - `projects/polymarket/polyquantbot/core/wallet_engine.py`
+  - `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+- Validation scope lock decision: phase-gated audit attempted; hard precondition failure in Phase 0 forced stop per instruction (`missing required artifact => BLOCKED`).
+
+## 2. Score
+- Score: **18 / 100**
+- Rationale:
+  - Precondition and artifact integrity failed (missing forge report, missing required observability files, missing target test).
+  - Static/runtime/test proof for requested P4 claims could not be executed as specified.
+  - `PROJECT_STATE.md` indicates P4 as next priority but repository does not contain the declared P4 validation artifacts yet.
+
+## 3. Findings by phase
+- Phase 0 — Preconditions: **FAILED (BLOCKING)**
+  - Forge report missing at declared path.
+  - Target test missing at declared path.
+  - Required observability files missing: `execution/trace_context.py`, `execution/event_logger.py`.
+  - Other listed runtime files exist.
+  - Scope cannot be validated as declared because mandatory artifacts are absent.
+- Phase 1 — Static evidence: **NOT EXECUTED**
+  - Blocked by Phase 0 artifact absence.
+- Phase 2 — Runtime proof: **NOT EXECUTED**
+  - Blocked by Phase 0 artifact absence.
+- Phase 3 — Test proof: **NOT EXECUTED**
+  - Blocked by Phase 0 artifact absence.
+- Phase 4 — Failure-mode checks: **NOT EXECUTED**
+  - Blocked by Phase 0 artifact absence.
+- Phase 5 — Regression scope check: **PARTIAL ONLY**
+  - No targeted runtime regression verification run because validation gate did not pass.
+
+## 4. Evidence
+- Command:
+  - `sed -n '1,260p' PROJECT_STATE.md`
+- Output evidence:
+  - `Last Updated  : 2026-04-07 22:38`
+  - `Next Priority: System Reliability & Observability Layer (P4)`
+- Command:
+  - `sed -n '1,260p' projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+- Output evidence:
+  - `sed: can't read projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md: No such file or directory`
+- Command:
+  - `python - <<'PY' ... Path.exists() ... PY`
+- Output evidence:
+  - `MISS projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+  - `MISS projects/polymarket/polyquantbot/execution/trace_context.py`
+  - `MISS projects/polymarket/polyquantbot/execution/event_logger.py`
+  - `MISS projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+  - Existing files confirmed for other declared paths (`trading_loop.py`, `executor.py`, `engine_router.py`, `position_manager.py`, `pnl.py`, `wallet_engine.py`).
+- Command:
+  - `git branch --show-current && git rev-parse --short HEAD && git status --short`
+- Output evidence:
+  - Current branch reported as `work` (Codex worktree behavior).
+  - Working tree clean before this SENTINEL report creation.
+
+## 5. Critical issues
+- **Critical issue 1: Required forge source report missing.**
+  - Path: `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+  - Impact: SENTINEL cannot anchor validation target/tier/claim traceability to FORGE artifact.
+- **Critical issue 2: Required observability implementation artifacts missing.**
+  - Paths:
+    - `projects/polymarket/polyquantbot/execution/trace_context.py`
+    - `projects/polymarket/polyquantbot/execution/event_logger.py`
+  - Impact: cannot prove trace generation/propagation and structured event emission contract as requested.
+- **Critical issue 3: Required targeted test missing.**
+  - Path: `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+  - Impact: required pytest proof cannot be run; runtime claims remain unverified.
+- **System drift detected:**
+  - component: P4 observability validation artifact set
+  - expected: declared forge report + observability modules + targeted test exist and are testable
+  - actual: required declared artifacts absent in repo at validation time
+
+## 6. Verdict
+**BLOCKED**
+
+Reason:
+- Phase 0 hard preconditions failed. Per COMMANDER rule, missing required artifact requires stop with BLOCKED verdict.
+
+Required unblock actions (FORGE-X):
+1. Add the declared forge report at exact path.
+2. Add/move declared observability files at exact paths.
+3. Add the declared targeted pytest file at exact path.
+4. Re-run SENTINEL validation request with the same target set after artifacts exist.


### PR DESCRIPTION
### Motivation
- Run SENTINEL validation for `trade_system_reliability_observability_p4_20260407` and produce an authoritative validation artifact when preconditions are met. 
- Validation discovered missing required P4 artifacts which must be reported and tracked before any further validation can proceed.

### Description
- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md` containing the required 6 sections and a `BLOCKED` verdict. 
- The report documents Phase 0 precondition failures: the forge report `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`, implementation files `projects/polymarket/polyquantbot/execution/trace_context.py` and `projects/polymarket/polyquantbot/execution/event_logger.py`, and the test `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` were all missing. 
- The report recommends explicit unblock actions for FORGE-X to add the missing artifacts and re-request validation. 

### Testing
- Ran `sed -n '1,260p' PROJECT_STATE.md` to confirm `P4` is the declared next priority and that metadata is present. (PASS)
- Attempted `sed -n '1,260p' projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md` which failed because the file is absent, providing the blocking evidence. (FAIL — blocking)
- Executed a Python existence audit via `python - <<'PY' ... Path.exists() ... PY` which reported `MISS` for the forge report, `trace_context.py`, `event_logger.py`, and the targeted test, and `OK` for other declared files; these results are recorded in the report. (PASS for existence audit; identified missing artifacts)
- Did not run `py_compile` or `pytest` for the P4 targets because Phase 0 preconditions failed; the report documents that the runtime/test phases were not executed. (SKIPPED)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59c8a4600832ea0320b80d28d08f4)