### PR TITLE
Fix P4 observability runtime integration — wire trace_id and enforce event contract

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-07 22:38
-- Status        : Trade-System Hardening P3 approved and merged to main; execution-boundary capital/exposure guardrails are now authoritative baseline
+- Last Updated  : 2026-04-08 00:45
+- Status        : P4 observability runtime remediation wired into one real execution lifecycle path; currently In validation (post-merge remediation).
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Trade-system reliability observability P4 runtime remediation pass (2026-04-08): enforced hard event contract validation, wired trace_id creation in trading loop real trade cycle, propagated trace_id into execution path, and emitted runtime `trade_start` / `execution_attempt` / `execution_result` events with lifecycle-focused tests.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
 - SENTINEL validation complete for `trade_system_hardening_p3_20260407` (2026-04-07): verdict **APPROVED**, score **97/100**; execution-boundary capital guardrails verified authoritative with explicit structured block reasons and successful allowed-path execution proof.
 - Telegram/UI text leakage audit pass (2026-04-07): removed `Untitled market (ref ...)` primary-label leakage, hardened user-facing fallback sanitization for placeholder strings (`None`/`N/A`/`null`), and sanitized callback fallback messaging to avoid internal action/error exposure.
@@ -85,6 +86,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P4 observability runtime remediation
+- In validation (post-merge remediation).
+- Scope: one real execution lifecycle path (`run_trading_loop` → `execute_trade`) with strict event contract enforcement and runtime lifecycle event emission proof tests.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -97,8 +102,6 @@ Status:
 - SENTINEL validation pending for `telegram-premium-nav-ux-20260407` (two-layer nav + premium UX consolidation).
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
----
-
 ## ❌ NOT STARTED
 
 - None.
@@ -107,18 +110,13 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Next Priority:
-System Reliability & Observability Layer (P4)
-
-Focus:
-- end-to-end execution traceability
-- failure observability completeness
-- monitoring consistency
-- audit replay capability
-- alerting readiness
+SENTINEL validation required for p4_observability_runtime_integration_fix_2026-04-08 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- P4 observability runtime remediation is currently in validation (post-merge remediation); awaiting SENTINEL final verification for real lifecycle wiring.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/core/execution/executor.py
+++ b/projects/polymarket/polyquantbot/core/execution/executor.py
@@ -59,6 +59,7 @@ from typing import Any, Callable, Awaitable, Optional, Set
 import structlog
 
 from ..signal.signal_engine import SignalResult
+from ...execution.event_logger import emit_event
 
 log = structlog.get_logger()
 
