### PR TITLE
[FORGE-X][STANDARD] S4 strategy aggregation & prioritization

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 02:05
-- Status        : FORGE-X S3 smart-money/copy-trading strategy complete (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 02:56
+- Status        : FORGE-X S4 strategy aggregation & prioritization complete (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 strategy outputs, normalized weighted score (edge+confidence), added deterministic ranking and top-candidate selection gates (`all below threshold` / `conflicting signals too strong`), and added focused five-case behavior tests.
 - S3 smart-money / copy-trading strategy (2026-04-09): added strategy-trigger wallet-signal input contract, basic wallet quality filters, signal-strength scoring (size/early/repetition), explicit ENTER/SKIP decision path with confidence + wallet info payload, and focused five-case behavior tests.
 - S2 cross-exchange arbitrage actionable-spread follow-up (2026-04-09): added explicit spread-actionability gate before fee/slippage net-edge evaluation and added focused skip-case test for non-actionable spread while preserving ENTER/SKIP output contract.
 - S2 cross-exchange arbitrage strategy (2026-04-09): added strategy-trigger Polymarket↔Kalshi market matching confidence logic, normalized probability comparison, fee/slippage-adjusted net edge gating, structured ENTER/SKIP output with matched markets info, and focused five-case tests.
@@ -98,6 +99,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S4 strategy aggregation & prioritization handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger aggregation, ranking, and single-trade selection behavior.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S3 smart-money / copy-trading handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger wallet signal ingestion, quality filtering, strength extraction, and ENTER/SKIP decision contract.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -151,11 +156,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_13_s3_smart_money_copy_trading.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration.
 - S3 smart-money strategy is currently narrow integration in strategy trigger only; execution-orchestration wiring remains out of scope for this task.
 - S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.
 - S2 actionable-spread gate is now enforced before net-edge entry gating; runtime orchestration wiring remains out of scope for this task.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -91,6 +91,23 @@ class SmartMoneyCopyTradingDecision:
     wallet_info: dict[str, object]
 
 
+@dataclass(frozen=True)
+class StrategyCandidateScore:
+    strategy_id: str
+    decision: str
+    reason: str
+    edge: float
+    confidence: float
+    score: float
+
+
+@dataclass(frozen=True)
+class StrategyAggregationDecision:
+    selected_trade: str | None
+    ranking: list[StrategyCandidateScore]
+    reason: str
+
+
 class StrategyTrigger:
     """Strategy trigger with execution intelligence.
     
@@ -371,6 +388,96 @@ class StrategyTrigger:
                 "size_usd": round(signal.size_usd, 2),
                 "aligned_wallets": aligned_wallets,
             },
+        )
+
+    def aggregate_strategy_decisions(
+        self,
+        s1_decision: StrategyDecision,
+        s2_decision: CrossExchangeArbitrageDecision,
+        s3_decision: SmartMoneyCopyTradingDecision,
+    ) -> StrategyAggregationDecision:
+        """
+        Aggregate S1/S2/S3 strategy outputs and select one best trade candidate.
+        """
+        candidates = [
+            self._build_strategy_candidate_score(
+                strategy_id="S1",
+                decision=s1_decision.decision,
+                reason=s1_decision.reason,
+                edge=s1_decision.edge,
+                confidence=None,
+            ),
+            self._build_strategy_candidate_score(
+                strategy_id="S2",
+                decision=s2_decision.decision,
+                reason=s2_decision.reason,
+                edge=s2_decision.edge,
+                confidence=None,
+            ),
+            self._build_strategy_candidate_score(
+                strategy_id="S3",
+                decision=s3_decision.decision,
+                reason=s3_decision.reason,
+                edge=max(0.0, s3_decision.confidence * self._config.min_edge),
+                confidence=s3_decision.confidence,
+            ),
+        ]
+        ranking = sorted(candidates, key=lambda item: (-item.score, item.strategy_id))
+        enter_candidates = [candidate for candidate in ranking if candidate.decision == "ENTER"]
+        min_score_threshold = 0.40
+        if not enter_candidates:
+            return StrategyAggregationDecision(
+                selected_trade=None,
+                ranking=ranking,
+                reason="no candidate qualified for entry",
+            )
+
+        top_candidate = enter_candidates[0]
+        if top_candidate.score < min_score_threshold:
+            return StrategyAggregationDecision(
+                selected_trade=None,
+                ranking=ranking,
+                reason="all candidates below threshold",
+            )
+
+        if len(enter_candidates) > 1:
+            runner_up = enter_candidates[1]
+            score_gap = abs(top_candidate.score - runner_up.score)
+            if score_gap <= 0.02:
+                return StrategyAggregationDecision(
+                    selected_trade=None,
+                    ranking=ranking,
+                    reason="conflicting signals too strong",
+                )
+
+        return StrategyAggregationDecision(
+            selected_trade=top_candidate.strategy_id,
+            ranking=ranking,
+            reason=f"selected highest-ranked candidate: {top_candidate.strategy_id}",
+        )
+
+    def _build_strategy_candidate_score(
+        self,
+        strategy_id: str,
+        decision: str,
+        reason: str,
+        edge: float,
+        confidence: float | None,
+    ) -> StrategyCandidateScore:
+        normalized_edge = min(max(edge, 0.0) / 0.10, 1.0)
+        normalized_confidence = (
+            min(max(confidence, 0.0), 1.0)
+            if confidence is not None
+            else min(normalized_edge + 0.15, 1.0)
+        )
+        score = round((0.7 * normalized_edge) + (0.3 * normalized_confidence), 6)
+        return StrategyCandidateScore(
+            strategy_id=strategy_id,
+            decision=decision,
+            reason=reason,
+            edge=round(max(edge, 0.0), 6),
+            confidence=round(normalized_confidence, 6),
+            score=score,
         )
 
     def _select_best_cross_exchange_match(

--- a/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
@@ -1,0 +1,101 @@
+# 24_14_s4_strategy_aggregation_prioritization
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy trigger layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - S1/S2/S3 decision aggregation logic in `aggregate_strategy_decisions(...)`
+  - score normalization + candidate ranking + single-trade selection behavior
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - Telegram UI changes
+  - individual strategy logic changes (S1/S2/S3 internals)
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`. Tier: STANDARD
+
+## 1. What was built
+- Added S4 strategy aggregation and prioritization as a narrow strategy-trigger integration.
+- Implemented deterministic collection of S1/S2/S3 outputs into unified candidate objects.
+- Added unified score normalization using weighted edge + confidence logic (`score = 0.7*edge_norm + 0.3*confidence_norm`).
+- Implemented ranking (highest score first, stable tie-break by strategy id).
+- Implemented single-trade selection contract:
+  - select top candidate only
+  - skip all candidates when all are below threshold
+  - skip all candidates when top two ENTER candidates are too close (strong conflict condition)
+- Added focused S4 tests for required behavior scenarios and deterministic output.
+
+## 2. Current system architecture
+- `StrategyTrigger.aggregate_strategy_decisions(...)` now orchestrates this sequence:
+  1. Collect S1/S2/S3 decisions into candidate score objects.
+  2. Normalize edge and confidence into a unified [0,1] score band.
+  3. Rank candidates by score descending (then by strategy id for deterministic ties).
+  4. Apply selection gates:
+     - no ENTER candidates → `selected_trade=None`
+     - top score below threshold → `selected_trade=None`
+     - top-two ENTER score gap <= conflict gap threshold → `selected_trade=None`
+  5. Return required output contract:
+     - `selected_trade` (or `None`)
+     - `ranking`
+     - `reason`
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required tests implemented and passing:
+  1. multiple candidates → best selected
+  2. all weak candidates → no trade
+  3. conflicting top candidates → no trade
+  4. score calculation correctness (weighted edge/confidence)
+  5. deterministic selection across identical input
+- Regression check with S1/S2/S3 suites passes.
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (5 passed)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (21 passed)
+
+Runtime proof examples:
+
+1) Example with 3 strategies → 1 selected
+```text
+Input:
+- S1: decision=ENTER, edge=0.038, reason="news momentum intact"
+- S2: decision=ENTER, edge=0.026, reason="actionable spread"
+- S3: decision=ENTER, confidence=0.78, reason="smart wallet alignment"
+
+Output:
+- selected_trade="S1"
+- ranking=[S1, S3, S2] (highest score first)
+- reason="selected highest-ranked candidate: S1"
+```
+
+2) Example with no valid trades
+```text
+Input:
+- S1: decision=ENTER, edge=0.012, reason="weak momentum"
+- S2: decision=ENTER, edge=0.011, reason="weak spread"
+- S3: decision=ENTER, confidence=0.30, reason="weak wallet signal"
+
+Output:
+- selected_trade=None
+- ranking=[S1, S2, S3]
+- reason="all candidates below threshold"
+```
+
+Ranking behavior:
+- Ranking is always deterministic because sorting uses `(score desc, strategy_id asc)`.
+- Only one top candidate is selected when selection gates pass.
+
+## 5. Known issues
+- Aggregation is currently narrow integration inside strategy trigger only and is not yet wired into full runtime execution orchestration.
+- Cross-strategy conflict detection in this scope is score-gap based for ENTER candidates; advanced semantic conflict modeling remains out of scope.
+- Environment warning remains unchanged: pytest reports `Unknown config option: asyncio_mode` while tests pass.
+
+## 6. What is next
+- Codex auto PR review on changed files and direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.

--- a/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeArbitrageDecision,
+    SmartMoneyCopyTradingDecision,
+    StrategyConfig,
+    StrategyDecision,
+    StrategyTrigger,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used in this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_NoopEngine(),
+        config=StrategyConfig(
+            market_id="m-s4-aggregation-1",
+            min_edge=0.02,
+            min_liquidity_usd=10_000.0,
+        ),
+    )
+
+
+def _s1(*, decision: str, edge: float, reason: str) -> StrategyDecision:
+    return StrategyDecision(decision=decision, reason=reason, edge=edge)
+
+
+def _s2(*, decision: str, edge: float, reason: str) -> CrossExchangeArbitrageDecision:
+    return CrossExchangeArbitrageDecision(
+        decision=decision,
+        reason=reason,
+        edge=edge,
+        matched_markets_info={"source": "kalshi"},
+    )
+
+
+def _s3(*, decision: str, confidence: float, reason: str) -> SmartMoneyCopyTradingDecision:
+    return SmartMoneyCopyTradingDecision(
+        decision=decision,
+        reason=reason,
+        confidence=confidence,
+        wallet_info={"source": "wallet"},
+    )
+
+
+def test_multiple_candidates_best_selected() -> None:
+    trigger = _make_trigger()
+
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.038, reason="news momentum intact"),
+        s2_decision=_s2(decision="ENTER", edge=0.026, reason="actionable spread"),
+        s3_decision=_s3(decision="ENTER", confidence=0.78, reason="smart wallet alignment"),
+    )
+
+    assert result.selected_trade == "S1"
+    assert result.ranking[0].strategy_id == "S1"
+    assert {candidate.strategy_id for candidate in result.ranking} == {"S1", "S2", "S3"}
+    assert "highest-ranked" in result.reason
+
+
+def test_all_weak_candidates_returns_no_trade() -> None:
+    trigger = _make_trigger()
+
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.012, reason="weak momentum"),
+        s2_decision=_s2(decision="ENTER", edge=0.011, reason="weak spread"),
+        s3_decision=_s3(decision="ENTER", confidence=0.30, reason="weak wallet signal"),
+    )
+
+    assert result.selected_trade is None
+    assert result.reason == "all candidates below threshold"
+
+
+def test_conflicting_signals_too_strong_returns_no_trade() -> None:
+    trigger = _make_trigger()
+
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.050, reason="momentum continuation"),
+        s2_decision=_s2(decision="ENTER", edge=0.049, reason="reversion spread signal"),
+        s3_decision=_s3(decision="SKIP", confidence=0.10, reason="low-confidence wallet signal"),
+    )
+
+    assert result.selected_trade is None
+    assert result.reason == "conflicting signals too strong"
+
+
+def test_score_calculation_uses_weighted_edge_confidence() -> None:
+    trigger = _make_trigger()
+
+    score = trigger._build_strategy_candidate_score(
+        strategy_id="S1",
+        decision="ENTER",
+        reason="score check",
+        edge=0.05,
+        confidence=0.8,
+    )
+
+    assert score.score == 0.59
+    assert score.edge == 0.05
+    assert score.confidence == 0.8
+
+
+def test_selection_is_deterministic_on_identical_inputs() -> None:
+    trigger = _make_trigger()
+
+    first = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.039, reason="news momentum"),
+        s2_decision=_s2(decision="ENTER", edge=0.027, reason="arb spread"),
+        s3_decision=_s3(decision="ENTER", confidence=0.80, reason="wallet alignment"),
+    )
+    second = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.039, reason="news momentum"),
+        s2_decision=_s2(decision="ENTER", edge=0.027, reason="arb spread"),
+        s3_decision=_s3(decision="ENTER", confidence=0.80, reason="wallet alignment"),
+    )
+
+    assert first.selected_trade == second.selected_trade
+    assert first.reason == second.reason
+    assert first.ranking == second.ranking


### PR DESCRIPTION
### Motivation
- Add a narrow-integration S4 layer that aggregates S1/S2/S3 strategy outputs and picks a single best trade candidate to improve capital efficiency. 
- Provide deterministic, score-based ranking and explicit skip gates for weak or strongly conflicting candidates. 

### Description
- Added new data contracts `StrategyCandidateScore` and `StrategyAggregationDecision` and implemented `StrategyTrigger.aggregate_strategy_decisions(...)` to normalize scores, rank candidates, and apply selection gates. 
- Scoring normalizes `edge` and `confidence` into a unified band and computes `score = 0.7*edge_norm + 0.3*confidence_norm` with deterministic tie-break by `strategy_id`. 
- Selection rules return `selected_trade` or `None` and explicit reasons for `all candidates below threshold` and `conflicting signals too strong`. 
- Added focused tests `projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`, and updated `PROJECT_STATE.md`. 

### Testing
- Ran static compile checks with `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` which passed. 
- Ran the S4 unit suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` which passed (5 passed). 
- Ran regression checks with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` which passed (21 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7148a5d74832e9fa05c6346b525fe)