### PR TITLE
S2 cross-exchange arbitrage: add Polymarket↔Kalshi matching + net-edge gating in StrategyTrigger

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 00:02
-- Status        : FORGE-X S1 breaking-news narrative momentum strategy completed (STANDARD, narrow integration); completed and merged into main.
+- Last Updated  : 2026-04-09 00:53
+- Status        : FORGE-X S2 cross-exchange arbitrage strategy completed (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S2 cross-exchange arbitrage strategy (2026-04-09): added strategy-trigger Polymarket↔Kalshi market matching confidence logic, normalized probability comparison, fee/slippage-adjusted net edge gating, structured ENTER/SKIP output with matched markets info, and focused five-case tests.
 - S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests; completed and merged into main.
 - Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
 - Telegram trade lifecycle alerts premium hierarchy pass (2026-04-08): added strict execution-boundary lifecycle alerts for entry/exit/skipped events with fixed `|-` field order, no duplicate command/callback trigger coverage, and focused format validation tests.
@@ -95,6 +96,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S2 cross-exchange arbitrage handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger matching, normalization, and net-edge arbitration decisions.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### Telegram trade lifecycle alerts handoff
 - STANDARD-tier narrow integration implementation is complete for execution-boundary lifecycle alerts and focused tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -140,11 +145,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_10_sync_project_state_after_s1_completion.md
-Tier: MINOR
+Source: projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md
+Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.
 - Pytest environment still reports unknown `asyncio_mode` config warning on focused lifecycle-alert tests; tests pass despite the warning.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import time
 import structlog
 import uuid
+import re
 
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
@@ -25,6 +26,9 @@ class StrategyConfig:
     min_market_lag: float = 0.03
     min_edge: float = 0.02
     min_liquidity_usd: float = 10_000.0
+    cross_exchange_min_net_edge: float = 0.02
+    cross_exchange_min_mapping_confidence: float = 0.55
+    cross_exchange_min_overlap_tokens: int = 2
 
 
 @dataclass(frozen=True)
@@ -42,6 +46,28 @@ class StrategyDecision:
     decision: str
     reason: str
     edge: float
+
+
+@dataclass(frozen=True)
+class CrossExchangeMarket:
+    exchange: str
+    market_id: str
+    title: str
+    probability: float
+    liquidity_usd: float
+    fee_bps: float = 0.0
+    slippage_bps: float = 0.0
+    timeframe: str = ""
+    resolution_criteria: str = ""
+    event_key: str = ""
+
+
+@dataclass(frozen=True)
+class CrossExchangeArbitrageDecision:
+    decision: str
+    reason: str
+    edge: float
+    matched_markets_info: dict[str, object]
 
 
 class StrategyTrigger:
@@ -125,6 +151,134 @@ class StrategyTrigger:
             reason="entry conditions met: social spike + market lag + edge",
             edge=round(edge, 6),
         )
