### PR TITLE
P8: Portfolio exposure balancing & correlation guard (pre-execution)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 03:58
-- Status        : FORGE-X P7 capital allocation & position sizing implemented (STANDARD, narrow integration) with dynamic edge/confidence sizing + S4 bridge; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 04:29
+- Status        : FORGE-X P8 portfolio exposure balancing & correlation guard implemented (STANDARD, narrow integration) in post-S4 pre-execution path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P8 portfolio exposure balancing & correlation guard (2026-04-09): added post-S4 pre-execution portfolio-fit guard in strategy trigger with same-market block, theme/similarity-aware correlation handling, exposure-cap-based size reduction/skip decisions, deterministic ENTER/SKIP/REDUCE output contract, and focused runtime-proof tests.
 - P7 capital allocation & position sizing (2026-04-09): implemented dynamic edge/confidence-driven position sizing in strategy trigger, added conservative fallback for missing confidence/borderline edge, enforced min-size + exposure constraints, integrated S4 selected-trade sizing before execution, and added focused six-case behavior tests.
 - S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 outputs with preserved metadata, enforced deterministic normalized scoring and tie-break ranking, implemented single-winner ENTER/SKIP output contract (`selected_trade`/`ranked_candidates`/`selection_reason`/`top_score`/`decision`), and added focused seven-case behavior tests.
 - S3 smart-money / copy-trading strategy (2026-04-09): added strategy-trigger wallet-signal input contract, basic wallet quality filters, signal-strength scoring (size/early/repetition), explicit ENTER/SKIP decision path with confidence + wallet info payload, and focused five-case behavior tests.
@@ -100,6 +101,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P8 portfolio exposure balancing & correlation guard handoff
+- STANDARD-tier narrow integration implementation is complete for post-S4 pre-execution portfolio validation, correlation-aware trade gating, and exposure-based size adjustment behavior.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P7 capital allocation & position sizing handoff
 - STANDARD-tier narrow integration implementation is complete for execution input sizing, strategy output→sizing bridge, and capital allocation constraints in strategy trigger scope.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -161,11 +166,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_15_p7_capital_allocation_position_sizing.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P8 portfolio exposure balancing is currently narrow integration in strategy-trigger pre-execution path only and is not yet generalized to broader runtime orchestration layers.
 - P7 position sizing is currently narrow integration in strategy-trigger execution input path only and is not yet generalized across full runtime orchestration.
 - S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration; conflict-hold gate currently relies on explicit `CONFLICT_HOLD` marker semantics.
 - S3 smart-money strategy is currently narrow integration in strategy trigger only; execution-orchestration wiring remains out of scope for this task.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -32,6 +32,10 @@ class StrategyConfig:
     cross_exchange_min_overlap_tokens: int = 2
     min_position_size_usd: float = 25.0
     max_position_size_ratio: float = 0.10
+    max_market_exposure_ratio: float = 0.15
+    max_theme_exposure_ratio: float = 0.20
+    correlation_size_reduction_factor: float = 0.50
+    high_similarity_overlap_ratio: float = 0.60
 
 
 @dataclass(frozen=True)
@@ -119,6 +123,14 @@ class PositionSizingDecision:
     size_reason: str
     applied_constraints: tuple[str, ...]
     normalized_score: float
+
+
+@dataclass(frozen=True)
+class PortfolioExposureDecision:
+    final_decision: str
+    adjusted_size: float
+    reason: str
+    flags: tuple[str, ...]
 
 
 class StrategyTrigger:
@@ -607,6 +619,169 @@ class StrategyTrigger:
             normalized_score=round(normalized_score, 6),
         )
 
