### PR TITLE
feat: S4 strategy aggregation & prioritization — deterministic scoring, ranking and single-winner selection

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,13 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 02:56
-- Status        : FORGE-X S4 strategy aggregation & prioritization complete (STANDARD, narrow integration); awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 03:41
+- Status        : FORGE-X S4 strategy aggregation & prioritization refined (STANDARD, narrow integration) with required output contract + seven-case tests; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
-- S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 strategy outputs, normalized weighted score (edge+confidence), added deterministic ranking and top-candidate selection gates (`all below threshold` / `conflicting signals too strong`), and added focused five-case behavior tests.
+- S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 outputs with preserved metadata, enforced deterministic normalized scoring and tie-break ranking, implemented single-winner ENTER/SKIP output contract (`selected_trade`/`ranked_candidates`/`selection_reason`/`top_score`/`decision`), and added focused seven-case behavior tests.
 - S3 smart-money / copy-trading strategy (2026-04-09): added strategy-trigger wallet-signal input contract, basic wallet quality filters, signal-strength scoring (size/early/repetition), explicit ENTER/SKIP decision path with confidence + wallet info payload, and focused five-case behavior tests.
 - S2 cross-exchange arbitrage actionable-spread follow-up (2026-04-09): added explicit spread-actionability gate before fee/slippage net-edge evaluation and added focused skip-case test for non-actionable spread while preserving ENTER/SKIP output contract.
 - S2 cross-exchange arbitrage strategy (2026-04-09): added strategy-trigger Polymarket↔Kalshi market matching confidence logic, normalized probability comparison, fee/slippage-adjusted net edge gating, structured ENTER/SKIP output with matched markets info, and focused five-case tests.
@@ -100,7 +100,7 @@ Status:
 ## 🚧 IN PROGRESS
 
 ### S4 strategy aggregation & prioritization handoff
-- STANDARD-tier narrow integration implementation is complete for strategy-trigger aggregation, ranking, and single-trade selection behavior.
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger aggregation, ranking, and single-trade selection behavior with required contract fields and deterministic tie-break handling.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### S3 smart-money / copy-trading handoff
@@ -161,7 +161,7 @@ Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
-- S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration.
+- S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration; conflict-hold gate currently relies on explicit `CONFLICT_HOLD` marker semantics.
 - S3 smart-money strategy is currently narrow integration in strategy trigger only; execution-orchestration wiring remains out of scope for this task.
 - S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.
 - S2 actionable-spread gate is now enforced before net-edge entry gating; runtime orchestration wiring remains out of scope for this task.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -93,19 +93,22 @@ class SmartMoneyCopyTradingDecision:
 
 @dataclass(frozen=True)
 class StrategyCandidateScore:
-    strategy_id: str
+    strategy_name: str
     decision: str
     reason: str
     edge: float
     confidence: float
     score: float
+    market_metadata: dict[str, object]
 
 
 @dataclass(frozen=True)
 class StrategyAggregationDecision:
     selected_trade: str | None
-    ranking: list[StrategyCandidateScore]
-    reason: str
+    ranked_candidates: list[StrategyCandidateScore]
+    selection_reason: str
+    top_score: float
+    decision: str
 
 
 class StrategyTrigger:
