### PR TITLE
P10: pre-execution execution-quality gate (spread/depth/slippage)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 05:21
-- Status        : FORGE-X S5 settlement-gap scanner implemented (STANDARD, narrow integration) in strategy-trigger layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 06:02
+- Status        : FORGE-X P10 execution quality & fill optimization implemented (STANDARD, narrow integration) in pre-execution strategy-trigger layer; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P10 execution quality & fill optimization (2026-04-09): added pre-execution execution-quality gate in strategy trigger with deterministic ENTER/SKIP/REDUCE contract (`final_decision`/`adjusted_size`/`expected_fill_price`/`expected_slippage`/`execution_quality_reason`), spread/depth/slippage checks, conservative fill-price discipline, and focused runtime-proof tests.
 - S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
 - S3.1 smart-money quality upgrade (2026-04-09): upgraded S3 wallet-quality scoring with H-Score + Wallet 360 features (consistency/discipline/frequency/diversity), added deterministic quality-score gating and skip conditions (low quality, poor consistency, erratic/bot-like activity), and updated confidence shaping with focused deterministic tests.
 - P9 performance feedback loop (2026-04-09): added per-strategy post-trade performance tracking (trades/win-loss/avg edge/avg pnl), computed win-rate + average-return + consistency metrics, introduced bounded adaptive strategy weighting/sizing/threshold adjustments with fallback defaults, and added focused deterministic stability tests.
@@ -104,6 +105,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P10 execution quality & fill optimization handoff
+- STANDARD-tier narrow integration implementation is complete for pre-execution spread/depth/slippage quality gating and conservative expected-fill bridge in strategy-trigger entry path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### S5 settlement-gap scanner handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger settlement detection, cross-market equivalence matching, and resolved-outcome price-gap entry/skip decisions.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -181,11 +186,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_19_s5_settlement_gap_scanner.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P10 execution quality gate is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into full runtime execution orchestration layers.
 - S5 settlement-gap scanner is currently narrow integration in strategy-trigger scope only and is not yet wired into full runtime execution orchestration.
 - S3.1 wallet quality upgrade is currently narrow integration in strategy-trigger S3 path only and is not yet wired into full runtime execution orchestration.
 - P9 feedback loop is currently narrow integration in strategy-trigger scope only and is not yet wired to persistent trade-result storage across full runtime orchestration.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -38,6 +38,13 @@ class StrategyConfig:
     max_theme_exposure_ratio: float = 0.20
     correlation_size_reduction_factor: float = 0.50
     high_similarity_overlap_ratio: float = 0.60
+    max_execution_spread: float = 0.04
+    borderline_execution_spread: float = 0.025
+    min_execution_depth_usd: float = 10_000.0
+    borderline_execution_depth_usd: float = 20_000.0
+    max_slippage_edge_consumption_ratio: float = 0.60
+    borderline_slippage_edge_consumption_ratio: float = 0.35
+    execution_reduction_factor: float = 0.50
 
 
 @dataclass(frozen=True)
@@ -170,6 +177,15 @@ class PortfolioExposureDecision:
     adjusted_size: float
     reason: str
     flags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExecutionQualityDecision:
+    final_decision: str
+    adjusted_size: float
+    expected_fill_price: float
+    expected_slippage: float
+    execution_quality_reason: str
 
 
 @dataclass(frozen=True)
@@ -1181,6 +1197,127 @@ class StrategyTrigger:
                 return True
         return False
 
