### PR TITLE
sentinel: validate telegram trade execution integration fix 20260408 (BLOCKED)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 12:41
-- Status        : P4 observability runtime + executor trace hardening is completed (conditional acceptance) and merged; project state synced to current repository truth.
+- Last Updated  : 2026-04-08 15:35
+- Status        : SENTINEL MAJOR validation for telegram_trade_execution_integration_fix_20260408 completed with BLOCKED verdict; callback execution trigger path remains render-only and requires FORGE-X fix before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- SENTINEL validation complete for `telegram_trade_execution_integration_fix_20260408` (2026-04-08): verdict **BLOCKED**; `trade_paper_execute` callback path confirmed render-only and does not reach execution trigger/pipeline; rework required before merge.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): Completed (Conditional) with hard event contract validation, trading-loop trace_id lifecycle wiring, execution-path trace propagation, and runtime `trade_start` / `execution_attempt` / `execution_result` event emission.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
@@ -87,6 +88,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### Telegram trade execution integration fix handoff
+- MAJOR post-block SENTINEL validation executed for `telegram_trade_execution_integration_fix_20260408`.
+- Validation remains blocked pending FORGE-X fix to wire `trade_paper_execute` callback to authoritative paper execution trigger with risk-before-execution and duplicate protection proof.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -107,10 +112,15 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER routing next: SENTINEL validation for Telegram Trade Menu MVP.
+FORGE-X fix required: wire Telegram `trade_paper_execute` callback to real execution trigger (risk-gated + dedup) before SENTINEL re-validation.
+
+Source: projects/polymarket/polyquantbot/reports/sentinel/24_5_telegram_trade_execution_integration_fix_20260408_validation.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- `trade_paper_execute` callback route currently renders Trade view but does not invoke execution trigger/pipeline in Telegram callback path.
+- Mandatory runtime proof for callback-triggered execution/risk/dedup is currently missing; SENTINEL verdict is BLOCKED until fixed.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_5_telegram_trade_execution_integration_fix_20260408_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_5_telegram_trade_execution_integration_fix_20260408_validation.md
@@ -1,0 +1,173 @@
+# SENTINEL Validation Report
+
+## Task Identity
+- Task: `telegram_trade_execution_integration_fix_20260408`
+- PR: `#288`
+- Validation Type: `MAJOR (POST-BLOCK FIX)`
+- Claim Level: `NARROW INTEGRATION`
+- Validation Target: `Telegram UI → handler → trade_paper_execute → execution trigger → execution pipeline`
+- Not in Scope: strategy logic, pricing models, risk math formulas, observability system, UI redesign, unrelated Telegram flows
+- Validation Date (UTC): `2026-04-08 15:33`
+
+## 1) What was validated
+- Verified callback router behavior for `trade_paper_execute` route in Telegram callback path.
+- Verified whether callback path triggers real execution (or only render/UX fallback).
+- Performed mandatory break attempts:
+  - spam clicks
+  - invalid selection
+  - malformed payload
+  - direct handler invocation
+
+## 2) Validation approach and architecture path
+Target path reviewed:
+- Telegram callback dispatch in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Trade handler module in `projects/polymarket/polyquantbot/telegram/handlers/trade.py`
+- Command handler trade execution path in `projects/polymarket/polyquantbot/telegram/command_handler.py`
+
+Validation method:
+1. Static route verification with file+line evidence.
+2. Runtime behavior verification via direct async invocation of `CallbackRouter._dispatch("trade_paper_execute")`.
+3. Negative/break testing with malformed/unknown payload and repeated click simulation.
+
+## 3) Files reviewed (full paths)
+- `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- `projects/polymarket/polyquantbot/telegram/handlers/trade.py`
+- `projects/polymarket/polyquantbot/telegram/command_handler.py`
+- `projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+
+## 4) Findings with required evidence
+
+### A. Execution Trigger (CRITICAL) — **FAIL**
+Expected:
+- `trade_paper_execute` callback must trigger real paper execution path.
+
+Observed:
+- Callback action `trade_paper_execute` is normalized to `trade` view rendering path and returns rendered menu content.
+- There is no invocation of execution trigger (`StrategyTrigger`, execution engine open/close, or dedicated paper execute handler) in this callback path.
+
+Code evidence:
+- In callback normalization, `trade_paper_execute` maps to `trade` render context.
+- In callback dispatch, normalized actions short-circuit into `_render_normalized_callback(action)` and return text + keyboard without execution call.
+- Actual execution logic exists only in `/trade test ...` command handler path, not in callback action route.
+
+Runtime proof:
+- Instrumented `projects.polymarket.polyquantbot.telegram.handlers.trade.handle_trade` with `AsyncMock`; dispatched `trade_paper_execute`; await count remained `0`.
+- This confirms callback route does not even invoke trade handler execution surface.
+
+### B. Risk Layer Enforcement (Telegram → RISK → EXECUTION) — **FAIL (NOT VERIFIABLE DUE TO MISSING TRIGGER)**
+Expected:
+- Telegram callback execution must pass through risk gate before execution.
+
+Observed:
+- Because callback does not trigger execution pipeline, risk-before-execution flow is never entered for `trade_paper_execute`.
+- No enforceable proof of Telegram callback -> risk -> execution path exists in current route.
+
+Conclusion:
+- Validation target for risk chain is unmet because trigger path is absent.
+
+### C. Duplicate Protection (spam clicks) — **FAIL (TARGET BEHAVIOR ABSENT)**
+Expected:
+- Repeated rapid clicks should not produce duplicate execution.
+
+Observed:
+- Repeated clicks produce repeated rendered responses and repeated callback dispatch logs.
+- Since no execution trigger occurs, duplicate execution protection is not demonstrably implemented for this callback route.
+
+Conclusion:
+- Requirement not satisfied for the declared integration target.
+
+### D. Input Safety (invalid payload rejection) — **PASS (LIMITED TO UI ROUTER LEVEL)**
+Observed:
+- Unknown/malformed action is routed to explicit "Unknown action" response and no execution call is attempted.
+
+Conclusion:
+- Invalid callback payload is rejected at router/UI layer for unknown action.
+
+### E. Failure Handling (user feedback + no silent failure) — **PARTIAL PASS**
+Observed:
+- Unknown action returns user-facing warning text.
+- Render failure path has logged fallback behavior.
+- However, required execution-failure feedback cannot be validated because execution is not reached from callback route.
+
+Conclusion:
+- General callback failure feedback exists; execution failure UX in target callback path remains unproven.
+
+## 5) Mandatory break attempts (results)
+1. Spam clicks (`trade_paper_execute` dispatched 3x quickly):
+   - Result: repeated callback dispatch + rendered output, no execution proof.
+2. Invalid selection (`unknown_malformed_payload`):
+   - Result: explicit unknown action warning, no execution.
+3. Malformed payload (invalid callback action string):
+   - Result: falls into unknown-action branch, no execution.
+4. Direct handler invocation attempt:
+   - Result: direct `_dispatch("trade_paper_execute")` invocation confirms render-only route; no trade execution call observed.
+
+## 6) Runtime proof artifacts
+### Command: targeted runtime probe
+```bash
+python - <<'PY'
+import asyncio
+from unittest.mock import AsyncMock, patch
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+class DummyCmd: pass
+class DummyState:
+    def snapshot(self):
+        return {"state":"RUNNING"}
+class DummyCfg:
+    def snapshot(self):
+        class S:
+            risk_multiplier=0.25
+            max_position=0.1
+            auto_trade_enabled=False
+            notify_enabled=True
+            mode="PAPER"
+        return S()
+
+async def main():
+    r=CallbackRouter("http://x",DummyCmd(),DummyState(),DummyCfg(),mode="PAPER")
+    with patch('projects.polymarket.polyquantbot.telegram.handlers.trade.handle_trade', new=AsyncMock(return_value=("TRADE", []))) as ht:
+        out = await r._dispatch('trade_paper_execute', user_id=1)
+        print('dispatch_ok', isinstance(out, tuple), len(out[0])>0)
+        print('handle_trade_called', ht.await_count)
+
+    for _ in range(3):
+        await r._dispatch('trade_paper_execute', user_id=1)
+
+    text,_=await r._dispatch('unknown_malformed_payload', user_id=1)
+    print('unknown_contains_notice', 'Unknown action' in text)
+
+asyncio.run(main())
+PY
+```
+
+### Key output
+- `handle_trade_called 0` (execution path not reached from callback).
+- `unknown_contains_notice True` (invalid payload rejected with user feedback).
+
+### Additional check
+```bash
+PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+```
+- Result: pass (menu routing contract only; does not prove execution trigger).
+
+## 7) Verdict
+- **BLOCKED**
+
+Reason:
+- Critical validation requirement failed: `trade_paper_execute` does not trigger real execution path.
+- Claimed narrow integration target (callback -> execution trigger -> execution pipeline) is not met in current code.
+
+## 8) Required fix before re-validation
+1. Wire `trade_paper_execute` callback to authoritative paper-execution trigger (not render-only fallback).
+2. Enforce explicit risk gate before execution invocation on callback path.
+3. Add idempotency/dedup guard for rapid repeated callback activation.
+4. Add focused tests proving:
+   - execution is called exactly once for valid callback
+   - invalid payload blocked with no execution
+   - spam clicks do not create duplicate execution
+   - failure path returns user feedback with structured logging
+
+## 9) Suggested next step
+- Return to FORGE-X for targeted callback->execution integration fix.
+- Re-run SENTINEL MAJOR validation after fix with runtime proof (logs/tests) across trigger, risk enforcement, dedup, and invalid payload handling.


