### PR TITLE
feat: add S5 settlement-gap scanner (Kalshi ↔ Polymarket)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 05:45
-- Status        : FORGE-X S3.1 smart-money quality upgrade implemented (STANDARD, narrow integration) in strategy-trigger S3 layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 05:21
+- Status        : FORGE-X S5 settlement-gap scanner implemented (STANDARD, narrow integration) in strategy-trigger layer; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
 - S3.1 smart-money quality upgrade (2026-04-09): upgraded S3 wallet-quality scoring with H-Score + Wallet 360 features (consistency/discipline/frequency/diversity), added deterministic quality-score gating and skip conditions (low quality, poor consistency, erratic/bot-like activity), and updated confidence shaping with focused deterministic tests.
 - P9 performance feedback loop (2026-04-09): added per-strategy post-trade performance tracking (trades/win-loss/avg edge/avg pnl), computed win-rate + average-return + consistency metrics, introduced bounded adaptive strategy weighting/sizing/threshold adjustments with fallback defaults, and added focused deterministic stability tests.
 - P8 portfolio exposure balancing & correlation guard (2026-04-09): added post-S4 pre-execution portfolio-fit guard in strategy trigger with same-market block, theme/similarity-aware correlation handling, exposure-cap-based size reduction/skip decisions, deterministic ENTER/SKIP/REDUCE output contract, and focused runtime-proof tests.
@@ -103,6 +104,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### S5 settlement-gap scanner handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger settlement detection, cross-market equivalence matching, and resolved-outcome price-gap entry/skip decisions.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S3.1 smart-money quality upgrade handoff
 - STANDARD-tier narrow integration implementation is complete for S3 wallet quality filtering/scoring and confidence adjustment behavior.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -176,11 +181,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_18_s3_1_smart_money_quality_upgrade.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- S5 settlement-gap scanner is currently narrow integration in strategy-trigger scope only and is not yet wired into full runtime execution orchestration.
 - S3.1 wallet quality upgrade is currently narrow integration in strategy-trigger S3 path only and is not yet wired into full runtime execution orchestration.
 - P9 feedback loop is currently narrow integration in strategy-trigger scope only and is not yet wired to persistent trade-result storage across full runtime orchestration.
 - P8 portfolio exposure balancing is currently narrow integration in strategy-trigger pre-execution path only and is not yet generalized to broader runtime orchestration layers.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -30,6 +30,8 @@ class StrategyConfig:
     cross_exchange_min_actionable_spread: float = 0.005
     cross_exchange_min_mapping_confidence: float = 0.55
     cross_exchange_min_overlap_tokens: int = 2
+    settlement_gap_underpriced_threshold: float = 0.95
+    settlement_gap_min_mapping_confidence: float = 0.60
     min_position_size_usd: float = 25.0
     max_position_size_ratio: float = 0.10
     max_market_exposure_ratio: float = 0.15
@@ -75,6 +77,38 @@ class CrossExchangeArbitrageDecision:
     reason: str
     edge: float
     matched_markets_info: dict[str, object]
+
+
+@dataclass(frozen=True)
+class KalshiResolvedMarket:
+    market_id: str
+    title: str
+    resolved: bool
+    resolved_outcome: str
+    event_key: str = ""
+    timeframe: str = ""
+    resolution_criteria: str = ""
+
+
+@dataclass(frozen=True)
+class PolymarketSettlementMarket:
+    market_id: str
+    title: str
+    yes_price: float
+    liquidity_usd: float
+    orderbook_depth_usd: float
+    is_open: bool = True
+    event_key: str = ""
+    timeframe: str = ""
+    resolution_criteria: str = ""
+
+
+@dataclass(frozen=True)
+class SettlementGapDecision:
+    decision: str
+    reason: str
+    edge: float
+    source: str
 
 
 @dataclass(frozen=True)
@@ -504,6 +538,76 @@ class StrategyTrigger:
                 "raw_edge": round(raw_edge, 6),
                 "net_edge": round(net_edge, 6),
             },
