### PR TITLE
P7: Dynamic position sizing (edge + confidence) — STANDARD, narrow integration

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 03:41
-- Status        : FORGE-X S4 strategy aggregation & prioritization refined (STANDARD, narrow integration) with required output contract + seven-case tests; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 03:58
+- Status        : FORGE-X P7 capital allocation & position sizing implemented (STANDARD, narrow integration) with dynamic edge/confidence sizing + S4 bridge; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P7 capital allocation & position sizing (2026-04-09): implemented dynamic edge/confidence-driven position sizing in strategy trigger, added conservative fallback for missing confidence/borderline edge, enforced min-size + exposure constraints, integrated S4 selected-trade sizing before execution, and added focused six-case behavior tests.
 - S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 outputs with preserved metadata, enforced deterministic normalized scoring and tie-break ranking, implemented single-winner ENTER/SKIP output contract (`selected_trade`/`ranked_candidates`/`selection_reason`/`top_score`/`decision`), and added focused seven-case behavior tests.
 - S3 smart-money / copy-trading strategy (2026-04-09): added strategy-trigger wallet-signal input contract, basic wallet quality filters, signal-strength scoring (size/early/repetition), explicit ENTER/SKIP decision path with confidence + wallet info payload, and focused five-case behavior tests.
 - S2 cross-exchange arbitrage actionable-spread follow-up (2026-04-09): added explicit spread-actionability gate before fee/slippage net-edge evaluation and added focused skip-case test for non-actionable spread while preserving ENTER/SKIP output contract.
@@ -99,6 +100,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P7 capital allocation & position sizing handoff
+- STANDARD-tier narrow integration implementation is complete for execution input sizing, strategy output→sizing bridge, and capital allocation constraints in strategy trigger scope.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S4 strategy aggregation & prioritization handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger aggregation, ranking, and single-trade selection behavior with required contract fields and deterministic tie-break handling.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -156,11 +161,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_14_s4_strategy_aggregation_prioritization.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P7 position sizing is currently narrow integration in strategy-trigger execution input path only and is not yet generalized across full runtime orchestration.
 - S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration; conflict-hold gate currently relies on explicit `CONFLICT_HOLD` marker semantics.
 - S3 smart-money strategy is currently narrow integration in strategy trigger only; execution-orchestration wiring remains out of scope for this task.
 - S2 cross-exchange arbitrage path is currently narrow integration in strategy trigger only and is not yet wired to runtime execution orchestration.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -30,6 +30,8 @@ class StrategyConfig:
     cross_exchange_min_actionable_spread: float = 0.005
     cross_exchange_min_mapping_confidence: float = 0.55
     cross_exchange_min_overlap_tokens: int = 2
+    min_position_size_usd: float = 25.0
+    max_position_size_ratio: float = 0.10
 
 
 @dataclass(frozen=True)
@@ -109,6 +111,14 @@ class StrategyAggregationDecision:
     selection_reason: str
     top_score: float
     decision: str
+
+
+@dataclass(frozen=True)
+class PositionSizingDecision:
+    position_size: float
+    size_reason: str
+    applied_constraints: tuple[str, ...]
+    normalized_score: float
 
 
 class StrategyTrigger:
@@ -498,6 +508,105 @@ class StrategyTrigger:
             market_metadata=market_metadata,
         )
 
