### PR TITLE
S2 cross-exchange arbitrage: actionable spread gate (STANDARD, NARROW INTEGRATION)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 00:53
-- Status        : FORGE-X S2 cross-exchange arbitrage strategy completed (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 01:20
+- Status        : FORGE-X S2 cross-exchange arbitrage follow-up complete (STANDARD, narrow integration) with actionable-spread gate; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S2 cross-exchange arbitrage actionable-spread follow-up (2026-04-09): added explicit spread-actionability gate before fee/slippage net-edge evaluation and added focused skip-case test for non-actionable spread while preserving ENTER/SKIP output contract.
 - S2 cross-exchange arbitrage strategy (2026-04-09): added strategy-trigger Polymarket↔Kalshi market matching confidence logic, normalized probability comparison, fee/slippage-adjusted net edge gating, structured ENTER/SKIP output with matched markets info, and focused five-case tests.
 - S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests; completed and merged into main.
 - Telegram market scanning presence premium UX pass (2026-04-08): added throttled `🔎 MARKET SCAN` heartbeat, optional `🧠 TOP CANDIDATE` preview, and `⚠️ NO TRADE` explanation with strict hierarchical formatting and duplicate/noise suppression in strategy loop integration.
@@ -97,7 +98,7 @@ Status:
 ## 🚧 IN PROGRESS
 
 ### S2 cross-exchange arbitrage handoff
-- STANDARD-tier narrow integration implementation is complete for strategy-trigger matching, normalization, and net-edge arbitration decisions.
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger matching, normalization, actionable-spread gating, and net-edge arbitration decisions.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### Telegram trade lifecycle alerts handoff
@@ -145,12 +146,13 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_11_s2_cross_exchange_arbitrage.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
 - S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.
+- S2 actionable-spread gate is now enforced before net-edge entry gating; runtime orchestration wiring remains out of scope for this task.
 - Pytest environment still reports unknown `asyncio_mode` config warning on focused lifecycle-alert tests; tests pass despite the warning.
 - External live Telegram device screenshot proof remains unavailable in this container environment for this UI-text audit pass.
 - Telegram Trade Menu MVP requires SENTINEL validation routing as the next focused workflow step.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -27,6 +27,7 @@ class StrategyConfig:
     min_edge: float = 0.02
     min_liquidity_usd: float = 10_000.0
     cross_exchange_min_net_edge: float = 0.02
+    cross_exchange_min_actionable_spread: float = 0.005
     cross_exchange_min_mapping_confidence: float = 0.55
     cross_exchange_min_overlap_tokens: int = 2
 
@@ -184,6 +185,20 @@ class StrategyTrigger:
         poly_prob = self._normalize_probability(polymarket.probability)
         kalshi_prob = self._normalize_probability(best_match.probability)
         raw_edge = abs(poly_prob - kalshi_prob)
+        if raw_edge < self._config.cross_exchange_min_actionable_spread:
+            return CrossExchangeArbitrageDecision(
+                decision="SKIP",
+                reason="spread not actionable",
+                edge=0.0,
+                matched_markets_info={
+                    "polymarket": polymarket.market_id,
+                    "kalshi": best_match.market_id,
+                    "mapping_confidence": round(confidence, 6),
+                    "raw_edge": round(raw_edge, 6),
+                    "net_edge": 0.0,
+                },
+            )
+
         fees_slippage = (
             self._bps_to_probability(polymarket.fee_bps + polymarket.slippage_bps)
             + self._bps_to_probability(best_match.fee_bps + best_match.slippage_bps)

--- a/projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md
@@ -1,0 +1,104 @@
+# 24_12_s2_cross_exchange_arbitrage_actionable_spread
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy trigger layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - market data normalization for cross-exchange probability comparison
+  - cross-market comparison logic for Polymarket↔Kalshi equivalence path
+  - fee/slippage-adjusted edge calculation and actionable-spread gate
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - order placement logic
+  - Telegram UI changes
+  - observability redesign
+  - exchange API integration expansion
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md`. Tier: STANDARD
+
+## 1. What was built
+- Extended S2 narrow integration with an explicit actionable spread filter before fee/slippage adjustment:
+  - Added `StrategyConfig.cross_exchange_min_actionable_spread`.
+  - Added skip path: `reason="spread not actionable"` when raw spread is too small to be operationally meaningful.
+- Preserved existing S2 output contract with `decision`, `edge`, `reason`, and `matched_markets_info`.
+- Added focused regression test for actionable-spread skip behavior.
+
+## 2. Current system architecture
+- `StrategyTrigger` now evaluates S2 in this order:
+  1. Select equivalent Kalshi market and confidence score.
+  2. Skip on no match / low mapping confidence.
+  3. Normalize both exchanges to probability space (0–1).
+  4. Compute `raw_edge = abs(prob_poly - prob_kalshi)`.
+  5. Skip when spread is not actionable (`raw_edge < cross_exchange_min_actionable_spread`).
+  6. Subtract total fees/slippage (bps → probability) to compute net edge.
+  7. Enforce liquidity and net-edge threshold for ENTER/SKIP decision.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required S2 contract remains intact:
+  - `decision: ENTER | SKIP`
+  - `edge: float`
+  - `reason: str`
+  - `matched_markets_info: dict`
+- Required requested behavior remains covered:
+  1. matched markets → edge detected
+  2. no match → skipped
+  3. edge < threshold → skipped
+  4. fees reduce edge → skipped
+  5. valid arbitrage → ENTER
+- Additional guard now covered:
+  - non-actionable raw spread → skipped with explicit reason.
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` ✅ (6 passed)
+
+Runtime proof examples:
+1) Example matched markets
+```text
+input:
+- Polymarket: poly-btc-60k, prob=0.64
+- Kalshi: KXBTCAPR60, prob=0.58
+- fees/slippage total: 33 bps
+output:
+- decision=ENTER
+- edge=0.0567
+- reason="cross-exchange arbitrage opportunity detected"
+- matched_markets_info includes polymarket/kalshi ids and mapping_confidence
+```
+
+2) Example arbitrage opportunity
+```text
+input:
+- equivalent event_key/timeframe/resolution_criteria
+- liquidity on both exchanges >= 10,000
+- net edge > 2%
+output:
+- decision=ENTER
+- edge>0.02
+```
+
+3) Example skipped case
+```text
+input:
+- Polymarket prob=0.6200, Kalshi prob=0.6210
+- raw edge=0.0010 (< actionable spread gate 0.0050)
+output:
+- decision=SKIP
+- reason="spread not actionable"
+- edge=0.0
+```
+
+## 5. Known issues
+- Existing pytest warning remains unchanged in this environment: `Unknown config option: asyncio_mode`.
+- S2 remains narrow integration in strategy trigger only; execution/risk/runtime orchestration wiring is intentionally out of scope.
+
+## 6. What is next
+- Codex auto PR review on changed files and direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.

