### PR TITLE
sentinel: validate trade_system_reliability_observability_p4 (BLOCKED — missing artifacts)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md
@@ -1,0 +1,200 @@
+# 1. Target
+
+- Task: `trade_system_reliability_observability_p4_20260407`
+- Role: SENTINEL
+- Intent: Validate that P4 observability is materially present, traceable, canonical, and reconstructable for the declared scope.
+- Target branch (requested): `feature/trade-system-reliability-observability-p4-2026-04-07`
+- Validation scope (requested):
+  - `PROJECT_STATE.md`
+  - `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+  - `projects/polymarket/polyquantbot/execution/trace_context.py`
+  - `projects/polymarket/polyquantbot/execution/event_logger.py`
+  - `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+  - `projects/polymarket/polyquantbot/core/execution/executor.py`
+  - `projects/polymarket/polyquantbot/execution/engine_router.py`
+  - `projects/polymarket/polyquantbot/core/portfolio/position_manager.py`
+  - `projects/polymarket/polyquantbot/core/portfolio/pnl.py`
+  - `projects/polymarket/polyquantbot/core/wallet_engine.py`
+  - `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+
+# 2. Score
+
+- **0 / 100**
+
+Rationale:
+- Hard precondition failure in Phase 0: required P4 FORGE artifact and required P4 observability/test files are missing, so runtime/test validation cannot be performed.
+- Per task rules, missing required artifacts forces immediate stop and `BLOCKED`.
+
+# 3. Findings by phase
+
+## Phase 0 — Preconditions
+
+Status: **FAILED (blocking)**
+
+Findings:
+1. Required FORGE report missing:
+   - `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+2. Required target artifacts missing:
+   - `projects/polymarket/polyquantbot/execution/trace_context.py`
+   - `projects/polymarket/polyquantbot/execution/event_logger.py`
+   - `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+3. Scope cannot be validated as declared because mandatory evidence surfaces are absent.
+4. `PROJECT_STATE.md` is not aligned to a completed P4 observability state; it still shows P4 as next priority rather than completed/validated delivery.
+
+Action taken:
+- Validation stopped at Phase 0 as required.
+
+## Phase 1 — Static evidence
+
+Status: **NOT EXECUTED (blocked by Phase 0)**
+
+- Could not inspect claimed P4-specific trace/event files because they do not exist.
+
+## Phase 2 — Runtime proof
+
+Status: **NOT EXECUTED (blocked by Phase 0)**
+
+- Runtime traceability/attribution proof cannot run without required implementation/test artifacts.
+
+## Phase 3 — Test proof
+
+Status: **NOT EXECUTED (blocked by Phase 0)**
+
+- Requested targeted test file is missing; requested py_compile target list is incomplete due missing files.
+
+## Phase 4 — Failure-mode checks
+
+Status: **NOT EXECUTED (blocked by Phase 0)**
+
+- Break attempts not possible on absent P4 observability surfaces.
+
+## Phase 5 — Regression scope check
+
+Status: **PARTIAL ONLY**
+
+- Only coarse drift snapshot was possible (`git log`, file existence checks, forge-report path probes).
+- Full regression assurance is not possible until required artifacts exist.
+
+# 4. Evidence
+
+Commands run and observed outputs:
+
+1. Confirm repository/AGENTS visibility
+
+```bash
+pwd && rg --files -g 'AGENTS.md'
+```
+
+Output snippet:
+
+```text
+/workspace/walker-ai-team
+AGENTS.md
+```
+
+2. Branch/head context snapshot
+
+```bash
+git status --short && git branch --show-current && git rev-parse --abbrev-ref HEAD
+```
+
+Output snippet:
+
+```text
+work
+work
+```
+
+3. Attempt to open required FORGE report
+
+```bash
+sed -n '1,260p' projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md
+```
+
+Output snippet:
+
+```text
+sed: can't read projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md: No such file or directory
+```
+
+4. Search forge reports for P4 observability/reliability artifact
+
+```bash
+rg --files projects/polymarket/polyquantbot/reports/forge | rg 'p4|observability|trade_system_reliability'
+```
+
+Output snippet:
+
+```text
+(no matches)
+```
+
+5. Required target file existence proof
+
+```bash
+for f in PROJECT_STATE.md projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md projects/polymarket/polyquantbot/execution/trace_context.py projects/polymarket/polyquantbot/execution/event_logger.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/execution/engine_router.py projects/polymarket/polyquantbot/core/portfolio/position_manager.py projects/polymarket/polyquantbot/core/portfolio/pnl.py projects/polymarket/polyquantbot/core/wallet_engine.py projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py; do if [ -f "$f" ]; then echo "FOUND $f"; else echo "MISSING $f"; fi; done
+```
+
+Output snippet:
+
+```text
+FOUND PROJECT_STATE.md
+MISSING projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md
+MISSING projects/polymarket/polyquantbot/execution/trace_context.py
+MISSING projects/polymarket/polyquantbot/execution/event_logger.py
+FOUND projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+FOUND projects/polymarket/polyquantbot/core/execution/executor.py
+FOUND projects/polymarket/polyquantbot/execution/engine_router.py
+FOUND projects/polymarket/polyquantbot/core/portfolio/position_manager.py
+FOUND projects/polymarket/polyquantbot/core/portfolio/pnl.py
+FOUND projects/polymarket/polyquantbot/core/wallet_engine.py
+MISSING projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
+```
+
+6. Branch-discovery probe for requested target branch name
+
+```bash
+git branch --all --list '*trade-system-reliability-observability-p4-2026-04-07*' && git log --oneline -n 5
+```
+
+Output snippet:
+
+```text
+(no matching branch listed)
+7290dee update: project state after project_state_sync_after_trade_system_hardening_p3 (#271)
+3a52372 sentinel: validate trade system hardening p3 guardrails (#270)
+...
+```
+
+# 5. Critical issues
+
+1. **Missing authoritative FORGE artifact (hard blocker)**
+   - Missing: `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`
+   - Impact: Validation cannot anchor to declared implementation claim set.
+
+2. **Missing P4 observability implementation files (hard blocker)**
+   - Missing: `projects/polymarket/polyquantbot/execution/trace_context.py`
+   - Missing: `projects/polymarket/polyquantbot/execution/event_logger.py`
+   - Impact: Cannot prove trace generation/propagation or structured event model in declared scope.
+
+3. **Missing targeted P4 test artifact (hard blocker)**
+   - Missing: `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+   - Impact: Required runtime/test proof cannot be executed.
+
+4. **State/report alignment drift**
+   - `PROJECT_STATE.md` currently frames P4 as a next priority, not a completed deliverable validated in this repository snapshot.
+   - Impact: Declared validation objective and repository state are inconsistent.
+
+System drift detected:
+- component: P4 observability validation artifact set
+- expected: forge report + trace/event implementation files + targeted P4 test file present at declared paths
+- actual: multiple required artifacts absent from repository snapshot
+
+# 6. Verdict
+
+**BLOCKED**
+
+Reason:
+- Mandatory Phase 0 preconditions failed.
+- Per instruction, validation must stop when required artifacts are missing.
+- No APPROVED/CONDITIONAL verdict is permissible without the missing artifacts and subsequent successful static/runtime/test proof.


### PR DESCRIPTION
### Motivation

- Validate that the P4 System Reliability & Observability work provides end-to-end trade lifecycle traceability, canonical structured events, and reconstructability for audit, and to confirm required artifacts exist at the declared paths.

### Description

- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_reliability_observability_p4_validation_20260407.md` containing the required six sections (`Target`, `Score`, `Findings by phase`, `Evidence`, `Critical issues`, `Verdict`).
- The report documents that required FORGE and implementation artifacts are missing, records exact evidence commands and outputs, and issues a final verdict of `BLOCKED` because Phase 0 preconditions failed.
- No code/runtime changes were made to implementation files; this change is a sentinel validation artifact only and does not modify runtime modules.

### Testing

- Ran repository and evidence probes including `pwd`, `rg --files`, `git status --short`, `git branch --show-current`, `git rev-parse --abbrev-ref HEAD`, and `git log` to capture HEAD/branch context and report presence, which showed no matching P4 forge report or branch.
- Performed direct file presence checks with a shell loop for each target file (listed in the report), which returned `MISSING` for `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md`, `projects/polymarket/polyquantbot/execution/trace_context.py`, `projects/polymarket/polyquantbot/execution/event_logger.py`, and `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` and `FOUND` for other declared, untargeted files.
- Attempted to open the claimed forge report with `sed -n '1,260p'` which produced `No such file or directory`, documented in the report evidence.
- Did not run `python -m py_compile` or the targeted `pytest` because required implementation/test artifacts were missing, preventing static/runtime/test validation; as a result the overall score is `0/100` and the verdict is `BLOCKED`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5baafb750832e820c3f073e4f2b25)