+        )
+
+    def evaluate_settlement_gap_scanner(
+        self,
+        kalshi_market: KalshiResolvedMarket,
+        polymarket_markets: list[PolymarketSettlementMarket],
+    ) -> SettlementGapDecision:
+        source = "settlement_gap"
+        if not kalshi_market.resolved:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="clear resolution signal missing",
+                edge=0.0,
+                source=source,
+            )
+
+        normalized_outcome = kalshi_market.resolved_outcome.strip().upper()
+        if normalized_outcome not in {"YES", "NO"}:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="clear resolution signal missing",
+                edge=0.0,
+                source=source,
+            )
+
+        best_match, confidence = self._select_best_settlement_gap_match(
+            kalshi_market=kalshi_market,
+            polymarket_markets=polymarket_markets,
+        )
+        if best_match is None or confidence < self._config.settlement_gap_min_mapping_confidence:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="mapping uncertain",
+                edge=0.0,
+                source=source,
+            )
+
+        if not best_match.is_open:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="market closed / illiquid",
+                edge=0.0,
+                source=source,
+            )
+
+        available_depth = min(best_match.liquidity_usd, best_match.orderbook_depth_usd)
+        if available_depth < self._config.min_liquidity_usd:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="liquidity insufficient",
+                edge=0.0,
+                source=source,
+            )
+
+        yes_price = self._normalize_probability(best_match.yes_price)
+        resolved_outcome_price = yes_price if normalized_outcome == "YES" else (1.0 - yes_price)
+        edge = max(0.0, 1.0 - resolved_outcome_price)
+        if resolved_outcome_price >= self._config.settlement_gap_underpriced_threshold:
+            return SettlementGapDecision(
+                decision="SKIP",
+                reason="already converged",
+                edge=round(edge, 6),
+                source=source,
+            )
+
+        return SettlementGapDecision(
+            decision="ENTER",
+            reason="settlement gap opportunity detected",
+            edge=round(edge, 6),
+            source=source,
         )
 
     def _compute_wallet_quality_score(self, signal: WalletTradeSignal) -> float:
@@ -1106,6 +1210,36 @@ class StrategyTrigger:
                 best_score = score
                 best_market = candidate
 
+        return best_market, best_score
+
+    def _select_best_settlement_gap_match(
+        self,
+        kalshi_market: KalshiResolvedMarket,
+        polymarket_markets: list[PolymarketSettlementMarket],
+    ) -> tuple[PolymarketSettlementMarket | None, float]:
+        best_market: PolymarketSettlementMarket | None = None
+        best_score = 0.0
+        kalshi_tokens = set(self._tokenize(kalshi_market.title))
+
+        for candidate in polymarket_markets:
+            candidate_tokens = set(self._tokenize(candidate.title))
+            overlap = len(kalshi_tokens & candidate_tokens)
+            overlap_score = min(
+                1.0,
+                overlap / max(float(self._config.cross_exchange_min_overlap_tokens), 1.0),
+            )
+            event_match = 1.0 if kalshi_market.event_key and kalshi_market.event_key == candidate.event_key else 0.0
+            timeframe_match = 1.0 if kalshi_market.timeframe and kalshi_market.timeframe == candidate.timeframe else 0.0
+            resolution_match = (
+                1.0
+                if kalshi_market.resolution_criteria
+                and kalshi_market.resolution_criteria == candidate.resolution_criteria
+                else 0.0
+            )
+            score = (0.4 * event_match) + (0.2 * timeframe_match) + (0.2 * resolution_match) + (0.2 * overlap_score)
+            if score > best_score:
+                best_score = score
+                best_market = candidate
         return best_market, best_score
 
     @staticmethod

