### PR TITLE
FORGE-X: rebuild Telegram execution entry contract (command + callback unification)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 12:41
-- Status        : P4 observability runtime + executor trace hardening is completed (conditional acceptance) and merged; project state synced to current repository truth.
+- Last Updated  : 2026-04-08 19:34
+- Status        : Telegram execution entry contract rebuild is complete (FORGE-X MAJOR pass) with unified command+callback execution entry and SENTINEL revalidation pending before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Telegram execution entry contract rebuild pass (2026-04-08): unified `/trade test ...` command and `trade_paper_execute` callback into one bounded `TelegramExecutionEntryService` enforcing ENTRY → RISK → EXECUTION with focused runtime-proof tests.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): Completed (Conditional) with hard event contract validation, trading-loop trace_id lifecycle wiring, execution-path trace propagation, and runtime `trade_start` / `execution_attempt` / `execution_result` event emission.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
@@ -87,6 +88,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### Telegram execution entry contract MAJOR validation handoff
+- FORGE-X rebuild for unified entry contract is complete with focused tests and runtime proof artifacts.
+- SENTINEL revalidation is required before merge per MAJOR tier.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -107,10 +112,13 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER routing next: SENTINEL validation for Telegram Trade Menu MVP.
+SENTINEL validation required for telegram execution entry contract rebuild before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- Telegram command/callback unified execution-entry rebuild is pending SENTINEL revalidation before merge (MAJOR tier gate).
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.

--- a/projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md
@@ -1,0 +1,77 @@
+# FORGE-X REPORT — 24_9_telegram_execution_entry_contract_rebuild
+
+## 1. What was built
+- Rebuilt Telegram execution entry as one bounded shared contract (`TelegramExecutionEntryService`) used by both command and callback paths.
+- Fixed `/trade test ...` routing so raw command arguments are preserved from `CommandRouter` to `CommandHandler` and no longer falsely fall back to usage for valid commands.
+- Rewired `trade_paper_execute` callback action to call the shared execution service instead of render-only UI fallback.
+- Enforced a unified ENTRY → RISK → EXECUTION flow in the shared service with explicit normalization, risk checks, execution call, dedup protection, and visible rejection reasons.
+- Added focused tests proving command + callback convergence to the same service, invalid input rejection, duplicate blocking, and failure-path feedback.
+
+Validation metadata:
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  - Telegram command entry for `/trade test ...`
+  - Telegram callback entry for `trade_paper_execute`
+  - Shared execution entry service
+  - Command parsing / argument normalization at execution boundary
+  - Callback normalization at execution boundary
+- Not in Scope:
+  - strategy redesign
+  - pricing model redesign
+  - observability redesign
+  - broad UI redesign
+  - unrelated Telegram handlers
+  - async redesign not required for entry unification
+- Suggested Next Step:
+  - SENTINEL validation
+
+## 2. Current system architecture
+- Command path:
+  - Telegram update `/trade test ...` → `CommandRouter` extracts `arg_str` → `CommandHandler.handle(..., args_text=...)` → `_handle_trade_test` → `TelegramExecutionEntryService.parse_command_test_args()` → `TelegramExecutionEntryService.execute()`.
+- Callback path:
+  - callback `action:trade_paper_execute` → `CallbackRouter._dispatch("trade_paper_execute")` → `TelegramExecutionEntryService.callback_default_entry()` → `TelegramExecutionEntryService.execute()`.
+- Shared bounded contract:
+  - ENTRY: normalize/validate market, side, size and signature.
+  - RISK: max concurrent trades, duplicate signature, duplicate market-position, and max position-size checks.
+  - EXECUTION: `ExecutionEngine.open_position(...)` and mark-to-market refresh, then portfolio merge/export payload.
+- Both entry paths now converge before risk/execution and return visible feedback for pass/fail outcomes.
+
+## 3. Files created / modified (full paths)
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/execution_entry_contract.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_router.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md
+- /workspace/walker-ai-team/PROJECT_STATE.md
+
+## 4. What is working
+- Valid `/trade test [market] [side] [size]` command reaches shared execution entry and executes through ENTRY → RISK → EXECUTION.
+- Valid `trade_paper_execute` callback reaches the same shared execution entry service and no longer remains render-only.
+- Shared-path proof exists in focused tests by asserting both command and callback call `TelegramExecutionEntryService.execute()`.
+- Invalid command arguments are rejected before execution with visible feedback.
+- Malformed callback action path does not execute shared service.
+- Duplicate entry signatures are blocked by service-level dedup and do not create duplicate execution.
+- Failure-path feedback remains visible on blocked execution outcomes.
+
+Runtime proof / test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/telegram/execution_entry_contract.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/telegram/command_router.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py` → PASS.
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` → PASS (8 passed).
+- Proof tests:
+  - `test_valid_trade_command_reaches_shared_execution_entry`
+  - `test_valid_callback_reaches_same_shared_execution_entry`
+  - `test_shared_path_proof_command_and_callback_use_identical_service`
+  - `test_invalid_command_is_rejected_without_execution`
+  - `test_invalid_callback_is_rejected_without_execution`
+  - `test_duplicate_protection_blocks_repeat_execution`
+  - `test_failure_path_feedback_is_visible`
+
+## 5. Known issues
+- Callback execute path currently uses bounded default callback entry parameters (`paper_test_market`, `YES`, `25.0`) because callback payload does not yet include explicit trade arguments.
+- Full external Telegram network/device visual proof is still unavailable in this container.
+
+## 6. What is next
+- SENTINEL revalidation required for telegram execution entry contract rebuild before merge.
+- Source: projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md
+- Tier: MAJOR

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -11,7 +11,7 @@ from ..config.runtime_config import ConfigManager
 from ..core.system_state import SystemState, SystemStateManager
 from ..interface.telegram.view_handler import render_view, safe_count, safe_number
 from ..execution.engine import export_execution_payload, get_execution_engine
