### PR TITLE
fix: persist Telegram ev_momentum toggle across callback and menu render

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 21:50
-- Status        : FORGE-X P6 observability review findings remediation completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-08 22:20
+- Status        : FORGE-X Telegram EV Momentum toggle persistence fix completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
@@ -40,6 +40,7 @@
 - SENTINEL validation complete for `telegram_command_driven_execution_20260408` (2026-04-08): verdict **BLOCKED**, score **38/100**; required callback→command→parser→execution runtime chain not met and FULL RUNTIME INTEGRATION claim not evidenced for target path.
 - FORGE-X fix pass `p5_execution_snapshot_contract_compatibility_20260408` completed (2026-04-08): added explicit `ExecutionSnapshot.implied_prob`/`ExecutionSnapshot.volatility` contract fields, corrected `StrategyTrigger` intelligence contract usage, routed callback paper execution into authoritative command-trade path, and added duplicate-intent block + focused MAJOR regression tests.
 - FORGE-X fix pass `p6_observability_review_findings_20260409` completed (2026-04-08): added canonical trade observability constants + explicit blocked outcome classification, enforced single terminal outcome emission per `/trade` attempt, and removed redundant risk-stage telemetry emission from command-handler scope with focused tests.
+- FORGE-X fix pass `telegram_ev_momentum_toggle_persistence_20260409` completed (2026-04-08): fixed strategy toggle persistence ordering so callback toggle mutates state before DB save, and added focused persistence/readback/non-regression tests for `ev_momentum` in Telegram strategy settings flow.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
 
@@ -110,6 +111,10 @@ Status:
 - STANDARD-tier observability correctness fix is complete with focused event-hygiene tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
+### Telegram EV Momentum toggle persistence handoff
+- STANDARD-tier toggle persistence fix is complete with focused callback/persistence/render-path evidence.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ## ❌ NOT STARTED
 
 - None.
@@ -119,7 +124,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_4_p6_observability_review_findings.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES

--- a/projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md
@@ -1,0 +1,68 @@
+# 24_5_telegram_ev_momentum_toggle_persistence
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+  - `projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py`
+  - Telegram strategy settings menu render/readback path for `ev_momentum`
+- Not in Scope:
+  - strategy logic changes
+  - execution logic
+  - risk logic
+  - Telegram observability changes
+  - other unrelated Telegram menus
+  - feature expansion
+  - refactor outside toggle persistence path
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md`. Tier: STANDARD
+
+## 1. What was built
+- Fixed Telegram strategy toggle persistence ordering for `ev_momentum` (and shared strategy toggle path) by moving DB save to run **after** in-memory toggle mutation.
+- Kept existing callback/action contract unchanged (`action:strategy_toggle:<name>` / `strategy_toggle:<name>`) and preserved normalized strategy re-render path.
+- Added focused regression tests for callback payload mapping, persistence write state, deterministic OFF→ON behavior, menu readback, and non-regression for another strategy toggle.
+
+## 2. Current system architecture
+- Strategy toggle callback flow now executes in this sequence:
+  1. Callback action parsed as `strategy_toggle:<name>`
+  2. `handle_strategy_toggle(strategy_name)` mutates `StrategyStateManager` in-memory state
+  3. `StrategyStateManager.save(db=...)` persists the **updated** state snapshot
+  4. `_render_normalized_callback("strategy")` re-renders menu based on the same strategy state source
+- This removes stale-state persistence where writes could capture pre-toggle values.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- `ev_momentum` ON toggle now persists as ON after callback handling.
+- Strategy menu re-render/readback shows `ev_momentum` active after enable.
+- OFF→ON toggle sequence for `ev_momentum` is deterministic and persisted in order.
+- Callback payload/action mapping remains aligned with strategy key:
+  - payload includes `action:strategy_toggle:ev_momentum`
+  - dispatch route parses `strategy_toggle:ev_momentum`
+- Non-regression check confirms toggling `mean_reversion` does not alter `ev_momentum` state.
+
+Focused runtime/test evidence:
+- Callback payload proof: `action:strategy_toggle:ev_momentum` asserted in test.
+- Persisted state proof after enable: `db.save_strategy_state` call argument contains `{"ev_momentum": True, ...}`.
+- Menu render proof after refresh/re-entry path: `settings_strategy` dispatch contains `EV MOMENTUM` with `Status: ✅ ACTIVE` after enable.
+- Non-regression proof: `mean_reversion` toggle changes only `mean_reversion` while `ev_momentum` remains unchanged.
+
+Checks run:
+- `python -m py_compile projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py` ✅ (4 passed)
+
+## 5. Known issues
+- Pytest emits existing environment warning: unknown `asyncio_mode` config option. Focused tests still pass.
+- This task does not add external live Telegram screenshot evidence (container-limited runtime environment).
+
+## 6. What is next
+- COMMANDER review for STANDARD-tier narrow integration fix and focused persistence evidence.
+- Merge decision after Codex auto PR review baseline and COMMANDER review.
+- No SENTINEL escalation required for this task tier/scope.
+
+Root cause found:
+- In `CallbackRouter._dispatch`, the strategy persistence call (`self._strategy_state.save(db=self._db)`) executed **before** `handle_strategy_toggle(strategy_name)`, so stored state could remain OFF even when user toggled ON.

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -869,7 +869,11 @@ class CallbackRouter:
         if action.startswith(_STRATEGY_TOGGLE_PREFIX):
             strategy_name = action.removeprefix(_STRATEGY_TOGGLE_PREFIX)
             from .strategy import handle_strategy_toggle  # noqa: PLC0415
-            # Persist toggle state to DB (non-blocking on failure)
+
+            await handle_strategy_toggle(strategy_name)
+
+            # Persist toggle state to DB after in-memory state mutation.
+            # Non-fatal by design: UI remains responsive if persistence fails.
             if self._strategy_state is not None:
                 try:
                     await self._strategy_state.save(db=self._db)
@@ -879,7 +883,7 @@ class CallbackRouter:
                         strategy=strategy_name,
                         error=str(save_exc),
                     )
-            await handle_strategy_toggle(strategy_name)
+
             return await self._render_normalized_callback("strategy")
 
         if action.startswith(_MARKET_CATEGORY_TOGGLE_PREFIX):

--- a/projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+from projects.polymarket.polyquantbot.strategy.strategy_manager import StrategyStateManager
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+from projects.polymarket.polyquantbot.telegram.ui.keyboard import build_strategy_menu
+
+
+def _make_router(*, strategy_state: StrategyStateManager, db: object | None = None) -> CallbackRouter:
+    cmd_handler = MagicMock()
+    cmd_handler._runner = None
+    cmd_handler._multi_metrics = None
+    cmd_handler._allocator = None
+    cmd_handler._risk_guard = None
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=cmd_handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+        strategy_state=strategy_state,
+        db=db,
+    )
+
+
+class TestTelegramEVMomentumTogglePersistence:
+    def test_ev_momentum_toggle_on_persists_after_callback(self) -> None:
+        strategy_state = StrategyStateManager(initial_state={"ev_momentum": False})
+        db = AsyncMock()
+        db.save_strategy_state = AsyncMock(return_value=True)
+        router = _make_router(strategy_state=strategy_state, db=db)
+
+        asyncio.run(router._dispatch("strategy_toggle:ev_momentum"))
+
+        assert strategy_state.get_state()["ev_momentum"] is True
+        db.save_strategy_state.assert_called_once()
+        persisted = db.save_strategy_state.call_args.args[0]
+        assert persisted["ev_momentum"] is True
+
+    def test_menu_rerender_reads_persisted_ev_momentum_active_state(self) -> None:
+        strategy_state = StrategyStateManager(initial_state={"ev_momentum": False})
+        db = AsyncMock()
+        db.save_strategy_state = AsyncMock(return_value=True)
+        router = _make_router(strategy_state=strategy_state, db=db)
+
+        asyncio.run(router._dispatch("strategy_toggle:ev_momentum"))
+        text, _ = asyncio.run(router._dispatch("settings_strategy"))
+
+        assert "EV MOMENTUM" in text
+        assert "Status: ✅ ACTIVE" in text
+
+    def test_ev_momentum_toggle_off_then_on_is_deterministic(self) -> None:
+        strategy_state = StrategyStateManager(initial_state={"ev_momentum": True})
+        db = AsyncMock()
+        db.save_strategy_state = AsyncMock(return_value=True)
+        router = _make_router(strategy_state=strategy_state, db=db)
+
+        asyncio.run(router._dispatch("strategy_toggle:ev_momentum"))
+        assert strategy_state.get_state()["ev_momentum"] is False
+
+        asyncio.run(router._dispatch("strategy_toggle:ev_momentum"))
+        assert strategy_state.get_state()["ev_momentum"] is True
+
+        persisted_states = [call.args[0]["ev_momentum"] for call in db.save_strategy_state.call_args_list]
+        assert persisted_states == [False, True]
+
+    def test_other_strategy_toggles_remain_intact(self) -> None:
+        strategy_state = StrategyStateManager(
+            initial_state={"ev_momentum": True, "mean_reversion": True, "liquidity_edge": True}
+        )
+        db = AsyncMock()
+        db.save_strategy_state = AsyncMock(return_value=True)
+        router = _make_router(strategy_state=strategy_state, db=db)
+
+        callbacks = [
+            btn["callback_data"]
+            for row in build_strategy_menu(["ev_momentum", "mean_reversion", "liquidity_edge"])
+            for btn in row
+        ]
+        assert "action:strategy_toggle:ev_momentum" in callbacks
+
+        asyncio.run(router._dispatch("strategy_toggle:mean_reversion"))
+
+        current = strategy_state.get_state()
+        assert current["ev_momentum"] is True
+        assert current["mean_reversion"] is False
+        assert current["liquidity_edge"] is True


### PR DESCRIPTION
### Motivation
- Fix a bug where toggling `ev_momentum` ON could revert to OFF because persistence wrote a pre-toggle snapshot. 
- Ensure the Telegram strategy toggle state for `ev_momentum` persists consistently across callback handling, storage, and menu re-render cycles. 
- Preserve existing callback/action contract and avoid regressions for other strategy toggles (`mean_reversion`, `liquidity_edge`).

### Description
- Reordered strategy toggle flow in `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` so `handle_strategy_toggle(...)` runs before calling `StrategyStateManager.save(...)`, ensuring the saved snapshot reflects the new in-memory state. 
- Added focused regression tests in `projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py` that assert persistence after callback, menu re-render readback, deterministic OFF→ON behavior, and non-regression for other toggles. 
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md` documenting root cause, changes, and evidence. 
- Updated `PROJECT_STATE.md` `Last Updated` and `Status` plus added a handoff entry pointing to the new forge report.

### Testing
- Ran syntax checks with `python -m py_compile projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py` which passed. 
- Ran focused unit tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_ev_momentum_toggle_persistence_20260409.py` which passed (4 passed, with an existing `asyncio_mode` pytest config warning only). 
- No regressions observed in the touched Telegram settings/toggle render path according to the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cfaaf704832ea32ad65e3c6f1350)