### PR TITLE
FORGE-X: S2 cross-exchange arbitrage (Polymarket ↔ Kalshi) narrow integration

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-08 23:34
-- Status        : FORGE-X S1 breaking-news narrative momentum strategy completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 00:04
+- Status        : FORGE-X S2 cross-exchange arbitrage strategy completed (STANDARD, narrow integration); pending Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S2 cross-exchange arbitrage strategy (2026-04-09): added Polymarket↔Kalshi equivalent-market mapping confidence checks, normalized probability comparison, fee/slippage-adjusted net-edge gating, ENTER/SKIP decision contract with matched-market info payload, and focused five-case behavior tests.
 - S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests.
 - Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
 - Telegram trade lifecycle alerts premium hierarchy pass (2026-04-08): added strict execution-boundary lifecycle alerts for entry/exit/skipped events with fixed `|-` field order, no duplicate command/callback trigger coverage, and focused format validation tests.
@@ -95,6 +96,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S2 cross-exchange arbitrage strategy handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger mapping, normalization, and net-edge decision logic with focused tests.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S1 breaking-news strategy handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger social pulse + lag decision logic and focused tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -144,7 +149,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_9_s1_breaking_news_momentum_strategy.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
@@ -159,3 +164,4 @@ Tier: STANDARD
 - MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.
 - Pytest environment still reports unknown `asyncio_mode` config warning; focused observability tests pass under synchronous `asyncio.run(...)` invocation.
 - Pytest environment still reports unknown `asyncio_mode` config warning on focused portfolio-render tests; tests pass despite the warning.
+- S2 arbitrage path is narrow integration only and not yet wired into broader runtime strategy orchestration.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import time
 import structlog
 import uuid
+import re
 
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
@@ -25,6 +26,8 @@ class StrategyConfig:
     min_market_lag: float = 0.03
     min_edge: float = 0.02
     min_liquidity_usd: float = 10_000.0
+    cross_exchange_min_mapping_confidence: float = 0.60
+    cross_exchange_min_net_edge: float = 0.02
 
 
 @dataclass(frozen=True)
@@ -42,6 +45,27 @@ class StrategyDecision:
     decision: str
     reason: str
     edge: float
+
+
+@dataclass(frozen=True)
+class CrossExchangeMarketInput:
+    exchange: str
+    market_id: str
+    title: str
+    timeframe: str
+    resolution_criteria: str
+    yes_probability: float
+    liquidity_usd: float
+    fee_rate: float
+    slippage_rate: float
+
+
+@dataclass(frozen=True)
+class CrossExchangeDecision:
+    decision: str
+    edge: float
+    reason: str
+    matched_markets: dict[str, str]
 
 
 class StrategyTrigger:
@@ -125,6 +149,109 @@ class StrategyTrigger:
             reason="entry conditions met: social spike + market lag + edge",
             edge=round(edge, 6),
         )
