### PR TITLE
fix: align Telegram portfolio positions summary with rendered list

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 22:20
-- Status        : FORGE-X Telegram EV Momentum toggle persistence fix completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-08 22:21
+- Status        : FORGE-X portfolio position render mismatch fix completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
@@ -41,6 +41,7 @@
 - FORGE-X fix pass `p5_execution_snapshot_contract_compatibility_20260408` completed (2026-04-08): added explicit `ExecutionSnapshot.implied_prob`/`ExecutionSnapshot.volatility` contract fields, corrected `StrategyTrigger` intelligence contract usage, routed callback paper execution into authoritative command-trade path, and added duplicate-intent block + focused MAJOR regression tests.
 - FORGE-X fix pass `p6_observability_review_findings_20260409` completed (2026-04-08): added canonical trade observability constants + explicit blocked outcome classification, enforced single terminal outcome emission per `/trade` attempt, and removed redundant risk-stage telemetry emission from command-handler scope with focused tests.
 - FORGE-X fix pass `telegram_ev_momentum_toggle_persistence_20260409` completed (2026-04-08): fixed strategy toggle persistence ordering so callback toggle mutates state before DB save, and added focused persistence/readback/non-regression tests for `ev_momentum` in Telegram strategy settings flow.
+- FORGE-X fix pass `portfolio_position_render_mismatch_20260409` completed (2026-04-08): unified positions summary/render dataset in Telegram view adapter, rendered all active position rows in premium positions view (including same-market/same-side entries), and added focused mismatch regression tests.
 
 ### Trade-System Hardening P2 — COMPLETED (2026-04-07)
 
@@ -115,6 +116,10 @@ Status:
 - STANDARD-tier toggle persistence fix is complete with focused callback/persistence/render-path evidence.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
+### Portfolio position render mismatch handoff
+- STANDARD-tier narrow integration fix is complete for Telegram positions rendering consistency.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ## ❌ NOT STARTED
 
 - None.
@@ -124,7 +129,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_5_telegram_ev_momentum_toggle_persistence.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
@@ -137,3 +142,4 @@ Tier: STANDARD
 - External live Telegram device screenshot proof is still unavailable in this container environment.
 - MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.
 - Pytest environment still reports unknown `asyncio_mode` config warning; focused observability tests pass under synchronous `asyncio.run(...)` invocation.
+- Pytest environment still reports unknown `asyncio_mode` config warning on focused portfolio-render tests; tests pass despite the warning.

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -92,10 +92,12 @@ def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     total_pnl = _first_present(payload, "pnl", default=None)
     if total_pnl is None:
         total_pnl = safe_number(realized, 0.0) + unrealized_total
+    derived_count = len(rows)
+    fallback_count = safe_count(payload.get("positions_count"), derived_count)
     return {
         "rows": rows,
         "primary": primary,
-        "positions_count": safe_count(payload.get("positions_count"), len(rows)),
+        "positions_count": derived_count if derived_count > 0 else fallback_count,
         "unrealized_total": unrealized_total,
         "largest_position_size": largest_position_size,
         "realized_pnl": safe_number(realized, 0.0),
@@ -173,6 +175,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "scope_fallback_policy": payload.get("scope_fallback_policy", ""),
         "scope_state_file": payload.get("scope_state_file", ""),
         "active_root": payload.get("active_root", _resolve_active_root(mode)),
+        "position_rows": metrics["rows"],
     }
 
 

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -412,6 +412,46 @@ def _render_position_card(payload: Mapping[str, Any], market_label: str) -> str:
     return _section("🎯 Position", _tree_group(lines))
 
 