+    def evaluate_execution_quality(
+        self,
+        *,
+        market_price: float,
+        proposed_size: float,
+        signal_edge: float,
+        market_context: dict[str, float] | None = None,
+    ) -> ExecutionQualityDecision:
+        context = market_context or {}
+        size = max(0.0, proposed_size)
+        if size <= 0.0:
+            return ExecutionQualityDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                expected_fill_price=round(max(market_price, 0.0), 6),
+                expected_slippage=0.0,
+                execution_quality_reason="insufficient_depth",
+            )
+
+        spread_val = float(context.get("spread", 0.0))
+        if spread_val < 0.0:
+            spread_val = 0.0
+        bid = float(context.get("best_bid", max(0.0, market_price - (spread_val / 2.0))))
+        ask = float(context.get("best_ask", min(1.0, market_price + (spread_val / 2.0))))
+        observed_spread = max(0.0, ask - bid, spread_val)
+
+        if observed_spread >= self._config.max_execution_spread:
+            expected_fill_price = round(max(market_price, ask), 6)
+            expected_slippage = round(max(expected_fill_price - market_price, 0.0), 6)
+            return ExecutionQualityDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                expected_fill_price=expected_fill_price,
+                expected_slippage=expected_slippage,
+                execution_quality_reason="spread_too_wide",
+            )
+
+        reduced = False
+        if observed_spread >= self._config.borderline_execution_spread:
+            size *= self._config.execution_reduction_factor
+            reduced = True
+
+        depth_key_present = any(
+            key in context for key in ("orderbook_depth_usd", "depth_usd", "liquidity_usd")
+        )
+        depth_usd = float(
+            context.get(
+                "orderbook_depth_usd",
+                context.get("depth_usd", context.get("liquidity_usd", 0.0)),
+            )
+        )
+        if depth_usd < 0.0:
+            depth_usd = 0.0
+
+        if depth_key_present:
+            if depth_usd < self._config.min_execution_depth_usd:
+                return ExecutionQualityDecision(
+                    final_decision="SKIP",
+                    adjusted_size=0.0,
+                    expected_fill_price=round(max(market_price, ask), 6),
+                    expected_slippage=round(max(ask - market_price, 0.0), 6),
+                    execution_quality_reason="insufficient_depth",
+                )
+            if depth_usd < self._config.borderline_execution_depth_usd:
+                size *= self._config.execution_reduction_factor
+                reduced = True
+            if size > depth_usd * self._config.max_position_size_ratio:
+                size = depth_usd * self._config.max_position_size_ratio
+                reduced = True
+
+        if 0.0 < size < self._config.min_position_size_usd:
+            return ExecutionQualityDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                expected_fill_price=round(max(market_price, ask), 6),
+                expected_slippage=round(max(ask - market_price, 0.0), 6),
+                execution_quality_reason="insufficient_depth",
+            )
+
+        depth_denominator = max(depth_usd, 1.0) if depth_key_present else max(size, 1.0)
+        market_impact = (size / depth_denominator) * 0.01
+        half_spread = observed_spread / 2.0
+        expected_slippage = max(0.0, half_spread + market_impact)
+        expected_fill_price = min(1.0, max(market_price, ask) + expected_slippage)
+        safe_signal_edge = max(signal_edge, 0.0)
+
+        if (
+            safe_signal_edge <= 0.0
+            or expected_slippage >= safe_signal_edge
+            or expected_slippage >= (safe_signal_edge * self._config.max_slippage_edge_consumption_ratio)
+        ):
+            return ExecutionQualityDecision(
+                final_decision="SKIP",
+                adjusted_size=0.0,
+                expected_fill_price=round(expected_fill_price, 6),
+                expected_slippage=round(expected_slippage, 6),
+                execution_quality_reason="slippage_too_high",
+            )
+
+        if (
+            not reduced
+            and expected_slippage
+            >= (safe_signal_edge * self._config.borderline_slippage_edge_consumption_ratio)
+        ):
+            size *= self._config.execution_reduction_factor
+            reduced = True
+            depth_denominator = max(depth_usd, 1.0) if depth_key_present else max(size, 1.0)
+            market_impact = (size / depth_denominator) * 0.01
+            expected_slippage = max(0.0, half_spread + market_impact)
+            expected_fill_price = min(1.0, max(market_price, ask) + expected_slippage)
+
+        decision = "REDUCE" if reduced and size < proposed_size else "ENTER"
+        reason = "size_reduced_for_liquidity" if decision == "REDUCE" else "fill_quality_ok"
+        return ExecutionQualityDecision(
+            final_decision=decision,
+            adjusted_size=round(max(size, 0.0), 2),
+            expected_fill_price=round(expected_fill_price, 6),
+            expected_slippage=round(expected_slippage, 6),
+            execution_quality_reason=reason,
+        )
+
     def _select_best_cross_exchange_match(
         self,
         polymarket: CrossExchangeMarket,
@@ -1262,6 +1399,7 @@ class StrategyTrigger:
         self,
         market_price: float,
         aggregation_decision: StrategyAggregationDecision | None = None,
+        market_context: dict[str, float] | None = None,
     ) -> str:
         now = time.time()
         if self._last_trigger_time and (now - self._last_trigger_time) < self._cooldown_seconds:
