### PR TITLE
P12 execution timing & entry optimization (STANDARD, narrow integration)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 06:28
-- Status        : FORGE-X P11 market regime detection implemented (STANDARD, narrow integration) in strategy-trigger S4 scoring context layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 07:05
+- Status        : FORGE-X P12 execution timing & entry optimization implemented (STANDARD, narrow integration) in strategy-trigger pre-execution path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P12 execution timing & entry optimization (2026-04-09): added pre-execution timing-aware gate with deterministic `ENTER_NOW`/`WAIT`/`SKIP` output contract, anti-chase spike delay/timeout skip handling, micro-pullback wait/re-evaluate/enter flow, bounded reevaluation windows, and timing-first coordination with existing P10 execution-quality gate plus focused deterministic tests.
 - P11 market regime detection (2026-04-09): added deterministic regime classification (`NEWS_DRIVEN`/`ARBITRAGE_DOMINANT`/`SMART_MONEY_DOMINANT`/`LOW_ACTIVITY_CHAOTIC`) from social/dispersion/wallet/activity signals, integrated bounded regime-based S4 strategy weighting modifiers with neutral fallback behavior, and added focused deterministic regime/aggregation contract tests.
 - P10 execution quality & fill optimization (2026-04-09): added pre-execution execution-quality gate in strategy trigger with deterministic ENTER/SKIP/REDUCE contract (`final_decision`/`adjusted_size`/`expected_fill_price`/`expected_slippage`/`execution_quality_reason`), spread/depth/slippage checks, conservative fill-price discipline, and focused runtime-proof tests.
 - S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
@@ -106,6 +107,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P12 execution timing & entry optimization handoff
+- STANDARD-tier narrow integration implementation is complete for timing-aware pre-execution decisioning (`ENTER_NOW`/`WAIT`/`SKIP`) and bounded reevaluation behavior coordinated with P10 quality gating.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P11 market regime detection handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger regime classification and S4 score-weight adjustment context output.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -191,11 +196,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_21_p11_market_regime_detection.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P12 entry timing layer is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime execution orchestration layers.
 - P11 market regime detection is currently narrow integration in strategy-trigger S4 scoring path only and is not yet wired into broader runtime execution orchestration.
 - P10 execution quality gate is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into full runtime execution orchestration layers.
 - S5 settlement-gap scanner is currently narrow integration in strategy-trigger scope only and is not yet wired into full runtime execution orchestration.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -45,6 +45,11 @@ class StrategyConfig:
     max_slippage_edge_consumption_ratio: float = 0.60
     borderline_slippage_edge_consumption_ratio: float = 0.35
     execution_reduction_factor: float = 0.50
+    anti_chase_extension_ratio: float = 0.025
+    anti_chase_spread_ratio: float = 0.030
+    micro_pullback_improvement_ratio: float = 0.008
+    timing_reevaluation_window_seconds: int = 15
+    timing_max_wait_cycles: int = 2
 
 
 @dataclass(frozen=True)
@@ -189,6 +194,29 @@ class ExecutionQualityDecision:
     expected_fill_price: float
     expected_slippage: float
     execution_quality_reason: str
+
+
+@dataclass(frozen=True)
+class EntryTimingDecision:
+    timing_decision: str
+    timing_reason: str
+    reference_price: float
+    reevaluation_window: int
+    final_execution_readiness: bool
+
+
+@dataclass(frozen=True)
+class EntryExecutionReadiness:
+    timing_decision: str
+    timing_reason: str
+    reference_price: float
+    reevaluation_window: int
+    final_execution_readiness: bool
+    execution_quality_decision: str
+    execution_quality_reason: str
+    adjusted_size: float
+    expected_fill_price: float
+    expected_slippage: float
 
 
 @dataclass(frozen=True)
@@ -1420,6 +1448,153 @@ class StrategyTrigger:
             execution_quality_reason=reason,
         )
 