@@ -401,83 +404,98 @@ class StrategyTrigger:
         """
         candidates = [
             self._build_strategy_candidate_score(
-                strategy_id="S1",
+                strategy_name="S1",
                 decision=s1_decision.decision,
                 reason=s1_decision.reason,
                 edge=s1_decision.edge,
                 confidence=None,
+                market_metadata={},
             ),
             self._build_strategy_candidate_score(
-                strategy_id="S2",
+                strategy_name="S2",
                 decision=s2_decision.decision,
                 reason=s2_decision.reason,
                 edge=s2_decision.edge,
                 confidence=None,
+                market_metadata=s2_decision.matched_markets_info,
             ),
             self._build_strategy_candidate_score(
-                strategy_id="S3",
+                strategy_name="S3",
                 decision=s3_decision.decision,
                 reason=s3_decision.reason,
                 edge=max(0.0, s3_decision.confidence * self._config.min_edge),
                 confidence=s3_decision.confidence,
+                market_metadata=s3_decision.wallet_info,
             ),
         ]
-        ranking = sorted(candidates, key=lambda item: (-item.score, item.strategy_id))
-        enter_candidates = [candidate for candidate in ranking if candidate.decision == "ENTER"]
+        ranked_candidates = sorted(candidates, key=lambda item: (-item.score, item.strategy_name))
+        enter_candidates = [candidate for candidate in ranked_candidates if candidate.decision == "ENTER"]
+        top_score = ranked_candidates[0].score if ranked_candidates else 0.0
         min_score_threshold = 0.40
+        has_global_conflict_hold = any(
+            candidate.reason.upper().startswith("CONFLICT_HOLD")
+            for candidate in enter_candidates
+        )
         if not enter_candidates:
             return StrategyAggregationDecision(
                 selected_trade=None,
-                ranking=ranking,
-                reason="no candidate qualified for entry",
+                ranked_candidates=ranked_candidates,
+                selection_reason="all candidates are SKIP",
+                top_score=top_score,
+                decision="SKIP",
+            )
+
+        if has_global_conflict_hold:
+            return StrategyAggregationDecision(
+                selected_trade=None,
+                ranked_candidates=ranked_candidates,
+                selection_reason="conflict rules require holding",
+                top_score=top_score,
+                decision="SKIP",
             )
 
         top_candidate = enter_candidates[0]
         if top_candidate.score < min_score_threshold:
             return StrategyAggregationDecision(
                 selected_trade=None,
-                ranking=ranking,
-                reason="all candidates below threshold",
+                ranked_candidates=ranked_candidates,
+                selection_reason="all candidates are weak",
+                top_score=top_score,
+                decision="SKIP",
             )
 
-        if len(enter_candidates) > 1:
-            runner_up = enter_candidates[1]
-            score_gap = abs(top_candidate.score - runner_up.score)
-            if score_gap <= 0.02:
-                return StrategyAggregationDecision(
-                    selected_trade=None,
-                    ranking=ranking,
-                    reason="conflicting signals too strong",
-                )
-
         return StrategyAggregationDecision(
-            selected_trade=top_candidate.strategy_id,
-            ranking=ranking,
-            reason=f"selected highest-ranked candidate: {top_candidate.strategy_id}",
+            selected_trade=top_candidate.strategy_name,
+            ranked_candidates=ranked_candidates,
+            selection_reason=f"selected highest-ranked candidate: {top_candidate.strategy_name}",
+            top_score=top_candidate.score,
+            decision="ENTER",
         )
 
     def _build_strategy_candidate_score(
         self,
-        strategy_id: str,
+        strategy_name: str,
         decision: str,
         reason: str,
         edge: float,
         confidence: float | None,
+        market_metadata: dict[str, object],
     ) -> StrategyCandidateScore:
         normalized_edge = min(max(edge, 0.0) / 0.10, 1.0)
         normalized_confidence = (
             min(max(confidence, 0.0), 1.0)
             if confidence is not None
-            else min(normalized_edge + 0.15, 1.0)
+            else 0.5
         )
         score = round((0.7 * normalized_edge) + (0.3 * normalized_confidence), 6)
         return StrategyCandidateScore(
-            strategy_id=strategy_id,
+            strategy_name=strategy_name,
             decision=decision,
             reason=reason,
             edge=round(max(edge, 0.0), 6),
             confidence=round(normalized_confidence, 6),
             score=score,
+            market_metadata=market_metadata,
         )
 
     def _select_best_cross_exchange_match(

--- a/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
@@ -5,97 +5,86 @@
 - Claim Level: NARROW INTEGRATION
 - Validation Target:
   - strategy trigger layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
-  - S1/S2/S3 decision aggregation logic in `aggregate_strategy_decisions(...)`
-  - score normalization + candidate ranking + single-trade selection behavior
+  - aggregation / prioritization logic in `aggregate_strategy_decisions(...)`
+  - candidate ranking and single-winner selection output contract
 - Not in Scope:
   - execution engine changes
   - risk model changes
+  - order placement changes
   - Telegram UI changes
-  - individual strategy logic changes (S1/S2/S3 internals)
+  - observability redesign
+  - S1 / S2 / S3 core logic changes
 - Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`. Tier: STANDARD
 
 ## 1. What was built
-- Added S4 strategy aggregation and prioritization as a narrow strategy-trigger integration.
-- Implemented deterministic collection of S1/S2/S3 outputs into unified candidate objects.
-- Added unified score normalization using weighted edge + confidence logic (`score = 0.7*edge_norm + 0.3*confidence_norm`).
-- Implemented ranking (highest score first, stable tie-break by strategy id).
-- Implemented single-trade selection contract:
-  - select top candidate only
-  - skip all candidates when all are below threshold
-  - skip all candidates when top two ENTER candidates are too close (strong conflict condition)
-- Added focused S4 tests for required behavior scenarios and deterministic output.
+- Implemented S4 strategy aggregation in strategy-trigger layer to consume S1/S2/S3 outputs and produce exactly one final trade decision (or no trade).
+- Added deterministic normalized scoring for cross-strategy comparison.
+- Added deterministic ranking and tie-break behavior.
+- Added global skip gates for all-SKIP, weak top score, and explicit conflict-hold cases.
+- Updated output contract to include:
+  - `selected_trade`
+  - `ranked_candidates`
+  - `selection_reason`
+  - `top_score`
+  - `decision` (`ENTER` / `SKIP`)
 
 ## 2. Current system architecture
-- `StrategyTrigger.aggregate_strategy_decisions(...)` now orchestrates this sequence:
-  1. Collect S1/S2/S3 decisions into candidate score objects.
-  2. Normalize edge and confidence into a unified [0,1] score band.
-  3. Rank candidates by score descending (then by strategy id for deterministic ties).
-  4. Apply selection gates:
-     - no ENTER candidates → `selected_trade=None`
-     - top score below threshold → `selected_trade=None`
-     - top-two ENTER score gap <= conflict gap threshold → `selected_trade=None`
-  5. Return required output contract:
-     - `selected_trade` (or `None`)
-     - `ranking`
-     - `reason`
+`StrategyTrigger.aggregate_strategy_decisions(...)` now performs:
+1. Collect candidate payloads from S1/S2/S3 while preserving per-candidate fields:
+   - strategy name
+   - decision
+   - edge
+   - confidence (or neutral fallback)
+   - reason
+   - market metadata
+2. Normalize score via deterministic formula:
+   - `edge_norm = clamp(edge / 0.10, 0, 1)`
+   - `confidence_norm = clamp(confidence, 0, 1)` if provided, else `0.5`
+   - `score = round(0.7 * edge_norm + 0.3 * confidence_norm, 6)`
+3. Rank candidates with deterministic ordering:
+   - primary: `score` descending
+   - tie-break: `strategy_name` ascending
+4. Select one best candidate from ENTER-only list, else SKIP globally.
 
 ## 3. Files created / modified (full paths)
 - Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
-- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`
-- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md`
 - Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
 
 ## 4. What is working
-- Required tests implemented and passing:
-  1. multiple candidates → best selected
-  2. all weak candidates → no trade
-  3. conflicting top candidates → no trade
-  4. score calculation correctness (weighted edge/confidence)
-  5. deterministic selection across identical input
-- Regression check with S1/S2/S3 suites passes.
+- Required behavior coverage implemented and passing:
+  1. Multiple valid candidates → highest score selected.
+  2. All weak candidates → no trade selected.
+  3. Mixed ENTER/SKIP candidates → only ENTER considered for winner.
+  4. Tie case → deterministic winner by strategy-name tie-break.
+  5. Missing confidence handled safely (neutral fallback `0.5`).
+  6. Ranking output order deterministic and score-descending.
+  7. Global skip behavior works for conflict-hold rule.
 
-Test evidence:
+### Runtime proof examples
+1) **S1 + S2 + S3, one winner selected**
+- Input: `S1 ENTER edge=0.040`, `S2 ENTER edge=0.028`, `S3 ENTER confidence=0.78`
+- Output: `decision=ENTER`, `selected_trade=S1`, deterministic ranked list present.
+
+2) **All candidates skipped**
+- Input: `S1 SKIP`, `S2 SKIP`, `S3 SKIP`
+- Output: `decision=SKIP`, `selected_trade=None`, reason `all candidates are SKIP`.
+
+3) **Deterministic ranking proof**
+- Input with ties at top score (`S1` and `S2` same score)
+- Output ordering always deterministic via tie-break: `S1` then `S2`.
+
+### Test evidence
 - `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅
-- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (5 passed)
-- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (21 passed)
-
-Runtime proof examples:
-
-1) Example with 3 strategies → 1 selected
-```text
-Input:
-- S1: decision=ENTER, edge=0.038, reason="news momentum intact"
-- S2: decision=ENTER, edge=0.026, reason="actionable spread"
-- S3: decision=ENTER, confidence=0.78, reason="smart wallet alignment"
-
-Output:
-- selected_trade="S1"
-- ranking=[S1, S3, S2] (highest score first)
-- reason="selected highest-ranked candidate: S1"
-```
-
-2) Example with no valid trades
-```text
-Input:
-- S1: decision=ENTER, edge=0.012, reason="weak momentum"
-- S2: decision=ENTER, edge=0.011, reason="weak spread"
-- S3: decision=ENTER, confidence=0.30, reason="weak wallet signal"
-
-Output:
-- selected_trade=None
-- ranking=[S1, S2, S3]
-- reason="all candidates below threshold"
-```
-
-Ranking behavior:
-- Ranking is always deterministic because sorting uses `(score desc, strategy_id asc)`.
-- Only one top candidate is selected when selection gates pass.
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (`7 passed`)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (`23 passed`)
 
 ## 5. Known issues
-- Aggregation is currently narrow integration inside strategy trigger only and is not yet wired into full runtime execution orchestration.
-- Cross-strategy conflict detection in this scope is score-gap based for ENTER candidates; advanced semantic conflict modeling remains out of scope.
-- Environment warning remains unchanged: pytest reports `Unknown config option: asyncio_mode` while tests pass.
+- S4 aggregation remains narrow integration in `strategy_trigger` only and is not wired into full runtime orchestration in this task.
+- Conflict-hold gate is currently explicit marker based (`reason` starts with `CONFLICT_HOLD`) and not a semantic contradiction engine.
+- Pytest environment still emits warning: `Unknown config option: asyncio_mode`.
 
 ## 6. What is next
-- Codex auto PR review on changed files and direct dependencies.
-- COMMANDER review for STANDARD-tier merge/hold decision.
+- Codex auto PR review baseline on changed files + direct dependencies.
+- COMMANDER review and merge decision for STANDARD-tier handoff.

--- a/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py
@@ -34,7 +34,7 @@ def _s2(*, decision: str, edge: float, reason: str) -> CrossExchangeArbitrageDec
         decision=decision,
         reason=reason,
         edge=edge,
-        matched_markets_info={"source": "kalshi"},
+        matched_markets_info={"exchange": "kalshi", "market_id": "k1"},
     )
 
 
@@ -43,81 +43,109 @@ def _s3(*, decision: str, confidence: float, reason: str) -> SmartMoneyCopyTradi
         decision=decision,
         reason=reason,
         confidence=confidence,
-        wallet_info={"source": "wallet"},
+        wallet_info={"wallet": "0xabc", "signal_type": "buy"},
     )
 
 
-def test_multiple_candidates_best_selected() -> None:
+def test_multiple_valid_candidates_selects_highest_score() -> None:
     trigger = _make_trigger()
 
     result = trigger.aggregate_strategy_decisions(
-        s1_decision=_s1(decision="ENTER", edge=0.038, reason="news momentum intact"),
-        s2_decision=_s2(decision="ENTER", edge=0.026, reason="actionable spread"),
+        s1_decision=_s1(decision="ENTER", edge=0.040, reason="news momentum intact"),
+        s2_decision=_s2(decision="ENTER", edge=0.028, reason="actionable spread"),
         s3_decision=_s3(decision="ENTER", confidence=0.78, reason="smart wallet alignment"),
     )
 
+    assert result.decision == "ENTER"
     assert result.selected_trade == "S1"
-    assert result.ranking[0].strategy_id == "S1"
-    assert {candidate.strategy_id for candidate in result.ranking} == {"S1", "S2", "S3"}
-    assert "highest-ranked" in result.reason
+    assert [candidate.strategy_name for candidate in result.ranked_candidates] == ["S1", "S2", "S3"]
+    assert result.top_score == result.ranked_candidates[0].score
+    assert "highest-ranked" in result.selection_reason
 
 
-def test_all_weak_candidates_returns_no_trade() -> None:
+def test_all_weak_candidates_returns_global_skip() -> None:
     trigger = _make_trigger()
 
     result = trigger.aggregate_strategy_decisions(
-        s1_decision=_s1(decision="ENTER", edge=0.012, reason="weak momentum"),
+        s1_decision=_s1(decision="ENTER", edge=0.010, reason="weak momentum"),
         s2_decision=_s2(decision="ENTER", edge=0.011, reason="weak spread"),
-        s3_decision=_s3(decision="ENTER", confidence=0.30, reason="weak wallet signal"),
+        s3_decision=_s3(decision="ENTER", confidence=0.20, reason="weak wallet signal"),
     )
 
+    assert result.decision == "SKIP"
     assert result.selected_trade is None
-    assert result.reason == "all candidates below threshold"
+    assert result.selection_reason == "all candidates are weak"
 
 
-def test_conflicting_signals_too_strong_returns_no_trade() -> None:
+def test_mixed_enter_skip_only_considers_enter_candidates() -> None:
     trigger = _make_trigger()
 
     result = trigger.aggregate_strategy_decisions(
-        s1_decision=_s1(decision="ENTER", edge=0.050, reason="momentum continuation"),
-        s2_decision=_s2(decision="ENTER", edge=0.049, reason="reversion spread signal"),
-        s3_decision=_s3(decision="SKIP", confidence=0.10, reason="low-confidence wallet signal"),
+        s1_decision=_s1(decision="SKIP", edge=0.060, reason="already priced in"),
+        s2_decision=_s2(decision="ENTER", edge=0.045, reason="actionable spread"),
+        s3_decision=_s3(decision="SKIP", confidence=0.90, reason="late wallet signal"),
     )
 
-    assert result.selected_trade is None
-    assert result.reason == "conflicting signals too strong"
+    assert result.decision == "ENTER"
+    assert result.selected_trade == "S2"
 
 
-def test_score_calculation_uses_weighted_edge_confidence() -> None:
+def test_tie_case_uses_deterministic_winner() -> None:
+    trigger = _make_trigger()
+
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.040, reason="s1 tie"),
+        s2_decision=_s2(decision="ENTER", edge=0.040, reason="s2 tie"),
+        s3_decision=_s3(decision="SKIP", confidence=0.30, reason="ignore"),
+    )
+
+    # tie score resolved by strategy_name ascending => S1 wins.
+    assert result.decision == "ENTER"
+    assert result.selected_trade == "S1"
+    assert result.ranked_candidates[0].score == result.ranked_candidates[1].score
+
+
+def test_missing_confidence_handled_safely_for_s1_s2() -> None:
     trigger = _make_trigger()
 
     score = trigger._build_strategy_candidate_score(
-        strategy_id="S1",
+        strategy_name="S1",
         decision="ENTER",
-        reason="score check",
+        reason="missing confidence",
         edge=0.05,
-        confidence=0.8,
+        confidence=None,
+        market_metadata={},
     )
 
-    assert score.score == 0.59
-    assert score.edge == 0.05
-    assert score.confidence == 0.8
+    assert score.confidence == 0.5
+    assert score.score == 0.5
 
 
-def test_selection_is_deterministic_on_identical_inputs() -> None:
+def test_ranking_output_order_is_stable_and_correct() -> None:
     trigger = _make_trigger()
 
-    first = trigger.aggregate_strategy_decisions(
-        s1_decision=_s1(decision="ENTER", edge=0.039, reason="news momentum"),
-        s2_decision=_s2(decision="ENTER", edge=0.027, reason="arb spread"),
-        s3_decision=_s3(decision="ENTER", confidence=0.80, reason="wallet alignment"),
-    )
-    second = trigger.aggregate_strategy_decisions(
-        s1_decision=_s1(decision="ENTER", edge=0.039, reason="news momentum"),
-        s2_decision=_s2(decision="ENTER", edge=0.027, reason="arb spread"),
-        s3_decision=_s3(decision="ENTER", confidence=0.80, reason="wallet alignment"),
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.030, reason="third"),
+        s2_decision=_s2(decision="ENTER", edge=0.050, reason="first"),
+        s3_decision=_s3(decision="ENTER", confidence=0.70, reason="second"),
     )
 
-    assert first.selected_trade == second.selected_trade
-    assert first.reason == second.reason
-    assert first.ranking == second.ranking
+    assert [candidate.strategy_name for candidate in result.ranked_candidates] == ["S2", "S1", "S3"]
+    assert [candidate.score for candidate in result.ranked_candidates] == sorted(
+        [candidate.score for candidate in result.ranked_candidates],
+        reverse=True,
+    )
+
+
+def test_global_skip_behavior_conflict_hold_rule() -> None:
+    trigger = _make_trigger()
+
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=_s1(decision="ENTER", edge=0.050, reason="CONFLICT_HOLD momentum/reversion"),
+        s2_decision=_s2(decision="ENTER", edge=0.048, reason="actionable spread"),
+        s3_decision=_s3(decision="ENTER", confidence=0.82, reason="smart wallet alignment"),
+    )
+
+    assert result.decision == "SKIP"
+    assert result.selected_trade is None
+    assert result.selection_reason == "conflict rules require holding"


### PR DESCRIPTION
### Motivation
- Provide a narrow integration S4 aggregator that consumes S1/S2/S3 outputs and deterministically selects a single best trade candidate to improve capital efficiency and downstream decision quality. 

### Description
- Updated `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to preserve per-candidate metadata and return a richer output contract (`selected_trade`, `ranked_candidates`, `selection_reason`, `top_score`, `decision`).
- Implemented deterministic score normalization and formula `score = round(0.7 * edge_norm + 0.3 * confidence_norm, 6)` with safe fallback `confidence=None -> 0.5`, stable tie-break (`strategy_name` ascending), and explicit global skip conditions (`all SKIP`, `all weak`, `CONFLICT_HOLD` marker).
- Added/updated focused S4 tests: expanded to 7 scenarios covering highest-score selection, all-weak skip, mixed ENTER/SKIP handling, tie determinism, missing-confidence handling, ranking order correctness, and global conflict-hold behavior at `projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`.
- Saved required FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md` and updated `PROJECT_STATE.md` (full timestamp) to reflect STANDARD / NARROW INTEGRATION handoff.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` — PASS.
- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` — PASS (`7 passed`).
- Full focused regression run `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s1_breaking_news_momentum_strategy_20260409.py projects/polymarket/polyquantbot/tests/test_s2_cross_exchange_arbitrage_20260409.py projects/polymarket/polyquantbot/tests/test_s3_smart_money_copy_trading_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` — PASS (`23 passed`); environment produced a non-blocking `Unknown config option: asyncio_mode` pytest warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71f83c260832eb07e95548dfa5938)