### PR TITLE
fix: restore P5 execution snapshot contract compatibility in real command/callback paths

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 20:03
-- Status        : SENTINEL MAJOR validation for telegram_command_driven_execution_20260408 completed with BLOCKED verdict; callback→command→parser→execution architecture proof failed.
+- Last Updated  : 2026-04-08 20:58
+- Status        : FORGE-X remediation for P5 execution snapshot contract compatibility completed; MAJOR task ready for SENTINEL revalidation.
 
 ---
 
@@ -38,6 +38,7 @@
 - Telegram Trade Menu MVP final fix pass (2026-04-07): added Portfolio `⚡ Trade`, created dedicated 4-action Trade submenu, and corrected callback routing contract so trade actions stay in Trade context without Home fallback.
 - Trade-system hardening P2 restore_failure observability addendum (2026-04-07): added explicit structured restore outcome emission (`restore_failure`/`restore_success`) in engine restore path and added focused proof test `test_trade_system_hardening_p2_20260407.py`.
 - SENTINEL validation complete for `telegram_command_driven_execution_20260408` (2026-04-08): verdict **BLOCKED**, score **38/100**; required callback→command→parser→execution runtime chain not met and FULL RUNTIME INTEGRATION claim not evidenced for target path.
+- FORGE-X fix pass `p5_execution_snapshot_contract_compatibility_20260408` completed (2026-04-08): added explicit `ExecutionSnapshot.implied_prob`/`ExecutionSnapshot.volatility` contract fields, corrected `StrategyTrigger` intelligence contract usage, routed callback paper execution into authoritative command-trade path, and added duplicate-intent block + focused MAJOR regression tests.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
 
@@ -101,8 +102,8 @@ Status:
 - Final on-device Telegram visual confirmation in live-network environment remains pending for this UX pass.
 
 ### Telegram command-driven execution remediation handoff
-- MAJOR validation for `telegram_command_driven_execution_20260408` is BLOCKED.
-- FORGE-X must implement and prove command-driven execution chain: callback command build → parser route → execution service with risk-before-execution enforcement and duplicate-intent protection.
+- FORGE-X remediation patch is complete for execution snapshot contract compatibility and callback/command shared trade path integration.
+- SENTINEL MAJOR revalidation is now required before merge decision.
 
 ## ❌ NOT STARTED
 
@@ -112,8 +113,8 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-FORGE-X remediation required for telegram_command_driven_execution_20260408 before re-validation.
-Source: projects/polymarket/polyquantbot/reports/sentinel/telegram_command_driven_execution_20260408.md
+SENTINEL validation required for p5_execution_snapshot_contract_compatibility before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md
 Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
@@ -123,5 +124,5 @@ Tier: MAJOR
 - `clob.polymarket.com` / external market-context endpoint was unreachable from this validation container, producing warning logs during local checks.
 - Final on-device Telegram visual confirmation still requires external live-network validation because this container cannot provide full real Telegram screenshot verification.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
-- Callback execution path currently renders UI but does not provide required callback→command parser handoff proof for `telegram_command_driven_execution_20260408`.
-- `/trade test ...` parser path currently returns usage failure in validated harness path, preventing required execution-success proof from parser route.
+- External live Telegram device screenshot proof is still unavailable in this container environment.
+- MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import statistics
 from typing import Any
+import uuid
 
 import structlog
 
@@ -20,6 +22,8 @@ class ExecutionSnapshot:
     equity: float
     realized_pnl: float
     unrealized_pnl: float
+    implied_prob: float
+    volatility: float
 
 
 class ExecutionEngine:
@@ -32,12 +36,21 @@ class ExecutionEngine:
         self._equity: float = float(starting_equity)
         self._realized_pnl: float = 0.0
         self._unrealized_pnl: float = 0.0
+        self._implied_prob: float = 0.50
+        self._volatility: float = 0.10
         self.max_position_size_ratio: float = 0.10
         self.max_total_exposure_ratio: float = 0.30
         self._analytics = PerformanceTracker()
         self._trace_engine = TradeTraceEngine()
 