--- a/projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md
@@ -1,0 +1,99 @@
+# 24_19_s5_settlement_gap_scanner
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - strategy_trigger settlement-gap scanner layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - cross-market comparison and equivalence matching logic
+  - settlement detection and resolved-outcome price-gap logic
+- Not in Scope:
+  - execution engine changes
+  - risk model changes
+  - Telegram UI changes
+  - observability redesign
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md`. Tier: STANDARD
+
+## 1. What was built
+- Added S5 settlement-gap scanner strategy logic in `StrategyTrigger` with explicit `ENTER` / `SKIP` decisions.
+- Added Kalshi resolved-market input model and Polymarket settlement-market input model.
+- Implemented settlement scanner output contract with required fields:
+  - `decision`
+  - `edge`
+  - `reason`
+  - `source` (`"settlement_gap"`)
+- Implemented resolution detection and strict skip behavior for unresolved/unclear outcomes.
+- Implemented cross-market equivalence selection for Kalshi↔Polymarket matching (event/timeframe/resolution/token overlap).
+- Added resolved-outcome price evaluation with underpricing threshold gate (`< 0.95` enter zone).
+- Added liquidity and tradability checks:
+  - market open requirement
+  - minimum executable depth requirement
+
+## 2. Current system architecture
+- S5 is integrated as a narrow strategy-trigger method:
+  `StrategyTrigger.evaluate_settlement_gap_scanner(kalshi_market, polymarket_markets)`.
+- Decision flow:
+  1. Validate Kalshi resolution signal and normalized final outcome (`YES`/`NO`).
+  2. Find best equivalent Polymarket market and require minimum mapping confidence.
+  3. Validate tradability (`is_open` + depth/liquidity gate).
+  4. Compute resolved-outcome price from Polymarket YES price mapping:
+     - resolved `YES` → `resolved_outcome_price = yes_price`
+     - resolved `NO` → `resolved_outcome_price = 1 - yes_price`
+  5. Return `ENTER` if `resolved_outcome_price < 0.95`; otherwise `SKIP`.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Required tests implemented and passing:
+  1. resolved market + price gap → ENTER
+  2. resolved market + no gap → SKIP
+  3. mapping failure → SKIP
+  4. low liquidity → SKIP
+  5. deterministic behavior
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py` ✅ (5 passed)
+
+Runtime proof:
+1) Example resolved → underpriced → ENTER
+```text
+input:
+- kalshi resolved outcome: YES
+- polymarket yes_price: 0.87
+- liquidity/depth: sufficient
+output:
+- decision: ENTER
+- edge: 0.13
+- reason: settlement gap opportunity detected
+- source: settlement_gap
+```
+
+2) Example resolved → already priced → SKIP
+```text
+input:
+- kalshi resolved outcome: YES
+- polymarket yes_price: 0.98
+- liquidity/depth: sufficient
+output:
+- decision: SKIP
+- edge: 0.02
+- reason: already converged
+- source: settlement_gap
+```
+
+## 5. Known issues
+- S5 remains narrow integration in strategy-trigger scope and is not yet wired into broader runtime orchestration/execution selection.
+- Mapping confidence currently uses deterministic metadata/token scoring and does not include external semantic matching services.
+- Existing pytest warning remains unchanged: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    KalshiResolvedMarket,
+    PolymarketSettlementMarket,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used in this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    config = StrategyConfig(
+        market_id="m-settlement-gap-1",
+        min_liquidity_usd=10_000.0,
+        settlement_gap_underpriced_threshold=0.95,
+        settlement_gap_min_mapping_confidence=0.60,
+        cross_exchange_min_overlap_tokens=2,
+    )
+    return StrategyTrigger(engine=_NoopEngine(), config=config)
+
+
+def _resolved_kalshi_market(*, outcome: str = "YES") -> KalshiResolvedMarket:
+    return KalshiResolvedMarket(
+        market_id="KXELECT2026NY",
+        title="Will candidate A win New York governor election 2026",
+        resolved=True,
+        resolved_outcome=outcome,
+        event_key="ny-governor-2026-candidate-a",
+        timeframe="2026",
+        resolution_criteria="winner-candidate-a",
+    )
+
+
+def _polymarket_market(
+    *,
+    yes_price: float,
+    liquidity_usd: float = 20_000.0,
+    orderbook_depth_usd: float = 18_000.0,
+    is_open: bool = True,
+) -> PolymarketSettlementMarket:
+    return PolymarketSettlementMarket(
+        market_id="poly-ny-gov-2026-a",
+        title="Will candidate A win NY governor race in 2026",
+        yes_price=yes_price,
+        liquidity_usd=liquidity_usd,
+        orderbook_depth_usd=orderbook_depth_usd,
+        is_open=is_open,
+        event_key="ny-governor-2026-candidate-a",
+        timeframe="2026",
+        resolution_criteria="winner-candidate-a",
+    )
+
+
+def test_resolved_market_with_price_gap_enters() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=_resolved_kalshi_market(outcome="YES"),
+        polymarket_markets=[_polymarket_market(yes_price=0.87)],
+    )
+
+    assert decision.decision == "ENTER"
+    assert decision.edge == 0.13
+    assert decision.source == "settlement_gap"
+
+
+def test_resolved_market_without_gap_skips() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=_resolved_kalshi_market(outcome="YES"),
+        polymarket_markets=[_polymarket_market(yes_price=0.98)],
+    )
+
+    assert decision.decision == "SKIP"
+    assert decision.reason == "already converged"
+    assert decision.source == "settlement_gap"
+
+
+def test_mapping_failure_skips() -> None:
+    trigger = _make_trigger()
+    uncertain_map = PolymarketSettlementMarket(
+        market_id="poly-unrelated-market",
+        title="Will it snow in Miami in August 2026",
+        yes_price=0.60,
+        liquidity_usd=25_000.0,
+        orderbook_depth_usd=25_000.0,
+        is_open=True,
+        event_key="",
+        timeframe="",
+        resolution_criteria="",
+    )
+
+    decision = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=_resolved_kalshi_market(outcome="YES"),
+        polymarket_markets=[uncertain_map],
+    )
+
+    assert decision.decision == "SKIP"
+    assert decision.reason == "mapping uncertain"
+    assert decision.source == "settlement_gap"
+
+
+def test_low_liquidity_skips() -> None:
+    trigger = _make_trigger()
+
+    decision = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=_resolved_kalshi_market(outcome="YES"),
+        polymarket_markets=[_polymarket_market(yes_price=0.84, liquidity_usd=9_000.0, orderbook_depth_usd=8_500.0)],
+    )
+
+    assert decision.decision == "SKIP"
+    assert decision.reason == "liquidity insufficient"
+    assert decision.source == "settlement_gap"
+
+
+def test_decision_is_deterministic() -> None:
+    trigger = _make_trigger()
+    kalshi = _resolved_kalshi_market(outcome="NO")
+    poly = _polymarket_market(yes_price=0.03)
+
+    first = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=kalshi,
+        polymarket_markets=[poly],
+    )
+    second = trigger.evaluate_settlement_gap_scanner(
+        kalshi_market=kalshi,
+        polymarket_markets=[poly],
+    )
+
+    assert first == second
+    assert first.decision == "SKIP"
+    assert first.reason == "already converged"


