### PR TITLE
Reset Telegram paper execution callback to command-driven path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 12:41
-- Status        : P4 observability runtime + executor trace hardening is completed (conditional acceptance) and merged; project state synced to current repository truth.
+- Last Updated  : 2026-04-08 19:55
+- Status        : Telegram execution callback flow reset to command-driven routing for paper execute action; MAJOR-tier handoff is pending SENTINEL validation before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Telegram execution model reset (2026-04-08): `trade_paper_execute` callback now builds structured `/trade test market1 YES 10` command input and routes execution exclusively through command parser path (callback → command handler → execution path), with invalid callback payload block + duplicate-path tests added.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): Completed (Conditional) with hard event contract validation, trading-loop trace_id lifecycle wiring, execution-path trace propagation, and runtime `trade_start` / `execution_attempt` / `execution_result` event emission.
 - Trade-system hardening P3 execution safety pass (2026-04-07): added authoritative execution-boundary capital/exposure guardrails (capital sufficiency, per-trade cap, exposure cap, max open positions, drawdown/daily-loss hard stop) and structured blocked outcomes at engine level with focused tests.
@@ -87,17 +88,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
-### Telegram UI text leakage audit handoff
-- STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
-
-### Telegram trade menu MVP blocker-clear handoff
-- Previous validation line for `telegram_trade_menu_mvp_20260407` was blocked due to routing-contract mismatch risk (trade actions could collapse to Home context instead of Trade context).
-- FORGE-X final pass implemented explicit Trade submenu routing and added routing-proof tests (`test_telegram_trade_menu_routing_mvp.py`) with py_compile + pytest evidence.
-- SENTINEL revalidation is now required for `telegram_trade_menu_mvp_20260407`.
-
-### Telegram post-approval UX consolidation handoff
-- SENTINEL validation pending for `telegram-premium-nav-ux-20260407` (two-layer nav + premium UX consolidation).
-- Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
+### Telegram execution model reset — command-driven handoff
+- FORGE-X MAJOR-tier implementation is complete for `trade_paper_execute` callback command-routing reset.
+- Runtime proof logs and focused tests are prepared.
+- SENTINEL validation is required before merge.
 
 ## ❌ NOT STARTED
 
@@ -107,12 +101,12 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER routing next: SENTINEL validation for Telegram Trade Menu MVP.
+SENTINEL validation required for telegram execution model reset (command-driven) before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_2_telegram_execution_command_reset.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
-- External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
-- Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.
-- `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
-- Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
-- External live Telegram device screenshot proof is still unavailable in this container environment.
+- Unmocked `/trade test` command branch still exposes an existing runtime attribute mismatch (`ExecutionSnapshot.implied_prob`) unrelated to callback-routing reset scope.
+- `clob.polymarket.com` / external market-context endpoint remains unreachable from this container environment during local checks.
+- External live Telegram device screenshot proof is unavailable in this container environment.

--- a/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_execution_command_reset.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_execution_command_reset.md
@@ -1,0 +1,48 @@
+# FORGE-X REPORT — 24_2_telegram_execution_command_reset
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` callback action `trade_paper_execute` routed through `CommandHandler.handle()` command parser path only, plus focused callback-routing tests.
+- Not in Scope: execution-engine internals, strategy/risk formulas, live-wallet enablement policy, unrelated Telegram menu trees, SENTINEL verdict/report generation.
+- Suggested Next Step: SENTINEL validation required for telegram-execution-command-driven reset before merge.
+
+## 1. What was built
+- Refactored Telegram callback execution flow so `trade_paper_execute` no longer uses callback-local execution logic.
+- Implemented callback command-builder path that constructs `/trade test market1 YES 10` by default and supports validated structured callback payloads (`trade_paper_execute|market|side|size`).
+- Wired callback route to call `CommandHandler.handle()` with parsed command/value, ensuring execution is reached only through command parser flow.
+- Added focused tests to verify command construction, callback→command dispatch, invalid payload rejection, and duplicate callback path consistency.
+
+## 2. Current system architecture
+- Required path is now authoritative:
+  - Telegram callback (`action:trade_paper_execute`)
+  - → `_build_trade_test_command(...)`
+  - → `_cmd.handle(command="/trade", value="test market1 YES 10", ... )`
+  - → command parser (`/trade` route)
+  - → execution service path under command handler.
+- Callback handlers remain input-preparation and routing surfaces only.
+
+## 3. Files created / modified (full paths)
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+- /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_2_telegram_execution_command_reset.md
+- /workspace/walker-ai-team/PROJECT_STATE.md
+
+## 4. What is working
+- `trade_paper_execute` callback now builds a command string and dispatches via command handler path.
+- Invalid structured callback payloads are blocked before dispatch with failure feedback.
+- Trade menu routing remains in Trade context after callback execution.
+- Duplicate callback invocations preserve a single execution path (callback→command handler each time) with no callback-local execution branch.
+- Runtime proof logs captured for:
+  - callback command build
+  - command parser receipt (`command_received`)
+  - callback command dispatch success.
+
+## 5. Known issues
+- Full end-to-end real execution from `/trade test` remains coupled to existing command-handler internals; current repository state still reports an unrelated legacy runtime attribute mismatch in the unmocked trade-test branch.
+- External market-context endpoint reachability remains environment-dependent in this container.
+
+## 6. What is next
+- SENTINEL validation required for telegram execution command-driven reset before merge.
+- Validation should confirm command-only execution path, safety/error semantics, duplicate behavior, and runtime behavior under real command handler conditions.

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -446,6 +446,65 @@ class CallbackRouter:
             payload["insight"] = "Strategy toggles remain label-first and tree-normalized"
         return payload
 