@@ -1323,11 +1461,28 @@ class StrategyTrigger:
             )
             if portfolio_guard.final_decision == "SKIP":
                 return "BLOCKED"
-            size = portfolio_guard.adjusted_size
+            signal_edge = max(self._config.min_edge, 0.0)
+            if selected_candidate is not None:
+                signal_edge = max(selected_candidate.edge, 0.0)
+            execution_quality = self.evaluate_execution_quality(
+                market_price=market_price,
+                proposed_size=portfolio_guard.adjusted_size,
+                signal_edge=signal_edge,
+                market_context=market_context,
+            )
+            if execution_quality.final_decision == "SKIP":
+                log.info(
+                    "execution_quality_blocked",
+                    reason=execution_quality.execution_quality_reason,
+                    expected_fill_price=execution_quality.expected_fill_price,
+                    expected_slippage=execution_quality.expected_slippage,
+                )
+                return "BLOCKED"
+            size = execution_quality.adjusted_size
             created = await self._engine.open_position(
                 market=target_market_id,
                 side=self._config.side,
-                price=market_price,
+                price=execution_quality.expected_fill_price,
                 size=size,
                 position_id=str(uuid.uuid4()),
             )

--- a/projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md
@@ -1,0 +1,116 @@
+# 24_20_p10_execution_quality_fill_optimization
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - pre-execution validation layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - execution input / fill estimation bridge in `StrategyTrigger.evaluate(...)` before paper `open_position(...)`
+  - order-quality decision logic (`ENTER` / `SKIP` / `REDUCE`) for paper execution entry path
+- Not in Scope:
+  - execution engine redesign
+  - risk model redesign
+  - async / concurrency redesign
+  - Telegram UI changes
+  - strategy logic redesign
+  - external routing / broker integration redesign
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md`. Tier: STANDARD
+
+## 1. What was built
+- Added an execution-quality decision contract (`ExecutionQualityDecision`) with required output fields:
+  - `final_decision`
+  - `adjusted_size`
+  - `expected_fill_price`
+  - `expected_slippage`
+  - `execution_quality_reason`
+- Added pre-execution quality controls in `StrategyTrigger.evaluate_execution_quality(...)`:
+  - spread quality gate (`spread_too_wide`)
+  - depth gate (`insufficient_depth`)
+  - slippage-vs-edge gate (`slippage_too_high`)
+  - deterministic size reduction path (`size_reduced_for_liquidity`)
+  - allow path (`fill_quality_ok`)
+- Wired execution-quality output into `StrategyTrigger.evaluate(...)` right before paper `open_position(...)` so execution uses conservative expected fill price instead of optimistic direct market price.
+
+## 2. Current system architecture
+- Preserved flow ordering: `S4 -> P7 sizing -> P8 portfolio guard -> P10 execution-quality gate -> paper execution`.
+- P10 runs as a narrow pre-execution layer only in strategy-trigger scope.
+- Decision policy:
+  1. Validate spread quality and hard-block if too wide.
+  2. Evaluate depth when present and block/reduce deterministically.
+  3. Estimate conservative expected fill + expected slippage from spread + size/depth impact.
+  4. Compare slippage against signal edge and block if edge is too degraded.
+  5. Return deterministic `ENTER` / `REDUCE` / `SKIP` with explicit reason code.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Fill-quality rules used:
+- Spread quality:
+  - hard block when spread exceeds configured max
+  - reduction for borderline spread
+- Liquidity/depth:
+  - hard block when depth is below minimum (when depth is present)
+  - reduction for borderline depth
+  - deterministic depth-aware size cap
+- Slippage-aware edge protection:
+  - hard block when expected slippage consumes too much strategy edge
+  - reduction on borderline slippage pressure
+- Price discipline:
+  - expected fill is conservative (`>= ask` in tested buy scenarios)
+  - no optimistic silent fill improvement
+
+Required behavior tests implemented and passing:
+1. tight spread + sufficient depth -> ENTER
+2. wide spread -> SKIP
+3. thin liquidity -> REDUCE
+4. high slippage destroys edge -> SKIP
+5. borderline quality -> REDUCE
+6. deterministic output for same input -> PASS
+7. no unrealistic paper fill assumption -> PASS
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` ✅ (9 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof examples:
+1) Normal quality -> ENTER
+```text
+input: market_price=0.50, bid/ask=0.495/0.505, depth=75,000, size=300, edge=0.08
+output: final_decision=ENTER, execution_quality_reason=fill_quality_ok
+```
+
+2) Wide spread -> SKIP
+```text
+input: market_price=0.50, bid/ask=0.46/0.54, depth=75,000, size=300, edge=0.08
+output: final_decision=SKIP, execution_quality_reason=spread_too_wide
+```
+
+3) Thin book -> REDUCE
+```text
+input: market_price=0.40, bid/ask=0.395/0.405, depth=15,000, size=500, edge=0.09
+output: final_decision=REDUCE, adjusted_size<500, execution_quality_reason=size_reduced_for_liquidity
+```
+
+4) Fill + slippage calculation example
+```text
+input: market_price=0.50, bid/ask=0.495/0.505, size=300, depth=75,000
+half_spread = (0.505 - 0.495)/2 = 0.005
+impact      = (300/75,000)*0.01 = 0.00004
+expected_slippage = 0.00504
+expected_fill_price = 0.505 + 0.00504 = 0.51004
+```
+
+## 5. Known issues
+- P10 is narrow integration in strategy-trigger scope only; broader runtime orchestration integration remains out of scope.
+- Existing test environment warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
+
+
+class _Engine:
+    max_total_exposure_ratio = 0.30
+    max_position_size_ratio = 0.10
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_Engine(),
+        config=StrategyConfig(
+            market_id="p10-market",
+            min_edge=0.02,
+            min_position_size_usd=25.0,
+            max_execution_spread=0.04,
+            borderline_execution_spread=0.025,
+            min_execution_depth_usd=10_000.0,
+            borderline_execution_depth_usd=20_000.0,
+            max_slippage_edge_consumption_ratio=0.60,
+            borderline_slippage_edge_consumption_ratio=0.35,
+            execution_reduction_factor=0.50,
+        ),
+    )
+
+
+def test_tight_spread_and_sufficient_depth_allows_execution() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.495, "best_ask": 0.505, "orderbook_depth_usd": 75_000.0},
+    )
+
+    assert result.final_decision == "ENTER"
+    assert result.adjusted_size == 300.0
+    assert result.execution_quality_reason == "fill_quality_ok"
+
+
+def test_wide_spread_skips_execution() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.46, "best_ask": 0.54, "orderbook_depth_usd": 90_000.0},
+    )
+
+    assert result.final_decision == "SKIP"
+    assert result.execution_quality_reason == "spread_too_wide"
+
+
+def test_thin_liquidity_reduces_size() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.40,
+        proposed_size=500.0,
+        signal_edge=0.09,
+        market_context={"best_bid": 0.395, "best_ask": 0.405, "orderbook_depth_usd": 15_000.0},
+    )
+
+    assert result.final_decision == "REDUCE"
+    assert 0.0 < result.adjusted_size < 500.0
+    assert result.execution_quality_reason == "size_reduced_for_liquidity"
+
+
+def test_insufficient_depth_skips_execution() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.40,
+        proposed_size=350.0,
+        signal_edge=0.07,
+        market_context={"best_bid": 0.395, "best_ask": 0.405, "orderbook_depth_usd": 5_000.0},
+    )
+
+    assert result.final_decision == "SKIP"
+    assert result.execution_quality_reason == "insufficient_depth"
+
+
+def test_high_slippage_consuming_edge_skips_execution() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.60,
+        proposed_size=1_000.0,
+        signal_edge=0.02,
+        market_context={"best_bid": 0.588, "best_ask": 0.612, "orderbook_depth_usd": 12_000.0},
+    )
+
+    assert result.final_decision == "SKIP"
+    assert result.execution_quality_reason == "slippage_too_high"
+
+
+def test_borderline_quality_reduces_size() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.55,
+        proposed_size=400.0,
+        signal_edge=0.03,
+        market_context={"best_bid": 0.538, "best_ask": 0.562, "orderbook_depth_usd": 30_000.0},
+    )
+
+    assert result.final_decision == "REDUCE"
+    assert result.execution_quality_reason == "size_reduced_for_liquidity"
+
+
+def test_execution_quality_is_deterministic_for_same_input() -> None:
+    trigger = _make_trigger()
+    market_context = {"best_bid": 0.495, "best_ask": 0.505, "orderbook_depth_usd": 60_000.0}
+
+    first = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context=market_context,
+    )
+    second = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context=market_context,
+    )
+
+    assert first == second
+
+
+def test_no_unrealistic_paper_fill_assumption() -> None:
+    trigger = _make_trigger()
+    result = trigger.evaluate_execution_quality(
+        market_price=0.44,
+        proposed_size=250.0,
+        signal_edge=0.07,
+        market_context={"best_bid": 0.438, "best_ask": 0.442, "orderbook_depth_usd": 80_000.0},
+    )
+
+    assert result.expected_fill_price >= 0.442
+    assert result.expected_fill_price >= 0.44
+    assert result.expected_slippage >= 0.0
+
+
+def test_runtime_proof_enter_skip_reduce_and_slippage_math() -> None:
+    trigger = _make_trigger()
+
+    enter = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.495, "best_ask": 0.505, "orderbook_depth_usd": 75_000.0},
+    )
+    skip = trigger.evaluate_execution_quality(
+        market_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.46, "best_ask": 0.54, "orderbook_depth_usd": 75_000.0},
+    )
+    reduce = trigger.evaluate_execution_quality(
+        market_price=0.40,
+        proposed_size=500.0,
+        signal_edge=0.09,
+        market_context={"best_bid": 0.395, "best_ask": 0.405, "orderbook_depth_usd": 15_000.0},
+    )
+
+    assert enter.final_decision == "ENTER"
+    assert skip.final_decision == "SKIP"
+    assert reduce.final_decision == "REDUCE"
+    assert enter.expected_fill_price >= 0.505
+    assert enter.expected_slippage == round(enter.expected_fill_price - 0.505, 6)