### PR DESCRIPTION
### Motivation
- Capture high-confidence settlement-gap opportunities where a Kalshi market has resolved but the equivalent Polymarket market remains underpriced, enabling near-risk-free edge capture. 
- Provide a deterministic, narrow-integration scanner inside the `strategy_trigger` layer that signals ENTER/SKIP decisions for downstream sizing/execution paths without changing execution/risk subsystems. 

### Description
- Added settlement scanner logic to `StrategyTrigger` with new dataclasses `KalshiResolvedMarket`, `PolymarketSettlementMarket`, and `SettlementGapDecision`, plus config controls `settlement_gap_underpriced_threshold` and `settlement_gap_min_mapping_confidence` in `StrategyConfig`.
- Implemented `evaluate_settlement_gap_scanner(...)` which enforces: resolution detection (`resolved` + `YES`/`NO`), equivalence matching (`_select_best_settlement_gap_match` using event/timeframe/resolution/token overlap), tradability/liquidity checks, resolved-outcome price computation, and `ENTER` when `resolved_outcome_price < 0.95` otherwise `SKIP`.
- Added focused unit tests `projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py` covering required cases (enter on gap, skip on no gap, mapping failure, low liquidity, deterministic behavior), and created the FORGE report `projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md`.
- Updated `PROJECT_STATE.md` with timestamped STANDARD-tier completion and handoff notes; changes are limited to strategy-trigger scope (Claim Level: NARROW INTEGRATION).

### Testing
- Ran static compile check: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py` — PASS.
- Ran unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s5_settlement_gap_scanner_20260409.py` — PASS (5 passed, with existing `asyncio_mode` pytest config warning only).
- Verified repository rules: no `phase*` folders detected and no hardcoded secrets introduced — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7368b37e4832eb2d731328ff90dab)