### PR TITLE
S1 breaking-news momentum strategy (social pulse + market lag)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 23:10
-- Status        : FORGE-X Telegram market scanning presence premium UX pass completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-08 23:34
+- Status        : FORGE-X S1 breaking-news narrative momentum strategy completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests.
 - Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
 - Telegram trade lifecycle alerts premium hierarchy pass (2026-04-08): added strict execution-boundary lifecycle alerts for entry/exit/skipped events with fixed `|-` field order, no duplicate command/callback trigger coverage, and focused format validation tests.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
@@ -94,6 +95,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S1 breaking-news strategy handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger social pulse + lag decision logic and focused tests.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### Telegram trade lifecycle alerts handoff
 - STANDARD-tier narrow integration implementation is complete for execution-boundary lifecycle alerts and focused tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -139,7 +144,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_8_market_scanning_presence.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -18,6 +18,30 @@ class StrategyConfig:
     side: str = "YES"
     threshold: float = 0.45
     target_pnl: float = 25.0
+    social_spike_threshold: float = 0.70
+    min_mention_surge_ratio: float = 1.8
+    min_author_diversity: int = 15
+    min_acceleration: float = 0.5
+    min_market_lag: float = 0.03
+    min_edge: float = 0.02
+    min_liquidity_usd: float = 10_000.0
+
+
+@dataclass(frozen=True)
+class SocialPulseInput:
+    mention_surge_ratio: float
+    author_diversity: int
+    acceleration: float
+    narrative_probability: float
+    liquidity_usd: float
+    risk_constraints_ok: bool = True
+
+
+@dataclass(frozen=True)
+class StrategyDecision:
+    decision: str
+    reason: str
+    edge: float
 
 
 class StrategyTrigger:
@@ -34,6 +58,73 @@ class StrategyTrigger:
         self._last_trigger_time: float | None = None
         self._cooldown_seconds = 30.0  # Anti-loop guard
         self._trace_engine = TradeTraceEngine()
+
+    def evaluate_breaking_news_momentum(
+        self,
+        market_price: float,
+        social_pulse: SocialPulseInput,
+    ) -> StrategyDecision:
+        mention_score = min(
+            1.0,
+            social_pulse.mention_surge_ratio / max(self._config.min_mention_surge_ratio, 1e-6),
+        )
+        author_score = min(
+            1.0,
+            social_pulse.author_diversity / max(float(self._config.min_author_diversity), 1.0),
+        )
+        acceleration_score = min(
+            1.0,
+            social_pulse.acceleration / max(self._config.min_acceleration, 1e-6),
+        )
+
+        spike_score = (0.5 * mention_score) + (0.3 * author_score) + (0.2 * acceleration_score)
+        if spike_score < self._config.social_spike_threshold:
+            return StrategyDecision(
+                decision="SKIP",
+                reason="weak signal: social spike below threshold",
+                edge=0.0,
+            )
+
+        narrative_prob = min(max(social_pulse.narrative_probability, 0.01), 0.99)
+        market_prob = min(max(market_price, 0.01), 0.99)
+        price_lag = abs(narrative_prob - market_prob)
+
+        if price_lag < self._config.min_market_lag:
+            return StrategyDecision(
+                decision="SKIP",
+                reason="already priced in: market lag too small",
+                edge=0.0,
+            )
+
+        implied_odds = (1.0 - market_prob) / market_prob
+        edge = max(0.0, (narrative_prob * implied_odds) - (1.0 - narrative_prob))
+
+        if edge <= self._config.min_edge:
+            return StrategyDecision(
+                decision="SKIP",
+                reason="weak signal: edge below threshold",
+                edge=round(edge, 6),
+            )
+
+        if social_pulse.liquidity_usd < self._config.min_liquidity_usd:
+            return StrategyDecision(
+                decision="SKIP",
+                reason="low liquidity: below minimum depth requirement",
+                edge=round(edge, 6),
+            )
+
+        if not social_pulse.risk_constraints_ok:
+            return StrategyDecision(
+                decision="SKIP",
+                reason="risk constraints blocked entry",
+                edge=round(edge, 6),
+            )
+
+        return StrategyDecision(
+            decision="ENTER",
+            reason="entry conditions met: social spike + market lag + edge",
+            edge=round(edge, 6),
+        )
 
     async def evaluate(self, market_price: float) -> str:
         now = time.time()