+
+    def evaluate_cross_exchange_arbitrage(
+        self,
+        polymarket: CrossExchangeMarketInput,
+        kalshi: CrossExchangeMarketInput,
+    ) -> CrossExchangeDecision:
+        mapping_confidence = self._mapping_confidence(polymarket=polymarket, kalshi=kalshi)
+        if mapping_confidence < self._config.cross_exchange_min_mapping_confidence:
+            return CrossExchangeDecision(
+                decision="SKIP",
+                edge=0.0,
+                reason="mapping confidence too low for equivalent-market assertion",
+                matched_markets={
+                    "polymarket_id": polymarket.market_id,
+                    "kalshi_id": kalshi.market_id,
+                    "mapping_confidence": f"{mapping_confidence:.3f}",
+                },
+            )
+
+        if (
+            polymarket.liquidity_usd < self._config.min_liquidity_usd
+            or kalshi.liquidity_usd < self._config.min_liquidity_usd
+        ):
+            return CrossExchangeDecision(
+                decision="SKIP",
+                edge=0.0,
+                reason="insufficient liquidity on one or both exchanges",
+                matched_markets={
+                    "polymarket_id": polymarket.market_id,
+                    "kalshi_id": kalshi.market_id,
+                    "mapping_confidence": f"{mapping_confidence:.3f}",
+                },
+            )
+
+        poly_prob = min(max(polymarket.yes_probability, 0.01), 0.99)
+        kalshi_prob = min(max(kalshi.yes_probability, 0.01), 0.99)
+        gross_edge = abs(poly_prob - kalshi_prob)
+        total_cost = (
+            polymarket.fee_rate
+            + kalshi.fee_rate
+            + polymarket.slippage_rate
+            + kalshi.slippage_rate
+        )
+        net_edge = max(0.0, gross_edge - total_cost)
+
+        if net_edge <= self._config.cross_exchange_min_net_edge:
+            return CrossExchangeDecision(
+                decision="SKIP",
+                edge=round(net_edge, 6),
+                reason="net edge below actionable threshold after fees/slippage",
+                matched_markets={
+                    "polymarket_id": polymarket.market_id,
+                    "kalshi_id": kalshi.market_id,
+                    "mapping_confidence": f"{mapping_confidence:.3f}",
+                    "gross_edge": f"{gross_edge:.6f}",
+                },
+            )
+
+        return CrossExchangeDecision(
+            decision="ENTER",
+            edge=round(net_edge, 6),
+            reason="cross-exchange arbitrage opportunity detected",
+            matched_markets={
+                "polymarket_id": polymarket.market_id,
+                "kalshi_id": kalshi.market_id,
+                "mapping_confidence": f"{mapping_confidence:.3f}",
+                "polymarket_probability": f"{poly_prob:.6f}",
+                "kalshi_probability": f"{kalshi_prob:.6f}",
+                "gross_edge": f"{gross_edge:.6f}",
+            },
+        )
+
+    def _mapping_confidence(
+        self,
+        polymarket: CrossExchangeMarketInput,
+        kalshi: CrossExchangeMarketInput,
+    ) -> float:
+        poly_tokens = self._normalized_tokens(polymarket.title)
+        kalshi_tokens = self._normalized_tokens(kalshi.title)
+        if not poly_tokens or not kalshi_tokens:
+            return 0.0
+
+        overlap = len(poly_tokens.intersection(kalshi_tokens))
+        union = len(poly_tokens.union(kalshi_tokens))
+        text_similarity = overlap / max(union, 1)
+
+        timeframe_match = (
+            polymarket.timeframe.strip().lower() == kalshi.timeframe.strip().lower()
+        )
+        resolution_match = (
+            polymarket.resolution_criteria.strip().lower()
+            == kalshi.resolution_criteria.strip().lower()
+        )
+        confidence = text_similarity * 0.6
+        confidence += 0.2 if timeframe_match else 0.0
+        confidence += 0.2 if resolution_match else 0.0
+        return min(max(confidence, 0.0), 1.0)
+
+    def _normalized_tokens(self, text: str) -> set[str]:
+        cleaned = re.sub(r"[^a-z0-9 ]+", " ", text.strip().lower())
+        tokens = {token for token in cleaned.split() if len(token) > 2}
+        stopwords = {"will", "that", "with", "from", "into", "than", "over", "under"}
+        return {token for token in tokens if token not in stopwords}
 
     async def evaluate(self, market_price: float) -> str:
         now = time.time()

--- a/projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md
@@ -1,0 +1,91 @@
+# 24_10_s2_cross_exchange_arbitrage
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy-trigger layer in `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - market data normalization to probability space (0–1)
+  - cross-market comparison logic for Polymarket ↔ Kalshi equivalence
+  - edge calculation with fees/slippage adjustment
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - order placement logic
+  - Telegram UI changes
+  - observability redesign
+  - exchange API integration expansion
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md`. Tier: STANDARD
+
+## 1. What was built
+- Added narrow-integration cross-exchange arbitrage decision path to `StrategyTrigger` via `evaluate_cross_exchange_arbitrage(...)`.
+- Added explicit typed contracts for cross-exchange comparison:
+  - `CrossExchangeMarketInput`
+  - `CrossExchangeDecision`
+- Implemented market-equivalence mapping confidence scoring using:
+  - title token overlap
+  - timeframe equality
+  - resolution-criteria equality
+- Implemented normalized probability comparison and net-edge logic:
+  - `gross_edge = abs(prob_poly - prob_kalshi)`
+  - `net_edge = gross_edge - (fees + slippage)`
+- Added actionable decision contract output for this strategy path:
+  - `decision` (`ENTER` / `SKIP`)
+  - `edge` (numeric)
+  - `reason` (explanation)
+  - `matched_markets` info payload
+
+## 2. Current system architecture
+- `StrategyTrigger` now provides strategy-specific narrow integrations:
+  - Existing S1 breaking-news momentum path
+  - New S2 cross-exchange arbitrage path
+- S2 flow:
+  1. Build equivalence confidence for Polymarket/Kalshi market pair
+  2. Reject low-confidence mapping (`SKIP`)
+  3. Enforce per-exchange liquidity minimum gate (`SKIP`)
+  4. Normalize both prices to bounded probability space `[0.01, 0.99]`
+  5. Compute gross edge and subtract fees/slippage
+  6. Enter only when `net_edge > 2%` and mapping/liquidity gates pass
+
+## 3. Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4. What is working
+- Equivalent market matching is now explicitly scored and can skip low-confidence pairs.
+- Probability normalization guarantees stable comparison across both exchanges.
+- Net edge calculation correctly adjusts for fees and slippage.
+- Decision contract includes actionable payload with matched market details.
+
+Required test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅ (5 passed)
+
+Required test scenarios covered:
+1. matched markets → edge detected ✅
+2. no match → skipped ✅
+3. edge < threshold → skipped ✅
+4. fees reduce edge → skipped ✅
+5. valid arbitrage → ENTER ✅
+
+Runtime proof examples:
+- Example matched markets:
+  - Input: Polymarket `poly-btc-60k` vs Kalshi `kalshi-btc-60k`
+  - Output: `decision=ENTER`, `edge=0.080000`, `mapping_confidence=0.900`
+- Example arbitrage opportunity:
+  - Input: `prob_poly=0.41`, `prob_kalshi=0.49`, total cost `0.006`
+  - Output: `gross_edge=0.080000`, `net_edge=0.074000`, `decision=ENTER`
+- Example skipped case:
+  - Input: BTC market vs unrelated rainfall market
+  - Output: `decision=SKIP`, reason `mapping confidence too low for equivalent-market assertion`
+
+## 5. Known issues
+- Existing environment warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- S2 path is intentionally narrow integration and is not yet wired into multi-strategy runtime orchestration.
+
+## 6. What is next
+- Codex auto PR review baseline for this STANDARD task.
+- COMMANDER review and merge/hold decision.
+- Optional follow-up (if requested): connect this S2 decision path into selected strategy trigger routing entrypoint.