### PR DESCRIPTION
### Motivation
- Reduce poor paper fills and avoid spread/slippage traps by making entry decisions execution-aware before calling the paper `open_position` path. 
- Provide deterministic, explainable outcomes (`ENTER` / `REDUCE` / `SKIP`) with explicit reason codes so downstream systems and operators understand why a trade was blocked or resized.

### Description
- Added an `ExecutionQualityDecision` contract and configurable execution thresholds to `StrategyConfig` (`max_execution_spread`, `borderline_execution_spread`, `min_execution_depth_usd`, `borderline_execution_depth_usd`, `max_slippage_edge_consumption_ratio`, `borderline_slippage_edge_consumption_ratio`, `execution_reduction_factor`).
- Implemented `StrategyTrigger.evaluate_execution_quality(...)` to evaluate spread, orderbook depth, expected slippage (spread + market-impact heuristic), and compare expected slippage vs signal edge to return `ENTER` / `REDUCE` / `SKIP` with `adjusted_size`, `expected_fill_price`, `expected_slippage`, and `execution_quality_reason` (e.g. `spread_too_wide`, `insufficient_depth`, `slippage_too_high`, `size_reduced_for_liquidity`, `fill_quality_ok`).
- Wired the execution-quality gate into the pre-execution path inside `StrategyTrigger.evaluate(...)` so portfolio sizing (`P7`) and exposure guard (`P8`) run first, then `P10` (this change) determines final `size` and conservative `expected_fill_price` used for `open_position` when allowed.
- Added focused tests and a FORGE report: modified `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, created `projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py`, and added report `projects/polymarket/polyquantbot/reports/forge/24_20_p10_execution_quality_fill_optimization.md`; updated `PROJECT_STATE.md` with timestamp and handoff notes (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION).

### Testing
- Type-check / compile: ran `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` and it passed.
- Unit tests: ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` and all tests passed (`9 passed`, one environment pytest config warning reported).
- Repo structure checks: verified no `phase*` folders present and required report + `PROJECT_STATE.md` updates included in the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d739a5e758832eb66ed470a08c4818)