### PR DESCRIPTION
### Motivation
- Perform MAJOR post-block SENTINEL validation for `telegram_trade_execution_integration_fix_20260408` to verify Telegram → handler → `trade_paper_execute` → execution trigger → execution pipeline integration. 
- Confirm that the callback path enforces risk-before-execution, prevents duplicate executions, and rejects malformed inputs per the validation target.

### Description
- Added SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/24_5_telegram_trade_execution_integration_fix_20260408_validation.md` documenting scope, approach, evidence, findings, and verdict **BLOCKED**. 
- Updated `PROJECT_STATE.md` (Last Updated: `2026-04-08 15:35`) to record the BLOCKED verdict, add the sentinel report to `COMPLETED PHASES`, and set `NEXT PRIORITY` to require a FORGE-X fix (wire callback → risk-gated execution + dedup) before re-validation. 
- Key finding: `trade_paper_execute` in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` is normalized to a render-only `trade` view and does not invoke the execution trigger; authoritative execution logic exists only in the `/trade test ...` command handler (`projects/polymarket/polyquantbot/telegram/command_handler.py`). 
- Conclusions recorded: missing execution trigger on callback path, no demonstrable risk gate for callback-triggered execution, duplicate-protection not verifiable for callback route, and router-level invalid payload handling is present.

### Testing
- Runtime probe: executed an instrumented async probe that dispatched `CallbackRouter._dispatch('trade_paper_execute')`, simulated spam clicks, and malformed payloads; probe output shows `handle_trade` not called (`handle_trade_called 0`) and unknown action returns user-facing warning. (PASS for router rejection behavior; FAIL for execution trigger requirement). 
- Unit test run: `pytest` initially failed in this environment without `PYTHONPATH` set due to import path resolution (`ModuleNotFoundError: No module named 'projects'`), and passed when run with `PYTHONPATH=.`, specifically `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` (tests for routing contract only). 
- Repo structure checks: confirmed no `phase*` folders present. 

Report: `projects/polymarket/polyquantbot/reports/sentinel/24_5_telegram_trade_execution_integration_fix_20260408_validation.md` 
State: `PROJECT_STATE.md` updated (Last Updated: `2026-04-08 15:35`) 
Validation Tier: MAJOR 
Claim Level: NARROW INTEGRATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6740676c8832ea59dc55ee7d7ad1f)