### PR TITLE
P4: Trace propagation hardening at executor boundary

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 00:45
-- Status        : P4 observability runtime remediation wired into one real execution lifecycle path; currently In validation (post-merge remediation).
+- Last Updated  : 2026-04-08 09:16
+- Status        : P4 trace propagation hardening complete at executor boundary for direct execute_trade invocation; ready for STANDARD-tier Codex code review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P4 trace propagation hardening pass (2026-04-08): enforced deterministic trace_id fallback at `execute_trade` boundary, removed trace-less direct invocation path, and proved `execution_attempt`/`execution_result` emission including failure-path observability for `trace_id=None`.
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): enforced hard event contract validation, wired trace_id creation in trading loop real trade cycle, propagated trace_id into execution path, and emitted runtime `trade_start` / `execution_attempt` / `execution_result` events with lifecycle-focused tests.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
 - SENTINEL validation complete for `trade_system_hardening_p3_20260407` (2026-04-07): verdict **APPROVED**, score **97/100**; execution-boundary capital guardrails verified authoritative with explicit structured block reasons and successful allowed-path execution proof.
@@ -87,8 +88,8 @@ Status:
 ## 🚧 IN PROGRESS
 
 ### P4 observability runtime remediation
-- In validation (post-merge remediation).
-- Scope: one real execution lifecycle path (`run_trading_loop` → `execute_trade`) with strict event contract enforcement and runtime lifecycle event emission proof tests.
+- Direct executor-boundary hardening pass complete for missing/invalid trace_id handling in `execute_trade(...)`.
+- Runtime proof tests executed for negative trace input and retry-exhausted failure observability.
 
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
@@ -110,13 +111,11 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-SENTINEL validation required for p4_observability_runtime_integration_fix_2026-04-08 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md
-Tier: MAJOR
+Codex code review required before merge. COMMANDER review after code review. Source: projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
-- P4 observability runtime remediation is currently in validation (post-merge remediation); awaiting SENTINEL final verification for real lifecycle wiring.
+- Remaining observability coverage is intentionally narrow to executor boundary and direct `execute_trade(...)` call path in this task.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/core/execution/executor.py
+++ b/projects/polymarket/polyquantbot/core/execution/executor.py
@@ -165,6 +165,20 @@ def reset_state() -> None:
     _open_trade_lock = None
 
 
+def _resolve_trace_id(trace_id: Optional[str], signal: SignalResult) -> str:
+    """Return a non-empty trace identifier for execution lifecycle events.
+
+    If a valid trace_id is provided, it is used as-is (after trimming). Otherwise
+    a deterministic fallback id is generated from stable signal identity fields.
+    """
+    if trace_id is not None:
+        normalized_trace_id = trace_id.strip()
+        if normalized_trace_id:
+            return normalized_trace_id
+    deterministic_seed = f"{signal.signal_id}:{signal.market_id}:{signal.side}"
+    return f"trace-{uuid.uuid5(uuid.NAMESPACE_URL, deterministic_seed).hex}"
+
+
 # ── execute_trade ──────────────────────────────────────────────────────────────
 
 
@@ -222,6 +236,7 @@ async def execute_trade(
     )
 
     trade_id = f"trade-{uuid.uuid4().hex[:12]}"
+    execution_trace_id = _resolve_trace_id(trace_id, signal)
 
     # ── Duplicate check ───────────────────────────────────────────────────────
     if signal.signal_id in _submitted_ids:
@@ -388,14 +403,13 @@ async def execute_trade(
     )
 
     # ── Execution (with single retry) ─────────────────────────────────────────