+    def compute_position_size_from_s4_selection(
+        self,
+        aggregation: StrategyAggregationDecision,
+        total_capital: float,
+        current_total_exposure: float,
+    ) -> PositionSizingDecision:
+        if aggregation.decision != "ENTER" or not aggregation.selected_trade:
+            return PositionSizingDecision(
+                position_size=0.0,
+                size_reason="no selected S4 trade",
+                applied_constraints=("selection_skip",),
+                normalized_score=0.0,
+            )
+
+        selected_candidate = next(
+            (item for item in aggregation.ranked_candidates if item.strategy_name == aggregation.selected_trade),
+            None,
+        )
+        if selected_candidate is None:
+            return PositionSizingDecision(
+                position_size=0.0,
+                size_reason="selected trade missing from ranked candidates",
+                applied_constraints=("selection_mismatch",),
+                normalized_score=0.0,
+            )
+
+        return self._compute_position_size(
+            strategy_name=selected_candidate.strategy_name,
+            edge=selected_candidate.edge,
+            confidence=(
+                None
+                if selected_candidate.strategy_name in {"S1", "S2"}
+                else selected_candidate.confidence
+            ),
+            total_capital=total_capital,
+            current_total_exposure=current_total_exposure,
+        )
+
+    def _compute_position_size(
+        self,
+        strategy_name: str,
+        edge: float,
+        confidence: float | None,
+        total_capital: float,
+        current_total_exposure: float,
+    ) -> PositionSizingDecision:
+        safe_capital = max(total_capital, 0.0)
+        max_position_size = safe_capital * self._config.max_position_size_ratio
+        max_total_exposure = safe_capital * self._engine.max_total_exposure_ratio
+        available_exposure = max(0.0, max_total_exposure - max(current_total_exposure, 0.0))
+        applied_constraints: list[str] = []
+
+        confidence_missing = confidence is None
+        confidence_val = (
+            0.35
+            if confidence_missing
+            else min(max(confidence, 0.0), 1.0)
+        )
+        edge_val = max(edge, 0.0)
+        edge_norm = min(edge_val / 0.10, 1.0)
+        base_score = (0.7 * edge_norm) + (0.3 * confidence_val)
+
+        conservative_multiplier = 1.0
+        if confidence_missing:
+            conservative_multiplier *= 0.7
+            applied_constraints.append("confidence_missing_conservative")
+        if edge_val <= (self._config.min_edge * 1.2):
+            conservative_multiplier *= 0.5
+            applied_constraints.append("borderline_edge_conservative")
+
+        normalized_score = min(max(base_score * conservative_multiplier, 0.0), 1.0)
+        scaled_score = normalized_score ** 2
+        raw_position_size = safe_capital * self._config.max_position_size_ratio * scaled_score
+        position_size = raw_position_size
+
+        if position_size > max_position_size:
+            position_size = max_position_size
+            applied_constraints.append("max_position_size_cap")
+
+        if position_size > available_exposure:
+            position_size = available_exposure
+            applied_constraints.append("total_exposure_cap")
+
+        if 0.0 < position_size < self._config.min_position_size_usd:
+            position_size = 0.0
+            applied_constraints.append("min_position_size_floor")
+
+        reason_suffix = ", ".join(applied_constraints) if applied_constraints else "no constraints applied"
+        size_reason = (
+            f"{strategy_name} sizing from edge/confidence score={normalized_score:.4f}; "
+            f"{reason_suffix}"
+        )
+        return PositionSizingDecision(
+            position_size=round(max(position_size, 0.0), 2),
+            size_reason=size_reason,
+            applied_constraints=tuple(applied_constraints),
+            normalized_score=round(normalized_score, 6),
+        )
+
     def _select_best_cross_exchange_match(
         self,
         polymarket: CrossExchangeMarket,
@@ -545,7 +654,11 @@ class StrategyTrigger:
     def _tokenize(value: str) -> list[str]:
         return [token for token in re.split(r"[^a-z0-9]+", value.lower()) if len(token) >= 3]
 
-    async def evaluate(self, market_price: float) -> str:
+    async def evaluate(
+        self,
+        market_price: float,
+        aggregation_decision: StrategyAggregationDecision | None = None,
+    ) -> str:
         now = time.time()
         if self._last_trigger_time and (now - self._last_trigger_time) < self._cooldown_seconds:
             return "COOLDOWN"
@@ -571,7 +684,22 @@ class StrategyTrigger:
         )
 
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
-            size = snapshot.equity * self._engine.max_position_size_ratio
+            current_total_exposure = sum(position.exposure() for position in snapshot.positions)
+            sizing = (
+                self.compute_position_size_from_s4_selection(
+                    aggregation=aggregation_decision,
+                    total_capital=snapshot.equity,
+                    current_total_exposure=current_total_exposure,
+                )
+                if aggregation_decision is not None
+                else PositionSizingDecision(
+                    position_size=round(snapshot.equity * self._engine.max_position_size_ratio, 2),
+                    size_reason="fallback fixed sizing (no S4 aggregation decision provided)",
+                    applied_constraints=("fallback_fixed_sizing",),
+                    normalized_score=1.0,
+                )
+            )
+            size = sizing.position_size
             created = await self._engine.open_position(
                 market=self._config.market_id,
                 side=self._config.side,

--- a/projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md
@@ -1,0 +1,90 @@
+# 24_15_p7_capital_allocation_position_sizing
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - execution input layer (position sizing) in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - strategy output → sizing bridge via `compute_position_size_from_s4_selection(...)`
+  - capital allocation logic for edge/confidence-based scaling and risk constraints
+- Not in Scope:
+  - execution engine redesign
+  - risk rule redesign
+  - strategy logic changes
+  - Telegram UI changes
+  - observability changes
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md`. Tier: STANDARD
+
+## 1. What was built
+- Implemented dynamic position sizing in strategy trigger using S4-selected trade context before execution.
+- Added `PositionSizingDecision` output contract with:
+  - `position_size`
+  - `size_reason`
+  - `applied_constraints`
+  - `normalized_score`
+- Added strategy-output → sizing bridge through `compute_position_size_from_s4_selection(...)`.
+- Wired sizing into `evaluate(...)` so sizing is applied before `open_position(...)`.
+- Added focused P7 tests covering strong/weak edge behavior, missing confidence fallback, cap/exposure constraints, determinism, and S4 integration.
+
+## 2. Current system architecture
+Sizing flow for this task scope:
+1. S4 aggregation provides `selected_trade` + ranked candidate payload.
+2. `compute_position_size_from_s4_selection(...)` resolves selected candidate.
+3. `_compute_position_size(...)` computes deterministic score:
+   - `edge_norm = clamp(edge / 0.10, 0, 1)`
+   - `confidence_val = clamp(confidence, 0, 1)` or `0.35` when missing
+   - `base_score = 0.7 * edge_norm + 0.3 * confidence_val`
+   - conservative multipliers:
+     - missing confidence: `× 0.7`
+     - borderline edge (`edge <= min_edge * 1.2`): `× 0.5`
+   - `normalized_score = clamp(base_score * conservative_multiplier, 0, 1)`
+   - smooth scaling: `scaled_score = normalized_score^2`
+   - `raw_size = capital × max_position_size_ratio × scaled_score`
+4. Constraints applied in order:
+   - total exposure cap (`max_total_exposure_ratio` from execution engine)
+   - min position floor (`min_position_size_usd`)
+5. Final sizing decision is used by `evaluate(...)` before order open call.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Dynamic edge/confidence sizing implemented with deterministic smooth scaling.
+- Conservative fallback implemented for:
+  - missing confidence
+  - borderline edge
+- Constraint handling working:
+  - per-position cap bounded by `≤ 10%` capital
+  - min position threshold enforced
+  - total exposure guard respected
+- S4 integration working:
+  - selected trade is bridged into sizing path
+  - sizing output is applied before execution open call
+
+### Runtime proof examples
+1) **Strong signal → larger position**
+- Input: edge `0.09`, confidence `0.92`, capital `10,000`, exposure `0`
+- Output: `position_size=820.84` (larger size, under 10% cap)
+
+2) **Weak signal → small position**
+- Input: edge `0.021`, confidence `0.55`, capital `10,000`, exposure `0`
+- Output: `position_size=24.34` raw then blocked by min threshold → `position_size=0.0`, constraint includes `min_position_size_floor`
+
+3) **Capped by exposure**
+- Input: edge `0.20`, confidence `1.0`, capital `10,000`, current exposure `2,700`
+- Exposure limit (`30%`) leaves `300` available
+- Output: `position_size=300.0`, constraint includes `total_exposure_cap`
+
+### Test evidence
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (`13 passed`)
+
+## 5. Known issues
+- P7 sizing integration is narrow to strategy-trigger execution input path and not a full execution-engine redesign.
+- Pytest still reports repository-level warning: `Unknown config option: asyncio_mode` (tests pass).
+
+## 6. What is next
+- Codex auto PR review + COMMANDER review for STANDARD-tier handoff and merge decision.

--- a/projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    PositionSizingDecision,
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    positions: tuple[object, ...]
+    cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    implied_prob: float
+    volatility: float
+
+
+class _Position:
+    def __init__(self, size: float) -> None:
+        self._size = size
+
+    def exposure(self) -> float:
+        return self._size
+
+
+class _SizingEngine:
+    def __init__(self, equity: float = 10_000.0, *, exposure_ratio: float = 0.30) -> None:
+        self.max_total_exposure_ratio = exposure_ratio
+        self.max_position_size_ratio = 0.10
+        self._snapshot = _Snapshot(
+            positions=tuple(),
+            cash=equity,
+            equity=equity,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+        self.open_calls: list[dict[str, float]] = []
+
+    async def snapshot(self) -> _Snapshot:
+        return self._snapshot
+
+    async def open_position(self, **kwargs: float):
+        self.open_calls.append(kwargs)
+        return type("Opened", (), {"position_id": str(kwargs.get("position_id", "p1"))})()
+
+    async def update_mark_to_market(self, _: dict[str, float]) -> float:
+        return 0.0
+
+    async def close_position(self, _position: object, _price: float) -> float:
+        return 0.0
+
+    def set_snapshot(self, *, equity: float, exposure: float = 0.0) -> None:
+        positions = tuple([_Position(exposure)]) if exposure > 0.0 else tuple()
+        self._snapshot = _Snapshot(
+            positions=positions,
+            cash=max(0.0, equity - exposure),
+            equity=equity,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+
+
+def _make_trigger(engine: _SizingEngine | None = None) -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=engine or _SizingEngine(),
+        config=StrategyConfig(
+            market_id="m-p7-sizing-1",
+            min_edge=0.02,
+            min_liquidity_usd=10_000.0,
+            min_position_size_usd=25.0,
+            max_position_size_ratio=0.10,
+        ),
+    )
+
+
+def _aggregation(*, edge: float, confidence: float | None, selected_trade: str = "S1") -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name=selected_trade,
+        decision="ENTER",
+        reason="selected for sizing",
+        edge=edge,
+        confidence=0.5 if confidence is None else confidence,
+        score=0.80,
+        market_metadata={},
+    )
+    return StrategyAggregationDecision(
+        selected_trade=selected_trade,
+        ranked_candidates=[candidate],
+        selection_reason="highest-ranked",
+        top_score=0.8,
+        decision="ENTER",
+    )
+
+
+def test_strong_edge_produces_larger_position_within_cap() -> None:
+    trigger = _make_trigger()
+    strong = trigger._compute_position_size("S1", edge=0.09, confidence=0.92, total_capital=10_000.0, current_total_exposure=0.0)
+    weak = trigger._compute_position_size("S1", edge=0.03, confidence=0.60, total_capital=10_000.0, current_total_exposure=0.0)
+
+    assert strong.position_size > weak.position_size
+    assert strong.position_size <= 1_000.0
+
+
+def test_weak_edge_produces_small_or_zero_size() -> None:
+    trigger = _make_trigger()
+    result = trigger._compute_position_size("S1", edge=0.021, confidence=0.55, total_capital=10_000.0, current_total_exposure=0.0)
+
+    assert result.position_size < 150.0
+    assert "borderline_edge_conservative" in result.applied_constraints
+
+
+def test_missing_confidence_is_conservative() -> None:
+    trigger = _make_trigger()
+    with_conf = trigger._compute_position_size("S1", edge=0.06, confidence=0.80, total_capital=10_000.0, current_total_exposure=0.0)
+    missing_conf = trigger._compute_position_size("S1", edge=0.06, confidence=None, total_capital=10_000.0, current_total_exposure=0.0)
+
+    assert missing_conf.position_size < with_conf.position_size
+    assert "confidence_missing_conservative" in missing_conf.applied_constraints
+
+
+def test_cap_and_total_exposure_constraints_are_enforced() -> None:
+    trigger = _make_trigger()
+    result = trigger._compute_position_size("S1", edge=0.20, confidence=1.0, total_capital=10_000.0, current_total_exposure=2_700.0)
+
+    assert result.position_size == 300.0
+    assert "total_exposure_cap" in result.applied_constraints
+
+
+def test_sizing_is_deterministic() -> None:
+    trigger = _make_trigger()
+    r1 = trigger._compute_position_size("S1", edge=0.045, confidence=0.67, total_capital=12_500.0, current_total_exposure=400.0)
+    r2 = trigger._compute_position_size("S1", edge=0.045, confidence=0.67, total_capital=12_500.0, current_total_exposure=400.0)
+
+    assert r1 == r2
+
+
+def test_s4_selected_trade_is_applied_before_execution() -> None:
+    engine = _SizingEngine(equity=10_000.0)
+    trigger = _make_trigger(engine)
+    aggregation = _aggregation(edge=0.09, confidence=0.95, selected_trade="S2")
+
+    async def _run() -> PositionSizingDecision:
+        outcome = await trigger.evaluate(market_price=0.20, aggregation_decision=aggregation)
+        assert outcome == "OPENED"
+        assert len(engine.open_calls) == 1
+        return trigger.compute_position_size_from_s4_selection(
+            aggregation=aggregation,
+            total_capital=10_000.0,
+            current_total_exposure=0.0,
+        )
+
+    sizing = asyncio.run(_run())
+    assert engine.open_calls[0]["size"] == sizing.position_size
+    assert sizing.position_size > 0.0


### PR DESCRIPTION
### Motivation
- Introduce deterministic, smooth position sizing that scales with strategy-provided `edge` and optional `confidence` while enforcing strict risk limits (per-trade cap, min-size floor, total exposure). 
- Ensure S4 aggregation output is bridged into the sizing layer so the selected candidate is sized before execution.

### Description
- Added `PositionSizingDecision` contract and sizing config fields (`min_position_size_usd`, `max_position_size_ratio`) to `StrategyTrigger` to expose `position_size`, `size_reason`, `applied_constraints`, and `normalized_score`.
- Implemented `compute_position_size_from_s4_selection(...)` and internal `_compute_position_size(...)` that: normalize `edge`/`confidence`, apply conservative multipliers when `confidence` is missing or edge is borderline, use a smooth scaling curve (`normalized_score^2`) × `max_position_size_ratio`, and then apply hard constraints (per-position cap ≤ 10% capital, available total exposure cap, min-size floor).
- Wired sizing into `StrategyTrigger.evaluate(...)` so sizing is applied (from S4 aggregation when provided) before calling `open_position(...)`, with a deterministic fallback sizing when no aggregation is passed.
- Added focused unit tests and a FORGE report; files changed/added: `projects/polymarket/polyquantbot/execution/strategy_trigger.py` (modified), `projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py` (new), `projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md` (new), and `PROJECT_STATE.md` (updated).

### Testing
- Ran `python -m py_compile` on the modified code and tests; result: PASS.
- Ran the focused pytest subset: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py`; result: `13 passed` (all tests in the run passed) with one non-blocking pytest config warning about `asyncio_mode`.
- Tests cover the required cases: strong edge → larger size (within cap), weak edge → small/zero size, missing confidence → conservative sizing, cap and exposure enforcement, deterministic outputs, and S4 selection → sizing → execution integration.

Report: `projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md`
State: `PROJECT_STATE.md` updated
Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72304e2c8832eb20a54d805e55d82)