-from ..execution.strategy_trigger import StrategyConfig, StrategyTrigger
+from .execution_entry_contract import get_telegram_execution_entry_service
 from .ui.keyboard import build_dashboard_menu
 from .handlers.portfolio_service import get_portfolio_service
 from .message_formatter import (
@@ -127,6 +127,7 @@ class CommandHandler:
         value: Optional[float] = None,
         user_id: Optional[str] = None,
         correlation_id: Optional[str] = None,
+        args_text: Optional[str] = None,
     ) -> CommandResult:
         """Dispatch a command to the appropriate handler.
 
@@ -146,6 +147,7 @@ class CommandHandler:
             "command_received",
             command=cmd,
             value=value,
+            args_text=args_text,
             user_id=user_id,
             correlation_id=cid,
             timestamp=time.time(),
@@ -153,7 +155,7 @@ class CommandHandler:
 
         async with self._lock:
             try:
-                result = await self._dispatch(cmd, value, cid)
+                result = await self._dispatch(cmd, value, cid, args_text=args_text)
             except Exception as exc:  # noqa: BLE001
                 log.error(
                     "command_handler_error",
@@ -193,7 +195,7 @@ class CommandHandler:
     # ── Handlers (one per command) ─────────────────────────────────────────────
 
     async def _dispatch(
-        self, cmd: str, value: Optional[float], cid: str
+        self, cmd: str, value: Optional[float], cid: str, args_text: Optional[str] = None
     ) -> CommandResult:
         """Route command string to the corresponding handler method."""
         if cmd in ("start", "help", "menu", "main_menu"):
@@ -248,7 +250,7 @@ class CommandHandler:
         if cmd == "alpha":
             return await self._handle_alpha()
         if cmd == "trade":
-            return await self._handle_trade(value)
+            return await self._handle_trade(args_text)
 
         # ── New menu callbacks (new Telegram system) ───────────────────────────
         if cmd == "wallet":
@@ -309,14 +311,14 @@ class CommandHandler:
             ),
         )
 
-    async def _handle_trade(self, args: Optional[float] = None) -> CommandResult:
+    async def _handle_trade(self, args: Optional[str] = None) -> CommandResult:
         """Parse /trade [test/close/status] [args]."""
         if args is None:
             return CommandResult(
                 success=False,
                 message="Usage: /trade [test|close|status] [args]",
             )
-        parts = str(args).split()
+        parts = args.split()
         if not parts:
             return CommandResult(
                 success=False,
@@ -335,53 +337,31 @@ class CommandHandler:
         )
 
     async def _handle_trade_test(self, args: str) -> CommandResult:
-        """Parse /trade test [market] [side] [size]."""
-        if not args:
+        """Parse /trade test [market] [side] [size] via unified execution entry."""
+        service = get_telegram_execution_entry_service()
+        normalized = service.parse_command_test_args(args)
+        if not hasattr(normalized, "signature"):
             return CommandResult(
                 success=False,
-                message="Usage: /trade test [market] [side YES/NO] [size]",
+                message=normalized.message,
+                payload={"execution_reason": normalized.reason, "pipeline_path": list(normalized.pipeline_path)},
             )
-        parts = args.split()
-        if len(parts) < 3:
+
+        result = await service.execute(normalized)
+        payload = dict(result.payload) if isinstance(result.payload, dict) else {}
+        payload["execution_reason"] = result.reason
+        payload["pipeline_path"] = list(result.pipeline_path)
+
+        if result.success:
             return CommandResult(
-                success=False,
-                message="Usage: /trade test [market] [side YES/NO] [size]",
+                success=True,
+                message=await render_view("positions", payload),
+                payload=payload,
             )
-        market, side, size_str = parts[0], parts[1].upper(), parts[2]
-        try:
-            size = float(size_str)
-        except ValueError:
-            return CommandResult(
-                success=False,
-                message="Size must be a number.",
-            )
-        if side not in ("YES", "NO"):
-            return CommandResult(
-                success=False,
-                message="Side must be YES or NO.",
-            )
-        engine = get_execution_engine()
-        trigger = StrategyTrigger(
-            engine=engine,
-            config=StrategyConfig(
-                market_id=market,
-                side=side,
-                threshold=0.45,
-                target_pnl=20.0,
-            ),
-        )
-        await trigger.evaluate(0.42)
-        await engine.update_mark_to_market({market: 0.46})
-        payload = await export_execution_payload()
-        get_portfolio_service().merge_execution_state(
-            positions=payload.get("positions", []),
-            cash=float(payload.get("cash", 0.0)),
-            equity=float(payload.get("equity", 0.0)),
-            realized_pnl=float(payload.get("realized", 0.0)),
-        )
+
         return CommandResult(
-            success=True,
-            message=await render_view("positions", payload),
+            success=False,
+            message=f"{result.message}\nPath: ENTRY → RISK → EXECUTION",
             payload=payload,
         )
 

--- a/projects/polymarket/polyquantbot/telegram/command_router.py
+++ b/projects/polymarket/polyquantbot/telegram/command_router.py
@@ -109,7 +109,8 @@ class CommandRouter:
     async def _route_structured(self, payload: dict) -> CommandResult:
         """Handle a structured {"command": ..., "value": ...} dict."""
         command = str(payload.get("command", "")).strip()
-        value = payload.get("value")
+        raw_value = payload.get("value")
+        value = raw_value
         user_id = str(payload.get("user_id", "structured"))
 
         if not command:
@@ -118,9 +119,9 @@ class CommandRouter:
                 message="❌ Missing 'command' field in structured payload.",
             )
 
-        if value is not None:
+        if raw_value is not None:
             try:
-                value = float(value)
+                value = float(raw_value)
             except (TypeError, ValueError):
                 return CommandResult(
                     success=False,
@@ -131,6 +132,7 @@ class CommandRouter:
             command=command,
             value=value,
             user_id=user_id,
+            args_text=arg_str if arg_str else None,
         )
 
     async def _route_telegram_update(self, update: dict) -> Optional[CommandResult]:
@@ -183,7 +185,7 @@ class CommandRouter:
             try:
                 value = float(arg_str)
             except ValueError:
-                pass  # value stays None — handler will report the error
+                pass  # value stays None — handler may use raw args_text
 
         log.info(
             "command_router_dispatching",
@@ -198,4 +200,5 @@ class CommandRouter:
             command=raw_cmd,
             value=value,
             user_id=user_id,
+            args_text=arg_str if arg_str else None,
         )

--- a/projects/polymarket/polyquantbot/telegram/execution_entry_contract.py
+++ b/projects/polymarket/polyquantbot/telegram/execution_entry_contract.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from dataclasses import dataclass
+
+import structlog
+
+from ..execution.engine import ExecutionEngine, export_execution_payload, get_execution_engine
+from .handlers.portfolio_service import get_portfolio_service
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_MARKET = "paper_test_market"
+_DEFAULT_SIDE = "YES"
+_DEFAULT_SIZE = 25.0
+_EXECUTION_PRICE = 0.42
+_MARK_PRICE = 0.46
+_MAX_CONCURRENT_TRADES = 5
+_MARKET_PATTERN = re.compile(r"^[A-Za-z0-9:_\-.]{3,128}$")
+
+
+@dataclass(frozen=True)
+class ExecutionEntry:
+    market: str
+    side: str
+    size: float
+    source: str
+    signature: str
+
+
+@dataclass(frozen=True)
+class ExecutionEntryResult:
+    success: bool
+    message: str
+    reason: str
+    payload: dict
+    pipeline_path: tuple[str, str, str]
+
+
+class TelegramExecutionEntryService:
+    """Unified Telegram ENTRY→RISK→EXECUTION bounded contract."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._seen_signatures: set[str] = set()
+
+    def parse_command_test_args(self, args: str) -> ExecutionEntryResult | ExecutionEntry:
+        parts = [part for part in args.split() if part]
+        if len(parts) < 3:
+            return ExecutionEntryResult(
+                success=False,
+                message="Usage: /trade test [market] [side YES/NO] [size]",
+                reason="invalid_command_args",
+                payload={},
+                pipeline_path=("entry", "risk", "execution"),
+            )
+        market, side_raw, size_raw = parts[0], parts[1], parts[2]
+        return self._normalize_entry(market=market, side=side_raw, size_raw=size_raw, source="telegram_command")
+
+    def callback_default_entry(self, market_hint: str | None = None) -> ExecutionEntryResult | ExecutionEntry:
+        market = (market_hint or _DEFAULT_MARKET).strip()
+        return self._normalize_entry(
+            market=market,
+            side=_DEFAULT_SIDE,
+            size_raw=str(_DEFAULT_SIZE),
+            source="telegram_callback",
+        )
+
+    def _normalize_entry(
+        self,
+        *,
+        market: str,
+        side: str,
+        size_raw: str,
+        source: str,
+    ) -> ExecutionEntryResult | ExecutionEntry:
+        normalized_market = market.strip()
+        if not normalized_market or not _MARKET_PATTERN.match(normalized_market):
+            return ExecutionEntryResult(
+                success=False,
+                message="Invalid market format. Use letters, numbers, :, _, -, .",
+                reason="invalid_market",
+                payload={},
+                pipeline_path=("entry", "risk", "execution"),
+            )
+        normalized_side = side.strip().upper()
+        if normalized_side not in {"YES", "NO"}:
+            return ExecutionEntryResult(
+                success=False,
+                message="Side must be YES or NO.",
+                reason="invalid_side",
+                payload={},
+                pipeline_path=("entry", "risk", "execution"),
+            )
+        try:
+            normalized_size = float(size_raw)
+        except ValueError:
+            return ExecutionEntryResult(
+                success=False,
+                message="Size must be a number.",
+                reason="invalid_size",
+                payload={},
+                pipeline_path=("entry", "risk", "execution"),
+            )
+        if normalized_size <= 0:
+            return ExecutionEntryResult(
+                success=False,
+                message="Size must be greater than 0.",
+                reason="size_non_positive",
+                payload={},
+                pipeline_path=("entry", "risk", "execution"),
+            )
+
+        signature = f"{normalized_market}:{normalized_side}:{normalized_size:.6f}"
+        return ExecutionEntry(
+            market=normalized_market,
+            side=normalized_side,
+            size=normalized_size,
+            source=source,
+            signature=signature,
+        )
+
+    async def execute(self, entry: ExecutionEntry, engine: ExecutionEngine | None = None) -> ExecutionEntryResult:
+        bounded_engine = engine or get_execution_engine()
+        async with self._lock:
+            snapshot = await bounded_engine.snapshot()
+
+            if entry.signature in self._seen_signatures:
+                log.warning("telegram_execution_entry_duplicate", signature=entry.signature, source=entry.source)
+                return ExecutionEntryResult(
+                    success=False,
+                    message="Duplicate execution blocked.",
+                    reason="duplicate_entry",
+                    payload={},
+                    pipeline_path=("entry", "risk", "execution"),
+                )
+
+            if len(snapshot.positions) >= _MAX_CONCURRENT_TRADES:
+                return ExecutionEntryResult(
+                    success=False,
+                    message="Execution blocked: max concurrent trades reached.",
+                    reason="max_concurrent_trades",
+                    payload={},
+                    pipeline_path=("entry", "risk", "execution"),
+                )
+
+            if any(pos.market_id == entry.market for pos in snapshot.positions):
+                return ExecutionEntryResult(
+                    success=False,
+                    message="Execution blocked: market already has an open position.",
+                    reason="duplicate_market_position",
+                    payload={},
+                    pipeline_path=("entry", "risk", "execution"),
+                )
+
+            max_position_size = max(snapshot.equity, 0.0) * bounded_engine.max_position_size_ratio
+            if entry.size > max_position_size:
+                return ExecutionEntryResult(
+                    success=False,
+                    message="Execution blocked: size exceeds max position limit.",
+                    reason="max_position_exceeded",
+                    payload={},
+                    pipeline_path=("entry", "risk", "execution"),
+                )
+
+            created = await bounded_engine.open_position(
+                market=entry.market,
+                side=entry.side,
+                price=_EXECUTION_PRICE,
+                size=entry.size,
+                position_id=f"tg-{uuid.uuid4()}",
+            )
+            if created is None:
+                return ExecutionEntryResult(
+                    success=False,
+                    message="Execution blocked by engine safeguards.",
+                    reason="engine_rejected",
+                    payload={},
+                    pipeline_path=("entry", "risk", "execution"),
+                )
+
+            self._seen_signatures.add(entry.signature)
+
+            await bounded_engine.update_mark_to_market({entry.market: _MARK_PRICE})
+            payload = await export_execution_payload()
+            get_portfolio_service().merge_execution_state(
+                positions=payload.get("positions", []),
+                cash=float(payload.get("cash", 0.0)),
+                equity=float(payload.get("equity", 0.0)),
+                realized_pnl=float(payload.get("realized", 0.0)),
+            )
+            return ExecutionEntryResult(
+                success=True,
+                message=f"Paper execution submitted: {entry.market} {entry.side} ${entry.size:.2f}",
+                reason="executed",
+                payload=payload,
+                pipeline_path=("entry", "risk", "execution"),
+            )
+
+
+_service_singleton: TelegramExecutionEntryService | None = None
+
+
+def get_telegram_execution_entry_service() -> TelegramExecutionEntryService:
+    global _service_singleton  # noqa: PLW0603
+    if _service_singleton is None:
+        _service_singleton = TelegramExecutionEntryService()
+    return _service_singleton

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -46,6 +46,7 @@ from ..ui.screens import (
     noop_screen,
 )
 from ..ui.components import render_kv_line, render_insight, SEP