-    if trace_id is not None:
-        emit_event(
-            trace_id=trace_id,
-            event_type="execution_attempt",
-            component="executor",
-            outcome="started",
-            payload={"trade_id": trade_id, "signal_id": signal.signal_id},
-        )
+    emit_event(
+        trace_id=execution_trace_id,
+        event_type="execution_attempt",
+        component="executor",
+        outcome="started",
+        payload={"trade_id": trade_id, "signal_id": signal.signal_id},
+    )
     result = await _attempt_execution(
         signal=signal,
         trade_id=trade_id,
@@ -417,14 +431,13 @@ async def execute_trade(
             log.info("trade_skipped", trade_id=trade_id, reason=f"retry_failed:{result.reason}")
             async with lock:
                 _open_trade_count = max(0, _open_trade_count - 1)
-            if trace_id is not None:
-                emit_event(
-                    trace_id=trace_id,
-                    event_type="execution_result",
-                    component="executor",
-                    outcome="failed",
-                    payload={"trade_id": trade_id, "reason": result.reason},
-                )
+            emit_event(
+                trace_id=execution_trace_id,
+                event_type="execution_result",
+                component="executor",
+                outcome="failed",
+                payload={"trade_id": trade_id, "reason": result.reason},
+            )
             return result
 
     async with lock:
@@ -458,14 +471,13 @@ async def execute_trade(
         force_mode=signal.force_mode,
     )
 
-    if trace_id is not None:
-        emit_event(
-            trace_id=trace_id,
-            event_type="execution_result",
-            component="executor",
-            outcome="executed",
-            payload={"trade_id": trade_id, "mode": _mode},
-        )
+    emit_event(
+        trace_id=execution_trace_id,
+        event_type="execution_result",
+        component="executor",
+        outcome="executed",
+        payload={"trade_id": trade_id, "mode": _mode},
+    )
 
     if signal.force_mode:
         log.info(

--- a/projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md
@@ -1,0 +1,57 @@
+# 24_8_p4_trace_propagation_hardening_20260408
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/core/execution/executor.py` and direct `execute_trade(...)` invocation paths validated by `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`.
+- Not in Scope: strategy logic, risk rules/capital allocation, order placement logic, async/concurrency redesign, multi-path observability expansion, UI/reporting/dashboard changes, unrelated refactors.
+- Suggested Next Step: Codex code review required before merge. COMMANDER review after code review.
+
+## 1. What was built
+- Hardened executor trace propagation at the execution boundary so `execute_trade(...)` always resolves a valid trace identifier before lifecycle event emission.
+- Implemented safe fallback trace resolution for missing/invalid `trace_id` input using deterministic UUIDv5 derived from signal identity fields.
+- Updated executor lifecycle event emission to always emit structured `execution_attempt` and terminal `execution_result` events with the resolved trace ID.
+- Added focused tests for direct executor invocation with `trace_id=None` (negative input) to prove auto-trace behavior and failure-path observability.
+
+## 2. Current system architecture
+- Narrow integration scope for execution boundary:
+  - `execute_trade(...)` resolves `execution_trace_id` via `_resolve_trace_id(trace_id, signal)`.
+  - If caller provides valid trace ID, it is used.
+  - If caller provides missing/blank trace ID, deterministic fallback trace ID is generated from `signal_id:market_id:side`.
+  - Executor emits `execution_attempt` before `_attempt_execution(...)`.
+  - Executor emits `execution_result` with `outcome=executed` on success or `outcome=failed` after retry-exhausted failure.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/core/execution/executor.py`
+- Modified: `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+- Added: `projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- No executor execution attempt path runs without a valid trace ID; missing/blank trace IDs now auto-resolve deterministically.
+- Structured lifecycle events are emitted at executor boundary for direct invocation:
+  - `execution_attempt`
+  - `execution_result`
+- Failure path is observable with trace continuity and explicit terminal event outcome (`failed`).
+- Negative-input proof (`trace_id=None`) demonstrates auto-trace behavior and lifecycle emission.
+
+## 5. Known issues
+- This task intentionally hardens only executor-boundary trace propagation and direct caller behavior for `execute_trade(...)`.
+- Broader multi-entry observability normalization remains out of scope for this STANDARD-tier pass.
+- Pytest environment still reports a non-blocking warning about unknown `asyncio_mode` config option in this container.
+
+## 6. What is next
+- Perform Codex code review for this STANDARD-tier change (changed files + direct dependencies only).
+- COMMANDER review decides merge/hold/rework after code review.
+
+## Runtime behavior changes
+- Before: executor emitted lifecycle events only when non-`None` trace ID was supplied by caller; direct calls with `trace_id=None` created trace-less execution observability at boundary.
+- After: executor deterministically resolves and uses a valid trace ID for lifecycle events even when caller passes `trace_id=None` or blank string.
+
+## Exact test evidence
+1. `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+   - Result: PASS
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+   - Result: PASS (`11 passed`)
+   - Includes negative test for `execute_trade(..., trace_id=None)` proving auto-trace behavior.
+   - Includes failure-path test proving structured `execution_result` emission with `outcome="failed"`.

--- a/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from projects.polymarket.polyquantbot.core.execution import executor
 from projects.polymarket.polyquantbot.core.execution.executor import reset_state
 from projects.polymarket.polyquantbot.core.pipeline import trading_loop
 from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
@@ -133,3 +134,101 @@ def test_emit_event_contract_raises_value_error(trace_id, event_type, component,
             component=component,
             outcome=outcome,
         )
+
+
+def _make_signal(signal_id: str = "s1") -> SignalResult:
+    return SignalResult(
+        signal_id=signal_id,
+        market_id="m1",
+        side="YES",
+        p_market=0.55,
+        p_model=0.60,
+        edge=0.05,
+        ev=0.10,
+        kelly_f=0.10,
+        size_usd=50.0,
+        liquidity_usd=20_000.0,
+        force_mode=False,
+        extra={},
+    )
+
+
+def test_execute_trade_autogenerates_trace_when_missing(monkeypatch):
+    reset_state()
+    captured_events: list[dict[str, object]] = []
+    original_emit = emit_event
+
+    def _capture_emit(*, trace_id, event_type, component, outcome, payload=None):
+        event = original_emit(
+            trace_id=trace_id,
+            event_type=event_type,
+            component=component,
+            outcome=outcome,
+            payload=payload,
+        )
+        captured_events.append(event)
+        return event
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.execution.executor.emit_event",
+        _capture_emit,
+    )
+
+    signal = _make_signal(signal_id="trace-none-case")
+    expected_trace_id = executor._resolve_trace_id(None, signal)
+    result = asyncio.run(executor.execute_trade(signal, mode="PAPER", trace_id=None))
+
+    assert result.success is True
+    assert [e["event_type"] for e in captured_events] == [
+        "execution_attempt",
+        "execution_result",
+    ]
+    assert captured_events[0]["trace_id"] == expected_trace_id
+    assert captured_events[1]["trace_id"] == expected_trace_id
+    assert captured_events[1]["outcome"] == "executed"
+
+
+def test_execute_trade_failure_path_emits_failed_execution_result(monkeypatch):
+    reset_state()
+    captured_events: list[dict[str, object]] = []
+    original_emit = emit_event
+
+    def _capture_emit(*, trace_id, event_type, component, outcome, payload=None):
+        event = original_emit(
+            trace_id=trace_id,
+            event_type=event_type,
+            component=component,
+            outcome=outcome,
+            payload=payload,
+        )
+        captured_events.append(event)
+        return event
+
+    async def _always_fail_callback(**_kwargs):
+        raise RuntimeError("simulated executor failure")
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.execution.executor.emit_event",
+        _capture_emit,
+    )
+
+    signal = _make_signal(signal_id="trace-failure-case")
+    expected_trace_id = executor._resolve_trace_id(None, signal)
+    result = asyncio.run(
+        executor.execute_trade(
+            signal,
+            mode="LIVE",
+            trace_id=None,
+            executor_callback=_always_fail_callback,
+        )
+    )
+
+    assert result.success is False
+    assert result.reason.startswith("execution_exception:")
+    assert [e["event_type"] for e in captured_events] == [
+        "execution_attempt",
+        "execution_result",
+    ]
+    assert captured_events[1]["outcome"] == "failed"
+    assert captured_events[0]["trace_id"] == expected_trace_id
+    assert captured_events[1]["trace_id"] == expected_trace_id


### PR DESCRIPTION
### Motivation
- Eliminate an observability blind spot at the executor boundary so no execution path can run without a valid `trace_id` and lifecycle events remain reconstructable.
- Provide a safe, deterministic fallback when callers omit or pass an empty `trace_id` to `execute_trade(...)` while preserving any valid caller-supplied trace id.

### Description
- Added `_resolve_trace_id(trace_id, signal)` in `projects/polymarket/polyquantbot/core/execution/executor.py` to preserve valid caller-supplied trace ids and deterministically generate a UUIDv5 fallback based on `signal_id:market_id:side` when missing/blank. 
- Updated `execute_trade(...)` to resolve and use `execution_trace_id` for all lifecycle event emissions so `execution_attempt` and terminal `execution_result` always carry a non-empty trace id (including failure/retry-exhausted paths). 
- Extended tests in `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` to prove: auto-generation for `trace_id=None` and failure-path observability (`outcome='failed'`) with trace continuity. 
- Added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md` and updated `PROJECT_STATE.md` to reflect completion and STANDARD-tier handoff to Codex code review. 
- Files changed: `projects/polymarket/polyquantbot/core/execution/executor.py`, `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`, `projects/polymarket/polyquantbot/reports/forge/24_8_p4_trace_propagation_hardening_20260408.md`, and `PROJECT_STATE.md`.

### Testing
- Ran syntax/compile checks with `python -m py_compile projects/polymarket/polyquantbot/core/execution/executor.py projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` and observed PASS. 
- Ran the focused test suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` and observed `11 passed` (one non-blocking pytest config warning about `asyncio_mode`). 
- Ran a targeted verification for the newly added cases with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py -k 'autogenerates_trace_when_missing or failure_path_emits_failed_execution_result'` and observed `2 passed` for the focused checks. 
- Confirmed no forbidden `phase*` folders exist in the repository (structure check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61c5cd040832e8589e8b7c5b169cf)