### PR TITLE
fix: restore P4 observability artifacts for trade_system_reliability_observability_p4_20260407

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 22:38
-- Status        : Trade-System Hardening P3 approved and merged to main; execution-boundary capital/exposure guardrails are now authoritative baseline
+- Last Updated  : 2026-04-08 03:00
+- Status        : P4 observability artifact repair completed on feature branch; required trace/event/test/report artifacts restored for SENTINEL revalidation
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P4 artifact repair complete for `trade_system_reliability_observability_p4_20260407` (2026-04-08): restored missing required artifacts at exact paths (`execution/trace_context.py`, `execution/event_logger.py`, `tests/test_trade_system_p4_observability_20260407.py`, and forge report) with targeted compile/test proof.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
 - SENTINEL validation complete for `trade_system_hardening_p3_20260407` (2026-04-07): verdict **APPROVED**, score **97/100**; execution-boundary capital guardrails verified authoritative with explicit structured block reasons and successful allowed-path execution proof.
 - Telegram/UI text leakage audit pass (2026-04-07): removed `Untitled market (ref ...)` primary-label leakage, hardened user-facing fallback sanitization for placeholder strings (`None`/`N/A`/`null`), and sanitized callback fallback messaging to avoid internal action/error exposure.
@@ -85,6 +86,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P4 observability artifact repair handoff
+- FORGE-X artifact restoration completed with required files created and targeted proof checks passing.
+- Awaiting SENTINEL revalidation for `trade_system_reliability_observability_p4_20260407`.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -107,18 +112,11 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Next Priority:
-System Reliability & Observability Layer (P4)
-
-Focus:
-- end-to-end execution traceability
-- failure observability completeness
-- monitoring consistency
-- audit replay capability
-- alerting readiness
+Codex code review required. COMMANDER review for validation decision. Source: projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- SENTINEL #275 previously BLOCKED due to missing P4 artifacts; revalidation is still pending until COMMANDER triggers SENTINEL on the repaired branch artifacts.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/execution/event_logger.py
+++ b/projects/polymarket/polyquantbot/execution/event_logger.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import structlog
+
+from .trace_context import get_trace_id
+
+log = structlog.get_logger(__name__)
+
+
+class EventLogger:
+    """Emit structured execution observability events."""
+
+    def __init__(self, sink: Callable[[dict[str, Any]], None] | None = None) -> None:
+        self._sink = sink
+
+    def emit_event(
+        self,
+        *,
+        event_type: str,
+        component: str,
+        outcome: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        event_payload: dict[str, Any] = {
+            "trace_id": get_trace_id(),
+            "event_type": event_type,
+            "component": component,
+            "outcome": outcome,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "payload": payload or {},
+        }
+
+        if self._sink is not None:
+            self._sink(event_payload)
+
+        if outcome == "failure":
+            log.warning("execution_observability_event", **event_payload)
+        else:
+            log.info("execution_observability_event", **event_payload)
+
+        return event_payload
+
+    def emit_failure(
+        self,
+        *,
+        event_type: str,
+        component: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return self.emit_event(
+            event_type=event_type,
+            component=component,
+            outcome="failure",
+            payload=payload,
+        )

--- a/projects/polymarket/polyquantbot/execution/trace_context.py
+++ b/projects/polymarket/polyquantbot/execution/trace_context.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Optional
+from uuid import uuid4
+
+_TRACE_ID: ContextVar[Optional[str]] = ContextVar("trade_trace_id", default=None)
+
+
+def generate_trace_id() -> str:
+    """Generate a lightweight UUID4 trace identifier."""
+    return uuid4().hex
+
+
+def get_trace_id() -> str:
+    """Return the current trace identifier, generating one when absent."""
+    trace_id = _TRACE_ID.get()
+    if trace_id:
+        return trace_id
+    new_trace_id = generate_trace_id()
+    _TRACE_ID.set(new_trace_id)
+    return new_trace_id
+
+
+def set_trace_id(trace_id: str) -> None:
+    """Set the current trace identifier for propagation across call chains."""
+    _TRACE_ID.set(trace_id)
+
+
+def clear_trace_id() -> None:
+    """Clear the active trace identifier."""
+    _TRACE_ID.set(None)

--- a/projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md
+++ b/projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md
@@ -1,0 +1,38 @@
+# trade_system_reliability_observability_p4_20260407
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Validation Target: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/trace_context.py`, `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/event_logger.py`, and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` artifact completeness + observability behavior proof.
+- Not in Scope: strategy changes, risk/capital guardrail changes, execution decision logic redesign, architecture modifications.
+
+## 1) What was built
+- Added lightweight trace-context utility (`trace_context.py`) that generates and propagates `trace_id` using standard-library `contextvars` and `uuid4`.
+- Added structured event emitter (`event_logger.py`) that emits observability events with required fields: `trace_id`, `event_type`, `component`, `outcome`, `timestamp`, and `payload`.
+- Added focused P4 observability test artifact (`test_trade_system_p4_observability_20260407.py`) covering trace creation, trace propagation, successful event emission, and structured failure event emission.
+
+## 2) Current system architecture
+- Execution observability now has two dedicated lightweight helpers:
+  1. Trace context boundary (`execution/trace_context.py`) for per-flow `trace_id` lifecycle.
+  2. Structured event emission boundary (`execution/event_logger.py`) for consistent event payload schema.
+- Tests validate artifact behavior directly without changing existing trade decision or risk enforcement flow.
+
+## 3) Files modified
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/trace_context.py` (created)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/event_logger.py` (created)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` (created)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md` (created)
+- `/workspace/walker-ai-team/PROJECT_STATE.md` (updated)
+
+## 4) What is working
+- `trace_id` generation works with no heavy dependencies.
+- `trace_id` propagation works through explicit setter/getter flow.
+- Structured event emission includes all required fields.
+- Failure events are emitted in structured format with `outcome="failure"`.
+- Local `py_compile` and targeted `pytest` pass for the new artifacts.
+
+## 5) Known issues
+- GitHub UI openability depends on remote push; this local task includes commit-ready artifacts and local verification, but UI visibility must be confirmed after push.
+
+## 6) What is next
+- Codex code review required. COMMANDER review for validation decision. Source: projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md. Tier: STANDARD
+- If COMMANDER requests, proceed with SENTINEL validation for the P4 artifact-repair scope.

--- a/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.event_logger import EventLogger
+from projects.polymarket.polyquantbot.execution.trace_context import (
+    clear_trace_id,
+    generate_trace_id,
+    get_trace_id,
+    set_trace_id,
+)
+
+
+def test_trace_id_exists() -> None:
+    clear_trace_id()
+    trace_id = get_trace_id()
+
+    assert isinstance(trace_id, str)
+    assert trace_id
+
+
+def test_trace_id_propagates() -> None:
+    clear_trace_id()
+    expected_trace_id = generate_trace_id()
+    set_trace_id(expected_trace_id)
+
+    assert get_trace_id() == expected_trace_id
+
+
+def test_event_emitted_with_structured_fields() -> None:
+    clear_trace_id()
+    captured_events: list[dict[str, object]] = []
+    logger = EventLogger(sink=captured_events.append)
+
+    event = logger.emit_event(
+        event_type="execution_attempt",
+        component="execution.engine_router",
+        outcome="success",
+        payload={"trade_id": "trade-001"},
+    )
+
+    assert captured_events
+    assert event == captured_events[0]
+    assert event["trace_id"]
+    assert event["event_type"] == "execution_attempt"
+    assert event["component"] == "execution.engine_router"
+    assert event["outcome"] == "success"
+    assert "timestamp" in event
+    assert event["payload"] == {"trade_id": "trade-001"}
+
+
+def test_failure_emits_structured_event() -> None:
+    clear_trace_id()
+    captured_events: list[dict[str, object]] = []
+    logger = EventLogger(sink=captured_events.append)
+
+    event = logger.emit_failure(
+        event_type="execution_attempt",
+        component="execution.engine_router",
+        payload={"reason": "capital_insufficient"},
+    )
+
+    assert captured_events
+    assert event["trace_id"]
+    assert event["event_type"] == "execution_attempt"
+    assert event["component"] == "execution.engine_router"
+    assert event["outcome"] == "failure"
+    assert "timestamp" in event
+    assert event["payload"] == {"reason": "capital_insufficient"}


### PR DESCRIPTION
### Motivation
- SENTINEL #275 was BLOCKED due to missing P4 observability artifacts, so restore the exact required artifacts without changing architecture or execution logic. 
- This is a strict artifact repair to enable SENTINEL revalidation for the reliability/observability P4 work.

### Description
- Added `projects/polymarket/polyquantbot/execution/trace_context.py` providing `generate_trace_id`, `get_trace_id`, `set_trace_id`, and `clear_trace_id` using `contextvars` + `uuid4` for lightweight trace propagation. 
- Added `projects/polymarket/polyquantbot/execution/event_logger.py` implementing `EventLogger.emit_event` and `EventLogger.emit_failure` that emit structured events with `trace_id`, `event_type`, `component`, `outcome`, `timestamp`, and `payload`, and optionally deliver to a sink and to `structlog`. 
- Added `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` validating that `trace_id` exists, propagates, events are emitted with required fields, and failures emit structured events. 
- Added forge report `projects/polymarket/polyquantbot/reports/forge/trade_system_reliability_observability_p4_20260407.md` with the required six sections and validation metadata, and updated `PROJECT_STATE.md`; all changes were committed on branch `feature/trade-system-reliability-observability-p4-2026-04-07`.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/execution/trace_context.py projects/polymarket/polyquantbot/execution/event_logger.py` and the compile check passed. 
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` and the targeted tests passed (`4 passed`). 
- Verified repository structure check for forbidden `phase*` folders and found none. 
- Commit created locally on `feature/trade-system-reliability-observability-p4-2026-04-07`, but `git push` failed in this environment because no `origin` remote is configured, so remote/UI visibility requires a push from an environment with proper GitHub remote access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c4674dc8832e98ce38f2d2c42a25)