+    def evaluate_portfolio_exposure_and_correlation(
+        self,
+        *,
+        target_market_id: str,
+        target_theme: str | None,
+        proposed_size: float,
+        open_positions: list[object],
+        total_capital: float,
+    ) -> PortfolioExposureDecision:
+        safe_capital = max(total_capital, 0.0)
+        if proposed_size <= 0.0 or safe_capital <= 0.0:
+            return PortfolioExposureDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                reason="invalid proposed size or capital",
+                flags=("invalid_input",),
+            )
+
+        current_total_exposure = sum(max(float(position.exposure()), 0.0) for position in open_positions)
+        total_exposure_cap = safe_capital * self._engine.max_total_exposure_ratio
+        available_total_exposure = max(0.0, total_exposure_cap - current_total_exposure)
+        if available_total_exposure <= 0.0:
+            return PortfolioExposureDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                reason="total exposure cap reached",
+                flags=("total_exposure_cap",),
+            )
+
+        same_market_exposure = sum(
+            max(float(position.exposure()), 0.0)
+            for position in open_positions
+            if getattr(position, "market_id", "") == target_market_id
+        )
+        if same_market_exposure > 0.0:
+            return PortfolioExposureDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                reason="correlated exposure: same market already open",
+                flags=("same_market_block",),
+            )
+
+        normalized_target_theme = (target_theme or "").strip().lower()
+        theme_exposure = 0.0
+        if normalized_target_theme:
+            theme_exposure = sum(
+                max(float(position.exposure()), 0.0)
+                for position in open_positions
+                if self._infer_position_theme(position) == normalized_target_theme
+            )
+            theme_cap = safe_capital * self._config.max_theme_exposure_ratio
+            if theme_exposure >= theme_cap:
+                return PortfolioExposureDecision(
+                    final_decision="SKIP",
+                    adjusted_size=0.0,
+                    reason="theme exposure cap reached",
+                    flags=("theme_exposure_cap",),
+                )
+
+        max_market_exposure = safe_capital * self._config.max_market_exposure_ratio
+        market_headroom = max(0.0, max_market_exposure - same_market_exposure)
+        final_size = min(proposed_size, available_total_exposure, market_headroom)
+        flags: list[str] = []
+        reason = "portfolio fit validated"
+
+        if normalized_target_theme:
+            theme_cap = safe_capital * self._config.max_theme_exposure_ratio
+            theme_headroom = max(0.0, theme_cap - theme_exposure)
+            if final_size > theme_headroom:
+                final_size = theme_headroom
+                flags.append("theme_exposure_cap")
+
+        if self._has_high_similarity_overlap(target_market_id=target_market_id, open_positions=open_positions):
+            reduced_size = final_size * self._config.correlation_size_reduction_factor
+            final_size = min(final_size, reduced_size)
+            flags.append("high_similarity_reduce")
+            reason = "correlated exposure: highly similar condition"
+
+        if final_size <= 0.0:
+            return PortfolioExposureDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                reason=reason if flags else "portfolio exposure constraint",
+                flags=tuple(flags or ["no_available_exposure"]),
+            )
+
+        if 0.0 < final_size < self._config.min_position_size_usd:
+            return PortfolioExposureDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                reason="adjusted size below minimum threshold",
+                flags=tuple(flags + ["min_position_size_floor"]),
+            )
+
+        if final_size < proposed_size:
+            if not reason.startswith("correlated exposure"):
+                reason = "exposure cap adjustment"
+            return PortfolioExposureDecision(
+                final_decision="REDUCE",
+                adjusted_size=round(final_size, 2),
+                reason=reason,
+                flags=tuple(flags or ["exposure_reduce"]),
+            )
+
+        return PortfolioExposureDecision(
+            final_decision="ENTER",
+            adjusted_size=round(final_size, 2),
+            reason=reason,
+            flags=tuple(flags),
+        )
+
+    def _resolve_candidate_market_context(
+        self,
+        selected_candidate: StrategyCandidateScore | None,
+    ) -> tuple[str, str | None]:
+        if selected_candidate is None:
+            return self._config.market_id, None
+        metadata = selected_candidate.market_metadata or {}
+        raw_market_id = (
+            metadata.get("market_id")
+            or metadata.get("polymarket")
+            or self._config.market_id
+        )
+        market_id = str(raw_market_id)
+        raw_theme = (
+            metadata.get("theme")
+            or metadata.get("event_key")
+            or metadata.get("event")
+            or metadata.get("category")
+        )
+        theme = str(raw_theme).strip() if raw_theme is not None else None
+        return market_id, theme
+
+    @staticmethod
+    def _infer_position_theme(position: object) -> str:
+        for attr in ("theme", "event_key", "category"):
+            value = getattr(position, attr, None)
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+        return ""
+
+    def _has_high_similarity_overlap(
+        self,
+        *,
+        target_market_id: str,
+        open_positions: list[object],
+    ) -> bool:
+        target_tokens = set(self._tokenize(target_market_id))
+        if not target_tokens:
+            return False
+        for position in open_positions:
+            market_id = str(getattr(position, "market_id", ""))
+            if not market_id or market_id == target_market_id:
+                continue
+            position_tokens = set(self._tokenize(market_id))
+            if not position_tokens:
+                continue
+            overlap = len(target_tokens & position_tokens)
+            overlap_ratio = overlap / max(len(target_tokens), len(position_tokens))
+            if overlap_ratio >= self._config.high_similarity_overlap_ratio:
+                return True
+        return False
+
     def _select_best_cross_exchange_match(
         self,
         polymarket: CrossExchangeMarket,
@@ -685,6 +860,16 @@ class StrategyTrigger:
 
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
             current_total_exposure = sum(position.exposure() for position in snapshot.positions)
+            selected_candidate = None
+            if aggregation_decision is not None and aggregation_decision.selected_trade:
+                selected_candidate = next(
+                    (
+                        item
+                        for item in aggregation_decision.ranked_candidates
+                        if item.strategy_name == aggregation_decision.selected_trade
+                    ),
+                    None,
+                )
             sizing = (
                 self.compute_position_size_from_s4_selection(
                     aggregation=aggregation_decision,
@@ -699,9 +884,19 @@ class StrategyTrigger:
                     normalized_score=1.0,
                 )
             )
-            size = sizing.position_size
+            target_market_id, target_theme = self._resolve_candidate_market_context(selected_candidate)
+            portfolio_guard = self.evaluate_portfolio_exposure_and_correlation(
+                target_market_id=target_market_id,
+                target_theme=target_theme,
+                proposed_size=sizing.position_size,
+                open_positions=list(snapshot.positions),
+                total_capital=snapshot.equity,
+            )
+            if portfolio_guard.final_decision == "SKIP":
+                return "BLOCKED"
+            size = portfolio_guard.adjusted_size
             created = await self._engine.open_position(
-                market=self._config.market_id,
+                market=target_market_id,
                 side=self._config.side,
                 price=market_price,
                 size=size,

--- a/projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md
@@ -1,0 +1,101 @@
+# 24_16_p8_portfolio_exposure_balancing_correlation_guard
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - post-S4 selection layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - pre-execution validation path before `open_position(...)`
+  - portfolio state inspection from execution snapshot open positions + exposure totals
+- Not in Scope:
+  - execution engine changes
+  - risk model redesign
+  - strategy logic changes
+  - Telegram UI changes
+  - observability redesign
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md`. Tier: STANDARD
+
+## 1. What was built
+- Added lightweight portfolio exposure + correlation guard at post-S4, pre-execution stage in strategy trigger.
+- Introduced `PortfolioExposureDecision` contract with required outputs:
+  - `final_decision` (`ENTER` / `SKIP` / `REDUCE`)
+  - `adjusted_size`
+  - `reason`
+  - `flags`
+- Implemented portfolio snapshot consumption from execution snapshot:
+  - open positions
+  - market identifiers (`market_id`)
+  - inferred themes (`theme` / `event_key` / `category` if available)
+  - total exposure aggregation
+- Added correlation handling:
+  - same market: block
+  - same theme cap: reduce/skip based on available headroom
+  - highly similar market condition (token-overlap heuristic): reduce with correlation factor
+- Integrated guard decision into `evaluate(...)` before `open_position(...)`.
+
+## 2. Current system architecture
+1. S4 produces `StrategyAggregationDecision` with selected candidate and metadata.
+2. Existing P7 sizing computes `proposed_size` from edge/confidence and total exposure budget.
+3. New portfolio guard resolves target market/theme context from selected candidate metadata.
+4. Guard inspects current snapshot open positions and evaluates:
+   - duplicate same-market exposure (hard block)
+   - total exposure cap headroom
+   - per-theme exposure cap
+   - high market-id similarity overlap
+5. Guard emits deterministic `PortfolioExposureDecision`.
+6. Runtime behavior:
+   - `SKIP` → evaluate returns `BLOCKED`
+   - `REDUCE` → execution continues with reduced `adjusted_size`
+   - `ENTER` → execution continues with original validated size
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Same-market duplication is blocked before execution.
+- Similar/high-overlap market conditions are reduced by deterministic correlation reduction factor.
+- Total exposure cap is enforced in guard path even when candidate passes signal checks.
+- Diversified positions pass guard and continue execution.
+- Deterministic behavior verified for identical inputs.
+
+### Correlation handling examples
+1) Same market block
+- Existing: `election-2026-winner`
+- Candidate: `election-2026-winner`
+- Output: `final_decision=SKIP`, reason `correlated exposure: same market already open`
+
+2) High-similarity reduction
+- Existing: `btc-hit-100k-2026`
+- Candidate: `btc-will-hit-100k-in-2026`
+- Output: `final_decision=REDUCE`, flag `high_similarity_reduce`
+
+### Exposure enforcement proof
+- Total capital `10,000`, exposure cap ratio `30%` ⇒ cap `3,000`
+- Current exposure `2,700`
+- Candidate proposed size `900`
+- Guard output: `final_decision=REDUCE`, `adjusted_size=300.0`
+
+### Runtime proof (required)
+1) Trade blocked due to correlation
+- `evaluate(...)` outcome: `BLOCKED` when same market already open.
+
+2) Trade reduced due to exposure
+- `evaluate(...)` outcome: `OPENED` with reduced size `300.0` under capped headroom.
+
+3) Normal trade allowed
+- `evaluate(...)` outcome: `OPENED` with positive non-zero size for diversified portfolio.
+
+### Test evidence
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py` ✅ (`14 passed`, 1 known pytest warning)
+
+## 5. Known issues
+- P8 guard currently uses lightweight similarity heuristics over market-id tokens and available metadata; no external correlation matrix integration is included in this scope.
+- Theme detection depends on available metadata/position attributes (`theme` / `event_key` / `category`) and falls back to non-theme checks when absent.
+- Repository pytest warning `Unknown config option: asyncio_mode` remains present but non-blocking for focused tests.
+
+## 6. What is next
+- COMMANDER review (STANDARD tier handoff with Codex auto PR review baseline).

--- a/projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    positions: tuple[object, ...]
+    cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    implied_prob: float
+    volatility: float
+
+
+class _Position:
+    def __init__(self, market_id: str, size: float, *, theme: str | None = None) -> None:
+        self.market_id = market_id
+        self._size = size
+        self.theme = theme
+
+    def exposure(self) -> float:
+        return self._size
+
+
+class _Engine:
+    def __init__(self, *, equity: float = 10_000.0, exposure_ratio: float = 0.30) -> None:
+        self.max_total_exposure_ratio = exposure_ratio
+        self.max_position_size_ratio = 0.10
+        self._snapshot = _Snapshot(
+            positions=tuple(),
+            cash=equity,
+            equity=equity,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+        self.open_calls: list[dict[str, float | str]] = []
+
+    async def snapshot(self) -> _Snapshot:
+        return self._snapshot
+
+    async def open_position(self, **kwargs: float | str):
+        self.open_calls.append(kwargs)
+        return type("Opened", (), {"position_id": str(kwargs.get("position_id", "p1"))})()
+
+    async def update_mark_to_market(self, _: dict[str, float]) -> float:
+        return 0.0
+
+    async def close_position(self, _position: object, _price: float) -> float:
+        return 0.0
+
+    def set_snapshot(self, *, equity: float, positions: tuple[_Position, ...]) -> None:
+        total_exposure = sum(item.exposure() for item in positions)
+        self._snapshot = _Snapshot(
+            positions=positions,
+            cash=max(0.0, equity - total_exposure),
+            equity=equity,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+
+
+def _make_trigger(engine: _Engine | None = None) -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=engine or _Engine(),
+        config=StrategyConfig(
+            market_id="market-default",
+            min_edge=0.02,
+            min_position_size_usd=25.0,
+            max_position_size_ratio=0.10,
+            max_market_exposure_ratio=0.15,
+            max_theme_exposure_ratio=0.20,
+            correlation_size_reduction_factor=0.50,
+            high_similarity_overlap_ratio=0.50,
+        ),
+    )
+
+
+def _aggregation(*, market_id: str, theme: str, edge: float = 0.09, confidence: float = 0.95) -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S2",
+        decision="ENTER",
+        reason="selected by S4",
+        edge=edge,
+        confidence=confidence,
+        score=0.90,
+        market_metadata={"market_id": market_id, "theme": theme},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S2",
+        ranked_candidates=[candidate],
+        selection_reason="top score",
+        top_score=0.90,
+        decision="ENTER",
+    )
+
+
+def test_same_market_is_blocked() -> None:
+    trigger = _make_trigger()
+    decision = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="election-2026-winner",
+        target_theme="us-politics",
+        proposed_size=500.0,
+        open_positions=[_Position("election-2026-winner", 300.0, theme="us-politics")],
+        total_capital=10_000.0,
+    )
+
+    assert decision.final_decision == "SKIP"
+    assert decision.adjusted_size == 0.0
+    assert "same_market_block" in decision.flags
+
+
+def test_similar_market_is_reduced() -> None:
+    trigger = _make_trigger()
+    decision = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="btc-will-hit-100k-in-2026",
+        target_theme="crypto",
+        proposed_size=800.0,
+        open_positions=[_Position("btc-hit-100k-2026", 300.0, theme="crypto")],
+        total_capital=10_000.0,
+    )
+
+    assert decision.final_decision == "REDUCE"
+    assert 0.0 < decision.adjusted_size < 800.0
+    assert "high_similarity_reduce" in decision.flags
+
+
+def test_diversified_portfolio_is_allowed() -> None:
+    trigger = _make_trigger()
+    decision = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="fed-rate-cut-july",
+        target_theme="macro",
+        proposed_size=500.0,
+        open_positions=[
+            _Position("nba-finals-2026", 250.0, theme="sports"),
+            _Position("weather-hurricane-atlantic", 350.0, theme="weather"),
+        ],
+        total_capital=10_000.0,
+    )
+
+    assert decision.final_decision == "ENTER"
+    assert decision.adjusted_size == 500.0
+
+
+def test_total_exposure_cap_is_enforced() -> None:
+    trigger = _make_trigger()
+    decision = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="new-clean-energy-bill",
+        target_theme="policy",
+        proposed_size=900.0,
+        open_positions=[_Position("existing-position", 2_700.0, theme="sports")],
+        total_capital=10_000.0,
+    )
+
+    assert decision.final_decision == "REDUCE"
+    assert decision.adjusted_size == 300.0
+
+
+def test_guard_is_deterministic() -> None:
+    trigger = _make_trigger()
+    p = [_Position("btc-hit-100k-2026", 400.0, theme="crypto")]
+    first = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="btc-will-hit-100k-in-2026",
+        target_theme="crypto",
+        proposed_size=700.0,
+        open_positions=p,
+        total_capital=10_000.0,
+    )
+    second = trigger.evaluate_portfolio_exposure_and_correlation(
+        target_market_id="btc-will-hit-100k-in-2026",
+        target_theme="crypto",
+        proposed_size=700.0,
+        open_positions=p,
+        total_capital=10_000.0,
+    )
+
+    assert first == second
+
+
+def test_runtime_proof_blocked_due_to_correlation() -> None:
+    engine = _Engine(equity=10_000.0)
+    engine.set_snapshot(
+        equity=10_000.0,
+        positions=(_Position("election-2026-winner", 250.0, theme="us-politics"),),
+    )
+    trigger = _make_trigger(engine)
+
+    async def _run() -> str:
+        return await trigger.evaluate(
+            market_price=0.20,
+            aggregation_decision=_aggregation(market_id="election-2026-winner", theme="us-politics"),
+        )
+
+    outcome = asyncio.run(_run())
+    assert outcome == "BLOCKED"
+    assert len(engine.open_calls) == 0
+
+
+def test_runtime_proof_reduced_due_to_exposure() -> None:
+    engine = _Engine(equity=10_000.0)
+    engine.set_snapshot(
+        equity=10_000.0,
+        positions=(_Position("existing-position", 2_700.0, theme="sports"),),
+    )
+    trigger = _make_trigger(engine)
+
+    async def _run() -> str:
+        return await trigger.evaluate(
+            market_price=0.20,
+            aggregation_decision=_aggregation(market_id="macro-fed-july", theme="macro", edge=0.10, confidence=0.95),
+        )
+
+    outcome = asyncio.run(_run())
+    assert outcome == "OPENED"
+    assert len(engine.open_calls) == 1
+    assert engine.open_calls[0]["size"] == 300.0
+
+
+def test_runtime_proof_normal_trade_allowed() -> None:
+    engine = _Engine(equity=10_000.0)
+    engine.set_snapshot(
+        equity=10_000.0,
+        positions=(_Position("weather-hurricane-atlantic", 300.0, theme="weather"),),
+    )
+    trigger = _make_trigger(engine)
+
+    async def _run() -> str:
+        return await trigger.evaluate(
+            market_price=0.20,
+            aggregation_decision=_aggregation(market_id="fed-rate-cut-july", theme="macro"),
+        )
+
+    outcome = asyncio.run(_run())
+    assert outcome == "OPENED"
+    assert len(engine.open_calls) == 1
+    assert 0.0 < float(engine.open_calls[0]["size"]) <= 1_000.0