--- a/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py
@@ -17,6 +17,7 @@ def _make_trigger() -> StrategyTrigger:
         market_id="m-arb-1",
         min_liquidity_usd=10_000.0,
         cross_exchange_min_net_edge=0.02,
+        cross_exchange_min_actionable_spread=0.005,
         cross_exchange_min_mapping_confidence=0.55,
         cross_exchange_min_overlap_tokens=2,
     )
@@ -107,6 +108,18 @@ def test_fees_eliminate_edge_is_skipped() -> None:
 
     assert decision.decision == "SKIP"
     assert "below threshold" in decision.reason
+
+
+def test_non_actionable_spread_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_cross_exchange_arbitrage(
+        polymarket=_poly_market(probability=0.6200),
+        kalshi_markets=[_kalshi_market(probability=0.6210, fee_bps=0.0, slippage_bps=0.0)],
+    )
+
+    assert decision.decision == "SKIP"
+    assert "spread not actionable" in decision.reason
 
 
 def test_valid_arbitrage_is_enter() -> None:


### PR DESCRIPTION
### Motivation
- Prevent chasing non-actionable micro-spreads by gating cross-exchange arbitrage on a minimum raw spread before fee/slippage adjustments. 
- Keep the S2 path a narrow integration inside the strategy trigger while improving signal quality and clarity of SKIP reasons.

### Description
- Added `StrategyConfig.cross_exchange_min_actionable_spread` and an early SKIP path in `evaluate_cross_exchange_arbitrage(...)` when `raw_edge < cross_exchange_min_actionable_spread`, returning `reason="spread not actionable"` and preserving the existing ENTER/SKIP output contract. 
- Extended the S2 test suite with `test_non_actionable_spread_is_skipped()` and updated trigger test config to include the new threshold. 
- Added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md` documenting the change, and updated `PROJECT_STATE.md` timestamp/status/next-priority entries to reflect the follow-up. 
- Files changed: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py`, `projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md`, and `PROJECT_STATE.md`.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` — PASS. 
- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py` — PASS (6 passed) with one environment warning `Unknown config option: asyncio_mode` (non-blocking). 
- Repository structure checks for forbidden `phase*` folders — PASS (none found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fcbee654832eb5899eb7106d8c41)