+
+    def evaluate_cross_exchange_arbitrage(
+        self,
+        polymarket: CrossExchangeMarket,
+        kalshi_markets: list[CrossExchangeMarket],
+    ) -> CrossExchangeArbitrageDecision:
+        best_match, confidence = self._select_best_cross_exchange_match(
+            polymarket=polymarket,
+            kalshi_markets=kalshi_markets,
+        )
+        if best_match is None:
+            return CrossExchangeArbitrageDecision(
+                decision="SKIP",
+                reason="no equivalent market match found",
+                edge=0.0,
+                matched_markets_info={"polymarket": polymarket.market_id, "match": None},
+            )
+
+        if confidence < self._config.cross_exchange_min_mapping_confidence:
+            return CrossExchangeArbitrageDecision(
+                decision="SKIP",
+                reason="mapping confidence too low",
+                edge=0.0,
+                matched_markets_info={
+                    "polymarket": polymarket.market_id,
+                    "kalshi": best_match.market_id,
+                    "mapping_confidence": round(confidence, 6),
+                },
+            )
+
+        poly_prob = self._normalize_probability(polymarket.probability)
+        kalshi_prob = self._normalize_probability(best_match.probability)
+        raw_edge = abs(poly_prob - kalshi_prob)
+        fees_slippage = (
+            self._bps_to_probability(polymarket.fee_bps + polymarket.slippage_bps)
+            + self._bps_to_probability(best_match.fee_bps + best_match.slippage_bps)
+        )
+        net_edge = max(0.0, raw_edge - fees_slippage)
+
+        if polymarket.liquidity_usd < self._config.min_liquidity_usd or best_match.liquidity_usd < self._config.min_liquidity_usd:
+            return CrossExchangeArbitrageDecision(
+                decision="SKIP",
+                reason="liquidity insufficient for actionable arbitrage",
+                edge=round(net_edge, 6),
+                matched_markets_info={
+                    "polymarket": polymarket.market_id,
+                    "kalshi": best_match.market_id,
+                    "mapping_confidence": round(confidence, 6),
+                    "raw_edge": round(raw_edge, 6),
+                    "net_edge": round(net_edge, 6),
+                },
+            )
+
+        if net_edge <= self._config.cross_exchange_min_net_edge:
+            return CrossExchangeArbitrageDecision(
+                decision="SKIP",
+                reason="fees/slippage adjusted edge below threshold",
+                edge=round(net_edge, 6),
+                matched_markets_info={
+                    "polymarket": polymarket.market_id,
+                    "kalshi": best_match.market_id,
+                    "mapping_confidence": round(confidence, 6),
+                    "raw_edge": round(raw_edge, 6),
+                    "net_edge": round(net_edge, 6),
+                },
+            )
+
+        return CrossExchangeArbitrageDecision(
+            decision="ENTER",
+            reason="cross-exchange arbitrage opportunity detected",
+            edge=round(net_edge, 6),
+            matched_markets_info={
+                "polymarket": polymarket.market_id,
+                "kalshi": best_match.market_id,
+                "mapping_confidence": round(confidence, 6),
+                "probability_polymarket": round(poly_prob, 6),
+                "probability_kalshi": round(kalshi_prob, 6),
+                "raw_edge": round(raw_edge, 6),
+                "net_edge": round(net_edge, 6),
+            },
+        )
+
+    def _select_best_cross_exchange_match(
+        self,
+        polymarket: CrossExchangeMarket,
+        kalshi_markets: list[CrossExchangeMarket],
+    ) -> tuple[CrossExchangeMarket | None, float]:
+        best_market: CrossExchangeMarket | None = None
+        best_score = 0.0
+        poly_tokens = set(self._tokenize(polymarket.title))
+
+        for candidate in kalshi_markets:
+            candidate_tokens = set(self._tokenize(candidate.title))
+            overlap = len(poly_tokens & candidate_tokens)
+            overlap_score = min(
+                1.0,
+                overlap / max(float(self._config.cross_exchange_min_overlap_tokens), 1.0),
+            )
+            event_match = 1.0 if polymarket.event_key and polymarket.event_key == candidate.event_key else 0.0
+            timeframe_match = 1.0 if polymarket.timeframe and polymarket.timeframe == candidate.timeframe else 0.0
+            resolution_match = (
+                1.0
+                if polymarket.resolution_criteria
+                and polymarket.resolution_criteria == candidate.resolution_criteria
+                else 0.0
+            )
+            score = (0.4 * event_match) + (0.2 * timeframe_match) + (0.2 * resolution_match) + (0.2 * overlap_score)
+            if score > best_score:
+                best_score = score
+                best_market = candidate
+
+        return best_market, best_score
+
+    @staticmethod
+    def _normalize_probability(raw_probability: float) -> float:
+        if raw_probability <= 1.0:
+            return min(max(raw_probability, 0.0), 1.0)
+        if raw_probability <= 100.0:
+            return min(max(raw_probability / 100.0, 0.0), 1.0)
+        return 1.0
+
+    @staticmethod
+    def _bps_to_probability(value_bps: float) -> float:
+        return max(value_bps, 0.0) / 10_000.0
+
+    @staticmethod
+    def _tokenize(value: str) -> list[str]:
+        return [token for token in re.split(r"[^a-z0-9]+", value.lower()) if len(token) >= 3]
 
     async def evaluate(self, market_price: float) -> str:
         now = time.time()

