### PR TITLE
feat(telegram): premium market-scanning presence (heartbeat, top-candidate, no-trade)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 23:01
-- Status        : FORGE-X Telegram trade lifecycle alerts premium hierarchy pass completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-08 23:10
+- Status        : FORGE-X Telegram market scanning presence premium UX pass completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
 - Telegram trade lifecycle alerts premium hierarchy pass (2026-04-08): added strict execution-boundary lifecycle alerts for entry/exit/skipped events with fixed `|-` field order, no duplicate command/callback trigger coverage, and focused format validation tests.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
 - Trade-system reliability observability P4 runtime remediation pass (2026-04-08): Completed (Conditional) with hard event contract validation, trading-loop trace_id lifecycle wiring, execution-path trace propagation, and runtime `trade_start` / `execution_attempt` / `execution_result` event emission.
@@ -97,6 +98,10 @@ Status:
 - STANDARD-tier narrow integration implementation is complete for execution-boundary lifecycle alerts and focused tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
+### Telegram market scanning presence handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-loop scan-presence visibility and focused tests.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### Telegram UI text leakage audit handoff
 - STANDARD-tier FORGE-X pass is complete; Codex code review baseline complete and COMMANDER validation-path decision is pending.
 
@@ -134,7 +139,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_7_trade_lifecycle_alerts.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES

--- a/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
+++ b/projects/polymarket/polyquantbot/core/pipeline/trading_loop.py
@@ -108,6 +108,11 @@ from ..logging.logger import (
     log_loop_throttled,
 )
 from ...telegram.message_formatter import format_trade_alert
+from ...telegram.message_formatter import (
+    format_market_scan_heartbeat,
+    format_no_trade_explanation,
+    format_top_candidate_preview,
+)
 from ...execution.trace_context import generate_trace_id
 from ...execution.event_logger import emit_event
 
@@ -137,6 +142,119 @@ _FAST_LOOP_GUARD_S: float = 0.5         # if a tick finishes in < 0.5 s, force a
 _MAX_MARKETS_PER_TICK: int = 50         # expanded from 20 → 50 for broader market coverage
 _NO_TRADE_FALLBACK_S: float = 1800.0    # 30 minutes — activate force mode when no trade in this window
 _FORCE_TRADE_COOLDOWN_S: float = 300.0  # 5 minutes per-market guard when in force-trade fallback