@@ -178,6 +179,7 @@ async def execute_trade(
     kill_switch_active: bool = False,
     executor_callback: Optional[Callable[..., Awaitable[dict[str, Any]]]] = None,
     telegram_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+    trace_id: Optional[str] = None,
 ) -> TradeResult:
     """Validate and execute (or simulate) a single trading signal.
 
@@ -386,6 +388,14 @@ async def execute_trade(
     )
 
     # ── Execution (with single retry) ─────────────────────────────────────────
+    if trace_id is not None:
+        emit_event(
+            trace_id=trace_id,
+            event_type="execution_attempt",
+            component="executor",
+            outcome="started",
+            payload={"trade_id": trade_id, "signal_id": signal.signal_id},
+        )
     result = await _attempt_execution(
         signal=signal,
         trade_id=trade_id,
@@ -407,6 +417,14 @@ async def execute_trade(
             log.info("trade_skipped", trade_id=trade_id, reason=f"retry_failed:{result.reason}")
             async with lock:
                 _open_trade_count = max(0, _open_trade_count - 1)
+            if trace_id is not None:
+                emit_event(
+                    trace_id=trace_id,
+                    event_type="execution_result",
+                    component="executor",
+                    outcome="failed",
+                    payload={"trade_id": trade_id, "reason": result.reason},
+                )
             return result
 
     async with lock:
@@ -439,6 +457,15 @@ async def execute_trade(
         latency_ms=round(result.latency_ms, 2),
         force_mode=signal.force_mode,
     )
+
+    if trace_id is not None:
+        emit_event(
+            trace_id=trace_id,
+            event_type="execution_result",
+            component="executor",
+            outcome="executed",
+            payload={"trade_id": trade_id, "mode": _mode},
+        )
 
     if signal.force_mode:
         log.info(

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -108,6 +108,8 @@ from ..logging.logger import (
     log_loop_throttled,
 )
 from ...telegram.message_formatter import format_trade_alert
+from ...execution.trace_context import generate_trace_id
+from ...execution.event_logger import emit_event
 
 log = structlog.get_logger()
 
@@ -986,6 +988,22 @@ async def run_trading_loop(
                 # ── 4. Execute each signal and update positions ───────────────────
                 _trades_this_tick: int = 0
                 for signal in signals:
+                    trade_context: dict[str, Any] = {
+                        "trace_id": generate_trace_id(),
+                        "signal_id": signal.signal_id,
+                        "market_id": signal.market_id,
+                    }
+                    emit_event(
+                        trace_id=trade_context["trace_id"],
+                        event_type="trade_start",
+                        component="trading_loop",
+                        outcome="started",
+                        payload={
+                            "signal_id": signal.signal_id,
+                            "market_id": signal.market_id,
+                        },
+                    )
+
                     # ── 4a. Force signal mode: max 1 trade per loop ───────────────
                     if _active_force and _trades_this_tick >= 1:
                         log.info(
@@ -1155,6 +1173,7 @@ async def run_trading_loop(
                             signal,
                             mode=_mode,
                             executor_callback=executor_callback,
+                            trace_id=trade_context["trace_id"],
                         )
                         if not result.success:
                             log.info(

--- a/projects/polymarket/polyquantbot/execution/event_logger.py
+++ b/projects/polymarket/polyquantbot/execution/event_logger.py
@@ -1,6 +1,23 @@
 from datetime import datetime
+from typing import Any
 
-def emit_event(trace_id, event_type, component, outcome, payload=None):
+
+def emit_event(
+    trace_id: str,
+    event_type: str,
+    component: str,
+    outcome: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if trace_id is None or str(trace_id).strip() == "":
+        raise ValueError("trace_id is required")
+    if event_type is None or str(event_type).strip() == "":
+        raise ValueError("event_type is required")
+    if component is None or str(component).strip() == "":
+        raise ValueError("component is required")
+    if outcome is None or str(outcome).strip() == "":
+        raise ValueError("outcome is required")
+
     return {
         "trace_id": trace_id,
         "event_type": event_type,

--- a/projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md
@@ -1,0 +1,48 @@
+# 24_2_p4_observability_runtime_integration_fix
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` runtime path into `projects/polymarket/polyquantbot/core/execution/executor.py` with strict event contract checks in `projects/polymarket/polyquantbot/execution/event_logger.py`.
+- Not in Scope: architecture redesign, trading strategy logic, capital/risk guardrail changes, async model changes, multi-path observability expansion.
+- Suggested Next Step: SENTINEL validation
+
+## 1. What was built
+- Enforced hard event contract checks in `emit_event(...)` so required fields (`trace_id`, `event_type`, `component`, `outcome`) now raise `ValueError` on missing/empty input.
+- Wired runtime trace lifecycle into a real trading execution path by generating `trace_id` in `run_trading_loop` trade cycle, attaching it to per-trade context, and emitting `trade_start`.
+- Propagated `trace_id` downstream into `execute_trade(...)` and emitted `execution_attempt` and `execution_result` inside executor runtime.
+- Upgraded P4 test coverage from utility-only checks to a runtime lifecycle flow using a minimal mocked trading-loop execution.
+
+## 2. Current system architecture
+- Narrow runtime integration path implemented:
+  - `run_trading_loop` creates `trade_context.trace_id` for each signal trade cycle.
+  - `run_trading_loop` emits `trade_start` and passes `trace_id` into `execute_trade`.
+  - `execute_trade` emits `execution_attempt` before execution attempt and `execution_result` after final outcome.
+  - `emit_event` enforces required event contract and rejects invalid payload contract inputs.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/execution/event_logger.py`
+- Modified: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- Modified: `projects/polymarket/polyquantbot/core/execution/executor.py`
+- Modified: `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+- Added: `projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Event contract now rejects missing required observability fields with explicit `ValueError`.
+- Trading loop runtime path emits `trade_start` and creates non-empty `trace_id` per trade cycle.
+- Executor runtime emits `execution_attempt` and `execution_result` using same trace ID passed from trading loop.
+- Target test now validates runtime path behavior (trading loop call) and contract-negative behavior.
+
+## 5. Known issues
+- Integration is intentionally narrow to one lifecycle path only; other execution entry paths are not yet wired in this task.
+- SENTINEL runtime verification is still required before merge decision.
+
+## 6. What is next
+- Run SENTINEL validation for this MAJOR runtime integration remediation.
+- If approved, decide whether to expand trace wiring to additional execution paths in a separate scoped task.
+
+## What changed after repeated BLOCK
+- Runtime wiring added on real lifecycle path (`trading_loop` → `execute_trade`).
+- Contract enforced in `emit_event` with strict required-field validation and no fallback.
+- Test upgraded from utility checks to lifecycle proof through trading loop runtime execution.

--- a/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
@@ -1,12 +1,135 @@
-from projects.polymarket.polyquantbot.execution.trace_context import generate_trace_id
+import asyncio
+
+import pytest
+
+from projects.polymarket.polyquantbot.core.execution.executor import reset_state
+from projects.polymarket.polyquantbot.core.pipeline import trading_loop
+from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
 from projects.polymarket.polyquantbot.execution.event_logger import emit_event
 
-def test_trace_id_exists():
-    trace_id = generate_trace_id()
-    assert trace_id is not None
 
-def test_event_structure():
-    event = emit_event("t1", "execution_attempt", "engine", "executed")
-    assert "trace_id" in event
-    assert "event_type" in event
-    assert "outcome" in event
+class _FakeDb:
+    async def get_positions(self, _user_id):
+        return []
+
+    async def upsert_position(self, _payload):
+        return None
+
+    async def insert_trade(self, _payload):
+        return None
+
+    async def update_trade_status(self, *_args, **_kwargs):
+        return None
+
+    async def get_recent_trades(self, limit=500):
+        return []
+
+
+def test_runtime_path_emits_trace_events(monkeypatch):
+    reset_state()
+
+    captured_events = []
+    original_emit = emit_event
+    stop_event = asyncio.Event()
+
+    def _capture_emit(*, trace_id, event_type, component, outcome, payload=None):
+        event = original_emit(
+            trace_id=trace_id,
+            event_type=event_type,
+            component=component,
+            outcome=outcome,
+            payload=payload,
+        )
+        captured_events.append(event)
+        return event
+
+    async def _fake_get_active_markets():
+        stop_event.set()
+        return [{"market_id": "m1", "p_market": 0.55}]
+
+    async def _fake_apply_market_scope(markets):
+        return markets, {
+            "selection_type": "All Markets",
+            "enabled_categories": [],
+            "fallback_applied_count": 0,
+            "all_markets_enabled": True,
+        }
+
+    def _fake_ingest_markets(_markets):
+        return [{"market_id": "m1", "p_market": 0.55}]
+
+    async def _fake_generate_signals(*args, **kwargs):
+        return [
+            SignalResult(
+                signal_id="s1",
+                market_id="m1",
+                side="YES",
+                p_market=0.55,
+                p_model=0.60,
+                edge=0.05,
+                ev=0.10,
+                kelly_f=0.10,
+                size_usd=50.0,
+                liquidity_usd=20_000.0,
+                force_mode=False,
+                extra={},
+            )
+        ]
+
+    monkeypatch.setattr(trading_loop, "emit_event", _capture_emit)
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.execution.executor.emit_event",
+        _capture_emit,
+    )
+    monkeypatch.setattr(trading_loop, "get_active_markets", _fake_get_active_markets)
+    monkeypatch.setattr(trading_loop, "apply_market_scope", _fake_apply_market_scope)
+    monkeypatch.setattr(trading_loop, "ingest_markets", _fake_ingest_markets)
+    monkeypatch.setattr(trading_loop, "generate_signals", _fake_generate_signals)
+
+    asyncio.run(trading_loop.run_trading_loop(
+        mode="PAPER",
+        db=_FakeDb(),
+        stop_event=stop_event,
+        loop_interval_s=0.01,
+        bankroll=1_000.0,
+    ))
+
+    trade_start_events = [e for e in captured_events if e["event_type"] == "trade_start"]
+    execution_attempt_events = [
+        e for e in captured_events if e["event_type"] == "execution_attempt"
+    ]
+    execution_result_events = [
+        e for e in captured_events if e["event_type"] == "execution_result"
+    ]
+
+    assert trade_start_events
+    assert execution_attempt_events
+    assert execution_result_events
+
+    trace_id = trade_start_events[0]["trace_id"]
+    assert trace_id
+    assert execution_attempt_events[0]["trace_id"] == trace_id
+    assert execution_result_events[0]["trace_id"] == trace_id
+
+
+@pytest.mark.parametrize(
+    ("trace_id", "event_type", "component", "outcome"),
+    [
+        (None, "execution_attempt", "executor", "started"),
+        ("", "execution_attempt", "executor", "started"),
+        ("t1", None, "executor", "started"),
+        ("t1", "", "executor", "started"),
+        ("t1", "execution_attempt", None, "started"),
+        ("t1", "execution_attempt", "", "started"),
+        ("t1", "execution_attempt", "executor", None),
+        ("t1", "execution_attempt", "executor", ""),
+    ],
+)
+def test_emit_event_contract_raises_value_error(trace_id, event_type, component, outcome):
+    with pytest.raises(ValueError):
+        emit_event(
+            trace_id=trace_id,
+            event_type=event_type,
+            component=component,
+            outcome=outcome,
+        )


### PR DESCRIPTION
### Motivation
- Address repeated SENTINEL BLOCK findings that observability existed only as utilities and was not wired into a real execution lifecycle.  
- Enforce a strict event contract so monitoring cannot emit incomplete trace data.  
- Provide a single, narrow runtime path proof (`run_trading_loop` → `execute_trade`) so SENTINEL can validate real lifecycle observability.

### Description
- Enforced hard contract in `projects/polymarket/polyquantbot/execution/event_logger.py` so `emit_event(...)` raises `ValueError` when any of `trace_id`, `event_type`, `component`, or `outcome` are missing/empty.  
- Wired runtime trace creation and emission in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` by generating a per-trade `trace_id`, attaching it to a `trade_context`, and emitting a `trade_start` event.  
- Propagated `trace_id` into the execution layer by adding `trace_id` parameter to `execute_trade(...)` calls and minimal downstream plumbing in `projects/polymarket/polyquantbot/core/execution/executor.py`.  
- Added runtime event emissions in executor: `execution_attempt` at start and `execution_result` on final outcome (both success and failed-final-retry paths).  
- Upgraded tests in `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` to exercise the real trading-loop path and to assert negative contract behavior (expect `ValueError` for invalid inputs).  
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md` and updated `PROJECT_STATE.md` to mark P4 as "In validation (post-merge remediation)" with a MAJOR SENTINEL handoff.

### Testing
- Ran byte-compile check: `python -m py_compile projects/polymarket/polyquantbot/execution/event_logger.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` — result: PASS.  
- Ran targeted pytest: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` — final result: PASS (9 passed).  
- Note: an initial pytest run failed due to missing async test plugin handling for `@pytest.mark.asyncio`; the test was adjusted to run the runtime path via `asyncio.run(...)` and was re-run successfully.  
- Verified repository structural checks: `find . -type d -name 'phase*'` returned no forbidden `phase*` folders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fdcf8d88832ea57b9233301072a8)