### PR TITLE
sentinel: revalidate telegram_trade_menu_mvp_20260407 (BLOCKED)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 12:41
-- Status        : P4 observability runtime + executor trace hardening is completed (conditional acceptance) and merged; project state synced to current repository truth.
+- Last Updated  : 2026-04-08 13:00
+- Status        : SENTINEL revalidation for telegram_trade_menu_mvp_20260407 is completed with BLOCKED verdict; routing contract is stable but execution-trigger integration remains missing on the Telegram trade action path.
 
 ---
 
@@ -36,6 +36,7 @@
 - SENTINEL trade system truth audit complete (2026-04-07) with verdict **PAPER-ACCEPTABLE WITH RISKS** and score **62/100**; identified critical risk-layer bypass on trading-loop execution path, startup wallet-restore mismatch risk, and partial-state reconciliation gaps blocking real-wallet readiness.
 - Trade-system truth audit report saved at `projects/polymarket/polyquantbot/reports/sentinel/trade_system_truth_audit_20260407.md`.
 - Telegram Trade Menu MVP final fix pass (2026-04-07): added Portfolio `⚡ Trade`, created dedicated 4-action Trade submenu, and corrected callback routing contract so trade actions stay in Trade context without Home fallback.
+- SENTINEL revalidation complete for `telegram_trade_menu_mvp_20260407` (2026-04-08): verdict **BLOCKED**, score **75/100**; Telegram trade menu callback routing is stable and safe, but `trade_paper_execute` remains render-only without execution-trigger integration for the commanded MAJOR validation target.
 - Trade-system hardening P2 restore_failure observability addendum (2026-04-07): added explicit structured restore outcome emission (`restore_failure`/`restore_success`) in engine restore path and added focused proof test `test_trade_system_hardening_p2_20260407.py`.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
@@ -91,9 +92,9 @@ Status:
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
 ### Telegram trade menu MVP blocker-clear handoff
-- Previous validation line for `telegram_trade_menu_mvp_20260407` was blocked due to routing-contract mismatch risk (trade actions could collapse to Home context instead of Trade context).
-- FORGE-X final pass implemented explicit Trade submenu routing and added routing-proof tests (`test_telegram_trade_menu_routing_mvp.py`) with py_compile + pytest evidence.
-- SENTINEL revalidation is now required for `telegram_trade_menu_mvp_20260407`.
+- Previous routing-contract blocker is resolved (trade actions remain in Trade context without Home fallback).
+- Current blocker after revalidation: `trade_paper_execute` still does not trigger execution pipeline integration under commanded MAJOR validation target.
+- FORGE-X follow-up implementation is required before SENTINEL revalidation retry.
 
 ### Telegram post-approval UX consolidation handoff
 - SENTINEL validation pending for `telegram-premium-nav-ux-20260407` (two-layer nav + premium UX consolidation).
@@ -107,12 +108,15 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER routing next: SENTINEL validation for Telegram Trade Menu MVP.
+FORGE-X fix required for telegram_trade_menu_mvp_20260407 before merge.
+Source: projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_revalidation_20260408.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.
+- Telegram Trade Menu MVP remains BLOCKED for MAJOR revalidation scope until `trade_paper_execute` is wired to an execution trigger path that preserves risk-before-execution safeguards.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.

