### PR TITLE
fix: wire trade_paper_execute callback to bounded paper execution path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 12:41
-- Status        : P4 observability runtime + executor trace hardening is completed (conditional acceptance) and merged; project state synced to current repository truth.
+- Last Updated  : 2026-04-08 15:48
+- Status        : Telegram callback execution wiring fix for `trade_paper_execute` is implemented with shared bounded execution path + duplicate protection; SENTINEL MAJOR revalidation pending before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Telegram callback execution wiring fix pass (2026-04-08): `trade_paper_execute` callback route now uses shared bounded paper execution entry path instead of render-only normalization; callback payload validation, duplicate-execute protection, and visible blocked/failure feedback added with focused execution wiring tests.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): Completed (Conditional) with hard event contract validation, trading-loop trace_id lifecycle wiring, execution-path trace propagation, and runtime `trade_start` / `execution_attempt` / `execution_result` event emission.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
@@ -87,6 +88,11 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### Telegram callback execution wiring MAJOR handoff
+- FORGE-X fix for `trade_paper_execute` callback execution path is complete.
+- Shared execution path proof added for callback and `/trade test` command flows.
+- SENTINEL revalidation is required before merge for this MAJOR task.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -107,10 +113,13 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER routing next: SENTINEL validation for Telegram Trade Menu MVP.
+SENTINEL validation required for telegram callback execution wiring before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_2_telegram_callback_execution_wiring.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- Callback execute path currently requires valid callback action payload state (`trade_paper_execute|market|side|size`) for execution trigger; empty execute state is now explicitly blocked with visible feedback.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_callback_execution_wiring.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_callback_execution_wiring.md
@@ -1,0 +1,69 @@
+# FORGE-X REPORT — 24_2_telegram_callback_execution_wiring
+
+## 1. What was built
+- Fixed Telegram callback execution wiring so `trade_paper_execute` no longer normalizes to render-only trade view.
+- Added callback payload parsing for `trade_paper_execute|market|side|size` and route-level trigger-boundary validation.
+- Wired callback execute path to the shared bounded paper execution entry point in `CommandHandler.execute_bounded_paper_trade(...)`.
+- Added callback-visible failure feedback for malformed payload, empty action state, and execution blocked/failed outcomes.
+- Added duplicate-click protection via shared dedup key handling on callback-triggered execution.
+- Refactored `/trade test` command path to use the same bounded shared execution function.
+
+Validation metadata:
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` callback route for `trade_paper_execute`, shared bounded execution entry wiring, risk-gated execution path invocation, duplicate-protection behavior.
+- Not in Scope: strategy logic, pricing models, risk formulas, observability rework, UI redesign, unrelated Telegram handlers, async redesign outside callback-trigger execution path.
+- Suggested Next Step: SENTINEL validation required for telegram callback execution wiring before merge.
+
+## 2. Current system architecture
+- Callback route flow for execute action now follows:
+  - `callback_query(data="action:trade_paper_execute|...")`
+  - `CallbackRouter.route(...)` parses action + payload + callback signature
+  - `CallbackRouter._dispatch("trade_paper_execute", action_payload=..., callback_signature=...)`
+  - payload validation (format, market, side, size)
+  - shared bounded execution call: `CommandHandler.execute_bounded_paper_trade(...)`
+  - bounded execution path runs strategy-triggered paper path and exports execution payload
+  - callback response returns visible success/blocked message with Trade keyboard
+- `/trade test [market] [side] [size]` now uses the same `execute_bounded_paper_trade(...)` shared entry point.
+- Duplicate callback click protection is enforced via dedup key with TTL in shared execution path.
+
+## 3. Files created / modified (full paths)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` (modified)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py` (modified)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` (modified)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py` (created)
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_callback_execution_wiring.md` (created)
+- `/workspace/walker-ai-team/PROJECT_STATE.md` (modified)
+
+## 4. What is working
+- Valid callback execute payload reaches shared bounded execution entry point.
+- Callback-triggered execute no longer falls back to render-only trade normalization path.
+- Duplicate callback execute attempts with same dedup key are blocked deterministically.
+- Malformed callback payloads are blocked before execution.
+- Empty callback action state for execute is blocked with visible feedback.
+- Blocked execution returns visible feedback to Telegram callback flow.
+- Command-triggered `/trade test` and callback-triggered execute now share the same bounded execution path.
+
+Runtime proof / test evidence:
+- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py`
+  - 6 passed
+  - includes proof cases:
+    - valid callback execute reaches shared execution entry
+    - duplicate-click protection blocks second callback execution
+    - malformed payload blocked
+    - failure-path feedback visible
+    - command path + callback path both use shared execution function
+- `python -m py_compile ...` on touched modules/tests passed.
+
+## 5. Known issues
+- Existing `pytest` config warning (`Unknown config option: asyncio_mode`) remains in repository test environment; does not block targeted test execution.
+- Keyboard button currently sends `action:trade_paper_execute` without inline payload in this narrow fix scope; execution requires valid callback action payload state from triggering context.
+
+## 6. What is next
+- SENTINEL revalidation required for this MAJOR task before merge.
+- Validation handoff target:
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - `projects/polymarket/polyquantbot/telegram/command_handler.py`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py`
+- Next step statement:
+  - SENTINEL validation required for telegram callback execution wiring before merge.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -102,6 +102,9 @@ class CommandHandler:
         self._risk_guard = risk_guard
         self._mode = mode
         self._lock = asyncio.Lock()