+_SCAN_HEARTBEAT_EVERY_TICKS: int = 8
+_SCAN_HEARTBEAT_MIN_INTERVAL_S: float = 600.0
+_TOP_CANDIDATE_MIN_INTERVAL_S: float = 300.0
+_NO_TRADE_MIN_INTERVAL_S: float = 300.0
+_TOP_CANDIDATE_MIN_EDGE_PCT: float = 2.0
+
+
+class MarketScanPresenceNotifier:
+    """Low-noise Telegram notifier for market scanning presence."""
+
+    def __init__(self) -> None:
+        self._last_heartbeat_at: float = 0.0
+        self._last_top_candidate_at: float = 0.0
+        self._last_no_trade_at: float = 0.0
+        self._last_no_trade_reason: str = ""
+        self._last_candidate_signature: str = ""
+
+    @staticmethod
+    def _resolve_status(active_candidates: int, reason: str) -> str:
+        if active_candidates <= 0:
+            return "No strong edge found"
+        if reason == "insufficient edge":
+            return "Waiting for confirmation"
+        if reason == "liquidity too low":
+            return "Monitoring high volatility markets"
+        return "Monitoring active candidates"
+
+    @staticmethod
+    def _to_edge_pct(signal: Any) -> float:
+        raw_edge = getattr(signal, "edge", None)
+        if raw_edge is None:
+            raw_edge = getattr(signal, "ev", 0.0)
+        try:
+            return float(raw_edge) * 100.0
+        except (TypeError, ValueError):
+            return 0.0
+
+    def build_messages(
+        self,
+        *,
+        now_ts: float,
+        tick: int,
+        markets_scanned: int,
+        signals: list[Any],
+        trades_executed: int,
+        no_trade_reason: str,
+    ) -> list[str]:
+        """Build throttled scan-presence Telegram messages."""
+        messages: list[str] = []
+        active_candidates = len(signals)
+        status = self._resolve_status(active_candidates, no_trade_reason)
+
+        should_send_heartbeat = (
+            tick % _SCAN_HEARTBEAT_EVERY_TICKS == 0
+            and now_ts - self._last_heartbeat_at >= _SCAN_HEARTBEAT_MIN_INTERVAL_S
+        )
+        if should_send_heartbeat:
+            self._last_heartbeat_at = now_ts
+            messages.append(
+                format_market_scan_heartbeat(
+                    markets_scanned=markets_scanned,
+                    active_candidates=active_candidates,
+                    status=status,
+                )
+            )
+
+        if trades_executed > 0:
+            return messages
+
+        if (
+            no_trade_reason != self._last_no_trade_reason
+            or now_ts - self._last_no_trade_at >= _NO_TRADE_MIN_INTERVAL_S
+        ):
+            self._last_no_trade_reason = no_trade_reason
+            self._last_no_trade_at = now_ts
+            messages.append(format_no_trade_explanation(reason=no_trade_reason))
+
+        if active_candidates <= 0:
+            return messages
+
+        top_candidate = max(signals, key=self._to_edge_pct)
+        top_edge_pct = self._to_edge_pct(top_candidate)
+        if top_edge_pct < _TOP_CANDIDATE_MIN_EDGE_PCT:
+            return messages
+
+        candidate_market = str(getattr(top_candidate, "market_id", "N/A"))
+        candidate_side = str(getattr(top_candidate, "side", "YES")).upper()
+        candidate_status = "borderline" if no_trade_reason == "insufficient edge" else "waiting"
+        candidate_reason = (
+            "edge below execution threshold"
+            if no_trade_reason == "insufficient edge"
+            else "awaiting next confirmation"
+        )
+        candidate_signature = (
+            f"{candidate_market}:{candidate_side}:{candidate_status}:{candidate_reason}:{top_edge_pct:.2f}"
+        )
+        if candidate_signature == self._last_candidate_signature:
+            return messages
+        if now_ts - self._last_top_candidate_at < _TOP_CANDIDATE_MIN_INTERVAL_S:
+            return messages
+
+        self._last_top_candidate_at = now_ts
+        self._last_candidate_signature = candidate_signature
+        messages.append(
+            format_top_candidate_preview(
+                market=candidate_market,
+                side=candidate_side,
+                edge_pct=top_edge_pct,
+                status=candidate_status,
+                reason=candidate_reason,
+            )
+        )
+        return messages
 
 
 def build_ui_view(command: str, data: dict[str, Any]) -> str:
@@ -547,6 +665,7 @@ async def run_trading_loop(
     _last_market_intel_payload: dict[str, Any] = {}
     _trade_type_distribution: dict[str, int] = {}
     _market_type_by_id: dict[str, str] = {}
+    _scan_presence_notifier = MarketScanPresenceNotifier()
 
     def _to_float(value: Any) -> float:
         """Return float-safe value for Telegram formatting."""
@@ -987,6 +1106,11 @@ async def run_trading_loop(
 
                 # ── 4. Execute each signal and update positions ───────────────────
                 _trades_this_tick: int = 0
+                _skip_reasons: dict[str, int] = {
+                    "insufficient edge": 0,
+                    "liquidity too low": 0,
+                    "risk limit reached": 0,
+                }
                 for signal in signals:
                     trade_context: dict[str, Any] = {
                         "trace_id": generate_trace_id(),
@@ -1020,6 +1144,7 @@ async def run_trading_loop(
                     except Exception:  # noqa: BLE001
                         open_count = 0
                     if open_count >= _max_open_positions:
+                        _skip_reasons["risk limit reached"] += 1
                         log.info(
                             "signal_skipped_max_positions",
                             market_id=signal.market_id,
@@ -1036,6 +1161,7 @@ async def run_trading_loop(
                     _now = time.time()
                     _last = _market_last_trade.get(signal.market_id, 0.0)
                     if _now - _last < _effective_cooldown:
+                        _skip_reasons["risk limit reached"] += 1
                         log.info(
                             "signal_skipped_cooldown",
                             market_id=signal.market_id,
@@ -1117,6 +1243,10 @@ async def run_trading_loop(
                         _pe_success = _paper_order.status in (_OS.FILLED, _OS.PARTIAL)
 
                         if not _pe_success:
+                            if str(_paper_order.reason).lower().find("liquid") >= 0:
+                                _skip_reasons["liquidity too low"] += 1
+                            else:
+                                _skip_reasons["risk limit reached"] += 1
                             log.info(
                                 "execution_failed",
                                 trade_id=signal.signal_id,
@@ -1176,6 +1306,10 @@ async def run_trading_loop(
                             trace_id=trade_context["trace_id"],
                         )
                         if not result.success:
+                            if str(result.reason).lower().find("liquid") >= 0:
+                                _skip_reasons["liquidity too low"] += 1
+                            else:
+                                _skip_reasons["risk limit reached"] += 1
                             log.info(
                                 "execution_failed",
                                 trade_id=result.trade_id,
@@ -1379,6 +1513,30 @@ async def run_trading_loop(
                             }
                             asyncio.create_task(
                                 _run_validation_hook(_val_trade, telegram_callback)
+                            )
+
+                _no_trade_reason = "insufficient edge"
+                if _trades_this_tick == 0 and signals:
+                    _no_trade_reason = max(
+                        _skip_reasons.items(),
+                        key=lambda item: item[1],
+                    )[0]
+                if _trades_this_tick == 0 and telegram_callback is not None:
+                    _scan_messages = _scan_presence_notifier.build_messages(
+                        now_ts=time.time(),
+                        tick=_tick,
+                        markets_scanned=len(normalised_markets),
+                        signals=signals,
+                        trades_executed=_trades_this_tick,
+                        no_trade_reason=_no_trade_reason,
+                    )
+                    for _scan_message in _scan_messages:
+                        try:
+                            await telegram_callback(_scan_message)
+                        except Exception as _scan_exc:  # noqa: BLE001
+                            log.warning(
+                                "scan_presence_telegram_failed",
+                                error=str(_scan_exc),
                             )
 
                 # ── 5. Compute and log PnL metrics (db always present) ───────────

--- a/projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md
@@ -1,0 +1,92 @@
+# 24_8_market_scanning_presence
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy evaluation loop in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+  - Telegram scan-presence message formatting in `projects/polymarket/polyquantbot/telegram/message_formatter.py`
+  - candidate selection / no-trade decision output in scan-presence notifier flow
+- Not in Scope:
+  - execution logic changes
+  - risk logic changes
+  - strategy algorithm changes
+  - order placement
+  - observability redesign
+  - trade lifecycle alerts
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md`. Tier: STANDARD
+
+## 1. What was built
+- Added premium scan-presence Telegram messaging support for non-execution cycles with strict hierarchical `|- field: value` formatting.
+- Implemented three new formatter outputs:
+  - `🔎 MARKET SCAN` heartbeat
+  - `🧠 TOP CANDIDATE` preview
+  - `⚠️ NO TRADE` explanation
+- Added `MarketScanPresenceNotifier` to throttle scan-presence updates and prevent repeat spam for unchanged no-trade reasons and duplicate candidate signatures.
+- Integrated notifier into the strategy evaluation loop so messages are emitted only when no trade executes in a tick and when throttle conditions pass.
+
+## 2. Current system architecture
+- Strategy evaluation loop (`run_trading_loop`) computes scan/no-trade context after signal generation and execution attempts.
+- New notifier layer (`MarketScanPresenceNotifier`) decides whether to emit scan-presence messages based on:
+  - tick cadence + heartbeat interval
+  - no-trade reason change / cooldown
+  - top-candidate uniqueness + cooldown + minimum edge threshold
+- Telegram message strings remain centralized in `message_formatter.py` (single formatting authority).
+- Trade entry/exit lifecycle alerts remain unchanged and continue to be higher-priority operational alerts.
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py`
+- Modified: `projects/polymarket/polyquantbot/telegram/message_formatter.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Scan heartbeat emits in strict hierarchy format and is throttled by both tick cadence and minimum interval.
+- Repeated identical no-trade reasons are not spammed continuously.
+- Top candidate preview selects strongest candidate (by edge), uses strict format, and suppresses duplicate repeated candidate previews.
+- No-trade explanation emits only for no-trade cycles; execution cycles skip no-trade messaging.
+- All scan-presence messages conform to mandatory hierarchy-line rule.
+
+Throttling behavior proof:
+- Heartbeat: notifier requires both tick cadence (`_SCAN_HEARTBEAT_EVERY_TICKS`) and minimum interval (`_SCAN_HEARTBEAT_MIN_INTERVAL_S`) before sending.
+- No-trade: notifier sends only when reason changes or cooldown window passes (`_NO_TRADE_MIN_INTERVAL_S`).
+- Candidate preview: notifier suppresses unchanged candidate signature and enforces `_TOP_CANDIDATE_MIN_INTERVAL_S` cooldown.
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/telegram/message_formatter.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py` ✅ (5 passed)
+
+Runtime proof (message examples):
+1) Scan heartbeat
+```text
+🔎 MARKET SCAN
+|- Markets scanned: 42
+|- Active candidates: 1
+|- Status: Waiting for confirmation
+```
+
+2) Top candidate preview
+```text
+🧠 TOP CANDIDATE
+|- Market: HIGH
+|- Side: YES
+|- Edge: 4.50%
+|- Status: borderline
+|- Reason: edge below execution threshold
+```
+
+3) No-trade explanation
+```text
+⚠️ NO TRADE
+|- Reason: insufficient edge
+```
+
+## 5. Known issues
+- Existing pytest environment warning persists (`Unknown config option: asyncio_mode`), but focused tests pass.
+- Live Telegram device screenshot proof remains unavailable in this container environment.
+
+## 6. What is next
+- COMMANDER review for STANDARD-tier narrow integration delivery.
+- Merge decision after Codex auto PR review baseline + COMMANDER review.
+- No SENTINEL escalation required unless COMMANDER explicitly reclassifies task impact.

--- a/projects/polymarket/polyquantbot/telegram/message_formatter.py
+++ b/projects/polymarket/polyquantbot/telegram/message_formatter.py
@@ -1043,6 +1043,54 @@ def format_trade_skipped(*, market: str, reason: str) -> str:
     )
 
 
+def format_market_scan_heartbeat(
+    *,
+    markets_scanned: int,
+    active_candidates: int,
+    status: str,
+) -> str:
+    """Format throttled market scan heartbeat for premium Telegram UX."""
+    return "\n".join(
+        [
+            "🔎 MARKET SCAN",
+            f"|- Markets scanned: {markets_scanned}",
+            f"|- Active candidates: {active_candidates}",
+            f"|- Status: {status}",
+        ]
+    )
+
+
+def format_top_candidate_preview(
+    *,
+    market: str,
+    side: str,
+    edge_pct: float,
+    status: str,
+    reason: str,
+) -> str:
+    """Format top candidate preview when a strong edge exists but is not executed."""
+    return "\n".join(
+        [
+            "🧠 TOP CANDIDATE",
+            f"|- Market: {market}",
+            f"|- Side: {side}",
+            f"|- Edge: {edge_pct:.2f}%",
+            f"|- Status: {status}",
+            f"|- Reason: {reason}",
+        ]
+    )
+
+
+def format_no_trade_explanation(*, reason: str) -> str:
+    """Format no-trade explanation with strict hierarchy lines."""
+    return "\n".join(
+        [
+            "⚠️ NO TRADE",
+            f"|- Reason: {reason}",
+        ]
+    )
+
+
 def format_heartbeat(
     ws_connected: bool,
     event_count: int,

--- a/projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from projects.polymarket.polyquantbot.core.pipeline.trading_loop import MarketScanPresenceNotifier
+from projects.polymarket.polyquantbot.telegram.message_formatter import (
+    format_market_scan_heartbeat,
+    format_no_trade_explanation,
+    format_top_candidate_preview,
+)
+
+
+def test_scan_heartbeat_emits_with_throttle_and_hierarchical_format() -> None:
+    notifier = MarketScanPresenceNotifier()
+    signals = [SimpleNamespace(market_id="MKT1", side="YES", edge=0.03)]
+
+    first = notifier.build_messages(
+        now_ts=1_000.0,
+        tick=8,
+        markets_scanned=42,
+        signals=signals,
+        trades_executed=0,
+        no_trade_reason="insufficient edge",
+    )
+    assert any(message.startswith("🔎 MARKET SCAN") for message in first)
+
+    second = notifier.build_messages(
+        now_ts=1_020.0,
+        tick=16,
+        markets_scanned=42,
+        signals=signals,
+        trades_executed=0,
+        no_trade_reason="insufficient edge",
+    )
+    assert not any(message.startswith("🔎 MARKET SCAN") for message in second)
+
+
+def test_no_spam_on_repeated_cycle_same_reason() -> None:
+    notifier = MarketScanPresenceNotifier()
+
+    first = notifier.build_messages(
+        now_ts=2_000.0,
+        tick=1,
+        markets_scanned=20,
+        signals=[],
+        trades_executed=0,
+        no_trade_reason="insufficient edge",
+    )
+    assert first.count("⚠️ NO TRADE\n|- Reason: insufficient edge") == 1
+
+    second = notifier.build_messages(
+        now_ts=2_050.0,
+        tick=2,
+        markets_scanned=20,
+        signals=[],
+        trades_executed=0,
+        no_trade_reason="insufficient edge",
+    )
+    assert "⚠️ NO TRADE\n|- Reason: insufficient edge" not in second
+
+
+def test_top_candidate_preview_format_and_reason() -> None:
+    notifier = MarketScanPresenceNotifier()
+    signals = [
+        SimpleNamespace(market_id="LOW", side="NO", edge=0.011),
+        SimpleNamespace(market_id="HIGH", side="YES", edge=0.045),
+    ]
+
+    messages = notifier.build_messages(
+        now_ts=3_000.0,
+        tick=9,
+        markets_scanned=55,
+        signals=signals,
+        trades_executed=0,
+        no_trade_reason="insufficient edge",
+    )
+
+    candidate = [msg for msg in messages if msg.startswith("🧠 TOP CANDIDATE")]
+    assert len(candidate) == 1
+    lines = candidate[0].splitlines()
+    assert lines == [
+        "🧠 TOP CANDIDATE",
+        "|- Market: HIGH",
+        "|- Side: YES",
+        "|- Edge: 4.50%",
+        "|- Status: borderline",
+        "|- Reason: edge below execution threshold",
+    ]
+
+
+def test_no_trade_explanation_only_when_no_trade_occurs() -> None:
+    notifier = MarketScanPresenceNotifier()
+
+    messages = notifier.build_messages(
+        now_ts=4_000.0,
+        tick=3,
+        markets_scanned=12,
+        signals=[SimpleNamespace(market_id="EXEC", side="YES", edge=0.08)],
+        trades_executed=1,
+        no_trade_reason="risk limit reached",
+    )
+    assert not any(msg.startswith("⚠️ NO TRADE") for msg in messages)
+
+
+def test_formatter_hierarchy_spec_for_scan_presence_messages() -> None:
+    heartbeat = format_market_scan_heartbeat(
+        markets_scanned=50,
+        active_candidates=2,
+        status="Waiting for confirmation",
+    )
+    candidate = format_top_candidate_preview(
+        market="MARKET-1",
+        side="YES",
+        edge_pct=3.25,
+        status="waiting",
+        reason="awaiting next confirmation",
+    )
+    no_trade = format_no_trade_explanation(reason="liquidity too low")
+
+    for message in (heartbeat, candidate, no_trade):
+        body = message.splitlines()[1:]
+        assert body
+        assert all(line.startswith("|-") for line in body)


### PR DESCRIPTION
### Motivation
- Improve operator visibility by surfacing low-noise market scanning activity and decision awareness when no trades execute. 
- Provide a premium, human-readable hierarchical message format without replacing or interfering with existing trade lifecycle alerts. 

### Description
- Added three strict hierarchical formatters in `projects/polymarket/polyquantbot/telegram/message_formatter.py`: `format_market_scan_heartbeat`, `format_top_candidate_preview`, and `format_no_trade_explanation` (all `|- field: value` lines). 
- Implemented `MarketScanPresenceNotifier` in `projects/polymarket/polyquantbot/core/pipeline/trading_loop.py` with throttling, duplicate candidate suppression, and reason-change logic, and integrated it to emit messages only on no-trade cycles via the existing `telegram_callback`. 
- Introduced configuration/constants for heartbeat/cooldowns and lightweight skip-reason collection to select appropriate `no-trade` reason and top candidate signature. 
- Added focused tests `projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py`, created a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md`, and updated `PROJECT_STATE.md` to reflect the STANDARD / NARROW INTEGRATION handoff. 

### Testing
- Syntax/compile check: `python -m py_compile projects/polymarket/polyquantbot/telegram/message_formatter.py projects/polymarket/polyquantbot/core/pipeline/trading_loop.py projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py` — PASS. 
- Unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_market_scanning_presence_20260409.py` — `5 passed` (with a non-blocking `asyncio_mode` pytest warning). 
- Repo structure checks: no `phase*` folders detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6dbe4e178832eb553f0224ebfe33b)