### PR DESCRIPTION
### Motivation
- Prevent overconcentration by applying portfolio-fit checks after S4 selection and before execution so trades are evaluated against current open positions and exposure budgets.  
- Detect same-market duplication, theme concentration, and high-similarity markets and take deterministic action (ENTER / REDUCE / SKIP) to protect portfolio quality.  

### Description
- Added new config fields to `StrategyConfig`: `max_market_exposure_ratio`, `max_theme_exposure_ratio`, `correlation_size_reduction_factor`, and `high_similarity_overlap_ratio`.  
- Introduced `PortfolioExposureDecision` and implemented `evaluate_portfolio_exposure_and_correlation(...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to compute final_decision / adjusted_size / reason / flags based on snapshot open positions and total capital.  
- Wire guard into the runtime `evaluate(...)` path: resolve selected candidate market/theme, run the portfolio guard before `open_position(...)`, return `BLOCKED` for `SKIP`, use reduced `adjusted_size` for `REDUCE`, and open with validated size for `ENTER`.  
- Added focused unit tests and a FORGE report and updated `PROJECT_STATE.md`. Files changed/added:  
  - Modified: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`  
  - Added: `projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py`  
  - Added: `projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md`  
  - Modified: `PROJECT_STATE.md` (Last Updated timestamp + P8 entry / NEXT PRIORITY).  

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py` — PASS.  
- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py` — PASS (`14 passed`, 1 non-blocking pytest warning reported).  
- Repository structure check (`find . -type d -name 'phase*'`) — PASS (no forbidden `phase*/` folders present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72a507198832e99aacabb0219f957)