+    def evaluate_entry_timing(
+        self,
+        *,
+        market_price: float,
+        signal_reference_price: float,
+        signal_edge: float,
+        market_context: dict[str, float] | None = None,
+        wait_cycles: int = 0,
+    ) -> EntryTimingDecision:
+        context = market_context or {}
+        normalized_wait_cycles = max(wait_cycles, 0)
+        reference_price = signal_reference_price if signal_reference_price > 0.0 else market_price
+        reference_price = max(reference_price, 0.0)
+        reevaluation_window = max(self._config.timing_reevaluation_window_seconds, 1)
+
+        bid = float(context.get("best_bid", market_price))
+        ask = float(context.get("best_ask", market_price))
+        spread = max(0.0, ask - bid)
+
+        if reference_price <= 0.0:
+            return EntryTimingDecision(
+                timing_decision="SKIP",
+                timing_reason="invalid_reference_price",
+                reference_price=0.0,
+                reevaluation_window=reevaluation_window,
+                final_execution_readiness=False,
+            )
+
+        extension_ratio = max((market_price - reference_price) / reference_price, 0.0)
+        spread_ratio = spread / max(reference_price, 1e-6)
+        post_signal_peak = max(float(context.get("post_signal_peak_price", market_price)), market_price)
+        pullback_from_peak = max((post_signal_peak - market_price) / max(post_signal_peak, 1e-6), 0.0)
+
+        chase_detected = (
+            extension_ratio >= self._config.anti_chase_extension_ratio
+            and spread_ratio >= self._config.anti_chase_spread_ratio
+        )
+        if chase_detected:
+            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+                return EntryTimingDecision(
+                    timing_decision="SKIP",
+                    timing_reason="anti_chase_timeout_skip",
+                    reference_price=round(reference_price, 6),
+                    reevaluation_window=0,
+                    final_execution_readiness=False,
+                )
+            return EntryTimingDecision(
+                timing_decision="WAIT",
+                timing_reason="anti_chase_spike_detected",
+                reference_price=round(reference_price, 6),
+                reevaluation_window=reevaluation_window,
+                final_execution_readiness=False,
+            )
+
+        if post_signal_peak > reference_price * (1.0 + (self._config.anti_chase_extension_ratio / 2.0)):
+            if pullback_from_peak >= self._config.micro_pullback_improvement_ratio:
+                return EntryTimingDecision(
+                    timing_decision="ENTER_NOW",
+                    timing_reason="micro_pullback_improved_entry",
+                    reference_price=round(reference_price, 6),
+                    reevaluation_window=0,
+                    final_execution_readiness=True,
+                )
+            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+                return EntryTimingDecision(
+                    timing_decision="SKIP",
+                    timing_reason="micro_pullback_timeout_skip",
+                    reference_price=round(reference_price, 6),
+                    reevaluation_window=0,
+                    final_execution_readiness=False,
+                )
+            return EntryTimingDecision(
+                timing_decision="WAIT",
+                timing_reason="awaiting_micro_pullback",
+                reference_price=round(reference_price, 6),
+                reevaluation_window=reevaluation_window,
+                final_execution_readiness=False,
+            )
+
+        if signal_edge <= 0.0:
+            return EntryTimingDecision(
+                timing_decision="ENTER_NOW",
+                timing_reason="timing_unclear_fallback_to_quality_gate",
+                reference_price=round(reference_price, 6),
+                reevaluation_window=0,
+                final_execution_readiness=True,
+            )
+
+        return EntryTimingDecision(
+            timing_decision="ENTER_NOW",
+            timing_reason="stable_entry_window",
+            reference_price=round(reference_price, 6),
+            reevaluation_window=0,
+            final_execution_readiness=True,
+        )
+
+    def evaluate_entry_execution_readiness(
+        self,
+        *,
+        market_price: float,
+        signal_reference_price: float,
+        proposed_size: float,
+        signal_edge: float,
+        market_context: dict[str, float] | None = None,
+        wait_cycles: int = 0,
+    ) -> EntryExecutionReadiness:
+        timing = self.evaluate_entry_timing(
+            market_price=market_price,
+            signal_reference_price=signal_reference_price,
+            signal_edge=signal_edge,
+            market_context=market_context,
+            wait_cycles=wait_cycles,
+        )
+        if timing.timing_decision != "ENTER_NOW":
+            return EntryExecutionReadiness(
+                timing_decision=timing.timing_decision,
+                timing_reason=timing.timing_reason,
+                reference_price=timing.reference_price,
+                reevaluation_window=timing.reevaluation_window,
+                final_execution_readiness=False,
+                execution_quality_decision="NOT_EVALUATED",
+                execution_quality_reason="timing_gate_blocked",
+                adjusted_size=0.0,
+                expected_fill_price=round(max(market_price, 0.0), 6),
+                expected_slippage=0.0,
+            )
+
+        execution_quality = self.evaluate_execution_quality(
+            market_price=market_price,
+            proposed_size=proposed_size,
+            signal_edge=signal_edge,
+            market_context=market_context,
+        )
+        execution_ready = execution_quality.final_decision in {"ENTER", "REDUCE"}
+        return EntryExecutionReadiness(
+            timing_decision=timing.timing_decision,
+            timing_reason=timing.timing_reason,
+            reference_price=timing.reference_price,
+            reevaluation_window=timing.reevaluation_window,
+            final_execution_readiness=execution_ready,
+            execution_quality_decision=execution_quality.final_decision,
+            execution_quality_reason=execution_quality.execution_quality_reason,
+            adjusted_size=execution_quality.adjusted_size,
+            expected_fill_price=execution_quality.expected_fill_price,
+            expected_slippage=execution_quality.expected_slippage,
+        )
+
     def _select_best_cross_exchange_match(
         self,
         polymarket: CrossExchangeMarket,
@@ -1566,25 +1741,44 @@ class StrategyTrigger:
             signal_edge = max(self._config.min_edge, 0.0)
             if selected_candidate is not None:
                 signal_edge = max(selected_candidate.edge, 0.0)
-            execution_quality = self.evaluate_execution_quality(
+            timing_wait_cycles = int((market_context or {}).get("timing_wait_cycles", 0.0))
+            signal_reference_price = float((market_context or {}).get("signal_reference_price", market_price))
+            readiness = self.evaluate_entry_execution_readiness(
                 market_price=market_price,
+                signal_reference_price=signal_reference_price,
                 proposed_size=portfolio_guard.adjusted_size,
                 signal_edge=signal_edge,
                 market_context=market_context,
+                wait_cycles=timing_wait_cycles,
             )
-            if execution_quality.final_decision == "SKIP":
+            if readiness.timing_decision == "WAIT":
                 log.info(
-                    "execution_quality_blocked",
-                    reason=execution_quality.execution_quality_reason,
-                    expected_fill_price=execution_quality.expected_fill_price,
-                    expected_slippage=execution_quality.expected_slippage,
+                    "entry_timing_wait",
+                    timing_reason=readiness.timing_reason,
+                    reference_price=readiness.reference_price,
+                    reevaluation_window=readiness.reevaluation_window,
+                )
+                return "HOLD"
+            if readiness.timing_decision == "SKIP":
+                log.info(
+                    "entry_timing_skip",
+                    timing_reason=readiness.timing_reason,
+                    reference_price=readiness.reference_price,
                 )
                 return "BLOCKED"
-            size = execution_quality.adjusted_size
+            if not readiness.final_execution_readiness:
+                log.info(
+                    "execution_quality_blocked",
+                    reason=readiness.execution_quality_reason,
+                    expected_fill_price=readiness.expected_fill_price,
+                    expected_slippage=readiness.expected_slippage,
+                )
+                return "BLOCKED"
+            size = readiness.adjusted_size
             created = await self._engine.open_position(
                 market=target_market_id,
                 side=self._config.side,
-                price=execution_quality.expected_fill_price,
+                price=readiness.expected_fill_price,
                 size=size,
                 position_id=str(uuid.uuid4()),
             )

--- a/projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md
@@ -1,0 +1,90 @@
+# 24_22_p12_execution_timing_entry_optimization
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - pre-execution decision layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - entry timing logic (`ENTER_NOW` / `WAIT` / `SKIP`)
+  - P10 coordination path via timing-first readiness then execution-quality gate
+- Not in Scope:
+  - execution engine redesign
+  - risk model redesign
+  - Telegram UI changes
+  - strategy logic redesign
+  - async/concurrency redesign
+  - full market making / HFT logic
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md`. Tier: STANDARD
+
+## 1. What was built
+- Added timing-aware entry layer before execution quality gate with deterministic output contract:
+  - `timing_decision` (`ENTER_NOW` / `WAIT` / `SKIP`)
+  - `timing_reason`
+  - `reference_price`
+  - `reevaluation_window`
+  - `final_execution_readiness`
+- Added anti-chase logic to delay or skip entries when post-signal move is abrupt and spread is expanded.
+- Added micro-pullback logic to support `WAIT -> re-evaluate -> ENTER_NOW` for improved short pullback entries.
+- Added bounded wait behavior with deterministic timeout (`timing_max_wait_cycles`) so system never waits indefinitely.
+- Added pre-execution coordinator method that applies timing first, then applies P10 execution quality gate only when timing allows entry.
+
+## 2. Current system architecture
+- Updated pre-execution order:
+  1. S4 output / selected candidate sizing path (existing)
+  2. portfolio exposure gate (P8 existing)
+  3. **entry timing gate (P12 new)**
+  4. execution quality gate (P10 existing)
+  5. execution open-position call
+- P10 compatibility is preserved by routing `ENTER_NOW` outcomes into `evaluate_execution_quality(...)` and carrying forward fill-quality reasons/readiness.
+- Timing uncertainty fallback defaults to normal quality-gated behavior via `timing_unclear_fallback_to_quality_gate` to avoid unnecessary blocks.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required behavior coverage implemented and verified:
+1. normal stable entry -> `ENTER_NOW`
+2. sharp spike/chase condition -> `WAIT` (or deterministic `SKIP` on timeout)
+3. micro pullback opportunity -> `WAIT` then `ENTER_NOW`
+4. reevaluation timeout -> deterministic final action
+5. timing + P10 interaction -> timing may allow entry but P10 can still block on quality (`spread_too_wide`)
+6. deterministic behavior for same input
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` ✅ (15 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof examples:
+1) normal stable entry -> `ENTER_NOW`
+```text
+EntryExecutionReadiness(timing_decision='ENTER_NOW', timing_reason='stable_entry_window', reference_price=0.5, reevaluation_window=0, final_execution_readiness=True, execution_quality_decision='ENTER', execution_quality_reason='fill_quality_ok', adjusted_size=300.0, expected_fill_price=0.510038, expected_slippage=0.005038)
+```
+
+2) chase condition -> `WAIT`
+```text
+EntryExecutionReadiness(timing_decision='WAIT', timing_reason='anti_chase_spike_detected', reference_price=0.5, reevaluation_window=15, final_execution_readiness=False, execution_quality_decision='NOT_EVALUATED', execution_quality_reason='timing_gate_blocked', adjusted_size=0.0, expected_fill_price=0.54, expected_slippage=0.0)
+```
+
+3) failed improvement timeout -> deterministic `SKIP`
+```text
+EntryExecutionReadiness(timing_decision='SKIP', timing_reason='anti_chase_timeout_skip', reference_price=0.5, reevaluation_window=0, final_execution_readiness=False, execution_quality_decision='NOT_EVALUATED', execution_quality_reason='timing_gate_blocked', adjusted_size=0.0, expected_fill_price=0.54, expected_slippage=0.0)
+```
+
+4) improved pullback entry -> `ENTER_NOW`
+```text
+EntryExecutionReadiness(timing_decision='ENTER_NOW', timing_reason='micro_pullback_improved_entry', reference_price=0.5, reevaluation_window=0, final_execution_readiness=True, execution_quality_decision='ENTER', execution_quality_reason='fill_quality_ok', adjusted_size=300.0, expected_fill_price=0.541033, expected_slippage=0.003033)
+```
+
+## 5. Known issues
+- P12 timing logic is intentionally narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime orchestration outside this subsystem.
+- Existing test environment warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
+
+
+class _Engine:
+    max_total_exposure_ratio = 0.30
+    max_position_size_ratio = 0.10
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_Engine(),
+        config=StrategyConfig(
+            market_id="p12-market",
+            min_edge=0.02,
+            min_position_size_usd=25.0,
+            max_execution_spread=0.04,
+            borderline_execution_spread=0.025,
+            min_execution_depth_usd=10_000.0,
+            borderline_execution_depth_usd=20_000.0,
+            max_slippage_edge_consumption_ratio=0.60,
+            borderline_slippage_edge_consumption_ratio=0.35,
+            execution_reduction_factor=0.50,
+            anti_chase_extension_ratio=0.025,
+            anti_chase_spread_ratio=0.030,
+            micro_pullback_improvement_ratio=0.008,
+            timing_reevaluation_window_seconds=15,
+            timing_max_wait_cycles=2,
+        ),
+    )
+
+
+def test_normal_stable_entry_returns_enter_now() -> None:
+    trigger = _make_trigger()
+
+    readiness = trigger.evaluate_entry_execution_readiness(
+        market_price=0.50,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.495, "best_ask": 0.505, "orderbook_depth_usd": 80_000.0},
+    )
+
+    assert readiness.timing_decision == "ENTER_NOW"
+    assert readiness.timing_reason == "stable_entry_window"
+    assert readiness.final_execution_readiness is True
+    assert readiness.execution_quality_decision in {"ENTER", "REDUCE"}
+
+
+def test_sharp_spike_chase_condition_returns_wait() -> None:
+    trigger = _make_trigger()
+
+    readiness = trigger.evaluate_entry_execution_readiness(
+        market_price=0.54,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={
+            "best_bid": 0.52,
+            "best_ask": 0.56,
+            "orderbook_depth_usd": 80_000.0,
+            "post_signal_peak_price": 0.56,
+        },
+        wait_cycles=0,
+    )
+
+    assert readiness.timing_decision == "WAIT"
+    assert readiness.timing_reason == "anti_chase_spike_detected"
+    assert readiness.reevaluation_window == 15
+    assert readiness.final_execution_readiness is False
+
+
+def test_micro_pullback_flow_wait_then_enter() -> None:
+    trigger = _make_trigger()
+
+    waiting = trigger.evaluate_entry_execution_readiness(
+        market_price=0.538,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={
+            "best_bid": 0.536,
+            "best_ask": 0.540,
+            "orderbook_depth_usd": 90_000.0,
+            "post_signal_peak_price": 0.54,
+        },
+        wait_cycles=0,
+    )
+    entered = trigger.evaluate_entry_execution_readiness(
+        market_price=0.535,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={
+            "best_bid": 0.532,
+            "best_ask": 0.538,
+            "orderbook_depth_usd": 90_000.0,
+            "post_signal_peak_price": 0.54,
+        },
+        wait_cycles=1,
+    )
+
+    assert waiting.timing_decision == "WAIT"
+    assert waiting.timing_reason == "awaiting_micro_pullback"
+    assert entered.timing_decision == "ENTER_NOW"
+    assert entered.timing_reason == "micro_pullback_improved_entry"
+    assert entered.final_execution_readiness is True
+
+
+def test_reevaluation_timeout_is_deterministic_skip() -> None:
+    trigger = _make_trigger()
+
+    timeout_result = trigger.evaluate_entry_execution_readiness(
+        market_price=0.54,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={
+            "best_bid": 0.52,
+            "best_ask": 0.56,
+            "orderbook_depth_usd": 80_000.0,
+            "post_signal_peak_price": 0.56,
+        },
+        wait_cycles=2,
+    )
+
+    assert timeout_result.timing_decision == "SKIP"
+    assert timeout_result.timing_reason == "anti_chase_timeout_skip"
+    assert timeout_result.reevaluation_window == 0
+    assert timeout_result.final_execution_readiness is False
+
+
+def test_coordination_with_p10_quality_gate_remains_correct() -> None:
+    trigger = _make_trigger()
+
+    readiness = trigger.evaluate_entry_execution_readiness(
+        market_price=0.50,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context={"best_bid": 0.46, "best_ask": 0.54, "orderbook_depth_usd": 90_000.0},
+    )
+
+    assert readiness.timing_decision == "ENTER_NOW"
+    assert readiness.execution_quality_decision == "SKIP"
+    assert readiness.execution_quality_reason == "spread_too_wide"
+    assert readiness.final_execution_readiness is False
+
+
+def test_timing_decision_is_deterministic_for_same_input() -> None:
+    trigger = _make_trigger()
+    context = {
+        "best_bid": 0.495,
+        "best_ask": 0.505,
+        "orderbook_depth_usd": 85_000.0,
+        "post_signal_peak_price": 0.505,
+    }
+
+    first = trigger.evaluate_entry_execution_readiness(
+        market_price=0.50,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context=context,
+        wait_cycles=0,
+    )
+    second = trigger.evaluate_entry_execution_readiness(
+        market_price=0.50,
+        signal_reference_price=0.50,
+        proposed_size=300.0,
+        signal_edge=0.08,
+        market_context=context,
+        wait_cycles=0,
+    )
+
+    assert first == second


