### PR TITLE
feat: implement S3 smart-money / copy-trading strategy (STANDARD, narrow integration)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 01:20
-- Status        : FORGE-X S2 cross-exchange arbitrage follow-up complete (STANDARD, narrow integration) with actionable-spread gate; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 02:05
+- Status        : FORGE-X S3 smart-money/copy-trading strategy complete (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S3 smart-money / copy-trading strategy (2026-04-09): added strategy-trigger wallet-signal input contract, basic wallet quality filters, signal-strength scoring (size/early/repetition), explicit ENTER/SKIP decision path with confidence + wallet info payload, and focused five-case behavior tests.
 - S2 cross-exchange arbitrage actionable-spread follow-up (2026-04-09): added explicit spread-actionability gate before fee/slippage net-edge evaluation and added focused skip-case test for non-actionable spread while preserving ENTER/SKIP output contract.
 - S2 cross-exchange arbitrage strategy (2026-04-09): added strategy-trigger Polymarket↔Kalshi market matching confidence logic, normalized probability comparison, fee/slippage-adjusted net edge gating, structured ENTER/SKIP output with matched markets info, and focused five-case tests.
 - S1 breaking-news / narrative momentum strategy (2026-04-08): added social-spike + market-lag decision path in strategy trigger, EV edge gating, enter/skip reasoning contract (`decision`/`reason`/`edge`), and focused five-case behavior tests; completed and merged into main.
@@ -97,6 +98,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S3 smart-money / copy-trading handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger wallet signal ingestion, quality filtering, strength extraction, and ENTER/SKIP decision contract.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S2 cross-exchange arbitrage handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger matching, normalization, actionable-spread gating, and net-edge arbitration decisions.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -146,11 +151,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_12_s2_cross_exchange_arbitrage_actionable_spread.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- S3 smart-money strategy is currently narrow integration in strategy trigger only; execution-orchestration wiring remains out of scope for this task.
 - S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.
 - S2 actionable-spread gate is now enforced before net-edge entry gating; runtime orchestration wiring remains out of scope for this task.
 - Pytest environment still reports unknown `asyncio_mode` config warning on focused lifecycle-alert tests; tests pass despite the warning.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -71,6 +71,26 @@ class CrossExchangeArbitrageDecision:
     matched_markets_info: dict[str, object]
 
 
+@dataclass(frozen=True)
+class WalletTradeSignal:
+    wallet_address: str
+    action: str
+    size_usd: float
+    liquidity_usd: float
+    timestamp_ms: int
+    market_move_pct: float
+    wallet_success_rate: float
+    wallet_activity_count: int
+
+
+@dataclass(frozen=True)
+class SmartMoneyCopyTradingDecision:
+    decision: str
+    reason: str
+    confidence: float
+    wallet_info: dict[str, object]
+
+
 class StrategyTrigger:
     """Strategy trigger with execution intelligence.
     
@@ -245,6 +265,111 @@ class StrategyTrigger:
                 "probability_kalshi": round(kalshi_prob, 6),
                 "raw_edge": round(raw_edge, 6),
                 "net_edge": round(net_edge, 6),
+            },
+        )
+
+    def evaluate_smart_money_copy_trading(
+        self,
+        signal: WalletTradeSignal,
+        related_wallet_signals: list[WalletTradeSignal],
+    ) -> SmartMoneyCopyTradingDecision:
+        min_success_rate = 0.60
+        min_activity_count = 15
+        large_position_usd = 10_000.0
+        early_entry_max_move_pct = 0.02
+        repeated_wallet_min_count = 2
+        min_confidence_threshold = 0.65
+
+        if signal.wallet_success_rate < min_success_rate or signal.wallet_activity_count < min_activity_count:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="low-quality wallet",
+                confidence=0.0,
+                wallet_info={
+                    "wallet_address": signal.wallet_address,
+                    "success_rate": round(signal.wallet_success_rate, 4),
+                    "activity_count": signal.wallet_activity_count,
+                },
+            )
+
+        if signal.market_move_pct > early_entry_max_move_pct:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="late entry",
+                confidence=0.0,
+                wallet_info={
+                    "wallet_address": signal.wallet_address,
+                    "market_move_pct": round(signal.market_move_pct, 6),
+                },
+            )
+
+        if signal.action.lower() not in {"buy", "sell"}:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="conflicting signals",
+                confidence=0.0,
+                wallet_info={"wallet_address": signal.wallet_address},
+            )
+
+        same_market_signals = [
+            item
+            for item in related_wallet_signals
+            if item.timestamp_ms >= signal.timestamp_ms - (30 * 60 * 1000)
+        ]
+
+        buy_votes = sum(1 for item in same_market_signals if item.action.lower() == "buy")
+        sell_votes = sum(1 for item in same_market_signals if item.action.lower() == "sell")
+        if buy_votes > 0 and sell_votes > 0:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="conflicting signals",
+                confidence=0.0,
+                wallet_info={
+                    "wallet_address": signal.wallet_address,
+                    "buy_votes": buy_votes,
+                    "sell_votes": sell_votes,
+                },
+            )
+
+        if signal.liquidity_usd < self._config.min_liquidity_usd:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="insufficient liquidity",
+                confidence=0.0,
+                wallet_info={
+                    "wallet_address": signal.wallet_address,
+                    "liquidity_usd": round(signal.liquidity_usd, 2),
+                },
+            )
+
+        size_score = min(1.0, signal.size_usd / large_position_usd)
+        early_score = max(0.0, 1.0 - (signal.market_move_pct / early_entry_max_move_pct))
+        aligned_wallets = sum(1 for item in same_market_signals if item.action.lower() == signal.action.lower())
+        repeated_score = min(1.0, aligned_wallets / max(float(repeated_wallet_min_count), 1.0))
+        confidence = round((0.4 * size_score) + (0.3 * early_score) + (0.3 * repeated_score), 6)
+
+        if confidence <= min_confidence_threshold:
+            return SmartMoneyCopyTradingDecision(
+                decision="SKIP",
+                reason="signal strength below threshold",
+                confidence=confidence,
+                wallet_info={
+                    "wallet_address": signal.wallet_address,
+                    "aligned_wallets": aligned_wallets,
+                },
+            )
+
+        return SmartMoneyCopyTradingDecision(
+            decision="ENTER",
+            reason="high-quality early smart-money signal",
+            confidence=confidence,
+            wallet_info={
+                "wallet_address": signal.wallet_address,
+                "action": signal.action.upper(),
+                "success_rate": round(signal.wallet_success_rate, 4),
+                "activity_count": signal.wallet_activity_count,
+                "size_usd": round(signal.size_usd, 2),
+                "aligned_wallets": aligned_wallets,
             },
         )
 

--- a/projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md
@@ -1,0 +1,119 @@
+# 24_13_s3_smart_money_copy_trading
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy trigger layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - wallet activity input normalization for copy-trading signal evaluation
+  - trade signal extraction (quality + strength + conflict detection)
+  - decision logic output (`ENTER` / `SKIP`) with required explanation contract
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - Telegram UI changes
+  - observability redesign
+  - wallet scoring system expansion beyond basic filter
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md`. Tier: STANDARD
+
+## 1. What was built
+- Implemented S3 smart-money/copy-trading strategy path in `StrategyTrigger` as a narrow integration focused on strategy decisioning.
+- Added wallet signal input contract:
+  - `wallet_address`
+  - `action` (buy/sell)
+  - `size_usd`
+  - `liquidity_usd`
+  - `timestamp_ms`
+  - `market_move_pct`
+  - `wallet_success_rate`
+  - `wallet_activity_count`
+- Added required output contract:
+  - `decision` (`ENTER` or `SKIP`)
+  - `reason`
+  - `confidence`
+  - `wallet_info`
+- Implemented filters and skip gates:
+  - low-quality wallet
+  - late entry
+  - conflicting signals
+  - insufficient liquidity
+  - below-threshold signal strength
+
+## 2. Current system architecture
+- `StrategyTrigger.evaluate_smart_money_copy_trading(...)` now runs this deterministic sequence:
+  1. Quality gate checks minimum wallet success rate and activity count.
+  2. Timing gate rejects late entries when market move already exceeds configured early-entry bound.
+  3. Action gate ensures action semantics and detects buy/sell conflicts across related wallet signals.
+  4. Liquidity gate enforces minimum market depth via existing strategy liquidity threshold.
+  5. Signal-strength scoring combines:
+     - position size score
+     - early-entry score
+     - repeated/aligned wallet behavior score
+  6. Final decision gate returns `ENTER` only when confidence exceeds threshold; otherwise returns explicit `SKIP` reason.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required behavior tests implemented and passing:
+  1. high-quality wallet → triggers entry
+  2. low-quality wallet → skipped
+  3. late entry → skipped
+  4. conflicting signals → skipped
+  5. valid early signal → ENTER
+- Output contract confirmed in tests (`decision`, `reason`, `confidence`, `wallet_info`).
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` ✅ (5 passed)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` ✅ (16 passed)
+
+Runtime proof examples:
+
+1) Example wallet signal input
+```text
+wallet_address=0xsmart1
+action=buy
+size_usd=18000
+liquidity_usd=40000
+timestamp_ms=1746000000000
+market_move_pct=0.004
+wallet_success_rate=0.71
+wallet_activity_count=28
+```
+
+2) Example entry decision
+```text
+input:
+- anchor signal from 0xsmart1 (BUY)
+- two additional aligned BUY wallet signals in last 30m
+- size is large, move is early, liquidity >= 10000
+output:
+- decision=ENTER
+- reason="high-quality early smart-money signal"
+- confidence=0.94
+- wallet_info includes wallet_address/action/success_rate/activity_count/size_usd/aligned_wallets
+```
+
+3) Example skip decision
+```text
+input:
+- anchor BUY signal and mixed BUY/SELL related signals inside 30m window
+output:
+- decision=SKIP
+- reason="conflicting signals"
+- confidence=0.0
+- wallet_info includes buy_votes/sell_votes
+```
+
+## 5. Known issues
+- This is narrow strategy-trigger integration only and is not yet wired to execution orchestration.
+- Wallet quality filtering is intentionally basic for this scope (success rate + activity count only); advanced scoring remains out of scope.
+- Existing environment warning remains unchanged: pytest reports `Unknown config option: asyncio_mode` while tests still pass.
+
+## 6. What is next
+- Codex auto PR review on changed files and direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.

--- a/projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    SmartMoneyCopyTradingDecision,
+    StrategyConfig,
+    StrategyTrigger,
+    WalletTradeSignal,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used by this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    config = StrategyConfig(
+        market_id="m-smart-money-1",
+        min_liquidity_usd=10_000.0,
+    )
+    return StrategyTrigger(engine=_NoopEngine(), config=config)
+
+
+def _signal(
+    *,
+    wallet_address: str = "0xsmart1",
+    action: str = "buy",
+    size_usd: float = 15_000.0,
+    liquidity_usd: float = 40_000.0,
+    timestamp_ms: int = 1_746_000_000_000,
+    market_move_pct: float = 0.01,
+    wallet_success_rate: float = 0.71,
+    wallet_activity_count: int = 28,
+) -> WalletTradeSignal:
+    return WalletTradeSignal(
+        wallet_address=wallet_address,
+        action=action,
+        size_usd=size_usd,
+        liquidity_usd=liquidity_usd,
+        timestamp_ms=timestamp_ms,
+        market_move_pct=market_move_pct,
+        wallet_success_rate=wallet_success_rate,
+        wallet_activity_count=wallet_activity_count,
+    )
+
+
+def _assert_output_contract(decision: SmartMoneyCopyTradingDecision) -> None:
+    assert set(decision.__dict__.keys()) == {"decision", "reason", "confidence", "wallet_info"}
+    assert decision.decision in {"ENTER", "SKIP"}
+    assert isinstance(decision.reason, str)
+    assert isinstance(decision.confidence, float)
+    assert isinstance(decision.wallet_info, dict)
+
+
+def test_high_quality_wallet_triggers_entry() -> None:
+    trigger = _make_trigger()
+    signal = _signal()
+
+    decision = trigger.evaluate_smart_money_copy_trading(
+        signal=signal,
+        related_wallet_signals=[signal, _signal(wallet_address="0xsmart2", size_usd=12_000.0)],
+    )
+
+    _assert_output_contract(decision)
+    assert decision.decision == "ENTER"
+    assert "smart-money signal" in decision.reason
+    assert decision.confidence > 0.65
+
+
+def test_low_quality_wallet_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_smart_money_copy_trading(
+        signal=_signal(wallet_success_rate=0.52, wallet_activity_count=8),
+        related_wallet_signals=[_signal(wallet_success_rate=0.52, wallet_activity_count=8)],
+    )
+
+    _assert_output_contract(decision)
+    assert decision.decision == "SKIP"
+    assert decision.reason == "low-quality wallet"
+
+
+def test_late_entry_is_skipped() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_smart_money_copy_trading(
+        signal=_signal(market_move_pct=0.05),
+        related_wallet_signals=[_signal(wallet_address="0xsmart2", market_move_pct=0.04)],
+    )
+
+    _assert_output_contract(decision)
+    assert decision.decision == "SKIP"
+    assert decision.reason == "late entry"
+
+
+def test_conflicting_signals_are_skipped() -> None:
+    trigger = _make_trigger()
+    anchor = _signal(action="buy")
+
+    decision = trigger.evaluate_smart_money_copy_trading(
+        signal=anchor,
+        related_wallet_signals=[
+            anchor,
+            _signal(wallet_address="0xsmart2", action="sell"),
+            _signal(wallet_address="0xsmart3", action="buy"),
+        ],
+    )
+
+    _assert_output_contract(decision)
+    assert decision.decision == "SKIP"
+    assert decision.reason == "conflicting signals"
+
+
+def test_valid_early_signal_is_enter() -> None:
+    trigger = _make_trigger()
+    signal = _signal(size_usd=18_000.0, market_move_pct=0.004)
+
+    decision = trigger.evaluate_smart_money_copy_trading(
+        signal=signal,
+        related_wallet_signals=[
+            signal,
+            _signal(wallet_address="0xsmart2", size_usd=20_000.0, market_move_pct=0.003),
+            _signal(wallet_address="0xsmart3", size_usd=16_000.0, market_move_pct=0.005),
+        ],
+    )
+
+    _assert_output_contract(decision)
+    assert decision.decision == "ENTER"
+    assert decision.reason == "high-quality early smart-money signal"
+    assert decision.wallet_info["wallet_address"] == "0xsmart1"


### PR DESCRIPTION
### Motivation
- Add an S3 strategy that follows high-quality wallets (smart money) to provide early-entry alpha signals as a narrow strategy-trigger integration. 
- Provide a deterministic ENTER / SKIP decision contract that includes `reason`, `confidence`, and wallet metadata for downstream consumers. 
- Keep runtime execution, risk, and UI out of scope while delivering a validation-ready strategy layer for Codex code review and COMMANDER review. 

### Description
- Added wallet signal and decision dataclasses and implemented `StrategyTrigger.evaluate_smart_money_copy_trading(...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` with quality, late-entry, conflict, liquidity, and confidence-scoring gates. 
- Signal-strength scoring combines `size`, `early-entry` and `repetition` to compute a `confidence` and only returns `ENTER` when a configurable threshold is exceeded. 
- Added focused behavior tests at `projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` covering the five required scenarios and added the FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md`. 
- Updated `PROJECT_STATE.md` to record completion, in-progress handoff, next-priority report source, and a narrow-integration known-issue note. 

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` which passed. 
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` which reported `5 passed` (and one environment warning). 
- Ran combined suite `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py` which reported `16 passed` (and one environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fe6cfcb4832eb4ac5aa94a6235d2)