--- a/projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md
@@ -1,0 +1,115 @@
+# 24_11_s2_cross_exchange_arbitrage
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy trigger layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - cross-exchange market data normalization to 0–1 probability space
+  - Polymarket↔Kalshi market matching confidence logic
+  - fee/slippage-adjusted edge calculation and ENTER/SKIP output contract
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - order placement logic
+  - Telegram UI changes
+  - observability redesign
+  - exchange API integration expansion
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md`. Tier: STANDARD
+
+## 1. What was built
+- Added a new narrow-integration strategy path `evaluate_cross_exchange_arbitrage(...)` to compare equivalent Polymarket and Kalshi markets and output a structured arbitrage decision.
+- Added typed cross-exchange contracts:
+  - `CrossExchangeMarket` input for normalized market snapshots and matching metadata.
+  - `CrossExchangeArbitrageDecision` output with `decision`, `edge`, `reason`, and `matched_markets_info`.
+- Implemented matching pipeline with confidence scoring based on:
+  - event key
+  - timeframe
+  - resolution criteria
+  - title token overlap
+- Implemented normalization + edge pipeline:
+  - normalize probabilities to `[0, 1]`
+  - compute `raw_edge = abs(prob_poly - prob_kalshi)`
+  - subtract fees and slippage (bps → probability)
+  - gate on minimum net edge and minimum liquidity
+- Added focused S2 tests for required behavior matrix.
+
+## 2. Current system architecture
+- `StrategyTrigger` now contains three decision paths:
+  1. `evaluate(...)` for existing execution-intelligence runtime path (unchanged)
+  2. `evaluate_breaking_news_momentum(...)` for S1 momentum trigger (unchanged)
+  3. `evaluate_cross_exchange_arbitrage(...)` for S2 Polymarket↔Kalshi arbitrage candidate evaluation (new, narrow integration)
+- S2 flow:
+  1. Select best equivalent Kalshi contract for a Polymarket market using semantic/metadata confidence score.
+  2. Skip if no match or confidence below threshold.
+  3. Normalize both probabilities into the same 0–1 space.
+  4. Compute raw edge then adjust by fees + slippage.
+  5. Enforce entry constraints: net edge threshold and minimum liquidity on both sides.
+  6. Emit required output contract with explicit reason and matched market metadata.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required output contract is produced for S2 path:
+  - `decision: ENTER | SKIP`
+  - `edge: float`
+  - `reason: str`
+  - `matched_markets_info: dict`
+- Required tests pass for the requested scenarios:
+  1. matched markets → edge detected
+  2. no match → skipped
+  3. edge < threshold → skipped
+  4. fees reduce edge → skipped
+  5. valid arbitrage → ENTER
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅ (5 passed)
+
+Runtime proof examples:
+1) Example matched markets (edge detected)
+```text
+input:
+- Polymarket: poly-btc-60k, prob=0.64
+- Kalshi: KXBTCAPR60, prob=0.58
+- fees/slippage total: 33 bps
+output:
+- decision=ENTER
+- edge=0.0567
+- reason="cross-exchange arbitrage opportunity detected"
+- matched_markets_info={polymarket: poly-btc-60k, kalshi: KXBTCAPR60, mapping_confidence: 1.0}
+```
+
+2) Example arbitrage opportunity (ENTER)
+```text
+input:
+- equivalent event_key/timeframe/resolution_criteria
+- sufficient liquidity on both exchanges (>10,000)
+- net edge above 2%
+output:
+- decision=ENTER
+- edge>0.02
+```
+
+3) Example skipped case
+```text
+input:
+- no Kalshi candidates available
+output:
+- decision=SKIP
+- edge=0.0
+- reason="no equivalent market match found"
+```
+
+## 5. Known issues
+- Existing pytest environment warning remains unchanged: `Unknown config option: asyncio_mode`.
+- S2 implementation is intentionally narrow integration inside strategy trigger and is not yet wired into broader runtime orchestration/execution.
+
+## 6. What is next
+- Codex auto PR review baseline for STANDARD-tier scope.
+- COMMANDER review and merge/hold decision.
+- Optional future step (out of current scope): route S2 decision path into selected live signal orchestration stage when requested.

--- a/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeMarket,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used in this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    config = StrategyConfig(
+        market_id="m-arb-1",
+        min_liquidity_usd=10_000.0,
+        cross_exchange_min_net_edge=0.02,
+        cross_exchange_min_mapping_confidence=0.55,
+        cross_exchange_min_overlap_tokens=2,
+    )
+    return StrategyTrigger(engine=_NoopEngine(), config=config)
+
+
+def _poly_market(probability: float = 0.62, liquidity_usd: float = 20_000.0) -> CrossExchangeMarket:
+    return CrossExchangeMarket(
+        exchange="polymarket",
+        market_id="poly-btc-60k",
+        title="Will BTC close above 60000 by end of April 2026",
+        probability=probability,
+        liquidity_usd=liquidity_usd,
+        fee_bps=10.0,
+        slippage_bps=8.0,
+        timeframe="2026-04",
+        resolution_criteria="btc-close-above-60000",
+        event_key="btc-above-60k-apr-2026",
+    )
+
+
+def _kalshi_market(
+    probability: float = 0.56,
+    *,
+    fee_bps: float = 8.0,
+    slippage_bps: float = 7.0,
+    liquidity_usd: float = 22_000.0,
+) -> CrossExchangeMarket:
+    return CrossExchangeMarket(
+        exchange="kalshi",
+        market_id="KXBTCAPR60",
+        title="Will bitcoin settle above 60000 at April close 2026",
+        probability=probability,
+        liquidity_usd=liquidity_usd,
+        fee_bps=fee_bps,
+        slippage_bps=slippage_bps,
+        timeframe="2026-04",
+        resolution_criteria="btc-close-above-60000",
+        event_key="btc-above-60k-apr-2026",
+    )
+
+
+def test_matched_markets_edge_detected() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(probability=0.62),
+        kalshi_markets=[_kalshi_market(probability=0.56)],
+    )
+
+    assert decision.decision == "ENTER"
+    assert decision.edge > 0.02
+    assert decision.matched_markets_info["polymarket"] == "poly-btc-60k"
+    assert decision.matched_markets_info["kalshi"] == "KXBTCAPR60"
+
+
+def test_no_match_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(),
+        kalshi_markets=[],
+    )
+
+    assert decision.decision == "SKIP"
+    assert "no equivalent market" in decision.reason
+
+
+def test_edge_below_threshold_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(probability=0.62),
+        kalshi_markets=[_kalshi_market(probability=0.61, fee_bps=0.0, slippage_bps=0.0)],
+    )
+
+    assert decision.decision == "SKIP"
+    assert "below threshold" in decision.reason
+
+
+def test_fees_eliminate_edge_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(probability=0.62),
+        kalshi_markets=[_kalshi_market(probability=0.59, fee_bps=120.0, slippage_bps=120.0)],
+    )
+
+    assert decision.decision == "SKIP"
+    assert "below threshold" in decision.reason
+
+
+def test_valid_arbitrage_is_enter() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(probability=0.64),
+        kalshi_markets=[_kalshi_market(probability=0.58)],
+    )
+
+    assert decision.decision == "ENTER"
+    assert decision.edge > 0.02
+    assert "arbitrage opportunity" in decision.reason


### PR DESCRIPTION
### Motivation
- Provide a narrow-integration strategy path to detect cross-exchange arbitrage opportunities between Polymarket and Kalshi at the strategy trigger layer without changing execution or risk subsystems. 
- Normalize market probabilities to a common 0–1 space, compute raw edge, subtract fees/slippage, and gate entries on net-edge and liquidity to avoid false/unsafe signals. 
- Emit a clear decision contract (`ENTER` / `SKIP`) with `edge`, `reason`, and `matched_markets_info` to make downstream decisioning deterministic and testable.

### Description
- Added cross-exchange contracts and configuration in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` including `CrossExchangeMarket`, `CrossExchangeArbitrageDecision`, and new `StrategyConfig` fields for mapping confidence, overlap tokens, and net-edge thresholds. 
- Implemented `evaluate_cross_exchange_arbitrage(...)` which selects the best Kalshi match via `_select_best_cross_exchange_match(...)`, normalizes probabilities, computes `raw_edge`, subtracts fees+slippage (`bps` → probability), enforces liquidity and net-edge gates, and returns a structured decision. 
- Added helper functions `_normalize_probability`, `_bps_to_probability`, and a tokenizer used for title token overlap scoring, and kept all logic scoped to the strategy-trigger (no execution/risk/order changes). 
- Created focused tests `projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` and a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md`, and updated `PROJECT_STATE.md` with the required 7-section changes and timestamp.

### Testing
- Ran static compile: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` and it passed. 
- Ran unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` and all tests passed (5 passed) with a non-blocking pytest config warning (`Unknown config option: asyncio_mode`). 
- Verified repository structure constraints (no `phase*/` folders) and that the report and `PROJECT_STATE.md` were updated as required for a STANDARD / NARROW INTEGRATION handoff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f7c3c930832e8aa9ac7e94999c47)