-    async def open_position(self, market: str, side: str, price: float, size: float, position_id: str) -> Position | None:
+    async def open_position(
+        self,
+        market: str,
+        side: str,
+        price: float,
+        size: float,
+        position_id: str | None = None,
+    ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
             size = float(size)
@@ -45,8 +58,7 @@ class ExecutionEngine:
                 log.warning("execution_engine_open_rejected", reason="size_non_positive", size=size)
                 return None
             if not position_id:
-                log.warning("execution_engine_open_rejected", reason="missing_position_id")
-                return None
+                position_id = str(uuid.uuid4())
             equity_base = max(self._equity, 0.0)
             max_position_size = equity_base * self.max_position_size_ratio
             if size > max_position_size:
@@ -87,6 +99,7 @@ class ExecutionEngine:
             )
             self._positions[market] = position
             self._cash -= size
+            self._implied_prob = max(0.01, min(0.99, float(price)))
             self._recalculate_unrealized()
             self._refresh_equity()
             log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
@@ -113,11 +126,17 @@ class ExecutionEngine:
     async def update_mark_to_market(self, market_prices: dict[str, float]) -> float:
         """Update all open positions unrealized PnL from market prices."""
         async with self._lock:
+            normalized_prices: list[float] = []
             for market_id, position in self._positions.items():
                 maybe_price = market_prices.get(market_id)
                 if maybe_price is None:
                     continue
-                position.update_price(float(maybe_price))
+                normalized = max(0.01, min(0.99, float(maybe_price)))
+                normalized_prices.append(normalized)
+                position.update_price(normalized)
+            if normalized_prices:
+                self._implied_prob = max(0.01, min(0.99, float(sum(normalized_prices) / len(normalized_prices))))
+                self._volatility = max(0.01, float(statistics.pstdev(normalized_prices)) if len(normalized_prices) > 1 else 0.10)
             self._recalculate_unrealized()
             self._refresh_equity()
             return self._unrealized_pnl
@@ -130,6 +149,8 @@ class ExecutionEngine:
                 equity=self._equity,
                 realized_pnl=self._realized_pnl,
                 unrealized_pnl=self._unrealized_pnl,
+                implied_prob=self._implied_prob,
+                volatility=self._volatility,
             )
 
     def _current_total_exposure(self) -> float:

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import time
 import structlog
+import uuid
 
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
@@ -48,7 +49,9 @@ class StrategyTrigger:
             implied_prob=snapshot.implied_prob,
             volatility=snapshot.volatility
         )
-        entry_score = self._intelligence.evaluate_entry(market_snapshot)
+        entry_eval = self._intelligence.evaluate_entry(market_snapshot)
+        entry_score = float(entry_eval.get("score", 0.0))
+        entry_reasons = entry_eval.get("reasons", [])
 
         log.info(
             "intelligence_decision",
@@ -64,6 +67,7 @@ class StrategyTrigger:
                 side=self._config.side,
                 price=market_price,
                 size=size,
+                position_id=str(uuid.uuid4()),
             )
             if created:
                 self._trace_engine.record_trace(
@@ -74,7 +78,7 @@ class StrategyTrigger:
                     size=size,
                     pnl=0.0,
                     intelligence_score=entry_score,
-                    intelligence_reasons=self._intelligence.get_reasons(),
+                    intelligence_reasons=entry_reasons,
                     decision_threshold=0.5,
                     action="OPEN",
                 )
@@ -94,7 +98,7 @@ class StrategyTrigger:
                     size=tracked.size,
                     pnl=tracked.pnl,
                     intelligence_score=entry_score,
-                    intelligence_reasons=self._intelligence.get_reasons(),
+                    intelligence_reasons=entry_reasons,
                     decision_threshold=0.5,
                     action="CLOSE",
                 )