+def _normalize_position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    rows = payload.get("position_rows")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+async def _render_position_cards(payload: Mapping[str, Any]) -> list[str]:
+    rows = _normalize_position_rows(payload)
+    if not rows:
+        market_context = await get_market_context(_safe_text(payload.get("market_id"), "")) or {}
+        market_label = _resolve_market_label(payload, market_context)
+        single_card = _render_position_card(payload, market_label)
+        return [single_card] if single_card else []
+
+    cards: list[str] = []
+    for row in rows:
+        row_payload: dict[str, Any] = dict(payload)
+        row_payload.update(
+            {
+                "market_id": row.get("market_id"),
+                "market_title": row.get("market_title", row.get("market_question")),
+                "market_question": row.get("market_question"),
+                "side": row.get("side"),
+                "entry": row.get("entry_price", row.get("avg_price")),
+                "current": row.get("current_price", row.get("entry_price", row.get("avg_price"))),
+                "size": row.get("size"),
+                "unrealized_pnl": row.get("unrealized_pnl", row.get("pnl", 0.0)),
+                "opened_at": row.get("opened_at"),
+                "position_status": row.get("position_status", payload.get("position_status")),
+            }
+        )
+        row_context = await get_market_context(_safe_text(row_payload.get("market_id"), "")) or {}
+        row_label = _resolve_market_label(row_payload, row_context)
+        card = _render_position_card(row_payload, row_label)
+        if card:
+            cards.append(card)
+    return cards
+
+
 def _render_market_card(payload: Mapping[str, Any], market_label: str) -> str:
     lines: list[tuple[str, object]] = [
         ("Title", market_label),
@@ -577,7 +617,9 @@ async def render_dashboard(payload: Mapping[str, Any]) -> str:
 
     blocks: list[str] = [_hero_block(mode, normalized), _primary_block(mode, normalized)]
 
-    if mode in {"positions", "trade"}:
+    if mode == "positions":
+        blocks.extend(await _render_position_cards(normalized))
+    elif mode == "trade":
         position_card = _render_position_card(normalized, market_label)
         if position_card:
             blocks.append(position_card)

--- a/projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md
@@ -1,0 +1,72 @@
+# 24_6_portfolio_position_render_mismatch
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - Telegram portfolio positions view rendering path via `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - Premium UI position-card rendering path via `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+  - Data-source consistency between summary position count and rendered position list
+- Not in Scope:
+  - execution logic
+  - risk logic
+  - position sizing
+  - strategy logic
+  - order placement
+  - observability system
+  - UI redesign
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md`. Tier: STANDARD
+
+## 1. What was built
+- Fixed Telegram positions view rendering mismatch so summary count and rendered position cards are produced from the same underlying `positions` dataset.
+- Removed count drift by deriving `positions_count` from actual position rows whenever rows exist (instead of trusting potentially stale external `positions_count` values).
+- Added full multi-row position-card rendering in premium UI for `positions` mode so all active positions are displayed (including same-market / same-side entries).
+- Added focused regression tests covering same-market multi-position rendering, different-market rendering, summary-to-render count parity, and similar-ID non-overwrite behavior.
+
+## 2. Current system architecture
+- `render_view("positions", payload)` now computes metrics from `_position_rows(payload)` and carries the exact row list into UI payload as `position_rows`.
+- `_base_payload(... )` uses that same derived metrics object for:
+  - `positions` summary value
+  - `largest_position_size`
+  - unrealized aggregation
+  - `position_rows` handoff
+- `render_dashboard(... )` for `mode == "positions"` now renders one position card per row from `position_rows` via `_render_position_cards(...)` (list-based iteration, no dict-key grouping).
+- Result: summary + rendered cards share one data source and cannot diverge due to stale count or key collision in render mapping.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Modified: `projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Multiple positions in the same market now render as separate cards (no subset drop).
+- Multiple positions across different markets all render in the same positions view.
+- Summary open-position count matches rendered card count because both derive from the same rows list.
+- Similar position IDs do not collide in rendering because rendering iterates row-by-row without key-based overwrite.
+
+Required tests (focused):
+- Multiple positions same market → both rendered ✅
+- Multiple positions different markets → all rendered ✅
+- Summary count matches rendered count ✅
+- No overwrite when IDs are similar ✅
+
+Runtime proof:
+- raw positions list length = 3
+- rendered output visible entries (`🎯 Position`) = 3
+- summary count line (`Open Positions`) = 3
+
+Commands run:
+- `python -m py_compile projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` ✅ (4 passed)
+- Runtime proof command (render sample payload through `render_view("positions", ...)`) ✅
+
+## 5. Known issues
+- Existing test-environment warning remains: pytest config reports unknown `asyncio_mode` option; focused tests still pass.
+- External live Telegram device screenshot proof is unavailable in this container environment.
+
+## 6. What is next
+- COMMANDER review for STANDARD-tier narrow integration fix.
+- Merge decision after Codex auto PR review baseline + COMMANDER review.
+- No SENTINEL escalation required unless COMMANDER explicitly reclassifies task impact.

--- a/projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.interface import ui_formatter
+from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+
+
+async def _stub_context(_: str) -> dict[str, str]:
+    return {}
+
+
+def _render_positions(payload: dict) -> str:
+    original = ui_formatter.get_market_context
+    ui_formatter.get_market_context = _stub_context
+    try:
+        return asyncio.run(render_view("positions", payload))
+    finally:
+        ui_formatter.get_market_context = original
+
+
+def test_positions_same_market_are_all_rendered() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "mkt-1", "market_question": "BTC > 100k?", "side": "YES", "entry_price": 0.45, "size": 100, "unrealized_pnl": 4.0},
+            {"market_id": "mkt-1", "market_question": "BTC > 100k?", "side": "YES", "entry_price": 0.47, "size": 150, "unrealized_pnl": 6.0},
+        ],
+        "positions_count": 2,
+        "unrealized_pnl": 10.0,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Open Positions: 2" in output
+    assert output.count("🎯 Position") == 2
+    assert "Size: $100.00" in output
+    assert "Size: $150.00" in output
+
+
+def test_positions_different_markets_are_all_rendered() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "mkt-a", "market_question": "ETH > 5k?", "side": "YES", "entry_price": 0.50, "size": 50, "unrealized_pnl": 1.5},
+            {"market_id": "mkt-b", "market_question": "SOL > 300?", "side": "NO", "entry_price": 0.40, "size": 75, "unrealized_pnl": -0.5},
+            {"market_id": "mkt-c", "market_question": "AVAX > 100?", "side": "YES", "entry_price": 0.35, "size": 90, "unrealized_pnl": 0.2},
+        ],
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("🎯 Position") == 3
+    assert "ETH > 5k?" in output
+    assert "SOL > 300?" in output
+    assert "AVAX > 100?" in output
+
+
+def test_summary_count_matches_rendered_position_count() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "mkt-1", "market_question": "Q1", "side": "YES", "entry_price": 0.10, "size": 10, "unrealized_pnl": 0.1},
+            {"market_id": "mkt-2", "market_question": "Q2", "side": "YES", "entry_price": 0.20, "size": 20, "unrealized_pnl": 0.2},
+            {"market_id": "mkt-3", "market_question": "Q3", "side": "NO", "entry_price": 0.30, "size": 30, "unrealized_pnl": -0.3},
+        ],
+        "positions_count": 1,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Open Positions: 3" in output
+    assert output.count("🎯 Position") == 3
+
+
+def test_similar_ids_do_not_overwrite_each_other() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "market-abc-001", "market_question": "Outcome A", "side": "YES", "entry_price": 0.42, "size": 42, "unrealized_pnl": 1.0},
+            {"market_id": "market-abc-001-extra", "market_question": "Outcome B", "side": "YES", "entry_price": 0.43, "size": 43, "unrealized_pnl": 2.0},
+        ],
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("🎯 Position") == 2
+    assert "Outcome A" in output
+    assert "Outcome B" in output


