### PR TITLE
feat: P9 adaptive performance feedback loop (strategy-trigger)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 04:29
-- Status        : FORGE-X P8 portfolio exposure balancing & correlation guard implemented (STANDARD, narrow integration) in post-S4 pre-execution path; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 05:05
+- Status        : FORGE-X P9 performance feedback loop implemented (STANDARD, narrow integration) in strategy-trigger adaptive layer; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P9 performance feedback loop (2026-04-09): added per-strategy post-trade performance tracking (trades/win-loss/avg edge/avg pnl), computed win-rate + average-return + consistency metrics, introduced bounded adaptive strategy weighting/sizing/threshold adjustments with fallback defaults, and added focused deterministic stability tests.
 - P8 portfolio exposure balancing & correlation guard (2026-04-09): added post-S4 pre-execution portfolio-fit guard in strategy trigger with same-market block, theme/similarity-aware correlation handling, exposure-cap-based size reduction/skip decisions, deterministic ENTER/SKIP/REDUCE output contract, and focused runtime-proof tests.
 - P7 capital allocation & position sizing (2026-04-09): implemented dynamic edge/confidence-driven position sizing in strategy trigger, added conservative fallback for missing confidence/borderline edge, enforced min-size + exposure constraints, integrated S4 selected-trade sizing before execution, and added focused six-case behavior tests.
 - S4 strategy aggregation & prioritization (2026-04-09): aggregated S1/S2/S3 outputs with preserved metadata, enforced deterministic normalized scoring and tie-break ranking, implemented single-winner ENTER/SKIP output contract (`selected_trade`/`ranked_candidates`/`selection_reason`/`top_score`/`decision`), and added focused seven-case behavior tests.
@@ -101,6 +102,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P9 performance feedback loop handoff
+- STANDARD-tier narrow integration implementation is complete for post-trade strategy performance tracking and bounded adaptive scoring/sizing/threshold adjustment in strategy-trigger scope.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P8 portfolio exposure balancing & correlation guard handoff
 - STANDARD-tier narrow integration implementation is complete for post-S4 pre-execution portfolio validation, correlation-aware trade gating, and exposure-based size adjustment behavior.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -166,11 +171,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_16_p8_portfolio_exposure_balancing_correlation_guard.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P9 feedback loop is currently narrow integration in strategy-trigger scope only and is not yet wired to persistent trade-result storage across full runtime orchestration.
 - P8 portfolio exposure balancing is currently narrow integration in strategy-trigger pre-execution path only and is not yet generalized to broader runtime orchestration layers.
 - P7 position sizing is currently narrow integration in strategy-trigger execution input path only and is not yet generalized across full runtime orchestration.
 - S4 aggregation is currently narrow integration in strategy trigger only and is not yet wired into runtime execution orchestration; conflict-hold gate currently relies on explicit `CONFLICT_HOLD` marker semantics.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -133,6 +133,28 @@ class PortfolioExposureDecision:
     flags: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class StrategyPerformanceStats:
+    strategy_name: str
+    total_trades: int
+    wins: int
+    losses: int
+    average_edge: float
+    average_pnl: float
+    average_return: float
+    win_rate: float
+    consistency_score: float
+
+
+@dataclass(frozen=True)
+class AdaptiveAdjustmentState:
+    strategy_weights: dict[str, float]
+    sizing_modifier: float
+    min_edge_threshold: float
+    confidence_threshold: float
+    explanation: str
+
+
 class StrategyTrigger:
     """Strategy trigger with execution intelligence.
     
@@ -147,6 +169,174 @@ class StrategyTrigger:
         self._last_trigger_time: float | None = None
         self._cooldown_seconds = 30.0  # Anti-loop guard
         self._trace_engine = TradeTraceEngine()
+        self._strategy_results: dict[str, list[dict[str, float]]] = {}
+        self._adaptive_weights: dict[str, float] = {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+        self._adaptive_sizing_modifier: float = 1.0
+        self._adaptive_edge_threshold: float = self._config.min_edge
+        self._adaptive_confidence_threshold: float = 0.65
+        self._adaptive_min_trades: int = 5
+        self._adaptive_step_limit: float = 0.03
+        self._adaptive_weight_bounds: tuple[float, float] = (0.80, 1.20)
+        self._adaptive_sizing_bounds: tuple[float, float] = (0.85, 1.15)
+        self._adaptive_edge_bounds: tuple[float, float] = (
+            max(0.005, self._config.min_edge * 0.80),
+            self._config.min_edge * 1.20,
+        )
+        self._adaptive_confidence_bounds: tuple[float, float] = (0.55, 0.80)
+        self._last_adjustment_explanation: str = "adaptive defaults active"
+
+    @staticmethod
+    def _clamp(value: float, lower: float, upper: float) -> float:
+        return min(max(value, lower), upper)
+
+    def record_trade_result(
+        self,
+        *,
+        strategy_name: str,
+        pnl: float,
+        edge: float,
+        position_size: float,
+    ) -> None:
+        normalized_strategy = strategy_name.strip().upper()
+        if normalized_strategy not in self._adaptive_weights:
+            return
+        safe_size = max(position_size, 1e-6)
+        trade_return = pnl / safe_size
+        bucket = self._strategy_results.setdefault(normalized_strategy, [])
+        bucket.append(
+            {
+                "pnl": pnl,
+                "edge": max(edge, 0.0),
+                "return": trade_return,
+            }
+        )
+        if len(bucket) > 50:
+            del bucket[0]
+        self._refresh_adaptive_state()
+
+    def _compute_strategy_performance(self, strategy_name: str) -> StrategyPerformanceStats:
+        results = self._strategy_results.get(strategy_name, [])
+        if not results:
+            return StrategyPerformanceStats(
+                strategy_name=strategy_name,
+                total_trades=0,
+                wins=0,
+                losses=0,
+                average_edge=0.0,
+                average_pnl=0.0,
+                average_return=0.0,
+                win_rate=0.0,
+                consistency_score=0.0,
+            )
+        total = len(results)
+        wins = sum(1 for item in results if item["pnl"] > 0.0)
+        losses = total - wins
+        avg_edge = sum(item["edge"] for item in results) / total
+        avg_pnl = sum(item["pnl"] for item in results) / total
+        avg_return = sum(item["return"] for item in results) / total
+        mean_abs_return = sum(abs(item["return"]) for item in results) / total
+        consistency = avg_return / max(mean_abs_return, 1e-6)
+        return StrategyPerformanceStats(
+            strategy_name=strategy_name,
+            total_trades=total,
+            wins=wins,
+            losses=losses,
+            average_edge=round(avg_edge, 6),
+            average_pnl=round(avg_pnl, 6),
+            average_return=round(avg_return, 6),
+            win_rate=round(wins / total, 6),
+            consistency_score=round(self._clamp(consistency, -1.0, 1.0), 6),
+        )
+
+    def _refresh_adaptive_state(self) -> None:
+        metrics = {
+            name: self._compute_strategy_performance(name)
+            for name in self._adaptive_weights
+        }
+        mature_metrics = [
+            item
+            for item in metrics.values()
+            if item.total_trades >= self._adaptive_min_trades
+        ]
+        if not mature_metrics:
+            self._adaptive_weights = {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+            self._adaptive_sizing_modifier = 1.0
+            self._adaptive_edge_threshold = self._config.min_edge
+            self._adaptive_confidence_threshold = 0.65
+            self._last_adjustment_explanation = "insufficient data; fallback to defaults"
+            return
+
+        target_weights: dict[str, float] = {}
+        for strategy_name, snapshot in metrics.items():
+            if snapshot.total_trades < self._adaptive_min_trades:
+                target_weights[strategy_name] = 1.0
+                continue
+            score_signal = (
+                (snapshot.win_rate - 0.5) * 0.60
+                + snapshot.consistency_score * 0.25
+                + self._clamp(snapshot.average_return, -0.10, 0.10) * 1.50
+            )
+            raw_weight = 1.0 + score_signal
+            target_weights[strategy_name] = self._clamp(
+                raw_weight,
+                self._adaptive_weight_bounds[0],
+                self._adaptive_weight_bounds[1],
+            )
+        self._adaptive_weights = {
+            name: round(
+                current + self._clamp(target_weights[name] - current, -self._adaptive_step_limit, self._adaptive_step_limit),
+                6,
+            )
+            for name, current in self._adaptive_weights.items()
+        }
+
+        aggregate_return = sum(item.average_return for item in mature_metrics) / len(mature_metrics)
+        aggregate_consistency = sum(item.consistency_score for item in mature_metrics) / len(mature_metrics)
+        sizing_target = self._clamp(
+            1.0 + (aggregate_return * 1.2) + (aggregate_consistency * 0.08),
+            self._adaptive_sizing_bounds[0],
+            self._adaptive_sizing_bounds[1],
+        )
+        self._adaptive_sizing_modifier = round(
+            self._adaptive_sizing_modifier
+            + self._clamp(sizing_target - self._adaptive_sizing_modifier, -self._adaptive_step_limit, self._adaptive_step_limit),
+            6,
+        )
+
+        edge_target = self._clamp(
+            self._config.min_edge - (aggregate_return * 0.01),
+            self._adaptive_edge_bounds[0],
+            self._adaptive_edge_bounds[1],
+        )
+        self._adaptive_edge_threshold = round(
+            self._adaptive_edge_threshold
+            + self._clamp(edge_target - self._adaptive_edge_threshold, -0.002, 0.002),
+            6,
+        )
+
+        confidence_target = self._clamp(
+            0.65 - (aggregate_return * 0.30),
+            self._adaptive_confidence_bounds[0],
+            self._adaptive_confidence_bounds[1],
+        )
+        self._adaptive_confidence_threshold = round(
+            self._adaptive_confidence_threshold
+            + self._clamp(confidence_target - self._adaptive_confidence_threshold, -0.015, 0.015),
+            6,
+        )
+        self._last_adjustment_explanation = (
+            f"adaptive update from {len(mature_metrics)} mature strategy histories; "
+            f"aggregate_return={aggregate_return:.5f}, aggregate_consistency={aggregate_consistency:.5f}"
+        )
+
+    def get_adaptive_adjustment_state(self) -> AdaptiveAdjustmentState:
+        return AdaptiveAdjustmentState(
+            strategy_weights=dict(self._adaptive_weights),
+            sizing_modifier=round(self._adaptive_sizing_modifier, 6),
+            min_edge_threshold=round(self._adaptive_edge_threshold, 6),
+            confidence_threshold=round(self._adaptive_confidence_threshold, 6),
+            explanation=self._last_adjustment_explanation,
+        )
 
     def evaluate_breaking_news_momentum(
         self,
@@ -188,7 +378,8 @@ class StrategyTrigger:
         implied_odds = (1.0 - market_prob) / market_prob
         edge = max(0.0, (narrative_prob * implied_odds) - (1.0 - narrative_prob))
 
-        if edge <= self._config.min_edge:
+        adaptive_min_edge = self.get_adaptive_adjustment_state().min_edge_threshold
+        if edge <= adaptive_min_edge:
             return StrategyDecision(
                 decision="SKIP",
                 reason="weak signal: edge below threshold",
@@ -320,7 +511,7 @@ class StrategyTrigger:
         large_position_usd = 10_000.0
         early_entry_max_move_pct = 0.02
         repeated_wallet_min_count = 2
-        min_confidence_threshold = 0.65
+        min_confidence_threshold = self.get_adaptive_adjustment_state().confidence_threshold
 
         if signal.wallet_success_rate < min_success_rate or signal.wallet_activity_count < min_activity_count:
             return SmartMoneyCopyTradingDecision(
@@ -510,13 +701,15 @@ class StrategyTrigger:
             else 0.5
         )
         score = round((0.7 * normalized_edge) + (0.3 * normalized_confidence), 6)
+        adaptive_weight = self._adaptive_weights.get(strategy_name, 1.0)
+        weighted_score = round(score * adaptive_weight, 6)
         return StrategyCandidateScore(
             strategy_name=strategy_name,
             decision=decision,
             reason=reason,
             edge=round(max(edge, 0.0), 6),
             confidence=round(normalized_confidence, 6),
-            score=score,
+            score=weighted_score,
             market_metadata=market_metadata,
         )
 
@@ -593,6 +786,7 @@ class StrategyTrigger:
         normalized_score = min(max(base_score * conservative_multiplier, 0.0), 1.0)
         scaled_score = normalized_score ** 2
         raw_position_size = safe_capital * self._config.max_position_size_ratio * scaled_score
+        raw_position_size *= self._adaptive_sizing_modifier
         position_size = raw_position_size
 
         if position_size > max_position_size:

--- a/projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md
@@ -1,0 +1,83 @@
+# 24_17_p9_performance_feedback_loop
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - post-trade result processing in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - strategy performance tracking and metric computation in strategy-trigger adaptive layer
+  - adaptive score/sizing/threshold adjustment used by S4 ranking + sizing path
+- Not in Scope:
+  - execution engine redesign
+  - risk model redesign
+  - Telegram UI changes
+  - full machine-learning system
+  - external data integration
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md`. Tier: STANDARD
+
+## 1. What was built
+- Added an adaptive performance-feedback layer to strategy trigger with explicit post-trade ingestion method `record_trade_result(...)`.
+- Implemented per-strategy tracking state for:
+  - total trades
+  - wins/losses
+  - average edge
+  - average PnL
+  - average return
+  - win rate
+  - consistency score
+- Added bounded, step-limited adaptive controls:
+  - strategy weights (`S1/S2/S3`) used in S4 candidate scoring
+  - global sizing modifier used in position sizing
+  - minimum edge threshold adjustment
+  - confidence threshold adjustment
+- Added deterministic adaptive state output contract via `get_adaptive_adjustment_state()` including explanation string.
+- Added focused P9 tests covering required behavior and stability constraints.
+
+## 2. Current system architecture
+1. Trade outcomes are recorded via `record_trade_result(strategy_name, pnl, edge, position_size)`.
+2. Internal tracker stores rolling per-strategy history (max 50 results each).
+3. `_compute_strategy_performance(...)` derives strategy metrics (win rate, average return, consistency score, average edge/PnL).
+4. `_refresh_adaptive_state()` computes bounded targets and applies step-limited updates to avoid jumps/oscillation.
+5. Adaptive outputs are consumed in runtime path:
+   - S4 scoring: per-strategy weight multiplier applied in `_build_strategy_candidate_score(...)`
+   - sizing: `raw_position_size` scaled by adaptive sizing modifier in `_compute_position_size(...)`
+   - thresholds: adaptive edge and confidence thresholds applied in S1/S3 decision gates
+6. `get_adaptive_adjustment_state()` exposes updated strategy weights, sizing modifier, thresholds, and explanation.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py`
+- Added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Good strategy performance increases weight above baseline (`> 1.0`) and poor performance decreases weight below baseline (`< 1.0`) after minimum data maturity.
+- Sizing modifier adapts but remains bounded (`0.85..1.15`) and step-limited.
+- Edge/confidence thresholds adapt inside safe bounds with gradual movement only.
+- Fallback defaults are enforced when history is insufficient.
+- Adaptive outputs are deterministic for identical input history.
+
+### Runtime proof (required)
+1) Strategy improving weight
+- Input: six positive S1 results with positive average return and high win rate.
+- Output: `strategy_weights["S1"] > 1.0`.
+
+2) Strategy penalized
+- Input: six negative S2 results with negative average return.
+- Output: `strategy_weights["S2"] < 1.0`.
+
+3) Adjusted sizing
+- Input: mature positive performance history.
+- Output: `sizing_modifier` increases but remains within cap `0.85..1.15`, and is applied in `_compute_position_size(...)`.
+
+### Test evidence
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py` ✅ (`20 passed`, 1 known pytest warning)
+
+## 5. Known issues
+- Feedback loop currently lives in strategy-trigger scope (narrow integration) and is not yet wired to a persistent database-backed performance ledger.
+- Post-trade recording currently depends on explicit `record_trade_result(...)` calls from integration points; broader lifecycle wiring is outside this task scope.
+- Existing repository warning `Unknown config option: asyncio_mode` remains present in pytest config but does not block focused tests.
+
+## 6. What is next
+- COMMANDER review (STANDARD-tier handoff with Codex auto PR review baseline).

--- a/projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    positions: tuple[object, ...]
+    cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    implied_prob: float
+    volatility: float
+
+
+class _Engine:
+    def __init__(self) -> None:
+        self.max_total_exposure_ratio = 0.30
+        self.max_position_size_ratio = 0.10
+        self._snapshot = _Snapshot(
+            positions=tuple(),
+            cash=10_000.0,
+            equity=10_000.0,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_Engine(),
+        config=StrategyConfig(market_id="m-p9-feedback", min_edge=0.02),
+    )
+
+
+def _record_series(trigger: StrategyTrigger, strategy_name: str, entries: list[tuple[float, float, float]]) -> None:
+    for pnl, edge, size in entries:
+        trigger.record_trade_result(
+            strategy_name=strategy_name,
+            pnl=pnl,
+            edge=edge,
+            position_size=size,
+        )
+
+
+def test_good_performance_increases_weight() -> None:
+    trigger = _make_trigger()
+    _record_series(
+        trigger,
+        "S1",
+        [
+            (150.0, 0.06, 1_000.0),
+            (120.0, 0.05, 900.0),
+            (90.0, 0.045, 800.0),
+            (110.0, 0.055, 950.0),
+            (85.0, 0.05, 850.0),
+            (95.0, 0.048, 900.0),
+        ],
+    )
+
+    state = trigger.get_adaptive_adjustment_state()
+    assert state.strategy_weights["S1"] > 1.0
+
+
+def test_poor_performance_decreases_weight() -> None:
+    trigger = _make_trigger()
+    _record_series(
+        trigger,
+        "S2",
+        [
+            (-120.0, 0.03, 900.0),
+            (-90.0, 0.028, 850.0),
+            (-80.0, 0.025, 800.0),
+            (-150.0, 0.02, 1_000.0),
+            (-70.0, 0.02, 750.0),
+            (-95.0, 0.03, 900.0),
+        ],
+    )
+
+    state = trigger.get_adaptive_adjustment_state()
+    assert state.strategy_weights["S2"] < 1.0
+
+
+def test_sizing_adjusts_safely_within_cap() -> None:
+    trigger = _make_trigger()
+    _record_series(
+        trigger,
+        "S1",
+        [
+            (140.0, 0.06, 1_000.0),
+            (120.0, 0.055, 900.0),
+            (100.0, 0.05, 800.0),
+            (90.0, 0.045, 700.0),
+            (110.0, 0.05, 850.0),
+        ],
+    )
+
+    state = trigger.get_adaptive_adjustment_state()
+    assert 0.85 <= state.sizing_modifier <= 1.15
+
+
+def test_thresholds_adapt_within_bounds() -> None:
+    trigger = _make_trigger()
+    _record_series(
+        trigger,
+        "S3",
+        [
+            (-50.0, 0.02, 600.0),
+            (-55.0, 0.025, 650.0),
+            (-45.0, 0.02, 600.0),
+            (-40.0, 0.02, 550.0),
+            (-60.0, 0.03, 700.0),
+            (-52.0, 0.025, 650.0),
+        ],
+    )
+
+    state = trigger.get_adaptive_adjustment_state()
+    assert 0.016 <= state.min_edge_threshold <= 0.024
+    assert 0.55 <= state.confidence_threshold <= 0.80
+
+
+def test_no_unstable_oscillation_step_limited() -> None:
+    trigger = _make_trigger()
+    _record_series(
+        trigger,
+        "S1",
+        [(120.0, 0.06, 900.0)] * 8,
+    )
+    high_state = trigger.get_adaptive_adjustment_state()
+    _record_series(
+        trigger,
+        "S1",
+        [(-120.0, 0.02, 900.0)] * 8,
+    )
+    low_state = trigger.get_adaptive_adjustment_state()
+
+    assert abs(low_state.strategy_weights["S1"] - high_state.strategy_weights["S1"]) <= 0.30
+
+
+def test_deterministic_behavior_and_default_fallback() -> None:
+    trigger_a = _make_trigger()
+    trigger_b = _make_trigger()
+    entries = [
+        (80.0, 0.05, 800.0),
+        (70.0, 0.045, 750.0),
+        (90.0, 0.055, 900.0),
+        (-30.0, 0.03, 700.0),
+        (60.0, 0.04, 800.0),
+    ]
+    _record_series(trigger_a, "S1", entries)
+    _record_series(trigger_b, "S1", entries)
+
+    assert trigger_a.get_adaptive_adjustment_state() == trigger_b.get_adaptive_adjustment_state()
+
+    fallback_trigger = _make_trigger()
+    fallback_state = fallback_trigger.get_adaptive_adjustment_state()
+    assert fallback_state.strategy_weights == {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+    assert fallback_state.sizing_modifier == 1.0


### PR DESCRIPTION
### Motivation
- Make strategy selection and sizing adaptive by using recent post-trade performance to improve decision quality over time.
- Provide a narrow-integration feedback layer that safely adjusts strategy influence, sizing, and thresholds without changing execution or risk cores. 
- Keep updates conservative, deterministic, and bounded to avoid oscillation or safety regressions.

### Description
- Added adaptive data structures and logic in `projects/polymarket/polyquantbot/execution/strategy_trigger.py`: `StrategyPerformanceStats`, `AdaptiveAdjustmentState`, `record_trade_result(...)`, `_compute_strategy_performance(...)`, `_refresh_adaptive_state()`, and `get_adaptive_adjustment_state()` to compute win-rate, average return, consistency, and produce bounded adjustments. 
- Integrated adaptive outputs into runtime paths by applying an adaptive `min_edge` threshold in S1, adaptive `confidence` threshold in S3, per-strategy `strategy_weights` multiplier in S4 scoring, and a bounded `sizing_modifier` in position sizing. 
- Added focused unit tests `projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_17_p9_performance_feedback_loop.md`, and updated `PROJECT_STATE.md` to record the P9 handoff (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION). 

### Testing
- Run `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py` and the compilation passed. 
- Ran pytest with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py projects/polymarket/polyquantbot/tests/test_p8_portfolio_exposure_balancing_correlation_guard_20260409.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py` and the suite passed (`20 passed`, `1` known pytest config warning). 
- Tests cover: weight increase for good performance, weight decrease for poor performance, sizing modifier bounds, threshold bounds, step-limited anti-oscillation, and deterministic behavior; all asserted checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72d56a87c832ea6c20b3f3e5c1138)