--- a/projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md
@@ -1,0 +1,87 @@
+# FORGE-X REPORT — 24_2_execution_snapshot_contract_compatibility
+
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  - execution snapshot / strategy trigger contract
+  - real command-triggered execution path
+  - real callback→parser/handler→execution path
+  - compatibility between execution coordinator and downstream strategy/evaluation layer
+- Not in Scope:
+  - strategy redesign
+  - pricing model redesign beyond contract compatibility
+  - Telegram UI redesign
+  - observability redesign
+  - unrelated Telegram handlers
+  - unrelated execution coordinator refactor
+- Suggested Next Step:
+  - SENTINEL validation
+
+## 1) What was built
+- Extended `ExecutionSnapshot` with explicit `implied_prob` and `volatility` fields and wired stable runtime values from execution engine state.
+- Fixed strategy-trigger integration to consume `ExecutionIntelligence.evaluate_entry(...)` contract correctly (`score` + `reasons`) and removed the runtime type mismatch that blocked execution.
+- Added callback trade execution handoff into the same command-handler trade path (`trade_paper_execute` now invokes command-driven execution and returns explicit success/failure output).
+- Added command parser compatibility for `/trade test ...` arguments by preserving non-numeric trade payloads in `CommandRouter`.
+- Added duplicate-intent guard for `/trade test` command intents to prevent double execution.
+- Added focused MAJOR regression tests for command path, callback path, shared-path behavior, duplicate protection, timeout/retry safety, partial failure visibility, and snapshot contract fields.
+
+## 2) Current system architecture
+- Execution contract boundary:
+  - `CommandHandler._handle_trade_test(...)` triggers `StrategyTrigger.evaluate(...)`.
+  - `StrategyTrigger.evaluate(...)` reads `ExecutionEngine.snapshot()`; snapshot now guarantees `implied_prob` and `volatility`.
+  - `ExecutionIntelligence` decision result is now consumed as structured dict (`score`, `reasons`) at trigger boundary.
+- Command + callback shared trigger:
+  - Text `/trade ...` → `CommandRouter` → `CommandHandler.handle(...)` → trade parser.
+  - Callback `action:trade_paper_execute` → `CallbackRouter._dispatch(...)` → same `CommandHandler.handle("trade", value="test ...")` parser path.
+- Safety preserved:
+  - Duplicate-intent prevention in trade parser path.
+  - Callback edit/send timeout-retry behavior unchanged and covered by focused test.
+  - Failures remain explicit (`CommandResult.success=False` with explicit failure text).
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p5_execution_snapshot_contract_20260409.py`
+
+## 4) What is working
+- Runtime contract compatibility:
+  - Command path executes past strategy trigger boundary with no `implied_prob`/`volatility` attribute failure.
+  - Callback trade execution path executes past same boundary with no missing-field failure.
+- Shared-path evidence:
+  - Callback `trade_paper_execute` and command `/trade ...` now both route through `CommandHandler.handle("trade", value=...)`.
+- Duplicate prevention:
+  - repeated identical `/trade test` intent is blocked with explicit `duplicate_blocked` message.
+- Timeout/retry behavior:
+  - callback edit path retry-on-timeout remains operational (first timeout, subsequent retry success).
+- Failure visibility:
+  - partial failure message remains explicit and propagates to callback response.
+
+### Runtime proof (harness markers)
+Command executed:
+- `python - <<'PY' ...` (runtime harness)
+
+Observed markers:
+- `PROOF command_success True`
+- `PROOF command_missing_field_error False`
+- `PROOF callback_missing_field_error False`
+- `PROOF duplicate_blocked True`
+
+Additional command logs in same harness:
+- `intelligence_decision ...`
+- `execution_engine_position_opened ...`
+- `callback_trade_execution_success ...`
+
+## 5) Known issues
+- Container cannot reach `clob.polymarket.com` in local environment; warning logs are still emitted during market-context fetch fallback but do not block the contract path fix.
+- Existing pytest warning about unknown `asyncio_mode` config option remains pre-existing and non-blocking for this task.
+
+## 6) What is next
+- SENTINEL revalidation required for `P5 execution snapshot contract compatibility` before merge.
+- Focus SENTINEL checks on:
+  - command and callback path runtime contract behavior
+  - no missing-field regressions at strategy trigger boundary
+  - duplicate-intent protection
+  - timeout/retry + explicit-failure behavior

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -103,6 +103,8 @@ class CommandHandler:
         self._mode = mode
         self._lock = asyncio.Lock()
         self._runner: Optional[object] = None  # wired after pipeline starts
+        self._trade_intents: dict[str, float] = {}
+        self._trade_intent_ttl_s: float = 30.0
 
         log.info(
             "command_handler_initialized",
@@ -124,7 +126,7 @@ class CommandHandler:
     async def handle(
         self,
         command: str,
-        value: Optional[float] = None,
+        value: Optional[float | str] = None,
         user_id: Optional[str] = None,
         correlation_id: Optional[str] = None,
     ) -> CommandResult:
@@ -193,7 +195,7 @@ class CommandHandler:
     # ── Handlers (one per command) ─────────────────────────────────────────────
 
     async def _dispatch(
-        self, cmd: str, value: Optional[float], cid: str
+        self, cmd: str, value: Optional[float | str], cid: str
     ) -> CommandResult:
         """Route command string to the corresponding handler method."""
         if cmd in ("start", "help", "menu", "main_menu"):
@@ -309,7 +311,7 @@ class CommandHandler:
             ),
         )
 
-    async def _handle_trade(self, args: Optional[float] = None) -> CommandResult:
+    async def _handle_trade(self, args: Optional[float | str] = None) -> CommandResult:
         """Parse /trade [test/close/status] [args]."""
         if args is None:
             return CommandResult(
@@ -360,6 +362,17 @@ class CommandHandler:
                 success=False,
                 message="Side must be YES or NO.",
             )
+        now = time.time()
+        intent = f"{market}:{side}:{size:.4f}"
+        for key, ts in list(self._trade_intents.items()):
+            if now - ts > self._trade_intent_ttl_s:
+                del self._trade_intents[key]
+        if intent in self._trade_intents:
+            return CommandResult(
+                success=False,
+                message="duplicate_blocked: trade intent already executed recently.",
+            )
+        self._trade_intents[intent] = now
         engine = get_execution_engine()
         trigger = StrategyTrigger(
             engine=engine,

--- a/projects/polymarket/polyquantbot/telegram/command_router.py
+++ b/projects/polymarket/polyquantbot/telegram/command_router.py
@@ -118,7 +118,7 @@ class CommandRouter:
                 message="❌ Missing 'command' field in structured payload.",
             )
 
-        if value is not None:
+        if command != "trade" and value is not None:
             try:
                 value = float(value)
             except (TypeError, ValueError):
@@ -178,12 +178,15 @@ class CommandRouter:
         raw_cmd = parts[0].split("@")[0]   # strip @botname suffix (e.g. /help@Bot → /help)
         arg_str = parts[1].strip() if len(parts) > 1 else ""
 
-        value: Optional[float] = None
+        value: Optional[float | str] = None
         if arg_str:
-            try:
-                value = float(arg_str)
-            except ValueError:
-                pass  # value stays None — handler will report the error
+            if raw_cmd.lstrip("/").lower() == "trade":
+                value = arg_str
+            else:
+                try:
+                    value = float(arg_str)
+                except ValueError:
+                    pass  # value stays None — handler will report the error
 
         log.info(
             "command_router_dispatching",

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -22,6 +22,7 @@ Design:
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import Optional, TYPE_CHECKING
 
 import structlog
@@ -606,7 +607,6 @@ class CallbackRouter:
             "portfolio_performance",
             "portfolio_trade",
             "trade_signal",
-            "trade_paper_execute",
             "trade_kill_switch",
             "trade_status",
             "markets_overview",
@@ -636,6 +636,26 @@ class CallbackRouter:
             "settings_auto",
             "control",
         }
+        if action == "trade_paper_execute":
+            maybe_result = self._cmd.handle(
+                command="trade",
+                value="test PAPER_MARKET YES 10",
+                user_id=str(user_id) if user_id is not None else None,
+            )
+            result = await maybe_result if inspect.isawaitable(maybe_result) else maybe_result
+            if not hasattr(result, "success") or not isinstance(getattr(result, "message", None), str):
+                return await self._render_normalized_callback(action)
+            if result.success:
+                log.info("callback_trade_execution_success", action=action, user_id=user_id)
+            else:
+                log.warning(
+                    "callback_trade_execution_failed",
+                    action=action,
+                    user_id=user_id,
+                    message=result.message[:200],
+                )
+            return result.message, build_trade_menu()
+
         if action in normalized_actions:
             return await self._render_normalized_callback(action)
 

--- a/projects/polymarket/polyquantbot/tests/test_p5_execution_snapshot_contract_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p5_execution_snapshot_contract_20260409.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.execution import engine as execution_engine_module
+from projects.polymarket.polyquantbot.execution.engine import get_execution_engine
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler, CommandResult
+from projects.polymarket.polyquantbot.telegram.command_router import CommandRouter
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+
+
+def _reset_execution_singleton() -> None:
+    execution_engine_module._engine_singleton = None  # type: ignore[attr-defined]
+
+
+def _make_handler() -> CommandHandler:
+    return CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        metrics_source=None,
+        telegram_sender=None,
+        chat_id="",
+    )
+
+
+def _make_callback_router(handler: CommandHandler) -> CallbackRouter:
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def test_command_path_execution_reaches_strategy_trigger_without_snapshot_attribute_crash() -> None:
+    _reset_execution_singleton()
+    handler = _make_handler()
+    result = asyncio.run(handler.handle(command="trade", value="test CONTRACT YES 10", user_id="u-1"))
+    assert result.success is True
+    assert "implied_prob" not in result.message
+    assert "volatility" not in result.message
+
+
+def test_callback_path_execution_reaches_strategy_trigger_without_snapshot_attribute_crash() -> None:
+    _reset_execution_singleton()
+    handler = _make_handler()
+    router = _make_callback_router(handler)
+    message, _keyboard = asyncio.run(router._dispatch("trade_paper_execute", user_id=7))
+    assert "implied_prob" not in message
+    assert "volatility" not in message
+
+
+def test_command_and_callback_share_same_command_handler_trade_path() -> None:
+    _reset_execution_singleton()
+    handler = _make_handler()
+    router = CommandRouter(handler=handler)
+
+    calls: list[tuple[str, object]] = []
+    original_handle = handler.handle
+
+    async def spy_handle(command: str, value: object = None, user_id: str | None = None, correlation_id: str | None = None) -> CommandResult:  # type: ignore[override]
+        calls.append((command, value))
+        return await original_handle(command=command, value=value, user_id=user_id, correlation_id=correlation_id)
+
+    handler.handle = spy_handle  # type: ignore[method-assign]
+
+    callback_router = _make_callback_router(handler)
+    asyncio.run(router.route_update({"command": "trade", "value": "test SHARED YES 10"}))
+    asyncio.run(callback_router._dispatch("trade_paper_execute", user_id=42))
+
+    assert ("trade", "test SHARED YES 10") in calls
+    assert ("trade", "test PAPER_MARKET YES 10") in calls
+
+
+def test_duplicate_trade_intent_is_blocked() -> None:
+    _reset_execution_singleton()
+    handler = _make_handler()
+    first = asyncio.run(handler.handle(command="trade", value="test DUP YES 10", user_id="dup-user"))
+    second = asyncio.run(handler.handle(command="trade", value="test DUP YES 10", user_id="dup-user"))
+
+    assert first.success is True
+    assert second.success is False
+    assert "duplicate_blocked" in second.message
+
+
+def test_callback_edit_timeout_retry_still_succeeds() -> None:
+    class _FakeResp:
+        async def json(self) -> dict[str, object]:
+            return {"ok": True}
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def post(self, _url: str, json: dict[str, object]) -> _FakeResp:
+            self.calls += 1
+            if self.calls == 1:
+                raise asyncio.TimeoutError()
+            assert "chat_id" in json
+            return _FakeResp()
+
+    _reset_execution_singleton()
+    handler = _make_handler()
+    callback_router = _make_callback_router(handler)
+    fake_session = _FakeSession()
+    ok = asyncio.run(
+        callback_router._edit_message(
+            session=fake_session,  # type: ignore[arg-type]
+            chat_id=1,
+            message_id=10,
+            text="retry-test",
+            keyboard=[],
+        )
+    )
+    assert ok is True
+    assert fake_session.calls == 2
+
+
+def test_partial_failure_feedback_remains_explicit() -> None:
+    handler = _make_handler()
+    handler.handle = AsyncMock(  # type: ignore[method-assign]
+        return_value=CommandResult(
+            success=False,
+            message="partial_failure: post-process failed",
+        )
+    )
+    callback_router = _make_callback_router(handler)
+    message, _keyboard = asyncio.run(callback_router._dispatch("trade_paper_execute", user_id=11))
+    assert "partial_failure" in message
+
+
+def test_execution_snapshot_contract_exposes_required_fields() -> None:
+    _reset_execution_singleton()
+    engine = get_execution_engine()
+    snapshot = asyncio.run(engine.snapshot())
+    assert hasattr(snapshot, "implied_prob")
+    assert hasattr(snapshot, "volatility")


### PR DESCRIPTION
### Motivation
- Sentinels reported a BLOCKED MAJOR validation because `StrategyTrigger.evaluate(...)` expected `ExecutionSnapshot.implied_prob` and `ExecutionSnapshot.volatility` which were not present, causing real command/callback-triggered execution to fail. 
- The goal was to restore a stable runtime contract at the execution→strategy boundary and ensure callback→parser→execution uses the same authoritative path without regressing safety (dedup, timeout/retry, explicit failures). 

### Description
- Extended `ExecutionSnapshot` to include `implied_prob` and `volatility` and wired stable engine-side updates so `ExecutionEngine.snapshot()` always exposes those fields (`projects/polymarket/polyquantbot/execution/engine.py`).
- Fixed `StrategyTrigger.evaluate(...)` to consume `ExecutionIntelligence.evaluate_entry(...)` structured return (`score` + `reasons`) and to supply explicit `position_id` and trace reasons when opening/closing positions (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`).
- Preserved real `/trade` parser semantics by allowing non-numeric trade payloads through `CommandRouter` and widened handler signatures accordingly (`projects/polymarket/polyquantbot/telegram/command_router.py`, `projects/polymarket/polyquantbot/telegram/command_handler.py`).
- Routed `action:trade_paper_execute` callback into the same authoritative command-handling trade path with safe awaitable handling and safe fallback to UI render when mocks/non-awaitable handlers are used (`projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`).
- Added duplicate-intent protection for `/trade test` to prevent double execution and preserve explicit failure feedback (`projects/polymarket/polyquantbot/telegram/command_handler.py`).
- Added a focused MAJOR-tier test file exercising command path, callback path, shared-path proof, dedup, timeout/retry edit retry, partial-failure visibility, and snapshot field presence (`projects/polymarket/polyquantbot/tests/test_p5_execution_snapshot_contract_20260409.py`).
- Added FORGE report and updated `PROJECT_STATE.md` to reflect remediation handoff for SENTINEL revalidation (`projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md` and `PROJECT_STATE.md`).

### Testing
- Ran syntax/compile checks with `python -m py_compile` on modified modules and the new test file, which passed. 
- Ran focused pytest selection with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p5_execution_snapshot_contract_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_mvp.py projects/polymarket/polyquantbot/tests/test_telegram_trade_menu_routing_mvp.py` and observed all tests pass (`11 passed, 1 warning`).
- Executed a runtime harness demonstration (inline Python harness used during validation) that produced proof markers: command execution success past the strategy trigger, callback execution success past the same boundary, no `implied_prob`/`volatility` attribute errors, and duplicate intent blocked as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6bfdc67f4832e9543b848f2483e3d)