### PR TITLE
P6 observability deepening: lifecycle traces, structured errors, and outcome classification

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 20:58
-- Status        : FORGE-X remediation for P5 execution snapshot contract compatibility completed; MAJOR task ready for SENTINEL revalidation.
+- Last Updated  : 2026-04-08 21:36
+- Status        : FORGE-X P6 observability deepening completed; MAJOR task ready for SENTINEL validation.
 
 ---
 
@@ -39,6 +39,7 @@
 - Trade-system hardening P2 restore_failure observability addendum (2026-04-07): added explicit structured restore outcome emission (`restore_failure`/`restore_success`) in engine restore path and added focused proof test `test_trade_system_hardening_p2_20260407.py`.
 - SENTINEL validation complete for `telegram_command_driven_execution_20260408` (2026-04-08): verdict **BLOCKED**, score **38/100**; required callback→command→parser→execution runtime chain not met and FULL RUNTIME INTEGRATION claim not evidenced for target path.
 - FORGE-X fix pass `p5_execution_snapshot_contract_compatibility_20260408` completed (2026-04-08): added explicit `ExecutionSnapshot.implied_prob`/`ExecutionSnapshot.volatility` contract fields, corrected `StrategyTrigger` intelligence contract usage, routed callback paper execution into authoritative command-trade path, and added duplicate-intent block + focused MAJOR regression tests.
+- P6 observability deepening pass `p6-observability-deepening-2026-04-09` completed (2026-04-08): added full execution lifecycle stage tracing (`ENTRY→VALIDATION→RISK→EXECUTION→RESULT`), structured failure diagnostics (`error_type`, `error_message`, `execution_stage`, `trace_id`), required outcome classification (`SUCCESS`/`FAILED`/`BLOCKED`/`TIMEOUT`/`DUPLICATE_PREVENTED`/`INVALID_INPUT`), anomaly signal emission, and focused MAJOR runtime tests.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
 
@@ -105,6 +106,10 @@ Status:
 - FORGE-X remediation patch is complete for execution snapshot contract compatibility and callback/command shared trade path integration.
 - SENTINEL MAJOR revalidation is now required before merge decision.
 
+### P6 observability deepening handoff
+- FORGE-X observability deepening implementation is complete with full runtime-stage tracing, structured failure diagnostics, and outcome classification coverage across command parser, callback entry, risk layer, execution coordinator, and execution result handling.
+- SENTINEL MAJOR validation is required for observability correctness before merge.
+
 ## ❌ NOT STARTED
 
 - None.
@@ -113,8 +118,8 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-SENTINEL validation required for p5_execution_snapshot_contract_compatibility before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md
+SENTINEL validation required for p6-observability-deepening-2026-04-09 before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_3_observability_deepening.md
 Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
@@ -126,3 +131,4 @@ Tier: MAJOR
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.
+- MAJOR task `p6-observability-deepening-2026-04-09` awaits SENTINEL validation for merge eligibility.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -8,6 +8,7 @@ import uuid
 
 import structlog
 
+from .observability import OUTCOME_BLOCKED, STAGE_RISK, emit_outcome, emit_stage
 from .models import Position
 from .analytics import PerformanceTracker
 from .trade_trace import TradeTraceEngine
@@ -50,12 +51,27 @@ class ExecutionEngine:
         price: float,
         size: float,
         position_id: str | None = None,
+        trace_id: str | None = None,
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
+            if trace_id:
+                emit_stage(
+                    trace_id=trace_id,
+                    stage=STAGE_RISK,
+                    component="risk_layer",
+                    payload={"market": market, "size": size},
+                )
             size = float(size)
             if size <= 0:
                 log.warning("execution_engine_open_rejected", reason="size_non_positive", size=size)
+                if trace_id:
+                    emit_outcome(
+                        trace_id=trace_id,
+                        outcome=OUTCOME_BLOCKED,
+                        component="risk_layer",
+                        payload={"reason": "size_non_positive", "market": market, "size": size},
+                    )
                 return None
             if not position_id:
                 position_id = str(uuid.uuid4())
@@ -69,6 +85,13 @@ class ExecutionEngine:
                     limit=max_position_size,
                     equity=equity_base,
                 )
+                if trace_id:
+                    emit_outcome(
+                        trace_id=trace_id,
+                        outcome=OUTCOME_BLOCKED,
+                        component="risk_layer",
+                        payload={"reason": "max_position_size_exceeded", "market": market, "size": size},
+                    )
                 return None
             if self._current_total_exposure() + size > equity_base * self.max_total_exposure_ratio:
                 log.warning(
@@ -78,6 +101,13 @@ class ExecutionEngine:
                     current_exposure=self._current_total_exposure(),
                     limit=equity_base * self.max_total_exposure_ratio,
                 )