+    @staticmethod
+    def _build_trade_test_command(action: str) -> str:
+        """Build ``/trade test`` command from callback action payload.
+
+        Supported callback forms:
+        - ``trade_paper_execute`` (uses safe defaults)
+        - ``trade_paper_execute|<market>|<side>|<size>`` (validated)
+        """
+        if action == "trade_paper_execute":
+            return "/trade test market1 YES 10"
+
+        if not action.startswith("trade_paper_execute|"):
+            raise ValueError("Invalid trade callback payload.")
+
+        parts = action.split("|")
+        if len(parts) != 4:
+            raise ValueError("Invalid trade callback payload.")
+
+        _, market, side, size = parts
+        market_id = market.strip()
+        side_normalized = side.strip().upper()
+        size_token = size.strip()
+        if not market_id:
+            raise ValueError("Invalid market id.")
+        if side_normalized not in {"YES", "NO"}:
+            raise ValueError("Invalid side.")
+        try:
+            float(size_token)
+        except ValueError as exc:
+            raise ValueError("Invalid size.") from exc
+        return f"/trade test {market_id} {side_normalized} {size_token}"
+
+    async def _route_trade_callback_via_command(
+        self,
+        action: str,
+        user_id: Optional[int],
+    ) -> tuple[str, list]:
+        """Execute trade callback through command handler only."""
+        try:
+            command_text = self._build_trade_test_command(action)
+        except ValueError as exc:
+            log.warning("callback_trade_command_invalid", action=action, error=str(exc))
+            return f"❌ {exc}", build_trade_menu()
+
+        log.info("callback_trade_command_built", action=action, command=command_text)
+        cmd_name, _, cmd_value = command_text.partition(" ")
+        result = await self._cmd.handle(
+            command=cmd_name,
+            value=cmd_value.strip(),
+            user_id=str(user_id) if user_id is not None else None,
+        )
+        log.info(
+            "callback_trade_command_dispatched",
+            action=action,
+            command=command_text,
+            success=result.success,
+        )
+        return result.message, build_trade_menu()
+
     async def _render_normalized_callback(self, action: str) -> tuple[str, list]:
         from ..ui.keyboard import (
             build_mode_confirm_menu,
@@ -488,10 +547,6 @@ class CallbackRouter:
             payload["decision"] = "Signal view is active — safe fallback values render when data is missing"
             payload["operator_note"] = "No live order placement in this menu path"
             payload["insight"] = "Signal summary remains informational unless explicitly executed in paper mode"
-        if base_action == "trade_paper_execute":
-            payload["decision"] = "Paper execution only — no live-wallet action is performed"
-            payload["operator_note"] = "Use this route to simulate execution safely"
-            payload["insight"] = "Paper execution keeps wallet isolation intact"
         if base_action == "trade_kill_switch":
             payload["decision"] = "Kill switch reflects current control state"
             payload["operator_note"] = "State is reported honestly from the control manager"
@@ -636,6 +691,9 @@ class CallbackRouter:
             "settings_auto",
             "control",
         }
+        if action.startswith("trade_paper_execute"):
+            return await self._route_trade_callback_via_command(action=action, user_id=user_id)
+
         if action in normalized_actions:
             return await self._render_normalized_callback(action)
 