--- a/projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md
@@ -1,0 +1,83 @@
+# 24_9_s1_breaking_news_momentum_strategy
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy-trigger decision layer in `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - social pulse input parsing and spike scoring
+  - edge computation + enter/skip decision logic output (`decision`, `reason`, `edge`)
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - Telegram UI changes
+  - observability redesign
+  - multi-strategy orchestration
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md`. Tier: STANDARD
+
+## 1. What was built
+- Added S1 breaking-news / narrative-momentum decision path into `StrategyTrigger` via `evaluate_breaking_news_momentum(...)`.
+- Added new typed inputs/outputs for this path:
+  - `SocialPulseInput` (mentions surge, author diversity, acceleration, narrative probability, liquidity, risk gate)
+  - `StrategyDecision` (decision/reason/edge)
+- Implemented social spike scoring, market lag detection, EV-based edge computation, and explicit skip reasons.
+- Added focused test suite `test_s1_breaking_news_momentum_strategy_20260409.py` covering all required behavior checks.
+
+## 2. Current system architecture
+- `StrategyTrigger` now has two paths:
+  - existing `evaluate(...)` execution-intelligence path (unchanged)
+  - new narrow integration `evaluate_breaking_news_momentum(...)` strategy-trigger path for S1 narrative spikes
+- S1 path flow:
+  1. Social spike scoring (mention surge + author diversity + acceleration)
+  2. Market lag gate (`|narrative_probability - market_price|`)
+  3. Edge calculation using EV math from implied odds
+  4. Entry gating (edge threshold + liquidity + risk constraints)
+  5. Standardized output contract (`decision`, `reason`, `edge`)
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Social spike candidate detection now uses weighted spike score from:
+  - mention surge ratio
+  - author diversity
+  - acceleration
+- Market lag check prevents entry when narrative is already priced in.
+- Edge/EV threshold blocks weak opportunities.
+- Liquidity and risk-constraint gates are enforced before enter.
+- Output format contract is stable (`decision`, `reason`, `edge`).
+
+Required test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py` ✅ (5 passed)
+
+Runtime proof examples:
+1) Example spike detection (candidate triggered)
+```text
+input: mention_surge_ratio=2.4, author_diversity=26, acceleration=0.9
+output: decision=ENTER, reason="entry conditions met: social spike + market lag + edge", edge=0.269231
+```
+
+2) Example entry decision (lag + edge present)
+```text
+input: narrative_probability=0.64, market_price=0.50, liquidity=15000, risk_constraints_ok=True
+output: decision=ENTER, reason="entry conditions met: social spike + market lag + edge", edge=0.28
+```
+
+3) Example skip decision (already priced)
+```text
+input: narrative_probability=0.58, market_price=0.56
+output: decision=SKIP, reason="already priced in: market lag too small", edge=0.0
+```
+
+## 5. Known issues
+- Existing pytest warning remains in environment: `Unknown config option: asyncio_mode`.
+- S1 strategy path is currently narrow-integration only and not yet wired into multi-strategy orchestrator runtime selection.
+
+## 6. What is next
+- COMMANDER review for STANDARD-tier narrow integration objective.
+- Merge decision after Codex auto PR review baseline + COMMANDER review.
+- Optional next phase: route S1 strategy decision path into selected runtime signal pipeline once requested.

--- a/projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    SocialPulseInput,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used by this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    config = StrategyConfig(
+        market_id="m-news-1",
+        social_spike_threshold=0.65,
+        min_mention_surge_ratio=1.6,
+        min_author_diversity=12,
+        min_acceleration=0.4,
+        min_market_lag=0.03,
+        min_edge=0.02,
+        min_liquidity_usd=10_000.0,
+    )
+    return StrategyTrigger(engine=_NoopEngine(), config=config)
+
+
+def test_social_spike_triggers_candidate() -> None:
+    trigger = _make_trigger()
+    pulse = SocialPulseInput(
+        mention_surge_ratio=2.4,
+        author_diversity=26,
+        acceleration=0.9,
+        narrative_probability=0.66,
+        liquidity_usd=25_000.0,
+        risk_constraints_ok=True,
+    )
+
+    decision = trigger.evaluate_breaking_news_momentum(market_price=0.52, social_pulse=pulse)
+
+    assert decision.decision == "ENTER"
+    assert decision.edge > 0.02
+
+
+def test_no_price_move_entry_allowed() -> None:
+    trigger = _make_trigger()
+    pulse = SocialPulseInput(
+        mention_surge_ratio=2.0,
+        author_diversity=18,
+        acceleration=0.7,
+        narrative_probability=0.64,
+        liquidity_usd=15_000.0,
+        risk_constraints_ok=True,
+    )
+
+    decision = trigger.evaluate_breaking_news_momentum(market_price=0.50, social_pulse=pulse)
+
+    assert decision.decision == "ENTER"
+    assert "entry conditions met" in decision.reason
+
+
+def test_already_priced_is_skipped() -> None:
+    trigger = _make_trigger()
+    pulse = SocialPulseInput(
+        mention_surge_ratio=2.5,
+        author_diversity=22,
+        acceleration=1.0,
+        narrative_probability=0.58,
+        liquidity_usd=20_000.0,
+        risk_constraints_ok=True,
+    )
+
+    decision = trigger.evaluate_breaking_news_momentum(market_price=0.56, social_pulse=pulse)
+
+    assert decision.decision == "SKIP"
+    assert "already priced in" in decision.reason
+
+
+def test_weak_signal_is_skipped() -> None:
+    trigger = _make_trigger()
+    pulse = SocialPulseInput(
+        mention_surge_ratio=1.1,
+        author_diversity=4,
+        acceleration=0.1,
+        narrative_probability=0.62,
+        liquidity_usd=18_000.0,
+        risk_constraints_ok=True,
+    )
+
+    decision = trigger.evaluate_breaking_news_momentum(market_price=0.50, social_pulse=pulse)
+
+    assert decision.decision == "SKIP"
+    assert "weak signal" in decision.reason
+
+
+def test_output_format_is_decision_reason_edge() -> None:
+    trigger = _make_trigger()
+    pulse = SocialPulseInput(
+        mention_surge_ratio=2.1,
+        author_diversity=17,
+        acceleration=0.8,
+        narrative_probability=0.65,
+        liquidity_usd=16_000.0,
+        risk_constraints_ok=True,
+    )
+
+    decision = trigger.evaluate_breaking_news_momentum(market_price=0.51, social_pulse=pulse)
+
+    assert set(decision.__dict__.keys()) == {"decision", "reason", "edge"}
+    assert isinstance(decision.decision, str)
+    assert isinstance(decision.reason, str)
+    assert isinstance(decision.edge, float)


### PR DESCRIPTION
### Motivation
- Implement a narrow-integration S1 strategy to detect social/narrative spikes and capture early market moves before price fully adjusts using social pulse + market-lag checks.
- Deliver a STANDARD-tier, NARROW_INTEGRATION decision layer that outputs a deterministic `ENTER`/`SKIP` decision with reasons and numeric `edge` for downstream evaluation.

### Description
- Added new config knobs to `StrategyConfig` for social spike and gating thresholds (`social_spike_threshold`, `min_mention_surge_ratio`, `min_author_diversity`, `min_acceleration`, `min_market_lag`, `min_edge`, `min_liquidity_usd`).
- Introduced typed contracts `SocialPulseInput` and `StrategyDecision` and implemented `evaluate_breaking_news_momentum(...)` on `StrategyTrigger` which runs: weighted social spike scoring → market-lag gate → EV-based edge calculation → liquidity + risk gates → returns `decision`, `reason`, `edge`.
- Added focused unit tests exercising the five required cases and output contract in `projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py`.
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md` and updated `PROJECT_STATE.md` to record completion and handoff for Codex auto PR review + COMMANDER review.
- Files changed: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py`, `projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md`, and `PROJECT_STATE.md`.

### Testing
- Ran syntax check: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py` → PASS.
- Ran unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py` → 5 passed (environment warning: `Unknown config option: asyncio_mode` observed but tests passed).
- Confirmed single commit includes code + report + `PROJECT_STATE.md` update on branch `feature/s1-breaking-news-momentum-strategy-2026-04-09`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e58f75b0832e9f8ec73bec4c8890)