+                if trace_id:
+                    emit_outcome(
+                        trace_id=trace_id,
+                        outcome=OUTCOME_BLOCKED,
+                        component="risk_layer",
+                        payload={"reason": "max_total_exposure_exceeded", "market": market, "size": size},
+                    )
                 return None
             if self._cash < size:
                 log.warning(
@@ -86,6 +116,13 @@ class ExecutionEngine:
                     requested=size,
                     cash=self._cash,
                 )
+                if trace_id:
+                    emit_outcome(
+                        trace_id=trace_id,
+                        outcome=OUTCOME_BLOCKED,
+                        component="risk_layer",
+                        payload={"reason": "insufficient_cash", "market": market, "size": size},
+                    )
                 return None
 
             position = Position(

--- a/projects/polymarket/polyquantbot/execution/observability.py
+++ b/projects/polymarket/polyquantbot/execution/observability.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+STAGE_ENTRY = "ENTRY"
+STAGE_VALIDATION = "VALIDATION"
+STAGE_RISK = "RISK"
+STAGE_EXECUTION = "EXECUTION"
+STAGE_RESULT = "RESULT"
+
+OUTCOME_SUCCESS = "SUCCESS"
+OUTCOME_FAILED = "FAILED"
+OUTCOME_BLOCKED = "BLOCKED"
+OUTCOME_TIMEOUT = "TIMEOUT"
+OUTCOME_DUPLICATE_PREVENTED = "DUPLICATE_PREVENTED"
+OUTCOME_INVALID_INPUT = "INVALID_INPUT"
+
+_RECENT_OUTCOMES: deque[str] = deque(maxlen=50)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def emit_stage(
+    *,
+    trace_id: str,
+    stage: str,
+    component: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event = {
+        "trace_id": trace_id,
+        "stage": stage,
+        "component": component,
+        "timestamp": _utc_now_iso(),
+        "payload": payload or {},
+    }
+    log.info("execution_stage_trace", **event)
+    return event
+
+
+def emit_outcome(
+    *,
+    trace_id: str,
+    outcome: str,
+    component: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event = {
+        "trace_id": trace_id,
+        "outcome": outcome,
+        "component": component,
+        "timestamp": _utc_now_iso(),
+        "payload": payload or {},
+    }
+    _RECENT_OUTCOMES.append(outcome)
+    log.info("execution_outcome", **event)
+    _emit_anomaly_signals(trace_id=trace_id, component=component)
+    return event
+
+
+def emit_error(
+    *,
+    trace_id: str,
+    execution_stage: str,
+    component: str,
+    error: Exception,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event = {
+        "trace_id": trace_id,
+        "error_type": type(error).__name__,
+        "error_message": str(error),
+        "execution_stage": execution_stage,
+        "component": component,
+        "timestamp": _utc_now_iso(),
+        "payload": payload or {},
+    }
+    log.error("execution_failure", **event, exc_info=True)
+    return event
+
+
+def classify_result(*, success: bool, message: str) -> str:
+    normalized = message.lower()
+    if "duplicate_blocked" in normalized:
+        return OUTCOME_DUPLICATE_PREVENTED
+    if "usage:" in normalized or "must be" in normalized or "invalid" in normalized:
+        return OUTCOME_INVALID_INPUT
+    if "timeout" in normalized:
+        return OUTCOME_TIMEOUT
+    if success:
+        return OUTCOME_SUCCESS
+    return OUTCOME_FAILED
+
+
+def _emit_anomaly_signals(*, trace_id: str, component: str) -> None:
+    recent = list(_RECENT_OUTCOMES)
+    if len(recent) < 5:
+        return
+
+    repeated_failures = recent[-5:].count(OUTCOME_FAILED)
+    timeout_count = recent[-10:].count(OUTCOME_TIMEOUT)
+    duplicate_count = recent[-10:].count(OUTCOME_DUPLICATE_PREVENTED)
+
+    if repeated_failures >= 3:
+        log.warning(
+            "execution_anomaly_signal",
+            trace_id=trace_id,
+            component=component,
+            anomaly_type="repeated_failures",
+            window="last_5",
+            count=repeated_failures,
+            timestamp=_utc_now_iso(),
+        )
+    if timeout_count >= 3:
+        log.warning(
+            "execution_anomaly_signal",
+            trace_id=trace_id,
+            component=component,
+            anomaly_type="abnormal_timeout_frequency",
+            window="last_10",
+            count=timeout_count,
+            timestamp=_utc_now_iso(),
+        )
+    if duplicate_count >= 4:
+        log.warning(
+            "execution_anomaly_signal",
+            trace_id=trace_id,
+            component=component,
+            anomaly_type="duplicate_spike",
+            window="last_10",
+            count=duplicate_count,
+            timestamp=_utc_now_iso(),
+        )

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -35,7 +35,7 @@ class StrategyTrigger:
         self._cooldown_seconds = 30.0  # Anti-loop guard
         self._trace_engine = TradeTraceEngine()
 
-    async def evaluate(self, market_price: float) -> str:
+    async def evaluate(self, market_price: float, trace_id: str | None = None) -> str:
         now = time.time()
         if self._last_trigger_time and (now - self._last_trigger_time) < self._cooldown_seconds:
             return "COOLDOWN"
@@ -68,6 +68,7 @@ class StrategyTrigger:
                 price=market_price,
                 size=size,
                 position_id=str(uuid.uuid4()),
+                trace_id=trace_id,
             )
             if created:
                 self._trace_engine.record_trace(

--- a/projects/polymarket/polyquantbot/reports/forge/24_3_observability_deepening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_3_observability_deepening.md
@@ -1,0 +1,88 @@
+# FORGE-X REPORT — 24_3_observability_deepening
+
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  - execution coordinator
+  - command parser
+  - callback entry
+  - risk layer
+  - execution result handling
+- Not in Scope:
+  - UI dashboard (BRIEFER layer)
+  - strategy redesign
+  - execution logic redesign
+  - Telegram UX changes
+- Suggested Next Step:
+  - SENTINEL validation
+
+## 1) What was built
+- Added a dedicated execution observability module (`execution/observability.py`) that emits:
+  - lifecycle stage traces (`ENTRY → VALIDATION → RISK → EXECUTION → RESULT`)
+  - canonical outcome classifications (`SUCCESS`, `FAILED`, `BLOCKED`, `TIMEOUT`, `DUPLICATE_PREVENTED`, `INVALID_INPUT`)
+  - structured failure events (`error_type`, `error_message`, `execution_stage`, `trace_id`)
+  - anomaly signals (`repeated_failures`, `abnormal_timeout_frequency`, `duplicate_spike`).
+- Integrated command parser tracing and error visibility in `telegram/command_router.py` with generated `trace_id` propagation to command execution.
+- Integrated execution coordinator tracing and outcome classification in `telegram/command_handler.py` for `/trade` path including timeout, duplicate, invalid input, blocked, failed, and success paths.
+- Integrated callback entry tracing and structured failure capture in `telegram/handlers/callback_router.py` and ensured callback trade execution forwards correlation id.
+- Integrated risk-layer outcome visibility in `execution/engine.py` for blocked open-position scenarios.
+- Extended strategy trigger/engine boundary to carry `trace_id` into risk-layer checks.
+- Added focused MAJOR tests that validate required traces and outcome classes.
+
+## 2) Current system architecture
+- `CommandRouter` creates `trace_id`, emits `ENTRY`/`VALIDATION`, and forwards `correlation_id`.
+- `CommandHandler` acts as execution coordinator, emits lifecycle stages, and classifies terminal outcomes for all `/trade` command executions.
+- `StrategyTrigger` forwards trace context into `ExecutionEngine.open_position(...)`.
+- `ExecutionEngine` emits risk-layer blocked outcomes for risk constraints.
+- `CallbackRouter` emits callback-entry traces and structured failures and links callback-triggered execution to the same command execution trace.
+- `execution/observability.py` centralizes stage events, error events, outcome events, and anomaly signals.
+
+## 3) Files created / modified (full paths)
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/observability.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py`
+
+## 4) What is working
+- Required outcome classes are now emitted on runtime command execution results.
+- Structured failure logging now includes `error_type`, `error_message`, `execution_stage`, and `trace_id`.
+- Stage tracing is emitted across the required lifecycle and linked through a single `trace_id`.
+- Failure paths no longer fail silently; they emit explicit structured failure and outcome events.
+- Anomaly signals are emitted when repeated failures, timeout spikes, or duplicate spikes exceed thresholds.
+- Focused tests pass for:
+  1. successful execution trace
+  2. failure trace (error)
+  3. timeout trace
+  4. duplicate prevention trace
+  5. invalid input trace
+
+### Runtime proof (log markers)
+Command(s):
+- `PYTHONPATH=. python - <<'PY' ...` (success + invalid-input lifecycle proof)
+- `PYTHONPATH=. python - <<'PY' ...` (failure/structured-error proof)
+
+Observed proof markers:
+- `PROOF stage ENTRY ...`
+- `PROOF stage VALIDATION ...`
+- `PROOF stage RISK ...`
+- `PROOF stage EXECUTION ...`
+- `PROOF stage RESULT ...`
+- `PROOF structured_error proof-failure RuntimeError proof_export_failure EXECUTION`
+- `PROOF outcome proof-success SUCCESS`
+- `PROOF outcome proof-invalid INVALID_INPUT`
+- `PROOF outcome proof-failure FAILED`
+
+## 5) Known issues
+- Existing repo-level pytest warning persists: `Unknown config option: asyncio_mode`.
+- External market context endpoint (`clob.polymarket.com`) remains unreachable from this container and may still produce warning logs during runtime checks.
+
+## 6) What is next
+- SENTINEL validation required for P6 observability deepening correctness before merge.
+- SENTINEL should verify:
+  - lifecycle trace completeness per execution (`ENTRY→VALIDATION→RISK→EXECUTION→RESULT`)
+  - outcome classification correctness for required categories
+  - structured failure contract completeness (`error_type`, `error_message`, `execution_stage`, `trace_id`)
+  - anomaly signal behavior on threshold-triggering patterns

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -11,6 +11,20 @@ from ..config.runtime_config import ConfigManager
 from ..core.system_state import SystemState, SystemStateManager
 from ..interface.telegram.view_handler import render_view, safe_count, safe_number
 from ..execution.engine import export_execution_payload, get_execution_engine
+from ..execution.observability import (
+    OUTCOME_BLOCKED,
+    OUTCOME_FAILED,
+    OUTCOME_TIMEOUT,
+    STAGE_ENTRY,
+    STAGE_EXECUTION,
+    STAGE_RESULT,
+    STAGE_RISK,
+    STAGE_VALIDATION,
+    classify_result,
+    emit_error,
+    emit_outcome,
+    emit_stage,
+)
 from ..execution.strategy_trigger import StrategyConfig, StrategyTrigger
 from .ui.keyboard import build_dashboard_menu
 from .handlers.portfolio_service import get_portfolio_service
@@ -152,11 +166,24 @@ class CommandHandler:
             correlation_id=cid,
             timestamp=time.time(),
         )
+        emit_stage(
+            trace_id=cid,
+            stage=STAGE_ENTRY,
+            component="execution_coordinator",
+            payload={"command": cmd, "user_id": user_id},
+        )
 
         async with self._lock:
             try:
                 result = await self._dispatch(cmd, value, cid)
             except Exception as exc:  # noqa: BLE001
+                emit_error(
+                    trace_id=cid,
+                    execution_stage=STAGE_EXECUTION,
+                    component="execution_coordinator",
+                    error=exc,
+                    payload={"command": cmd, "user_id": user_id},
+                )
                 log.error(
                     "command_handler_error",
                     command=cmd,
@@ -185,6 +212,20 @@ class CommandHandler:
             success=result.success,
             timestamp=time.time(),
         )
+        if cmd == "trade":
+            classification = classify_result(success=result.success, message=result.message)
+            emit_stage(
+                trace_id=cid,
+                stage=STAGE_RESULT,
+                component="execution_result_handler",
+                payload={"command": cmd},
+            )
+            emit_outcome(
+                trace_id=cid,
+                outcome=classification,
+                component="execution_result_handler",
+                payload={"command": cmd, "success": result.success},
+            )
 
         # Send response back via Telegram only if not called from polling loop
         # (polling loop handles its own reply to preserve correct chat_id)
@@ -250,7 +291,7 @@ class CommandHandler:
         if cmd == "alpha":
             return await self._handle_alpha()
         if cmd == "trade":
-            return await self._handle_trade(value)
+            return await self._handle_trade(value, cid)
 
         # ── New menu callbacks (new Telegram system) ───────────────────────────
         if cmd == "wallet":
@@ -311,8 +352,20 @@ class CommandHandler:
             ),
         )
 
-    async def _handle_trade(self, args: Optional[float | str] = None) -> CommandResult:
+    async def _handle_trade(
+        self,
+        args: Optional[float | str] = None,
+        trace_id: Optional[str] = None,
+    ) -> CommandResult:
         """Parse /trade [test/close/status] [args]."""
+        if trace_id is None:
+            trace_id = str(uuid.uuid4())
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_VALIDATION,
+            component="execution_coordinator",
+            payload={"route": "trade"},
+        )
         if args is None:
             return CommandResult(
                 success=False,
@@ -326,7 +379,7 @@ class CommandHandler:
             )
         action = parts[0].lower()
         if action == "test":
-            return await self._handle_trade_test(" ".join(parts[1:]))
+            return await self._handle_trade_test(" ".join(parts[1:]), trace_id=trace_id)
         if action == "close":
             return await self._handle_trade_close(" ".join(parts[1:]))
         if action == "status":
@@ -336,7 +389,7 @@ class CommandHandler:
             message="Usage: /trade [test|close|status] [args]",
         )
 
-    async def _handle_trade_test(self, args: str) -> CommandResult:
+    async def _handle_trade_test(self, args: str, *, trace_id: str) -> CommandResult:
         """Parse /trade test [market] [side] [size]."""
         if not args:
             return CommandResult(
@@ -350,6 +403,12 @@ class CommandHandler:
                 message="Usage: /trade test [market] [side YES/NO] [size]",
             )
         market, side, size_str = parts[0], parts[1].upper(), parts[2]
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_VALIDATION,
+            component="execution_coordinator",
+            payload={"market": market, "side": side},
+        )
         try:
             size = float(size_str)
         except ValueError:
@@ -368,6 +427,18 @@ class CommandHandler:
             if now - ts > self._trade_intent_ttl_s:
                 del self._trade_intents[key]
         if intent in self._trade_intents:
+            emit_stage(
+                trace_id=trace_id,
+                stage=STAGE_RESULT,
+                component="execution_result_handler",
+                payload={"reason": "duplicate_intent"},
+            )
+            emit_outcome(
+                trace_id=trace_id,
+                outcome="DUPLICATE_PREVENTED",
+                component="execution_result_handler",
+                payload={"market": market, "side": side, "size": size},
+            )
             return CommandResult(
                 success=False,
                 message="duplicate_blocked: trade intent already executed recently.",
@@ -383,7 +454,72 @@ class CommandHandler:
                 target_pnl=20.0,
             ),
         )
-        await trigger.evaluate(0.42)
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_RISK,
+            component="risk_layer",
+            payload={"market": market, "size": size},
+        )
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_EXECUTION,
+            component="execution_coordinator",
+            payload={"market": market, "side": side, "size": size},
+        )
+        try:
+            trigger_result = await asyncio.wait_for(
+                trigger.evaluate(0.42, trace_id=trace_id),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError as exc:
+            emit_error(
+                trace_id=trace_id,
+                execution_stage=STAGE_EXECUTION,
+                component="execution_coordinator",
+                error=exc,
+                payload={"market": market, "side": side},
+            )
+            emit_stage(
+                trace_id=trace_id,
+                stage=STAGE_RESULT,
+                component="execution_result_handler",
+                payload={"result": "timeout"},
+            )
+            emit_outcome(
+                trace_id=trace_id,
+                outcome=OUTCOME_TIMEOUT,
+                component="execution_result_handler",
+                payload={"market": market, "side": side},
+            )
+            return CommandResult(success=False, message="execution timeout during trade test.")
+        if trigger_result == "BLOCKED":
+            emit_stage(
+                trace_id=trace_id,
+                stage=STAGE_RESULT,
+                component="execution_result_handler",
+                payload={"result": trigger_result},
+            )
+            emit_outcome(
+                trace_id=trace_id,
+                outcome=OUTCOME_BLOCKED,
+                component="execution_result_handler",
+                payload={"market": market, "side": side, "size": size},
+            )
+            return CommandResult(success=False, message="trade execution blocked by risk constraints.")
+        if trigger_result not in {"OPENED", "CLOSED", "HOLD", "COOLDOWN"}:
+            emit_stage(
+                trace_id=trace_id,
+                stage=STAGE_RESULT,
+                component="execution_result_handler",
+                payload={"result": trigger_result},
+            )
+            emit_outcome(
+                trace_id=trace_id,
+                outcome=OUTCOME_FAILED,
+                component="execution_result_handler",
+                payload={"market": market, "side": side, "size": size},
+            )
+            return CommandResult(success=False, message=f"trade execution failed: {trigger_result}.")
         await engine.update_mark_to_market({market: 0.46})
         payload = await export_execution_payload()
         get_portfolio_service().merge_execution_state(
@@ -391,6 +527,18 @@ class CommandHandler:
             cash=float(payload.get("cash", 0.0)),
             equity=float(payload.get("equity", 0.0)),
             realized_pnl=float(payload.get("realized", 0.0)),
+        )
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_RESULT,
+            component="execution_result_handler",
+            payload={"result": trigger_result},
+        )
+        emit_outcome(
+            trace_id=trace_id,
+            outcome="SUCCESS",
+            component="execution_result_handler",
+            payload={"market": market, "side": side, "size": size, "result": trigger_result},
         )
         return CommandResult(
             success=True,

--- a/projects/polymarket/polyquantbot/telegram/command_router.py
+++ b/projects/polymarket/polyquantbot/telegram/command_router.py
@@ -38,6 +38,13 @@ from typing import Optional
 
 import structlog
 
+from ..execution.observability import (
+    STAGE_ENTRY,
+    STAGE_VALIDATION,
+    emit_error,
+    emit_stage,
+)
+from ..execution.trace_context import generate_trace_id
 from .command_handler import CommandHandler, CommandResult
 
 log = structlog.get_logger()
@@ -108,6 +115,13 @@ class CommandRouter:
 
     async def _route_structured(self, payload: dict) -> CommandResult:
         """Handle a structured {"command": ..., "value": ...} dict."""
+        trace_id = generate_trace_id()
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_ENTRY,
+            component="command_parser",
+            payload={"input_type": "structured"},
+        )
         command = str(payload.get("command", "")).strip()
         value = payload.get("value")
         user_id = str(payload.get("user_id", "structured"))
@@ -126,15 +140,29 @@ class CommandRouter:
                     success=False,
                     message=f"❌ Invalid 'value': expected numeric, got {value!r}",
                 )
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_VALIDATION,
+            component="command_parser",
+            payload={"command": command, "user_id": user_id},
+        )
 
         return await self._handler.handle(
             command=command,
             value=value,
             user_id=user_id,
+            correlation_id=trace_id,
         )
 
     async def _route_telegram_update(self, update: dict) -> Optional[CommandResult]:
         """Handle a Telegram Bot API update dict."""
+        trace_id = generate_trace_id()
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_ENTRY,
+            component="command_parser",
+            payload={"input_type": "telegram_update"},
+        )
         update_id = update.get("update_id")
 
         # Dedup by update_id
@@ -186,6 +214,13 @@ class CommandRouter:
                 try:
                     value = float(arg_str)
                 except ValueError:
+                    emit_error(
+                        trace_id=trace_id,
+                        execution_stage=STAGE_VALIDATION,
+                        component="command_parser",
+                        error=ValueError(f"Invalid numeric argument: {arg_str!r}"),
+                        payload={"command": raw_cmd, "user_id": user_id},
+                    )
                     pass  # value stays None — handler will report the error
 
         log.info(
@@ -196,9 +231,16 @@ class CommandRouter:
             update_id=update_id,
             timestamp=time.time(),
         )
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_VALIDATION,
+            component="command_parser",
+            payload={"command": raw_cmd, "user_id": user_id},
+        )
 
         return await self._handler.handle(
             command=raw_cmd,
             value=value,
             user_id=user_id,
+            correlation_id=trace_id,
         )

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -48,6 +48,8 @@ from ..ui.screens import (
 )
 from ..ui.components import render_kv_line, render_insight, SEP
 from ...interface.telegram.view_handler import render_view, safe_number, safe_count
+from ...execution.observability import STAGE_ENTRY, STAGE_RESULT, emit_error, emit_stage
+from ...execution.trace_context import generate_trace_id
 from ...core.market_scope import (
     MARKET_SCOPE_CATEGORIES,
     get_market_scope_snapshot,
@@ -245,6 +247,7 @@ class CallbackRouter:
             cq: Telegram ``callback_query`` dict from ``getUpdates``.
         """
         cb_data: str = (cq.get("data") or "").strip()
+        trace_id = generate_trace_id()
         chat_id: Optional[int] = cq.get("message", {}).get("chat", {}).get("id")
         message_id: Optional[int] = cq.get("message", {}).get("message_id")
         cq_id: str = cq.get("id", "")
@@ -256,6 +259,12 @@ class CallbackRouter:
             chat_id=chat_id,
             message_id=message_id,
             user_id=user_id,
+        )
+        emit_stage(
+            trace_id=trace_id,
+            stage=STAGE_ENTRY,
+            component="callback_entry",
+            payload={"callback_data": cb_data, "user_id": user_id},
         )
         log.info("telegram_handler", handler="NEW_SYSTEM")
 
@@ -278,7 +287,7 @@ class CallbackRouter:
             if any(x in cb_data for x in ("health", "strategies")):
                 log.warning("callback_legacy_blocked", callback_data=cb_data)
                 raise RuntimeError("LEGACY UI DISABLED")
-            text, keyboard = await self._dispatch(action, user_id=user_id)
+            text, keyboard = await self._dispatch(action, user_id=user_id, trace_id=trace_id)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -287,6 +296,13 @@ class CallbackRouter:
                 action=action,
                 error=str(exc),
                 exc_info=True,
+            )
+            emit_error(
+                trace_id=trace_id,
+                execution_stage="EXECUTION",
+                component="callback_entry",
+                error=exc,
+                payload={"action": action, "user_id": user_id},
             )
             text = error_screen(context=action, error=str(exc))
             keyboard = build_dashboard_menu()
@@ -563,7 +579,12 @@ class CallbackRouter:
 
     # ── Dispatch table ─────────────────────────────────────────────────────────
 
-    async def _dispatch(self, action: str, user_id: Optional[int] = None) -> tuple[str, list]:
+    async def _dispatch(
+        self,
+        action: str,
+        user_id: Optional[int] = None,
+        trace_id: Optional[str] = None,
+    ) -> tuple[str, list]:
         """Route ``action`` to the correct handler.
 
         Args:
@@ -641,6 +662,7 @@ class CallbackRouter:
                 command="trade",
                 value="test PAPER_MARKET YES 10",
                 user_id=str(user_id) if user_id is not None else None,
+                correlation_id=trace_id,
             )
             result = await maybe_result if inspect.isawaitable(maybe_result) else maybe_result
             if not hasattr(result, "success") or not isinstance(getattr(result, "message", None), str):
@@ -653,6 +675,13 @@ class CallbackRouter:
                     action=action,
                     user_id=user_id,
                     message=result.message[:200],
+                )
+            if trace_id is not None:
+                emit_stage(
+                    trace_id=trace_id,
+                    stage=STAGE_RESULT,
+                    component="callback_entry",
+                    payload={"action": action, "success": result.success},
                 )
             return result.message, build_trade_menu()
 

--- a/projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler
+from projects.polymarket.polyquantbot.execution import observability
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyTrigger
+
+
+class _DummyStateManager:
+    async def pause(self, reason: str) -> None:
+        _ = reason
+
+    def snapshot(self) -> dict[str, str]:
+        return {"state": "RUNNING"}
+
+
+class _DummyConfigManager:
+    def snapshot(self):
+        class _Cfg:
+            risk_multiplier = 0.25
+            max_position = 0.10
+
+        return _Cfg()
+
+
+class _SpyLog:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+
+    def info(self, event: str, **kwargs) -> None:
+        self.events.append(("info", event, kwargs))
+
+    def warning(self, event: str, **kwargs) -> None:
+        self.events.append(("warning", event, kwargs))
+
+    def error(self, event: str, **kwargs) -> None:
+        self.events.append(("error", event, kwargs))
+
+
+def _build_handler() -> CommandHandler:
+    return CommandHandler(
+        state_manager=_DummyStateManager(),  # type: ignore[arg-type]
+        config_manager=_DummyConfigManager(),  # type: ignore[arg-type]
+    )
+
+
+def _stage_names(events: list[tuple[str, str, dict]], trace_id: str) -> list[str]:
+    return [
+        payload["stage"]
+        for level, event, payload in events
+        if level == "info"
+        and event == "execution_stage_trace"
+        and payload.get("trace_id") == trace_id
+    ]
+
+
+def _outcomes(events: list[tuple[str, str, dict]], trace_id: str) -> list[str]:
+    return [
+        payload["outcome"]
+        for level, event, payload in events
+        if level == "info"
+        and event == "execution_outcome"
+        and payload.get("trace_id") == trace_id
+    ]
+
+
+def test_successful_execution_trace(monkeypatch):
+    spy = _SpyLog()
+    monkeypatch.setattr(observability, "log", spy)
+    handler = _build_handler()
+
+    result = asyncio.run(
+        handler.handle("trade", value="test PM1 YES 10", correlation_id="trace-success")
+    )
+
+    assert result.success is True
+    stages = _stage_names(spy.events, "trace-success")
+    assert stages[0] == "ENTRY"
+    assert "VALIDATION" in stages
+    assert "RISK" in stages
+    assert "EXECUTION" in stages
+    assert stages[-1] == "RESULT"
+    assert _outcomes(spy.events, "trace-success")[-1] == "SUCCESS"
+
+
+def test_failure_trace_structured_error(monkeypatch):
+    spy = _SpyLog()
+    monkeypatch.setattr(observability, "log", spy)
+    handler = _build_handler()
+
+    async def _raise_export_error() -> dict:
+        raise RuntimeError("payload_export_failed")
+
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.telegram.command_handler.export_execution_payload",
+        _raise_export_error,
+    )
+
+    result = asyncio.run(
+        handler.handle("trade", value="test PM2 YES 10", correlation_id="trace-failure")
+    )
+
+    assert result.success is False
+    assert _outcomes(spy.events, "trace-failure")[-1] == "FAILED"
+    error_events = [
+        payload
+        for level, event, payload in spy.events
+        if level == "error" and event == "execution_failure"
+    ]
+    assert error_events
+    assert error_events[-1]["error_type"] == "RuntimeError"
+    assert error_events[-1]["execution_stage"] == "EXECUTION"
+    assert error_events[-1]["trace_id"] == "trace-failure"
+
+
+def test_timeout_trace(monkeypatch):
+    spy = _SpyLog()
+    monkeypatch.setattr(observability, "log", spy)
+    handler = _build_handler()
+
+    async def _slow_eval(self, market_price: float, trace_id: str | None = None) -> str:
+        _ = self, market_price, trace_id
+        await asyncio.sleep(5.2)
+        return "OPENED"
+
+    monkeypatch.setattr(StrategyTrigger, "evaluate", _slow_eval)
+
+    result = asyncio.run(
+        handler.handle("trade", value="test PM3 YES 10", correlation_id="trace-timeout")
+    )
+
+    assert result.success is False
+    assert _outcomes(spy.events, "trace-timeout")[-1] == "TIMEOUT"
+
+
+def test_duplicate_prevention_trace(monkeypatch):
+    spy = _SpyLog()
+    monkeypatch.setattr(observability, "log", spy)
+    handler = _build_handler()
+
+    first = asyncio.run(
+        handler.handle("trade", value="test PM4 YES 10", correlation_id="trace-dup-1")
+    )
+    second = asyncio.run(
+        handler.handle("trade", value="test PM4 YES 10", correlation_id="trace-dup-2")
+    )
+
+    assert first.success is True
+    assert second.success is False
+    assert _outcomes(spy.events, "trace-dup-2")[-1] == "DUPLICATE_PREVENTED"
+
+
+def test_invalid_input_trace(monkeypatch):
+    spy = _SpyLog()
+    monkeypatch.setattr(observability, "log", spy)
+    handler = _build_handler()
+
+    result = asyncio.run(
+        handler.handle("trade", value="test PM5 YES bad-size", correlation_id="trace-invalid")
+    )
+
+    assert result.success is False
+    assert _outcomes(spy.events, "trace-invalid")[-1] == "INVALID_INPUT"


### PR DESCRIPTION
### Motivation
- Provide full runtime visibility and structured diagnostics across the command→parser→risk→execution→result path so every execution is traceable and failures are classified.
- Ensure no silent failures and produce machine-friendly error events with `trace_id` linkage for downstream monitoring and SENTINEL validation.
- Meet the MAJOR validation tier requirement and deliver a FULL RUNTIME INTEGRATION handoff covering execution coordinator, command parser, callback entry, risk layer, and result handling.

### Description
- Added a centralized observability module `projects/polymarket/polyquantbot/execution/observability.py` that emits stage traces (`ENTRY/VALIDATION/RISK/EXECUTION/RESULT`), canonical outcomes (`SUCCESS/FAILED/BLOCKED/TIMEOUT/DUPLICATE_PREVENTED/INVALID_INPUT`), structured error events (`error_type`, `error_message`, `execution_stage`, `trace_id`), and anomaly signals.
- Propagated `trace_id` and stage events from the command layer by instrumenting `telegram/command_router.py` (generates `trace_id`, emits `ENTRY/VALIDATION`, forwards `correlation_id`) and `telegram/command_handler.py` (emits lifecycle stages, classifies outcomes, emits `execution_failure` events and outcome events for `/trade`).
- Linked callback flows to the same trace context in `telegram/handlers/callback_router.py` so callback-triggered trade executions emit `ENTRY`/`RESULT` traces and structured failure events. 
- Exposed risk-layer visibility by wiring trace context into `execution/strategy_trigger.py` and `execution/engine.py` so blocked open-position checks emit outcome events; added outcome emissions for common blocked reasons. 
- Added focused MAJOR tests `projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py`, created the FORGE report `projects/polymarket/polyquantbot/reports/forge/24_3_observability_deepening.md`, and updated `PROJECT_STATE.md` with timestamped handoff requiring SENTINEL validation.

### Testing
- Static/compile checks run: `python -m py_compile projects/polymarket/polyquantbot/execution/observability.py projects/polymarket/polyquantbot/telegram/command_router.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py` — PASS.
- Unit test run: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_p6_observability_deepening_20260409.py` — all focused tests passed (5 passed, 1 repo warning about `asyncio_mode` persisted but is pre-existing).
- Runtime proof harnesses executed via `PYTHONPATH=. python - <<'PY' ...` produced lifecycle trace markers and structured failure outputs including `PROOF stage ...`, `PROOF structured_error ...`, and `PROOF outcome ...`, demonstrating full trace lifecycle and correct outcome classification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c90afee4832e8904b9c03808b141)