+from ..execution_entry_contract import get_telegram_execution_entry_service
 from ...interface.telegram.view_handler import render_view, safe_number, safe_count
 from ...core.market_scope import (
     MARKET_SCOPE_CATEGORIES,
@@ -587,6 +588,48 @@ class CallbackRouter:
         )
         from .settings import handle_settings, handle_settings_strategy, handle_mode_confirm_switch
         from .control import handle_control, handle_pause, handle_resume, handle_kill
+
+        if action == "trade_paper_execute":
+            service = get_telegram_execution_entry_service()
+            normalized = service.callback_default_entry()
+            if not hasattr(normalized, "signature"):
+                payload = self._build_normalized_payload("trade")
+                payload.update(
+                    {
+                        "active_root": "portfolio",
+                        "decision": normalized.message,
+                        "operator_note": "Callback payload rejected safely",
+                        "insight": "ENTRY → RISK → EXECUTION contract blocked invalid input",
+                        "execution_reason": normalized.reason,
+                        "pipeline_path": list(normalized.pipeline_path),
+                    }
+                )
+                text = await render_view("trade", payload)
+                return text, build_trade_menu()
+
+            result = await service.execute(normalized)
+            payload = self._build_normalized_payload("trade")
+            payload.update(
+                {
+                    "active_root": "portfolio",
+                    "execution_reason": result.reason,
+                    "pipeline_path": list(result.pipeline_path),
+                }
+            )
+            if isinstance(result.payload, dict):
+                payload.update(result.payload)
+
+            if result.success:
+                payload["decision"] = result.message
+                payload["operator_note"] = "Callback path entered shared execution service"
+                payload["insight"] = "Unified ENTRY → RISK → EXECUTION contract succeeded"
+            else:
+                payload["decision"] = result.message
+                payload["operator_note"] = "Execution blocked with visible feedback"
+                payload["insight"] = "Unified ENTRY → RISK → EXECUTION contract enforced safeguards"
+
+            text = await render_view("trade", payload)
+            return text, build_trade_menu()
 
         normalized_actions = {
             "back_main",

--- a/projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler
+from projects.polymarket.polyquantbot.telegram.command_router import CommandRouter
+from projects.polymarket.polyquantbot.telegram.execution_entry_contract import (
+    ExecutionEntry,
+    ExecutionEntryResult,
+    get_telegram_execution_entry_service,
+)
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+def _reset_entry_service_state() -> None:
+    service = get_telegram_execution_entry_service()
+    service._seen_signatures.clear()  # noqa: SLF001
+
+
+def _make_command_handler() -> CommandHandler:
+    return CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def _make_callback_router(cmd_handler: CommandHandler | None = None) -> CallbackRouter:
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler or _make_command_handler(),
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def test_valid_trade_command_reaches_shared_execution_entry(monkeypatch) -> None:
+    _reset_entry_service_state()
+    handler = _make_command_handler()
+    router = CommandRouter(handler=handler)
+    service = get_telegram_execution_entry_service()
+
+    called: list[str] = []
+
+    async def fake_execute(entry: ExecutionEntry, engine=None) -> ExecutionEntryResult:
+        called.append(entry.source)
+        return ExecutionEntryResult(
+            success=True,
+            message="ok",
+            reason="executed",
+            payload={"positions": []},
+            pipeline_path=("entry", "risk", "execution"),
+        )
+
+    monkeypatch.setattr(service, "execute", fake_execute)
+
+    update = {"update_id": 1, "message": {"from": {"id": 123}, "text": "/trade test market_alpha YES 10"}}
+    result = asyncio.run(router.route_update(update))
+
+    assert result is not None
+    assert result.success is True
+    assert called == ["telegram_command"]
+
+
+def test_valid_callback_reaches_same_shared_execution_entry(monkeypatch) -> None:
+    _reset_entry_service_state()
+    service = get_telegram_execution_entry_service()
+    called: list[str] = []
+
+    async def fake_execute(entry: ExecutionEntry, engine=None) -> ExecutionEntryResult:
+        called.append(entry.source)
+        return ExecutionEntryResult(
+            success=True,
+            message="ok",
+            reason="executed",
+            payload={"positions": []},
+            pipeline_path=("entry", "risk", "execution"),
+        )
+
+    monkeypatch.setattr(service, "execute", fake_execute)
+
+    router = _make_callback_router()
+    text, _ = asyncio.run(router._dispatch("trade_paper_execute"))
+
+    assert "Trade Detail" in text
+    assert called == ["telegram_callback"]
+
+
+def test_shared_path_proof_command_and_callback_use_identical_service(monkeypatch) -> None:
+    _reset_entry_service_state()
+    service = get_telegram_execution_entry_service()
+    calls: list[tuple[str, tuple[str, str, str]]] = []
+
+    async def fake_execute(entry: ExecutionEntry, engine=None) -> ExecutionEntryResult:
+        path = ("entry", "risk", "execution")
+        calls.append((entry.source, path))
+        return ExecutionEntryResult(True, "ok", "executed", {"positions": []}, path)
+
+    monkeypatch.setattr(service, "execute", fake_execute)
+
+    command_router = CommandRouter(handler=_make_command_handler())
+    callback_router = _make_callback_router()
+
+    update = {"update_id": 2, "message": {"from": {"id": 555}, "text": "/trade test market_beta NO 5"}}
+    result = asyncio.run(command_router.route_update(update))
+    assert result is not None and result.success
+
+    asyncio.run(callback_router._dispatch("trade_paper_execute"))
+
+    assert [c[0] for c in calls] == ["telegram_command", "telegram_callback"]
+    assert all(path == ("entry", "risk", "execution") for _, path in calls)
+
+
+def test_invalid_command_is_rejected_without_execution(monkeypatch) -> None:
+    _reset_entry_service_state()
+    handler = _make_command_handler()
+    router = CommandRouter(handler=handler)
+    service = get_telegram_execution_entry_service()
+
+    execute_mock = MagicMock()
+    monkeypatch.setattr(service, "execute", execute_mock)
+
+    update = {"update_id": 3, "message": {"from": {"id": 123}, "text": "/trade test bad_market MAYBE 10"}}
+    result = asyncio.run(router.route_update(update))
+
+    assert result is not None
+    assert result.success is False
+    assert execute_mock.call_count == 0
+
+
+def test_invalid_callback_is_rejected_without_execution(monkeypatch) -> None:
+    _reset_entry_service_state()
+    service = get_telegram_execution_entry_service()
+    execute_mock = MagicMock()
+    monkeypatch.setattr(service, "execute", execute_mock)
+
+    router = _make_callback_router()
+    asyncio.run(router._dispatch("trade_paper_execute:malformed"))
+
+    assert execute_mock.call_count == 0
+
+
+def test_duplicate_protection_blocks_repeat_execution() -> None:
+    _reset_entry_service_state()
+    service = get_telegram_execution_entry_service()
+
+    class _StubEngine:
+        max_position_size_ratio = 0.10
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def snapshot(self):
+            return SimpleNamespace(positions=(), equity=1000.0)
+
+        async def open_position(self, **kwargs):
+            self.calls += 1
+            return SimpleNamespace(position_id="p1")
+
+        async def update_mark_to_market(self, _prices):
+            return 0.0
+
+    entry = ExecutionEntry(
+        market="market_dup",
+        side="YES",
+        size=10.0,
+        source="telegram_command",
+        signature="market_dup:YES:10.000000",
+    )
+
+    engine = _StubEngine()
+    first = asyncio.run(service.execute(entry, engine=engine))
+    second = asyncio.run(service.execute(entry, engine=engine))
+
+    assert first.success is True
+    assert second.success is False
+    assert second.reason == "duplicate_entry"
+    assert engine.calls == 1
+
+
+def test_failure_path_feedback_is_visible() -> None:
+    _reset_entry_service_state()
+    service = get_telegram_execution_entry_service()
+
+    class _StubBlockedEngine:
+        max_position_size_ratio = 0.10
+
+        async def snapshot(self):
+            return SimpleNamespace(positions=(), equity=1000.0)
+
+        async def open_position(self, **kwargs):
+            return None
+
+    entry = ExecutionEntry(
+        market="market_fail",
+        side="YES",
+        size=10.0,
+        source="telegram_callback",
+        signature="market_fail:YES:10.000000",
+    )
+    result = asyncio.run(service.execute(entry, engine=_StubBlockedEngine()))
+
+    assert result.success is False
+    assert "blocked" in result.message.lower()
+    assert result.pipeline_path == ("entry", "risk", "execution")


### PR DESCRIPTION
### Motivation
- Fix SENTINEL-blocking routing: `/trade test ...` command and `trade_paper_execute` callback did not reliably reach the same execution path and rendered UI instead of entering execution. 
- Provide a single authoritative, risk-first entry so both paths converge and preserve safety guarantees (ENTRY → RISK → EXECUTION). 

### Description
- Introduced a bounded shared service `TelegramExecutionEntryService` at `projects/polymarket/polyquantbot/telegram/execution_entry_contract.py` that normalizes inputs, enforces risk checks (max concurrent trades, duplicate signature, duplicate market position, max position size), executes via the existing execution engine, updates portfolio state, and returns structured visible feedback. 
- Wired command flow to preserve raw args by passing `args_text` from `CommandRouter` → `CommandHandler` and replaced `/trade test` handling with a call to the shared entry service (`get_telegram_execution_entry_service()`), removing the false usage fallback. 
- Rewired callback `trade_paper_execute` in `CallbackRouter` to call the same shared service (no render-only fallback) and present visible success/blocked feedback while keeping Trade menu context. 
- Added focused runtime tests `projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py` proving: valid command and callback hit the shared service, both sources call identical execution function, invalid inputs are rejected before execution, duplicate calls are blocked, and failure paths produce visible feedback. 
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/24_9_telegram_execution_entry_contract_rebuild.md` and updated `PROJECT_STATE.md` (Last Updated: `2026-04-08 19:34`) with MAJOR-tier handoff to SENTINEL. 

### Testing
- Ran `python -m py_compile` against changed files and the new test file, which passed. 
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_execution_entry_contract_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` and all tests passed (8 passed, 1 warning). 
- Tests exercise and assert runtime proof that command and callback reach the same service and that risk/dedup safeguards and visible failure feedback behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6acb9df2c832ea9232ce46f81839e)