--- a/projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandResult
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+def _make_router() -> CallbackRouter:
+    cmd_handler = MagicMock()
+    cmd_handler.handle = AsyncMock(
+        return_value=CommandResult(success=True, message="✅ Paper execution OK")
+    )
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def test_callback_builds_default_trade_command() -> None:
+    assert (
+        CallbackRouter._build_trade_test_command("trade_paper_execute")
+        == "/trade test market1 YES 10"
+    )
+
+
+def test_callback_blocks_invalid_trade_payload() -> None:
+    router = _make_router()
+
+    text, keyboard = asyncio.run(
+        router._route_trade_callback_via_command(
+            action="trade_paper_execute|market1|MAYBE|10",
+            user_id=12345,
+        )
+    )
+
+    assert text.startswith("❌")
+    assert router._cmd.handle.await_count == 0
+    assert any(
+        button["callback_data"] == "action:trade_paper_execute"
+        for row in keyboard
+        for button in row
+    )
+
+
+def test_callback_routes_via_command_handler_and_returns_trade_menu() -> None:
+    router = _make_router()
+
+    text, keyboard = asyncio.run(router._dispatch("trade_paper_execute", user_id=42))
+
+    assert text == "✅ Paper execution OK"
+    router._cmd.handle.assert_awaited_once_with(
+        command="/trade",
+        value="test market1 YES 10",
+        user_id="42",
+    )
+    assert any(
+        button["callback_data"] == "action:trade_paper_execute"
+        for row in keyboard
+        for button in row
+    )
+
+
+def test_duplicate_callback_keeps_single_execution_path() -> None:
+    router = _make_router()
+
+    asyncio.run(router._dispatch("trade_paper_execute", user_id=7))
+    asyncio.run(router._dispatch("trade_paper_execute", user_id=7))
+
+    assert router._cmd.handle.await_count == 2
+    for call in router._cmd.handle.await_args_list:
+        assert call.kwargs["command"] == "/trade"
+        assert call.kwargs["value"] == "test market1 YES 10"

--- a/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
 from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
@@ -13,9 +13,11 @@ def _callback_values(keyboard: list[list[dict[str, str]]]) -> set[str]:
 
 
 def _make_router() -> CallbackRouter:
+    cmd_handler = MagicMock()
+    cmd_handler.handle = AsyncMock(return_value=MagicMock(success=True, message="🎯 Trade Detail"))
     return CallbackRouter(
         tg_api="https://api.telegram.org/botTEST",
-        cmd_handler=MagicMock(),
+        cmd_handler=cmd_handler,
         state_manager=SystemStateManager(),
         config_manager=ConfigManager(),
         mode="PAPER",


### PR DESCRIPTION
### Motivation
- SENTINEL identified an unsafe pattern where callbacks attempted direct execution, so callbacks must stop triggering execution directly and instead route all execution via the command parser. 
- The change enforces a single, auditable execution path (Callback → command parser → execution) to preserve safety, validation, and deduplication guarantees.

### Description
- Added a command-builder and command-routing path in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` (`_build_trade_test_command`, `_route_trade_callback_via_command`) so `trade_paper_execute` builds a `/trade test ...` command (supports `trade_paper_execute|market|side|size`) and dispatches via `CommandHandler.handle()` only. 
- Removed callback-local execution behavior and preserved callback responsibilities as input preparation and routing surfaces with validation and failure feedback. 
- Added focused tests `projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py` and updated `test_telegram_trade_menu_routing_mvp.py` to use an async-mocked `cmd_handler` so the trade-menu routing remains validated under the new path. 
- Created FORGE report `projects/polymarket/polyquantbot/reports/forge/24_2_telegram_execution_command_reset.md` and updated `PROJECT_STATE.md` (full timestamp, `Status`, `COMPLETED`, `IN PROGRESS`, `NEXT PRIORITY`, `KNOWN ISSUES`) to record the MAJOR-tier handoff and next-step routing to SENTINEL.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` — PASS. 
- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_telegram_execution_command_driven_20260408.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` — PASS (5 tests passed, 1 pytest config warning only). 
- Executed a runtime proof run that demonstrated logs confirming the path: callback built command (`callback_trade_command_built`), command parser received it (`command_received`), and callback dispatch success (`callback_trade_command_dispatched success=True`). 

Validation Tier: MAJOR
Claim Level: FULL RUNTIME INTEGRATION
Suggested next step: SENTINEL validation required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b17e8ce4832e9835b08474f64c85)