--- a/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeMarketInput,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used by this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    config = StrategyConfig(
+        market_id="m-cross-exchange",
+        min_liquidity_usd=10_000.0,
+        cross_exchange_min_mapping_confidence=0.60,
+        cross_exchange_min_net_edge=0.02,
+    )
+    return StrategyTrigger(engine=_NoopEngine(), config=config)
+
+
+def _market(
+    *,
+    exchange: str,
+    market_id: str,
+    title: str,
+    timeframe: str = "2026-12-31",
+    resolution_criteria: str = "close_above_60000",
+    yes_probability: float,
+    liquidity_usd: float,
+    fee_rate: float,
+    slippage_rate: float,
+) -> CrossExchangeMarketInput:
+    return CrossExchangeMarketInput(
+        exchange=exchange,
+        market_id=market_id,
+        title=title,
+        timeframe=timeframe,
+        resolution_criteria=resolution_criteria,
+        yes_probability=yes_probability,
+        liquidity_usd=liquidity_usd,
+        fee_rate=fee_rate,
+        slippage_rate=slippage_rate,
+    )
+
+
+def test_matched_markets_edge_detected() -> None:
+    trigger = _make_trigger()
+    poly = _market(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60k by 2026?",
+        yes_probability=0.43,
+        liquidity_usd=25_000.0,
+        fee_rate=0.003,
+        slippage_rate=0.002,
+    )
+    kalshi = _market(
+        exchange="kalshi",
+        market_id="kalshi-btc-60k",
+        title="BTC above 60k settlement by 2026 close",
+        yes_probability=0.52,
+        liquidity_usd=22_000.0,
+        fee_rate=0.003,
+        slippage_rate=0.002,
+    )
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(polymarket=poly, kalshi=kalshi)
+
+    assert decision.decision == "ENTER"
+    assert decision.edge > 0.02
+    assert decision.matched_markets["polymarket_id"] == "poly-btc-60k"
+    assert decision.matched_markets["kalshi_id"] == "kalshi-btc-60k"
+
+
+def test_no_match_skipped() -> None:
+    trigger = _make_trigger()
+    poly = _market(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60k by 2026?",
+        yes_probability=0.43,
+        liquidity_usd=25_000.0,
+        fee_rate=0.002,
+        slippage_rate=0.002,
+    )
+    kalshi = _market(
+        exchange="kalshi",
+        market_id="kalshi-weather-rain",
+        title="Will New York rainfall exceed 4 inches next week?",
+        timeframe="2026-05-01",
+        resolution_criteria="rainfall_inches_gt_4",
+        yes_probability=0.56,
+        liquidity_usd=30_000.0,
+        fee_rate=0.002,
+        slippage_rate=0.002,
+    )
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(polymarket=poly, kalshi=kalshi)
+
+    assert decision.decision == "SKIP"
+    assert "mapping confidence too low" in decision.reason
+
+
+def test_edge_below_threshold_skipped() -> None:
+    trigger = _make_trigger()
+    poly = _market(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60k by 2026?",
+        yes_probability=0.49,
+        liquidity_usd=20_000.0,
+        fee_rate=0.003,
+        slippage_rate=0.002,
+    )
+    kalshi = _market(
+        exchange="kalshi",
+        market_id="kalshi-btc-60k",
+        title="BTC above 60k settlement by 2026 close",
+        yes_probability=0.50,
+        liquidity_usd=20_000.0,
+        fee_rate=0.003,
+        slippage_rate=0.002,
+    )
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(polymarket=poly, kalshi=kalshi)
+
+    assert decision.decision == "SKIP"
+    assert decision.edge == 0.0
+    assert "net edge below actionable threshold" in decision.reason
+
+
+def test_fees_reduce_edge_skipped() -> None:
+    trigger = _make_trigger()
+    poly = _market(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60k by 2026?",
+        yes_probability=0.45,
+        liquidity_usd=20_000.0,
+        fee_rate=0.008,
+        slippage_rate=0.007,
+    )
+    kalshi = _market(
+        exchange="kalshi",
+        market_id="kalshi-btc-60k",
+        title="BTC above 60k settlement by 2026 close",
+        yes_probability=0.48,
+        liquidity_usd=20_000.0,
+        fee_rate=0.008,
+        slippage_rate=0.007,
+    )
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(polymarket=poly, kalshi=kalshi)
+
+    assert decision.decision == "SKIP"
+    assert decision.edge == 0.0
+    assert "net edge below actionable threshold" in decision.reason
+
+
+def test_valid_arbitrage_enters() -> None:
+    trigger = _make_trigger()
+    poly = _market(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60k by 2026?",
+        yes_probability=0.41,
+        liquidity_usd=18_000.0,
+        fee_rate=0.002,
+        slippage_rate=0.001,
+    )
+    kalshi = _market(
+        exchange="kalshi",
+        market_id="kalshi-btc-60k",
+        title="BTC above 60k settlement by 2026 close",
+        yes_probability=0.49,
+        liquidity_usd=17_000.0,
+        fee_rate=0.002,
+        slippage_rate=0.001,
+    )
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(polymarket=poly, kalshi=kalshi)
+
+    assert decision.decision == "ENTER"
+    assert decision.edge == 0.074
+    assert "arbitrage opportunity" in decision.reason


