### PR TITLE
fix: resolve P6 observability review findings for /trade event hygiene

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 20:58
-- Status        : FORGE-X remediation for P5 execution snapshot contract compatibility completed; MAJOR task ready for SENTINEL revalidation.
+- Last Updated  : 2026-04-08 21:50
+- Status        : FORGE-X P6 observability review findings remediation completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
@@ -39,6 +39,7 @@
 - Trade-system hardening P2 restore_failure observability addendum (2026-04-07): added explicit structured restore outcome emission (`restore_failure`/`restore_success`) in engine restore path and added focused proof test `test_trade_system_hardening_p2_20260407.py`.
 - SENTINEL validation complete for `telegram_command_driven_execution_20260408` (2026-04-08): verdict **BLOCKED**, score **38/100**; required callback→command→parser→execution runtime chain not met and FULL RUNTIME INTEGRATION claim not evidenced for target path.
 - FORGE-X fix pass `p5_execution_snapshot_contract_compatibility_20260408` completed (2026-04-08): added explicit `ExecutionSnapshot.implied_prob`/`ExecutionSnapshot.volatility` contract fields, corrected `StrategyTrigger` intelligence contract usage, routed callback paper execution into authoritative command-trade path, and added duplicate-intent block + focused MAJOR regression tests.
+- FORGE-X fix pass `p6_observability_review_findings_20260409` completed (2026-04-08): added canonical trade observability constants + explicit blocked outcome classification, enforced single terminal outcome emission per `/trade` attempt, and removed redundant risk-stage telemetry emission from command-handler scope with focused tests.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
 
@@ -105,6 +106,10 @@ Status:
 - FORGE-X remediation patch is complete for execution snapshot contract compatibility and callback/command shared trade path integration.
 - SENTINEL MAJOR revalidation is now required before merge decision.
 
+### P6 observability review findings handoff
+- STANDARD-tier observability correctness fix is complete with focused event-hygiene tests.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ## ❌ NOT STARTED
 
 - None.
@@ -113,9 +118,9 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-SENTINEL validation required for p5_execution_snapshot_contract_compatibility before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_2_execution_snapshot_contract_compatibility.md
-Tier: MAJOR
+Codex auto PR review + COMMANDER review required before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md
+Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
@@ -126,3 +131,4 @@ Tier: MAJOR
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.
+- Pytest environment still reports unknown `asyncio_mode` config warning; focused observability tests pass under synchronous `asyncio.run(...)` invocation.