### PR DESCRIPTION
### Motivation
- Reduce poor immediate entries by inserting a timing-aware pre-execution decision layer that avoids chasing spike tops and waits for short, cleaner pullbacks. 
- Improve overall fill quality by coordinating timing decisions with the existing P10 execution-quality gate while guaranteeing bounded wait behavior (no over-waiting). 

### Description
- Added timing configuration knobs to `StrategyConfig` (`anti_chase_extension_ratio`, `anti_chase_spread_ratio`, `micro_pullback_improvement_ratio`, `timing_reevaluation_window_seconds`, `timing_max_wait_cycles`).
- Introduced deterministic timing contracts: `EntryTimingDecision` and `EntryExecutionReadiness`, plus `evaluate_entry_timing(...)` and `evaluate_entry_execution_readiness(...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to produce `ENTER_NOW` / `WAIT` / `SKIP` decisions with `timing_reason`, `reference_price`, and `reevaluation_window`.
- Implemented anti-chase detection (delay or timeout-skip) and micro-pullback flow (`WAIT` → re-evaluate → `ENTER_NOW`), and a safe fallback path that defers to the P10 quality gate when timing is unclear.
- Integrated timing-first coordination into the pre-execution path so timing outcomes drive whether we call `evaluate_execution_quality(...)`; preserved existing P10 semantics and carried expected fill price / adjusted size through readiness.
- Added focused unit tests and a FORGE report, and updated `PROJECT_STATE.md` to reflect the P12 handoff (STANDARD, Narrow Integration).

### Testing
- Ran syntax checks: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` which passed.
- Ran unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py` which returned `15 passed` and one environment warning (`Unknown config option: asyncio_mode`).
- Executed runtime examples that print representative `EntryExecutionReadiness` objects for normal entry, chase/wait, timeout/skip, and improved pullback → all produced the expected deterministic outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d776ee9c7c832ea220fdc097e56ba9)