--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_revalidation_20260408.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_revalidation_20260408.md
@@ -1,0 +1,170 @@
+# SENTINEL REVALIDATION REPORT — telegram_trade_menu_mvp_20260407
+
+- Date: 2026-04-08
+- Validation Type: REVALIDATION (previously BLOCKED)
+- Validation Tier: MAJOR (commanded)
+- Claim from FORGE report (exact scope basis): "final narrow routing-contract fix for Telegram Trade Menu MVP under Portfolio context."
+- Validation Target: Telegram UI → handler → trade selection → execution trigger path (no scope expansion)
+- Not in Scope: strategy logic, pricing models, risk math formulas, observability system P4, unrelated UI, external API behavior.
+
+## 🧪 TEST PLAN
+
+Environment: local container, PAPER mode callback-router runtime, targeted pytest, direct async route/dispatch invocations.
+
+Commands run:
+1. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+2. `PYTHONPATH=/workspace/walker-ai-team python - <<'PY' ...` (runtime break-attempt harness: spam clicks, invalid selection, malformed payload injection, empty callback data)
+
+## 🔍 FINDINGS
+
+### 1) Execution Trigger Integrity
+
+Result: **BLOCKED (for execution-trigger integration objective)**
+
+Evidence (code):
+- Trade submenu wires actions: `trade_signal`, `trade_paper_execute`, `trade_kill_switch`, `trade_status`. No direct execution action beyond menu callback contract.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/ui/keyboard.py`
+  - Lines: 74-79
+  - Snippet:
+    ```python
+    return [
+        [_btn("📡 Signal", "trade_signal"), _btn("🧪 Paper Execute", "trade_paper_execute")],
+        [_btn("🛑 Kill Switch", "trade_kill_switch"), _btn("📊 Trade Status", "trade_status")],
+    ]
+    ```
+
+Evidence (code):
+- `trade_paper_execute` normalizes to `trade` render path; no downstream order/execute call in this handler branch.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - Lines: 469-473, 491-494, 523-524, 639-640
+  - Snippet:
+    ```python
+    "trade_paper_execute": "trade",
+    ...
+    if base_action == "trade_paper_execute":
+        payload["decision"] = "Paper execution only — no live-wallet action is performed"
+    ...
+    if base_action.startswith("trade_"):
+        return text, build_trade_menu()
+    ```
+
+Evidence (runtime break attempt):
+- Spam-clicking `trade_paper_execute` 5 times produced stable trade-detail render each time and **zero command-handler execution calls**.
+- Runtime output excerpt:
+  ```text
+  === Break attempt: spam clicks on trade_paper_execute ===
+  0 title_ok= True buttons= 4
+  ...
+  4 title_ok= True buttons= 4
+  cmd_handler_calls []
+  ```
+
+Conclusion: routing fix is valid; execution trigger integration is not present on this path.
+
+### 2) Input Safety
+
+Result: **PASS**
+
+Evidence (code):
+- Invalid callback format is rejected before dispatch.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - Lines: 264-266
+  - Snippet:
+    ```python
+    if not cb_data.startswith(ACTION_PREFIX):
+        log.warning("callback_invalid_format", callback_data=cb_data)
+        return
+    ```
+
+Evidence (runtime break attempt):
+- Empty callback data generated `callback_invalid_format`; no edit/send occurred.
+  ```text
+  callback_invalid_format callback_data=
+  edit_called= 0 send_called= 0
+  ```
+
+### 3) State Consistency
+
+Result: **PASS**
+
+Evidence (tests):
+- Trade action routes keep Trade context keyboard and avoid Home fallback.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+  - Lines: 25-45
+
+Evidence (runtime):
+- Invalid selection index `trade_signal_999` falls to known-safe dashboard action set (no crash/desync).
+  ```text
+  callback_unknown_action action=trade_signal_999
+  has_dashboard_buttons= True
+  ```
+
+### 4) Execution Boundary Protection
+
+Result: **PASS (for non-bypass)**
+
+Evidence (code):
+- Known normalized action list is explicit; unknown/malformed action string does not map to execute path.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - Lines: 600-640
+
+Evidence (runtime break attempt):
+- Payload injection style callback `action:trade_paper_execute;DROP_TABLE` is treated as unknown callback action, not execution.
+  ```text
+  INLINE_UPDATE action=trade_paper_execute;DROP_TABLE
+  callback_unknown_action action=trade_paper_execute;DROP_TABLE
+  ```
+
+### 5) Failure Handling
+
+Result: **PASS**
+
+Evidence (code):
+- Dispatch exceptions render explicit error screen and safe dashboard keyboard fallback.
+  - File: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - Lines: 283-291
+
+Evidence (runtime):
+- Malformed/unknown actions handled with warning + fallback path; no uncaught exception in break harness.
+
+### 6) Runtime Evidence Summary
+
+- Valid flow: targeted pytest pass + runtime dispatch proof.
+- Blocked invalid input: empty callback data rejected pre-dispatch.
+- Failure path: unknown/injected action handled without execution and without silent failure.
+
+## ⚠️ CRITICAL ISSUES
+
+1. **Missing execution-trigger integration on trade menu path for `trade_paper_execute`**
+   - The commanded validation target includes interaction→execution trigger path.
+   - Current behavior is render-only mapping (`trade_paper_execute` → `trade`) with no call into execution pipeline.
+   - This is a blocker for approving execution-trigger integrity within this MAJOR revalidation target.
+
+## 📊 STABILITY SCORE
+
+- Execution Trigger Integrity: 8/25 (routing stable, but no integration trigger path)
+- Input Safety: 18/20
+- State Consistency: 18/20
+- Execution Boundary Protection: 17/20
+- Failure Handling: 14/15
+
+**Total: 75/100**
+
+## 🚫 GO-LIVE STATUS
+
+**VERDICT: BLOCKED**
+
+Reason: Telegram Trade Menu MVP routing contract is stable and input/failure safeguards pass, but the commanded MAJOR revalidation target explicitly includes interaction→execution trigger integration, and `trade_paper_execute` remains render-only in current implementation.
+
+## 🛠 FIX RECOMMENDATIONS
+
+1. Wire `trade_paper_execute` to a dedicated paper-execution trigger handler (explicitly bounded to PAPER mode).
+2. Ensure trigger enters existing risk-before-execution guarded pipeline path (no direct execution bypass).
+3. Add focused negative tests for duplicate click dedup and malformed payload rejection at trigger boundary.
+4. Re-run this same revalidation scope only.
+
+## 📱 TELEGRAM PREVIEW
+
+- Portfolio → ⚡ Trade → Trade submenu shows 4 approved actions correctly.
+- `trade_signal` / `trade_paper_execute` both render Trade Detail context.
+- `trade_kill_switch` renders Control context; `trade_status` renders System Status context.


### PR DESCRIPTION
### Motivation
- Perform a MAJOR revalidation of the Telegram Trade Menu MVP (`telegram_trade_menu_mvp_20260407`) focused on the exact path `Telegram UI → handler → trade selection → execution trigger` to verify the FORGE-X routing fix and confirm whether the menu action actually triggers the execution pipeline. 
- Produce evidence-backed SENTINEL findings (code snippets, file/line references, runtime break attempts) and update repo state to reflect the revalidation outcome.

### Description
- Added a SENTINEL revalidation report at `projects/polymarket/polyquantbot/reports/sentinel/telegram_trade_menu_mvp_revalidation_20260408.md` containing scoped evidence, runtime break attempts, snippets, scoring, verdict, and remediation recommendations. 
- Updated `PROJECT_STATE.md` to record the SENTINEL revalidation timestamp, verdict **BLOCKED**, score **75/100**, and set `NEXT PRIORITY` to request FORGE-X follow-up for the missing execution-trigger integration. 
- Key finding: routing and input/failure safeguards for the Trade submenu are correct, but the `trade_paper_execute` action is render-only (normalizes to the `trade` view) and does not invoke any execution-trigger into the execution pipeline, which blocks approval under the commanded MAJOR validation target. 
- Recommended next step: FORGE-X must wire `trade_paper_execute` to a bounded paper-execution trigger that passes through the risk-before-execution guards and add focused dedup/malformed-payload tests at the trigger boundary.

### Testing
- Ran unit tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` which passed (4 tests passed, 1 warning). 
- Initial `pytest` run without `PYTHONPATH` failed during collection with `ModuleNotFoundError: No module named 'projects'`, which was resolved by setting `PYTHONPATH` as above. 
- Executed a runtime break-attempt harness with `PYTHONPATH=/workspace/walker-ai-team python - <<'PY' ...` exercising spam clicks, invalid selection index, malformed payload injection, and empty callback data; findings show spam clicks render stable trade views with `cmd_handler_calls []`, malformed/injected payloads are treated as unknown actions and do not trigger execution, and empty callback data is rejected pre-dispatch. 
- Result: automated evidence collected and saved; revalidation `VERDICT: BLOCKED` (Score: 75/100) because the commanded interaction→execution trigger integration is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64ff6e114832eb0e8035c01f613da)