### PR TITLE
sync: update PROJECT_STATE after S1 completion

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,13 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 23:34
-- Status        : FORGE-X S1 breaking-news narrative momentum strategy completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 00:02
+- Status        : FORGE-X S1 breaking-news narrative momentum strategy completed (STANDARD, narrow integration); completed and merged into main.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
-- S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests.
+- S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests; completed and merged into main.
 - Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
 - Telegram trade lifecycle alerts premium hierarchy pass (2026-04-08): added strict execution-boundary lifecycle alerts for entry/exit/skipped events with fixed `|-` field order, no duplicate command/callback trigger coverage, and focused format validation tests.
 - P4 completion closure (2026-04-08): marked Completed (Conditional) with runtime observability integrated, trace propagation finalized, and executor trace hardening completed (#283).
@@ -95,10 +95,6 @@ Status:
 
 ## 🚧 IN PROGRESS
 
-### S1 breaking-news strategy handoff
-- STANDARD-tier narrow integration implementation is complete for strategy-trigger social pulse + lag decision logic and focused tests.
-- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
-
 ### Telegram trade lifecycle alerts handoff
 - STANDARD-tier narrow integration implementation is complete for execution-boundary lifecycle alerts and focused tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -144,8 +140,8 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md
-Tier: STANDARD
+Source: projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md
+Tier: MINOR
 
 ## ⚠️ KNOWN ISSUES
 

--- a/projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md
@@ -1,0 +1,39 @@
+# 24_10_sync_project_state_after_s1_completion
+
+## Validation Metadata
+- Validation Tier: MINOR
+- Claim Level: FOUNDATION
+- Validation Target:
+  - `PROJECT_STATE.md` S1 status wording and handoff placement
+- Not in Scope:
+  - code changes
+  - strategy logic
+  - execution logic
+  - Telegram UI
+  - observability
+  - any other files
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md`. Tier: MINOR
+
+## 1. What was built
+- Updated `PROJECT_STATE.md` to mark S1 breaking-news narrative momentum strategy as completed and merged into main.
+- Removed S1 from `IN PROGRESS` handoff block so it is no longer represented as pending review/merge work.
+
+## 2. Current system architecture
+- No runtime architecture changes.
+- State/reporting layer now reflects S1 as finalized historical completion rather than active handoff work.
+
+## 3. Files created / modified (full paths)
+- Modified: `PROJECT_STATE.md`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md`
+
+## 4. What is working
+- S1 status line now uses completion wording (`completed and merged into main`) instead of pending-review wording.
+- S1 handoff subsection is no longer present under `IN PROGRESS`.
+- Markdown structure remains intact after edit.
+
+## 5. Known issues
+- None introduced by this scope-limited PROJECT_STATE sync task.
+
+## 6. What is next
+- Codex auto PR review coverage for this MINOR update.
+- COMMANDER review for merge decision.


### PR DESCRIPTION
### Motivation
- Mark the S1 breaking-news narrative momentum strategy as completed and merged so `PROJECT_STATE.md` no longer lists S1 as pending review/merge.

### Description
- Updated `PROJECT_STATE.md` `Last Updated` timestamp and `Status` wording to state S1 is "completed and merged into main", merged the S1 completed note into the Completed list, removed the S1 handoff subsection from `IN PROGRESS`, and added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md`; changes committed on branch `feature/sync-project-state-after-s1-2026-04-09`.

### Testing
- Ran structural verification checks: `git diff -- PROJECT_STATE.md projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md` (PASS), `rg --files | rg '/phase[0-9]+' || true` (no forbidden `phase*` folders found, PASS), and `git status --short` (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ec5e615c832e9f8eeb3ac3eef54d)