### PR TITLE
harden executor trace propagation for PR #282

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 00:45
-- Status        : P4 observability runtime remediation wired into one real execution lifecycle path; currently In validation (post-merge remediation).
+- Last Updated  : 2026-04-08 12:20
+- Status        : Executor trace hardening remediation for PR #282 applied on narrow executor path; awaiting COMMANDER re-check after Codex code review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Executor trace hardening remediation for PR #282 (2026-04-08): normalized executor `trace_id` with safe string conversion before trim, bound `execution_trace_id` into executor logger context, and added focused non-string trace normalization regression proof test.
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): enforced hard event contract validation, wired trace_id creation in trading loop real trade cycle, propagated trace_id into execution path, and emitted runtime `trade_start` / `execution_attempt` / `execution_result` events with lifecycle-focused tests.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
 - SENTINEL validation complete for `trade_system_hardening_p3_20260407` (2026-04-07): verdict **APPROVED**, score **97/100**; execution-boundary capital guardrails verified authoritative with explicit structured block reasons and successful allowed-path execution proof.
@@ -86,9 +87,9 @@ Status:
 
 ## 🚧 IN PROGRESS
 
-### P4 observability runtime remediation
-- In validation (post-merge remediation).
-- Scope: one real execution lifecycle path (`run_trading_loop` → `execute_trade`) with strict event contract enforcement and runtime lifecycle event emission proof tests.
+### PR #282 executor trace hardening handoff
+- STANDARD-tier FORGE-X pass complete for executor-only observability hardening.
+- Awaiting COMMANDER re-check on updated PR #282 after Codex code review artifact.
 
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
@@ -110,13 +111,11 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-SENTINEL validation required for p4_observability_runtime_integration_fix_2026-04-08 before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_2_p4_observability_runtime_integration_fix.md
-Tier: MAJOR
+Codex code review required before merge. COMMANDER review after code review. Source: projects/polymarket/polyquantbot/reports/forge/24_3_executor_trace_propagation_hardening.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
-- P4 observability runtime remediation is currently in validation (post-merge remediation); awaiting SENTINEL final verification for real lifecycle wiring.
+- PR #282 executor trace hardening is scoped and complete, but final merge decision is pending COMMANDER re-check after STANDARD-tier code review artifact.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Previous `telegram_trade_menu_mvp_20260407` validation remained blocked until this final routing-contract fix pass; SENTINEL must confirm routing behavior against the new artifacts before merge.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/core/execution/executor.py
+++ b/projects/polymarket/polyquantbot/core/execution/executor.py
@@ -207,6 +207,13 @@ async def execute_trade(
     """
     global _submitted_ids, _open_trade_count
 
+    execution_trace_id: Optional[str] = None
+    if trace_id is not None:
+        normalized_trace_id = str(trace_id).strip()
+        if normalized_trace_id != "":
+            execution_trace_id = normalized_trace_id
+    executor_log = log.bind(execution_trace_id=execution_trace_id)
+
     _mode = (mode or os.getenv("TRADING_MODE", _DEFAULT_MODE)).upper()
     _max_c = max_concurrent if max_concurrent is not None else _env_int(
         "EXECUTION_MAX_CONCURRENT", _MAX_CONCURRENT_TRADES
@@ -225,7 +232,7 @@ async def execute_trade(
 
     # ── Duplicate check ───────────────────────────────────────────────────────
     if signal.signal_id in _submitted_ids:
-        log.info(
+        executor_log.info(
             "trade_skipped",
             trade_id=trade_id,
             signal_id=signal.signal_id,
@@ -351,7 +358,7 @@ async def execute_trade(
     lock = _get_lock()
     async with lock:
         if _open_trade_count >= _max_c:
-            log.info(
+            executor_log.info(
                 "trade_skipped",
                 trade_id=trade_id,
                 signal_id=signal.signal_id,
@@ -375,7 +382,7 @@ async def execute_trade(
     # Mark as submitted (dedup)
     _submitted_ids.add(signal.signal_id)
 
-    log.info(
+    executor_log.info(
         "signal_generated",
         trade_id=trade_id,
         signal_id=signal.signal_id,
@@ -388,9 +395,9 @@ async def execute_trade(
     )
 
     # ── Execution (with single retry) ─────────────────────────────────────────
-    if trace_id is not None:
+    if execution_trace_id is not None:
         emit_event(
-            trace_id=trace_id,
+            trace_id=execution_trace_id,
             event_type="execution_attempt",
             component="executor",
             outcome="started",
@@ -404,9 +411,9 @@ async def execute_trade(
     )
 
     if not result.success:
-        log.info("trade_skipped", trade_id=trade_id, reason=result.reason)
+        executor_log.info("trade_skipped", trade_id=trade_id, reason=result.reason)
         # Retry once
-        log.info("execution_retry", trade_id=trade_id, signal_id=signal.signal_id)
+        executor_log.info("execution_retry", trade_id=trade_id, signal_id=signal.signal_id)
         result = await _attempt_execution(
             signal=signal,
             trade_id=trade_id,
@@ -414,12 +421,12 @@ async def execute_trade(
             executor_callback=executor_callback,
         )
         if not result.success:
-            log.info("trade_skipped", trade_id=trade_id, reason=f"retry_failed:{result.reason}")
+            executor_log.info("trade_skipped", trade_id=trade_id, reason=f"retry_failed:{result.reason}")
             async with lock:
                 _open_trade_count = max(0, _open_trade_count - 1)
-            if trace_id is not None:
+            if execution_trace_id is not None:
                 emit_event(
-                    trace_id=trace_id,
+                    trace_id=execution_trace_id,
                     event_type="execution_result",
                     component="executor",
                     outcome="failed",
@@ -430,7 +437,7 @@ async def execute_trade(
     async with lock:
         _open_trade_count = max(0, _open_trade_count - 1)
 
-    log.info(
+    executor_log.info(
         "trade_executed_realistic",
         trade_id=trade_id,
         signal_id=signal.signal_id,
@@ -445,7 +452,7 @@ async def execute_trade(
         force_mode=signal.force_mode,
     )
     # Keep legacy event name for backwards-compatibility with existing monitors
-    log.info(
+    executor_log.info(
         "trade_executed",
         trade_id=trade_id,
         signal_id=signal.signal_id,
@@ -458,9 +465,9 @@ async def execute_trade(
         force_mode=signal.force_mode,
     )
 
-    if trace_id is not None:
+    if execution_trace_id is not None:
         emit_event(
-            trace_id=trace_id,
+            trace_id=execution_trace_id,
             event_type="execution_result",
             component="executor",
             outcome="executed",
@@ -468,7 +475,7 @@ async def execute_trade(
         )
 
     if signal.force_mode:
-        log.info(
+        executor_log.info(
             "force_trade_executed",
             trade_id=trade_id,
             market_id=signal.market_id,
@@ -486,13 +493,13 @@ async def execute_trade(
                 size=result.filled_size_usd,
                 market_id=signal.market_id,
             )
-            log.info(
+            executor_log.info(
                 "telegram_sent",
                 trade_id=trade_id,
                 market_id=signal.market_id,
             )
         except Exception as tg_exc:  # noqa: BLE001
-            log.warning(
+            executor_log.warning(
                 "telegram_failed",
                 trade_id=trade_id,
                 market_id=signal.market_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_3_executor_trace_propagation_hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3_executor_trace_propagation_hardening.md
@@ -1,0 +1,40 @@
+# 24_3_executor_trace_propagation_hardening
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/core/execution/executor.py` trace normalization + executor-scope logger context binding; focused regression proof in `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`.
+- Not in Scope: strategy logic, risk logic, order semantics, async redesign, broad observability rollout, unrelated refactor.
+- Suggested Next Step: Codex code review required before merge. COMMANDER review after code review.
+
+## 1. What was built
+- Hardened executor trace input handling to avoid non-string `trace_id` attribute failures by normalizing via string conversion before whitespace trim.
+- Added resolved `execution_trace_id` context binding at executor scope so all executor-path logs in `execute_trade(...)` consistently carry trace context.
+- Preserved existing observability fallback behavior: event emission still occurs only when the normalized trace id is non-empty.
+- Added focused test coverage proving non-string trace IDs normalize safely and propagate as string in emitted execution lifecycle events.
+
+## 2. Current system architecture
+- In `execute_trade(...)`, raw `trace_id` input is normalized to `execution_trace_id` using `str(trace_id).strip()` when provided.
+- Executor logger is bound once per call with `execution_trace_id` and reused for executor-scope logging.
+- `emit_event(...)` calls for `execution_attempt` and `execution_result` continue only when a valid normalized trace id exists.
+- Existing execution/risk/order behavior and retry semantics are unchanged.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/core/execution/executor.py`
+- Modified: `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`
+- Added: `projects/polymarket/polyquantbot/reports/forge/24_3_executor_trace_propagation_hardening.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Non-string `trace_id` input no longer risks `.strip()` type errors in executor trace preprocessing.
+- Executor-scope logs inside `execute_trade(...)` now include bound `execution_trace_id` context for consistent correlation.
+- Focused regression test confirms integer trace input (`12345`) is normalized to string (`"12345"`) and used in emitted execution events.
+- Focused py_compile and pytest checks pass for the changed executor path and test module.
+
+## 5. Known issues
+- This patch intentionally hardens only executor-scope observability in one narrow runtime surface.
+- Wider trace-context consistency across non-executor modules remains outside this task scope.
+
+## 6. What is next
+- COMMANDER re-check on updated PR #282.
+- If additional trace-context requirements are identified, handle them in a separate scoped follow-up task.

--- a/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
+++ b/projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from projects.polymarket.polyquantbot.core.execution.executor import reset_state
+from projects.polymarket.polyquantbot.core.execution.executor import execute_trade, reset_state
 from projects.polymarket.polyquantbot.core.pipeline import trading_loop
 from projects.polymarket.polyquantbot.core.signal.signal_engine import SignalResult
 from projects.polymarket.polyquantbot.execution.event_logger import emit_event
@@ -133,3 +133,53 @@ def test_emit_event_contract_raises_value_error(trace_id, event_type, component,
             component=component,
             outcome=outcome,
         )
+
+
+def test_execute_trade_normalizes_non_string_trace_id(monkeypatch):
+    reset_state()
+    captured_events = []
+
+    def _capture_emit(*, trace_id, event_type, component, outcome, payload=None):
+        captured_events.append(
+            {
+                "trace_id": trace_id,
+                "event_type": event_type,
+                "component": component,
+                "outcome": outcome,
+                "payload": payload,
+            }
+        )
+        return {
+            "trace_id": trace_id,
+            "event_type": event_type,
+            "component": component,
+            "outcome": outcome,
+            "payload": payload or {},
+        }
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.core.execution.executor.emit_event",
+        _capture_emit,
+    )
+
+    signal = SignalResult(
+        signal_id="s-trace-int",
+        market_id="m-trace-int",
+        side="YES",
+        p_market=0.40,
+        p_model=0.55,
+        edge=0.15,
+        ev=0.10,
+        kelly_f=0.10,
+        size_usd=25.0,
+        liquidity_usd=20_000.0,
+        force_mode=False,
+        extra={},
+    )
+
+    result = asyncio.run(execute_trade(signal, mode="PAPER", trace_id=12345))
+
+    assert result.success is True
+    assert captured_events
+    assert captured_events[0]["event_type"] == "execution_attempt"
+    assert captured_events[0]["trace_id"] == "12345"


### PR DESCRIPTION
### Motivation
- Fix executor crash risk when `trace_id` is a non-string by normalizing input before calling `.strip()` and improve executor-level logging observability without changing execution semantics.

### Description
- In `projects/polymarket/polyquantbot/core/execution/executor.py` normalize incoming `trace_id` via `str(trace_id).strip()` and store as `execution_trace_id` to avoid `AttributeError` on non-string inputs.
- Bind the resolved `execution_trace_id` into a call-scoped logger (`executor_log = log.bind(execution_trace_id=execution_trace_id)`) and switch executor-scope logs to use `executor_log` so logs consistently carry trace context.
- Preserve existing behavior: `emit_event(...)` is still gated and only called when the normalized trace id is non-empty, so order/risk semantics are unchanged.
- Added a focused regression test in `projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` verifying integer `trace_id` (`12345`) is normalized to string and used in emitted execution events, and added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_3_executor_trace_propagation_hardening.md` and updated `PROJECT_STATE.md` timestamp and next-step handoff.

### Testing
- Ran `python -m py_compile` against the modified module and test file: PASS.
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py` in the default environment: FAIL during collection due to module import path (`ModuleNotFoundError: No module named 'projects'`).
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_trade_system_p4_observability_20260407.py`: PASS (10 tests passed, 1 warning).
- Repository structure check for forbidden `phase*/` folders: PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d647b44d14832e8a2bf6b7f5745c29)