--- a/projects/polymarket/polyquantbot/execution/observability.py
+++ b/projects/polymarket/polyquantbot/execution/observability.py
@@ -1,0 +1,43 @@
+"""Observability helpers for Telegram-triggered trade execution paths.
+
+This module centralizes event constants and deterministic terminal-outcome
+classification for the `/trade` command path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+EVENT_STAGE: str = "stage"
+EVENT_OUTCOME: str = "outcome"
+
+STAGE_COMMAND: str = "command"
+STAGE_EXECUTION: str = "execution"
+STAGE_RISK: str = "risk"
+
+OUTCOME_STARTED: str = "started"
+OUTCOME_EXECUTED: str = "executed"
+OUTCOME_FAILED: str = "failed"
+OUTCOME_BLOCKED: str = "blocked"
+
+
+@dataclass(frozen=True)
+class ClassifiedOutcome:
+    """Deterministic classification for a terminal `/trade` result."""
+
+    outcome: str
+    reason: str
+
+
+def classify_result(*, success: bool, message: str) -> ClassifiedOutcome:
+    """Classify a terminal command result into canonical observability outcomes.
+
+    BLOCKED outcomes are explicitly identified and never fall through to the
+    generic FAILED bucket.
+    """
+
+    normalized_message = str(message or "").strip().lower()
+    if "blocked" in normalized_message:
+        return ClassifiedOutcome(outcome=OUTCOME_BLOCKED, reason="blocked_message")
+    if success:
+        return ClassifiedOutcome(outcome=OUTCOME_EXECUTED, reason="success")
+    return ClassifiedOutcome(outcome=OUTCOME_FAILED, reason="failure")

--- a/projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md
@@ -1,0 +1,61 @@
+# 24_4_p6_observability_review_findings
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - `projects/polymarket/polyquantbot/execution/observability.py`
+  - `projects/polymarket/polyquantbot/telegram/command_router.py`
+  - `projects/polymarket/polyquantbot/telegram/command_handler.py`
+  - directly related observability helpers touched in this fix
+- Not in Scope:
+  - strategy logic
+  - Telegram strategy toggle persistence
+  - execution model redesign
+  - risk logic changes
+  - order semantics
+  - retry/timeout/idempotency behavior
+  - UI redesign
+  - unrelated refactor
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md`. Tier: STANDARD
+
+## 1. What was built
+- Added canonical `/trade` observability constants and deterministic terminal-outcome classification in `execution/observability.py`.
+- Implemented explicit blocked-outcome mapping in `classify_result(...)` so blocked messages classify to canonical `blocked` outcome instead of ambiguous fallback.
+- Wrapped `/trade` dispatch in `CommandHandler` with deterministic observability emissions:
+  - stage start for command stage
+  - stage start for execution stage
+  - exactly one terminal outcome event per execution attempt
+- Removed redundant risk-stage emission from this `/trade` telemetry surface by not emitting `STAGE_RISK` in `CommandHandler`, avoiding duplicate stage spam when risk stage is emitted authoritatively elsewhere.
+- Normalized observability usage by replacing ad-hoc literals in new `/trade` event emissions with canonical constants imported from `execution/observability.py`.
+
+## 2. Current system architecture
+- `/trade` command observability now flows through `CommandHandler._handle_trade_with_observability(...)`.
+- CommandHandler emits structured observability events via `_emit_observability_event(...)` and optional injected sink for focused test capture.
+- Terminal result classification is delegated to `execution.observability.classify_result(...)`, which explicitly checks blocked semantics before generic success/failure classification.
+- Event sequence remains reconstructable for each command trace via `trace_id` + ordered stage and terminal outcome events.
+
+## 3. Files created / modified (full paths)
+- Created: `projects/polymarket/polyquantbot/execution/observability.py`
+- Modified: `projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Modified: `projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- BLOCKED classification is deterministic and explicit.
+- `/trade` emits one authoritative terminal observability outcome per execution attempt.
+- `/trade` observability path does not emit redundant risk-stage events.
+- Existing success/error paths continue emitting expected observability events.
+- Focused checks executed:
+  - `python -m py_compile projects/polymarket/polyquantbot/execution/observability.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py` ✅
+  - `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py` ✅ (6 passed)
+
+## 5. Known issues
+- `projects/polymarket/polyquantbot/telegram/command_router.py` did not require code change for this scope; `/trade` observability fix is centralized in command handling + helper constants.
+- Environment warning persists in pytest output about unknown `asyncio_mode` config option, but focused tests pass.
+
+## 6. What is next
+- COMMANDER review on PR #306 fix scope and observability hygiene evidence.
+- Merge decision after Codex auto PR review baseline and COMMANDER review.
+- No SENTINEL escalation required for this STANDARD-tier narrow integration task.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import structlog
 
@@ -11,6 +11,14 @@ from ..config.runtime_config import ConfigManager
 from ..core.system_state import SystemState, SystemStateManager
 from ..interface.telegram.view_handler import render_view, safe_count, safe_number
 from ..execution.engine import export_execution_payload, get_execution_engine
+from ..execution.observability import (
+    EVENT_OUTCOME,
+    EVENT_STAGE,
+    OUTCOME_STARTED,
+    STAGE_COMMAND,
+    STAGE_EXECUTION,
+    classify_result,
+)
 from ..execution.strategy_trigger import StrategyConfig, StrategyTrigger
 from .ui.keyboard import build_dashboard_menu
 from .handlers.portfolio_service import get_portfolio_service
@@ -90,6 +98,7 @@ class CommandHandler:
         multi_metrics: Optional[object] = None,
         risk_guard: Optional[object] = None,
         mode: str = "PAPER",
+        observability_sink: Optional[Callable[[dict[str, Any]], None]] = None,
     ) -> None:
         self._state = state_manager
         self._config = config_manager
@@ -101,6 +110,7 @@ class CommandHandler:
         self._multi_metrics = multi_metrics
         self._risk_guard = risk_guard
         self._mode = mode
+        self._observability_sink = observability_sink
         self._lock = asyncio.Lock()
         self._runner: Optional[object] = None  # wired after pipeline starts
         self._trade_intents: dict[str, float] = {}
@@ -250,7 +260,7 @@ class CommandHandler:
         if cmd == "alpha":
             return await self._handle_alpha()
         if cmd == "trade":
-            return await self._handle_trade(value)
+            return await self._handle_trade_with_observability(value=value, cid=cid)
 
         # ── New menu callbacks (new Telegram system) ───────────────────────────
         if cmd == "wallet":
@@ -335,6 +345,60 @@ class CommandHandler:
             success=False,
             message="Usage: /trade [test|close|status] [args]",
         )
+
+    async def _handle_trade_with_observability(
+        self,
+        *,
+        value: Optional[float | str],
+        cid: str,
+    ) -> CommandResult:
+        """Wrap `/trade` handling with deterministic observability emissions."""
+
+        self._emit_observability_event(
+            trace_id=cid,
+            event_type=EVENT_STAGE,
+            stage=STAGE_COMMAND,
+            outcome=OUTCOME_STARTED,
+            payload={},
+        )
+        self._emit_observability_event(
+            trace_id=cid,
+            event_type=EVENT_STAGE,
+            stage=STAGE_EXECUTION,
+            outcome=OUTCOME_STARTED,
+            payload={},
+        )
+
+        result = await self._handle_trade(args=value)
+        classified = classify_result(success=result.success, message=result.message)
+        self._emit_observability_event(
+            trace_id=cid,
+            event_type=EVENT_OUTCOME,
+            stage=STAGE_EXECUTION,
+            outcome=classified.outcome,
+            payload={"reason": classified.reason},
+        )
+        return result
+
+    def _emit_observability_event(
+        self,
+        *,
+        trace_id: str,
+        event_type: str,
+        stage: str,
+        outcome: str,
+        payload: dict[str, Any],
+    ) -> None:
+        event_payload: dict[str, Any] = {
+            "trace_id": trace_id,
+            "event_type": event_type,
+            "stage": stage,
+            "outcome": outcome,
+            "payload": payload,
+        }
+        log.info("telegram_trade_observability_event", **event_payload)
+        if self._observability_sink is not None:
+            self._observability_sink(event_payload)
 
     async def _handle_trade_test(self, args: str) -> CommandResult:
         """Parse /trade test [market] [side] [size]."""

--- a/projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.execution.observability import (
+    EVENT_OUTCOME,
+    EVENT_STAGE,
+    OUTCOME_BLOCKED,
+    OUTCOME_EXECUTED,
+    OUTCOME_FAILED,
+    STAGE_RISK,
+    classify_result,
+)
+from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler
+
+
+@pytest.mark.parametrize(
+    ("success", "message", "expected"),
+    [
+        (False, "duplicate_blocked: trade intent already executed recently.", OUTCOME_BLOCKED),
+        (True, "ok", OUTCOME_EXECUTED),
+        (False, "Usage: /trade [test|close|status] [args]", OUTCOME_FAILED),
+    ],
+)
+def test_classify_result_includes_explicit_blocked(success: bool, message: str, expected: str) -> None:
+    classified = classify_result(success=success, message=message)
+    assert classified.outcome == expected
+
+
+def test_trade_emits_single_terminal_outcome_event() -> None:
+    observed: list[dict[str, object]] = []
+    handler = CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        observability_sink=observed.append,
+    )
+
+    result = asyncio.run(handler.handle(command="trade", value="invalid"))
+
+    assert result.success is False
+    terminal_events = [
+        event for event in observed if event["event_type"] == EVENT_OUTCOME
+    ]
+    assert len(terminal_events) == 1
+
+
+def test_trade_path_does_not_emit_redundant_risk_stage() -> None:
+    observed: list[dict[str, object]] = []
+    handler = CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        observability_sink=observed.append,
+    )
+
+    asyncio.run(handler.handle(command="trade", value="status"))
+
+    risk_stage_events = [
+        event for event in observed
+        if event["event_type"] == EVENT_STAGE and event["stage"] == STAGE_RISK
+    ]
+    assert risk_stage_events == []
+
+
+def test_success_and_error_paths_keep_expected_observability_events() -> None:
+    observed: list[dict[str, object]] = []
+    handler = CommandHandler(
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        observability_sink=observed.append,
+    )
+
+    success_result = asyncio.run(handler.handle(command="trade", value="status"))
+    error_result = asyncio.run(handler.handle(command="trade", value="bad"))
+
+    assert success_result.success is True
+    assert error_result.success is False
+
+    stage_events = [event for event in observed if event["event_type"] == EVENT_STAGE]
+    terminal_events = [event for event in observed if event["event_type"] == EVENT_OUTCOME]
+
+    assert len(stage_events) == 4  # two stage events per /trade attempt
+    assert len(terminal_events) == 2
+    assert terminal_events[0]["outcome"] == OUTCOME_EXECUTED
+    assert terminal_events[1]["outcome"] == OUTCOME_FAILED


### PR DESCRIPTION
### Motivation
- Address P6 observability review findings to ensure deterministic outcome classification and clean event hygiene for the `/trade` command path (Validation Tier: `STANDARD`, Claim Level: `NARROW INTEGRATION`).
- Eliminate duplicate terminal outcome emissions and redundant `STAGE_RISK` stage spam that polluted observability/anomaly signals.
- Normalize observability constants and import usage so telemetry is consistent and reconstructable per-trace.

### Description
- Added canonical observability helper module `projects/polymarket/polyquantbot/execution/observability.py` with stage/outcome constants and a deterministic `classify_result(...)` that explicitly maps blocked messages to `OUTCOME_BLOCKED`.
- Wrapped `/trade` handling in `projects/polymarket/polyquantbot/telegram/command_handler.py` with `CommandHandler._handle_trade_with_observability(...)`, which emits ordered stage events and exactly one terminal outcome per invocation, uses canonical constants, and accepts an injectable `observability_sink` for test capture.
- Introduced `_emit_observability_event(...)` in `CommandHandler` and wired the `/trade` dispatch to use the wrapper instead of emitting ad-hoc literals; removed redundant `STAGE_RISK` emission from this command handler surface.
- Added focused regression tests in `projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py`, created the FORGE report `projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md`, and updated `PROJECT_STATE.md` with the task outcome and timestamp.

### Testing
- Ran Python compile checks: `python -m py_compile projects/polymarket/polyquantbot/execution/observability.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py` which passed.
- Ran focused unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p6_observability_review_findings_20260409.py` which passed (all tests green, focused coverage for blocked classification, single terminal outcome emission, no redundant risk stage, and success/error observability paths).
- Verified no `phase*/` folders were introduced and updated `PROJECT_STATE.md` with full timestamp `2026-04-08 21:50` to reflect the STANDARD-tier remediation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cd095ea4832e8da6c1d00d5407ef)