### PR DESCRIPTION
### Motivation
- Resolve inconsistency where the portfolio summary count reported more open positions than the Telegram UI actually rendered by ensuring a single source-of-truth for the positions dataset. 
- Prevent unintended filtering / key-collision that caused subsets to be shown (e.g., only primary position, same-market overwrites). 

### Description
- Ensure summary and rendered cards share the same row list by deriving `positions_count` from `_position_rows(payload)` and passing the rows forward as `position_rows` via `_base_payload` in `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`.
- Implement multi-row position-card rendering in the premium formatter by adding `_normalize_position_rows` and `_render_position_cards` and using them for `mode == "positions"` in `projects/polymarket/polyquantbot/interface/ui_formatter.py`, so each row produces its own position card (no dict-key grouping or overwrite).
- Add focused regression tests `projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` covering same-market multi-position rendering, multi-market rendering, summary/render count parity, and similar-ID collision safety.
- Add FORGE report `projects/polymarket/polyquantbot/reports/forge/24_6_portfolio_position_render_mismatch.md` documenting the change and update `PROJECT_STATE.md` with the STANDARD-tier / NARROW INTEGRATION handoff.

### Testing
- Ran syntax checks: `python -m py_compile projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` — PASS.
- Ran focused unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` — PASS (4 passed, 1 pytest config warning about `asyncio_mode` which is pre-existing).
- Performed runtime proof by invoking `render_view("positions", payload)` with a sample payload and verified raw positions length, rendered `🎯 Position` cards, and the `Open Positions` summary line matched (example proof: raw=3, rendered=3, summary=3) — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d429cb40832eb1cdb2ace9d1eb8b)