+        self._paper_execution_lock = asyncio.Lock()
+        self._paper_execution_dedup: dict[str, float] = {}
+        self._paper_execution_dedup_ttl_s = 4.0
         self._runner: Optional[object] = None  # wired after pipeline starts
 
         log.info(
@@ -360,30 +363,102 @@ class CommandHandler:
                 success=False,
                 message="Side must be YES or NO.",
             )
-        engine = get_execution_engine()
-        trigger = StrategyTrigger(
-            engine=engine,
-            config=StrategyConfig(
-                market_id=market,
-                side=side,
-                threshold=0.45,
-                target_pnl=20.0,
-            ),
+        return await self.execute_bounded_paper_trade(
+            market=market,
+            side=side,
+            size=size,
+            source="telegram_command_trade_test",
+            dedup_key=None,
         )
-        await trigger.evaluate(0.42)
-        await engine.update_mark_to_market({market: 0.46})
-        payload = await export_execution_payload()
-        get_portfolio_service().merge_execution_state(
-            positions=payload.get("positions", []),
-            cash=float(payload.get("cash", 0.0)),
-            equity=float(payload.get("equity", 0.0)),
-            realized_pnl=float(payload.get("realized", 0.0)),
-        )
-        return CommandResult(
-            success=True,
-            message=await render_view("positions", payload),
-            payload=payload,
-        )
+
+    async def execute_bounded_paper_trade(
+        self,
+        market: str,
+        side: str,
+        size: float,
+        source: str,
+        dedup_key: Optional[str],
+    ) -> CommandResult:
+        """Execute bounded paper trade using shared command/callback path."""
+        normalized_market = (market or "").strip()
+        normalized_side = (side or "").strip().upper()
+
+        if not normalized_market:
+            return CommandResult(success=False, message="Trade execution blocked: market is required.")
+        if normalized_side not in ("YES", "NO"):
+            return CommandResult(success=False, message="Trade execution blocked: side must be YES or NO.")
+        if size <= 0:
+            return CommandResult(success=False, message="Trade execution blocked: size must be greater than 0.")
+
+        now = time.monotonic()
+        async with self._paper_execution_lock:
+            self._paper_execution_dedup = {
+                key: ts
+                for key, ts in self._paper_execution_dedup.items()
+                if now - ts < self._paper_execution_dedup_ttl_s
+            }
+            if dedup_key is not None and dedup_key in self._paper_execution_dedup:
+                log.warning(
+                    "paper_trade_duplicate_blocked",
+                    dedup_key=dedup_key,
+                    source=source,
+                    market=normalized_market,
+                    side=normalized_side,
+                    size=size,
+                )
+                return CommandResult(
+                    success=False,
+                    message="Duplicate execute request blocked. Please wait before retrying.",
+                )
+            if dedup_key is not None:
+                self._paper_execution_dedup[dedup_key] = now
+
+        try:
+            engine = get_execution_engine()
+            trigger = StrategyTrigger(
+                engine=engine,
+                config=StrategyConfig(
+                    market_id=normalized_market,
+                    side=normalized_side,
+                    threshold=0.45,
+                    target_pnl=20.0,
+                ),
+            )
+            await trigger.evaluate(0.42)
+            await engine.update_mark_to_market({normalized_market: 0.46})
+            payload = await export_execution_payload()
+            get_portfolio_service().merge_execution_state(
+                positions=payload.get("positions", []),
+                cash=float(payload.get("cash", 0.0)),
+                equity=float(payload.get("equity", 0.0)),
+                realized_pnl=float(payload.get("realized", 0.0)),
+            )
+            log.info(
+                "paper_trade_execute_success",
+                source=source,
+                market=normalized_market,
+                side=normalized_side,
+                size=size,
+            )
+            return CommandResult(
+                success=True,
+                message=await render_view("positions", payload),
+                payload=payload,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.error(
+                "paper_trade_execute_failed",
+                source=source,
+                market=normalized_market,
+                side=normalized_side,
+                size=size,
+                error=str(exc),
+                exc_info=True,
+            )
+            return CommandResult(
+                success=False,
+                message=f"Paper execution failed: {exc}",
+            )
 
     async def _handle_trade_close(self, args: str) -> CommandResult:
         """Parse /trade close [market]."""

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -22,6 +22,7 @@ Design:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import Optional, TYPE_CHECKING
 
 import structlog
@@ -277,7 +278,13 @@ class CallbackRouter:
             if any(x in cb_data for x in ("health", "strategies")):
                 log.warning("callback_legacy_blocked", callback_data=cb_data)
                 raise RuntimeError("LEGACY UI DISABLED")
-            text, keyboard = await self._dispatch(action, user_id=user_id)
+            action_name, action_payload = self._split_action(action)
+            text, keyboard = await self._dispatch(
+                action_name,
+                user_id=user_id,
+                action_payload=action_payload,
+                callback_signature=self._callback_signature(chat_id, message_id, action),
+            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -374,6 +381,36 @@ class CallbackRouter:
         if action.startswith("help_") or action in {"help", "guidance", "bot_info"}:
             return "help"
         return "dashboard"
+
+    @staticmethod
+    def _split_action(action: str) -> tuple[str, str]:
+        if "|" not in action:
+            return action, ""
+        name, payload = action.split("|", 1)
+        return name, payload.strip()
+
+    @staticmethod
+    def _callback_signature(chat_id: Optional[int], message_id: Optional[int], action: str) -> str:
+        raw = f"{chat_id}:{message_id}:{action}".encode("utf-8")
+        return hashlib.sha256(raw).hexdigest()[:20]
+
+    @staticmethod
+    def _parse_trade_execute_payload(payload: str) -> tuple[str, str, float]:
+        fields = [part.strip() for part in payload.split("|")]
+        if len(fields) != 3:
+            raise ValueError("Malformed execute payload. Expected market|side|size.")
+        market, side, size_raw = fields
+        if not market:
+            raise ValueError("Invalid trade selection: market is empty.")
+        if side.upper() not in {"YES", "NO"}:
+            raise ValueError("Invalid trade selection: side must be YES or NO.")
+        try:
+            size = float(size_raw)
+        except ValueError as exc:
+            raise ValueError("Invalid trade selection: size must be numeric.") from exc
+        if size <= 0:
+            raise ValueError("Invalid trade selection: size must be greater than 0.")
+        return market, side.upper(), size
 
     def _build_normalized_payload(self, action: str) -> dict[str, object]:
         state_snapshot = self._state.snapshot()
@@ -562,7 +599,13 @@ class CallbackRouter:
 
     # ── Dispatch table ─────────────────────────────────────────────────────────
 
-    async def _dispatch(self, action: str, user_id: Optional[int] = None) -> tuple[str, list]:
+    async def _dispatch(
+        self,
+        action: str,
+        user_id: Optional[int] = None,
+        action_payload: str = "",
+        callback_signature: Optional[str] = None,
+    ) -> tuple[str, list]:
         """Route ``action`` to the correct handler.
 
         Args:
@@ -606,7 +649,6 @@ class CallbackRouter:
             "portfolio_performance",
             "portfolio_trade",
             "trade_signal",
-            "trade_paper_execute",
             "trade_kill_switch",
             "trade_status",
             "markets_overview",
@@ -638,6 +680,70 @@ class CallbackRouter:
         }
         if action in normalized_actions:
             return await self._render_normalized_callback(action)
+
+        if action == "trade_paper_execute":
+            if not action_payload:
+                return (
+                    "\n".join(
+                        [
+                            "⚠️ *Paper Execute Blocked*",
+                            "",
+                            "_No action state provided. Use a valid trade selection before executing._",
+                        ]
+                    ),
+                    build_trade_menu(),
+                )
+            try:
+                market, side, size = self._parse_trade_execute_payload(action_payload)
+            except ValueError as parse_error:
+                log.warning(
+                    "callback_trade_execute_invalid_payload",
+                    payload=action_payload,
+                    error=str(parse_error),
+                )
+                return (
+                    "\n".join(
+                        [
+                            "⚠️ *Paper Execute Blocked*",
+                            "",
+                            f"_{parse_error}_",
+                        ]
+                    ),
+                    build_trade_menu(),
+                )
+
+            result = await self._cmd.execute_bounded_paper_trade(
+                market=market,
+                side=side,
+                size=size,
+                source="telegram_callback_trade_paper_execute",
+                dedup_key=f"callback:{callback_signature}:{market}:{side}:{size}",
+            )
+            if result.success:
+                log.info(
+                    "callback_trade_execute_success",
+                    market=market,
+                    side=side,
+                    size=size,
+                )
+                return result.message, build_trade_menu()
+            log.warning(
+                "callback_trade_execute_blocked",
+                market=market,
+                side=side,
+                size=size,
+                reason=result.message,
+            )
+            return (
+                "\n".join(
+                    [
+                        "⚠️ *Paper Execute Blocked*",
+                        "",
+                        result.message,
+                    ]
+                ),
+                build_trade_menu(),
+            )
 
         if action == "markets_all_toggle":
             await toggle_all_markets()

--- a/projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler, CommandResult
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+class _DummyEngine:
+    async def update_mark_to_market(self, _payload: dict[str, float]) -> None:
+        return None
+
+
+def _make_command_handler() -> CommandHandler:
+    return CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+    )
+
+
+def _make_router(cmd_handler: CommandHandler | MagicMock) -> CallbackRouter:
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def test_callback_execute_valid_payload_reaches_shared_execution_entry() -> None:
+    cmd = MagicMock()
+    cmd.execute_bounded_paper_trade = AsyncMock(
+        return_value=CommandResult(success=True, message="EXECUTED", payload={})
+    )
+    router = _make_router(cmd)
+
+    text, _ = asyncio.run(
+        router._dispatch(
+            "trade_paper_execute",
+            action_payload="market-1|YES|5",
+            callback_signature="sig-1",
+        )
+    )
+
+    assert text == "EXECUTED"
+    cmd.execute_bounded_paper_trade.assert_awaited_once()
+
+
+def test_callback_execute_rejects_malformed_payload_without_execution() -> None:
+    cmd = MagicMock()
+    cmd.execute_bounded_paper_trade = AsyncMock()
+    router = _make_router(cmd)
+
+    text, _ = asyncio.run(
+        router._dispatch(
+            "trade_paper_execute",
+            action_payload="bad-payload",
+            callback_signature="sig-1",
+        )
+    )
+
+    assert "Paper Execute Blocked" in text
+    assert "Malformed execute payload" in text
+    cmd.execute_bounded_paper_trade.assert_not_called()
+
+
+def test_callback_execute_failure_feedback_is_visible() -> None:
+    cmd = MagicMock()
+    cmd.execute_bounded_paper_trade = AsyncMock(
+        return_value=CommandResult(success=False, message="Risk blocked execution", payload={})
+    )
+    router = _make_router(cmd)
+
+    text, _ = asyncio.run(
+        router._dispatch(
+            "trade_paper_execute",
+            action_payload="market-1|NO|2",
+            callback_signature="sig-1",
+        )
+    )
+
+    assert "Paper Execute Blocked" in text
+    assert "Risk blocked execution" in text
+
+
+def test_shared_execution_path_used_by_command_and_callback() -> None:
+    cmd_handler = _make_command_handler()
+    router = _make_router(cmd_handler)
+
+    with patch.object(
+        cmd_handler,
+        "execute_bounded_paper_trade",
+        new=AsyncMock(return_value=CommandResult(success=True, message="ok", payload={})),
+    ) as execute_mock:
+        asyncio.run(cmd_handler._handle_trade_test("market-1 YES 1"))
+        asyncio.run(
+            router._dispatch(
+                "trade_paper_execute",
+                action_payload="market-1|YES|1",
+                callback_signature="sig-1",
+            )
+        )
+
+    assert execute_mock.await_count == 2
+
+
+def test_duplicate_click_protection_blocks_repeated_callback_execution() -> None:
+    cmd_handler = _make_command_handler()
+
+    with patch(
+        "projects.polymarket.polyquantbot.telegram.command_handler.get_execution_engine",
+        return_value=_DummyEngine(),
+    ), patch(
+        "projects.polymarket.polyquantbot.telegram.command_handler.export_execution_payload",
+        new=AsyncMock(return_value={"positions": [], "cash": 1000.0, "equity": 1000.0, "realized": 0.0}),
+    ), patch(
+        "projects.polymarket.polyquantbot.telegram.command_handler.get_portfolio_service",
+    ) as service_mock, patch(
+        "projects.polymarket.polyquantbot.telegram.command_handler.StrategyTrigger.evaluate",
+        new=AsyncMock(return_value=None),
+    ) as evaluate_mock:
+        service_mock.return_value.merge_execution_state = MagicMock()
+
+        first = asyncio.run(
+            cmd_handler.execute_bounded_paper_trade(
+                market="market-1",
+                side="YES",
+                size=1.0,
+                source="telegram_callback_trade_paper_execute",
+                dedup_key="callback:same",
+            )
+        )
+        second = asyncio.run(
+            cmd_handler.execute_bounded_paper_trade(
+                market="market-1",
+                side="YES",
+                size=1.0,
+                source="telegram_callback_trade_paper_execute",
+                dedup_key="callback:same",
+            )
+        )
+
+    assert first.success is True
+    assert second.success is False
+    assert "Duplicate execute request blocked" in second.message
+    assert evaluate_mock.await_count == 1

--- a/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
@@ -33,7 +33,7 @@ def test_trade_menu_routing_contract_routes_without_home_fallback() -> None:
     routes = {
         "portfolio_trade": "🎯 Trade Detail",
         "trade_signal": "🎯 Trade Detail",
-        "trade_paper_execute": "🎯 Trade Detail",
+        "trade_paper_execute": "⚠️ *Paper Execute Blocked*",
         "trade_kill_switch": "🎛️ Control",
         "trade_status": "🧠 System Status",
     }


### PR DESCRIPTION
### Motivation
- Resolve SENTINEL-blocked behavior where `trade_paper_execute` callback normalized to a render-only trade view instead of invoking the bounded paper-execution path.
- Ensure callback-triggered execution follows the shared risk-gated execution surface and prevent duplicate or malformed callback-triggered executions.

### Description
- Parse `action:trade_paper_execute|market|side|size` payloads in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`, generate a callback signature, validate fields, and surface clear failure feedback for malformed/empty input.
- Wire the callback to the shared bounded execution entry `CommandHandler.execute_bounded_paper_trade(...)` in `projects/polymarket/polyquantbot/telegram/command_handler.py` so the callback and `/trade test` command use the same execution path and risk checks.
- Add duplicate-click protection using a dedup map + TTL guarded by an asyncio lock to deterministically block rapid repeated executions.
- Add/update focused tests and update routing expectation: created `test_telegram_callback_execution_wiring_20260408.py`, adjusted `test_telegram_trade_menu_routing_mvp.py`, and added a FORGE report plus `PROJECT_STATE.md` update declaring this MAJOR / NARROW INTEGRATION handoff.

### Testing
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_callback_execution_wiring_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` which passed (6 passed, 1 warning).
- Ran `python -m py_compile` on touched modules and tests which completed with no syntax errors.
- Verified there are no `phase*` folders with `find . -type d -name 'phase*'` and no `phase` imports via `rg` (no matches).
- Result: targeted unit tests and static compile checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d677d39ee0832ebe187f2339d7208d)