### PR DESCRIPTION
### Motivation
- Implement a narrow-integration S2 strategy to detect actionable cross-exchange arbitrage between Polymarket and Kalshi by identifying equivalent markets and measuring a fees/slippage-adjusted net edge. 
- Provide a deterministic, testable decision contract (`ENTER` / `SKIP` + `edge` + `reason` + `matched_markets`) at the `strategy_trigger` layer without changing execution, risk, or order-placement engines. 
- Ensure mapping confidence and liquidity gates prevent false positives and keep the feature scoped to strategy-trigger logic only. 

### Description
- Added config gates and types in `projects/polymarket/polyquantbot/execution/strategy_trigger.py`: `cross_exchange_min_mapping_confidence` and `cross_exchange_min_net_edge`, plus `CrossExchangeMarketInput` and `CrossExchangeDecision` dataclasses. 
- Implemented `evaluate_cross_exchange_arbitrage(...)` which computes title-token mapping confidence, enforces timeframe/resolution matching and liquidity, normalizes probabilities to `[0.01,0.99]`, computes `gross_edge = abs(prob_poly - prob_kalshi)`, subtracts fees+slippage to produce `net_edge`, and returns `ENTER` only when actionable. 
- Added helper methods `_mapping_confidence(...)` and `_normalized_tokens(...)` for text-similarity based equivalence scoring, and kept all logic inside `StrategyTrigger` to preserve narrow integration scope. 
- Added tests `projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_10_s2_cross_exchange_arbitrage.md`, and updated `PROJECT_STATE.md` to reflect the STANDARD-tier narrow-integration handoff. 

### Testing
- Ran static compile check with `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` and it passed. 
- Ran unit tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` and all tests passed (`5 passed, 1 warning`). 
- Executed a small runtime proof script that calls `evaluate_cross_exchange_arbitrage(...)` for example matched, opportunity, and skipped cases and observed expected `ENTER`/`SKIP` outputs. 
- Note: the test run produced a non-blocking `PytestConfigWarning: Unknown config option: asyncio_mode` which is an existing environment warning and does not affect the S2 tests outcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ec703684832eba68888fe0411116)