### PR TITLE
TG-1: Fix market title resolution — preserve `market_title` across execution → portfolio → Telegram

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 06:28
-- Status        : FORGE-X P11 market regime detection implemented (STANDARD, narrow integration) in strategy-trigger S4 scoring context layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 10:05
+- Status        : FORGE-X TG-1 market title resolution fix implemented (STANDARD, narrow integration) across execution→portfolio payload→Telegram formatter path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- TG-1 market title resolution fix (2026-04-09): preserved `market_title` across execution payload, portfolio normalization, callback payload builder, and Telegram formatter position rendering; reduced fallback-heavy title logic and added warning-only unresolved-title logging with focused regression tests.
 - P11 market regime detection (2026-04-09): added deterministic regime classification (`NEWS_DRIVEN`/`ARBITRAGE_DOMINANT`/`SMART_MONEY_DOMINANT`/`LOW_ACTIVITY_CHAOTIC`) from social/dispersion/wallet/activity signals, integrated bounded regime-based S4 strategy weighting modifiers with neutral fallback behavior, and added focused deterministic regime/aggregation contract tests.
 - P10 execution quality & fill optimization (2026-04-09): added pre-execution execution-quality gate in strategy trigger with deterministic ENTER/SKIP/REDUCE contract (`final_decision`/`adjusted_size`/`expected_fill_price`/`expected_slippage`/`execution_quality_reason`), spread/depth/slippage checks, conservative fill-price discipline, and focused runtime-proof tests.
 - S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
@@ -106,6 +107,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### TG-1 market title resolution handoff
+- STANDARD-tier narrow integration implementation is complete for market-title preservation in execution output mapping, portfolio payload normalization, and Telegram position formatting path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P11 market regime detection handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger regime classification and S4 score-weight adjustment context output.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -191,11 +196,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_21_p11_market_regime_detection.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- TG-1 title flow fix is narrow integration in Telegram-facing execution payload and formatter surfaces only; broader market metadata backfill outside active position paths remains out of scope.
 - P11 market regime detection is currently narrow integration in strategy-trigger S4 scoring path only and is not yet wired into broader runtime execution orchestration.
 - P10 execution quality gate is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into full runtime execution orchestration layers.
 - S5 settlement-gap scanner is currently narrow integration in strategy-trigger scope only and is not yet wired into full runtime execution orchestration.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -46,6 +46,7 @@ class ExecutionEngine:
     async def open_position(
         self,
         market: str,
+        market_title: str,
         side: str,
         price: float,
         size: float,
@@ -90,6 +91,7 @@ class ExecutionEngine:
 
             position = Position(
                 market_id=market,
+                market_title=str(market_title or "").strip(),
                 side=side.upper(),
                 entry_price=float(price),
                 current_price=float(price),
@@ -184,6 +186,7 @@ async def export_execution_payload() -> dict[str, Any]:
         "positions": [
             {
                 "market_id": pos.market_id,
+                "market_title": pos.market_title,
                 "side": pos.side,
                 "entry_price": pos.entry_price,
                 "current_price": pos.current_price,

--- a/projects/polymarket/polyquantbot/execution/models.py
+++ b/projects/polymarket/polyquantbot/execution/models.py
@@ -10,6 +10,7 @@ class Position:
     """Paper trading position state for execution engine."""
 
     market_id: str
+    market_title: str
     side: str
     entry_price: float
     current_price: float

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -1250,9 +1250,9 @@ class StrategyTrigger:
     def _resolve_candidate_market_context(
         self,
         selected_candidate: StrategyCandidateScore | None,
-    ) -> tuple[str, str | None]:
+    ) -> tuple[str, str | None, str]:
         if selected_candidate is None:
-            return self._config.market_id, None
+            return self._config.market_id, None, ""
         metadata = selected_candidate.market_metadata or {}
         raw_market_id = (
             metadata.get("market_id")
@@ -1266,8 +1266,15 @@ class StrategyTrigger:
             or metadata.get("event")
             or metadata.get("category")
         )
+        raw_market_title = (
+            metadata.get("market_title")
+            or metadata.get("question")
+            or metadata.get("title")
+            or metadata.get("name")
+        )
         theme = str(raw_theme).strip() if raw_theme is not None else None
-        return market_id, theme
+        market_title = str(raw_market_title).strip() if raw_market_title is not None else ""
+        return market_id, theme, market_title
 
     @staticmethod
     def _infer_position_theme(position: object) -> str:
@@ -1553,7 +1560,7 @@ class StrategyTrigger:
                     normalized_score=1.0,
                 )
             )
-            target_market_id, target_theme = self._resolve_candidate_market_context(selected_candidate)
+            target_market_id, target_theme, target_market_title = self._resolve_candidate_market_context(selected_candidate)
             portfolio_guard = self.evaluate_portfolio_exposure_and_correlation(
                 target_market_id=target_market_id,
                 target_theme=target_theme,
@@ -1583,6 +1590,7 @@ class StrategyTrigger:
             size = execution_quality.adjusted_size
             created = await self._engine.open_position(
                 market=target_market_id,
+                market_title=target_market_title,
                 side=self._config.side,
                 price=execution_quality.expected_fill_price,
                 size=size,

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -70,11 +70,29 @@ def safe_count(value: Any, default: int = 0) -> int:
 
 
 def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    def _normalize_rows(raw_rows: list[Any]) -> list[Mapping[str, Any]]:
+        normalized: list[Mapping[str, Any]] = []
+        for row in raw_rows:
+            if not isinstance(row, Mapping):
+                continue
+            row_dict = dict(row)
+            row_dict["market_title"] = _first_present(
+                row,
+                "market_title",
+                "market_question",
+                "question",
+                "title",
+                "name",
+                default="",
+            )
+            normalized.append(row_dict)
+        return normalized
+
     rows = _as_list(payload.get("positions"))
     if rows and isinstance(rows[0], Mapping):
-        return [row for row in rows if isinstance(row, Mapping)]
+        return _normalize_rows(rows)
     open_rows = _as_list(payload.get("open_positions"))
-    return [row for row in open_rows if isinstance(row, Mapping)]
+    return _normalize_rows(open_rows)
 
 
 def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -142,7 +160,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "confidence": payload.get("confidence", 0),
         "decision": payload.get("decision"),
         "operator_note": payload.get("operator_note"),
-        "market_title": _first_present(payload, "market_title", "market_name", "question", default=primary.get("market_title")),
+        "market_title": _first_present(payload, "market_title", default=primary.get("market_title")),
         "market_question": payload.get("question"),
         "market_id": _first_present(payload, "market_id", "market", default=primary.get("market_id")),
         "current": _first_present(payload, "current", "current_price", "last_price", default=primary.get("current_price")),

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
+import structlog
+
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
+
+log = structlog.get_logger(__name__)
 
 VIEW_TITLE = {
     "home": "🏠 Home Command",
@@ -170,16 +174,18 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
 
     for candidate in (
         payload.get("market_title"),
-        payload.get("market_question"),
-        payload.get("market_name"),
         context.get("question"),
         context.get("name"),
-        payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
         if text and not _is_generic_label(text) and not _is_internal_fallback_label(text):
             return text
 
+    log.warning(
+        "telegram_market_title_missing_fallback",
+        market_id=_safe_text(payload.get("market_id"), ""),
+        fallback="Untitled Market",
+    )
     return "Untitled Market"
 
 
@@ -433,7 +439,7 @@ async def _render_position_cards(payload: Mapping[str, Any]) -> list[str]:
         row_payload.update(
             {
                 "market_id": row.get("market_id"),
-                "market_title": row.get("market_title", row.get("market_question")),
+                "market_title": row.get("market_title"),
                 "market_question": row.get("market_question"),
                 "side": row.get("side"),
                 "entry": row.get("entry_price", row.get("avg_price")),

--- a/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
@@ -1,0 +1,108 @@
+# 24_22_tg1_market_title_resolution
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - position data structure in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+  - execution output mapping in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - portfolio payload builder in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - Telegram formatter in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Not in Scope:
+  - execution engine strategy/risk decisions
+  - strategy logic/scoring changes
+  - sizing/risk constant changes
+  - Telegram layout redesign
+  - trade history features
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`. Tier: STANDARD
+
+## 1. What was built
+- Fixed Telegram portfolio title resolution by preserving `market_title` end-to-end across:
+  - execution position model + exported execution payload
+  - portfolio service normalized position schema
+  - callback-router normalized payload
+  - Telegram view payload normalization
+  - Telegram UI formatter position-card rendering
+- Replaced broad title fallback inputs with standardized `market_title` plus context lookup (`question` / `name`) only.
+- Added warning-only behavior when title is truly unresolved (`telegram_market_title_missing_fallback`) while keeping UI fallback only for genuinely unresolvable titles.
+- Added focused TG-1 tests covering required scenarios and non-regression.
+
+Root cause:
+- `market_title` was dropped in callback-router normalization and execution export paths, while formatter relied on mixed field names/fallback-heavy logic. This broke identity continuity and produced `Untitled Market` for valid positions.
+
+## 2. Current system architecture
+- Flow now enforced:
+  - `ExecutionEngine.open_position(..., market_title=...)` stores title in `Position.market_title`
+  - `export_execution_payload()` emits `{market_id, market_title, ...}` per position
+  - portfolio service + callback router normalize and retain `market_title`
+  - view adapter normalizes any legacy row keys into `market_title`
+  - formatter displays `market_title` first, then market-context lookup, and falls back to `Untitled Market` only when both are unresolved
+- Claim level remains narrow integration in Telegram portfolio rendering surfaces; broader market metadata infrastructure is unchanged.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/models.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests implemented and passing:
+1. position with valid title -> displayed correctly
+2. multiple positions -> all show correct titles
+3. same market multiple positions -> consistent title
+4. missing title -> fallback only when truly absent (with cache/context recovery)
+5. no regression in portfolio rendering
+
+Additional mapping checks implemented and passing:
+- execution output payload includes `market_id` + `market_title`
+- portfolio payload builder keeps `market_title` from primary normalized position
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/models.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` ✅ (10 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof:
+1) Telegram output BEFORE fix behavior (missing title unresolved)
+```text
+🎯 Position
+├ Market: Untitled Market
+...
+```
+
+2) Telegram output AFTER fix behavior (resolved title displayed)
+```text
+🎯 Position
+├ Market: Will ETH close above $4,000 this week?
+...
+```
+
+3) Telegram output AFTER fix with multiple positions
+```text
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will SOL close above $300 this month?
+...
+```
+
+## 5. Known issues
+- When both payload `market_title` and market-context resolution are unavailable, UI still intentionally falls back to `Untitled Market` and logs a warning (expected safe fallback).
+- External market-context endpoint may be unreachable in container environments; fallback and warnings are expected in that case.
+- Existing pytest warning remains: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -347,6 +347,18 @@ class CallbackRouter:
             normalized.append(
                 {
                     "market_id": str(self._extract_field(pos, "market_id", "") or ""),
+                    "market_title": str(
+                        self._extract_field(
+                            pos,
+                            "market_title",
+                            self._extract_field(
+                                pos,
+                                "market_question",
+                                self._extract_field(pos, "question", ""),
+                            ),
+                        )
+                        or ""
+                    ).strip(),
                     "side": str(self._extract_field(pos, "side", "flat") or "flat"),
                     "entry_price": safe_number(
                         self._extract_field(
@@ -424,7 +436,7 @@ class CallbackRouter:
             "unrealized_pnl": unrealized_total,
             "exposure": exposure,
             "market_id": (primary or {}).get("market_id", ""),
-            "market_title": "",
+            "market_title": (primary or {}).get("market_title", ""),
             "side": (primary or {}).get("side", "flat"),
             "entry": safe_number((primary or {}).get("entry_price", 0.0)),
             "size": safe_number((primary or {}).get("size", 0.0)),

--- a/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
@@ -17,6 +17,7 @@ log = structlog.get_logger(__name__)
 @dataclass(frozen=True)
 class PortfolioPosition:
     market_id: str
+    market_title: str
     side: str
     avg_price: float
     size: float
@@ -85,6 +86,12 @@ class PortfolioService:
             normalized.append(
                 PortfolioPosition(
                     market_id=str(pos.get("market_id", "")),
+                    market_title=str(
+                        pos.get("market_title")
+                        or pos.get("market_question")
+                        or pos.get("question")
+                        or ""
+                    ).strip(),
                     side=str(pos.get("side", "")),
                     avg_price=self._safe_float(pos.get("entry_price", pos.get("avg_price", 0.0)), 0.0),
                     size=self._safe_float(pos.get("size", 0.0), 0.0),
@@ -173,6 +180,12 @@ class PortfolioService:
                 positions.append(
                     PortfolioPosition(
                         market_id=market_id,
+                        market_title=str(
+                            getattr(pos, "market_title", "")
+                            or getattr(pos, "market_question", "")
+                            or getattr(pos, "question", "")
+                            or ""
+                        ).strip(),
                         side=side,
                         avg_price=avg_price,
                         size=size,

--- a/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution import engine as execution_engine_module
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, export_execution_payload
+from projects.polymarket.polyquantbot.interface import ui_formatter
+from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+
+
+@dataclass(frozen=True)
+class _PortfolioStateStub:
+    positions: tuple[dict[str, object], ...]
+    equity: float
+    cash: float
+    pnl: float
+
+
+class _PortfolioServiceStub:
+    def __init__(self, state: _PortfolioStateStub) -> None:
+        self._state = state
+
+    def get_state(self) -> _PortfolioStateStub:
+        return self._state
+
+
+def _make_router() -> CallbackRouter:
+    command_handler = type("CommandHandlerStub", (), {"_runner": None, "_multi_metrics": None, "_allocator": None, "_risk_guard": None})()
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=command_handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def _render_positions(payload: dict) -> str:
+    return asyncio.run(render_view("positions", payload))
+
+
+def test_execution_output_mapping_includes_market_title(monkeypatch) -> None:
+    isolated_engine = ExecutionEngine(starting_equity=10_000.0)
+    monkeypatch.setattr(execution_engine_module, "_engine_singleton", isolated_engine)
+
+    asyncio.run(
+        isolated_engine.open_position(
+            market="mkt-ev-1",
+            market_title="Will ETH close above $4,000 this week?",
+            side="YES",
+            price=0.45,
+            size=100.0,
+            position_id="tg1-1",
+        )
+    )
+
+    payload = asyncio.run(export_execution_payload())
+
+    assert payload["positions"][0]["market_id"] == "mkt-ev-1"
+    assert payload["positions"][0]["market_title"] == "Will ETH close above $4,000 this week?"
+
+
+def test_portfolio_payload_builder_keeps_market_title(monkeypatch) -> None:
+    router = _make_router()
+    portfolio_state = _PortfolioStateStub(
+        positions=(
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.52,
+                "size": 150.0,
+                "unrealized_pnl": 12.5,
+            },
+        ),
+        equity=10_500.0,
+        cash=9_000.0,
+        pnl=12.5,
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.telegram.handlers.callback_router.get_portfolio_service",
+        lambda: _PortfolioServiceStub(portfolio_state),
+    )
+
+    payload = router._build_normalized_payload("positions")
+
+    assert payload["market_id"] == "mkt-btc-1"
+    assert payload["market_title"] == "Will BTC close above $100k this month?"
+
+
+def test_position_with_valid_title_displays_correctly() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-eth-1",
+                "market_title": "Will ETH close above $4,000 this week?",
+                "side": "YES",
+                "entry_price": 0.45,
+                "size": 100.0,
+                "unrealized_pnl": 4.0,
+            }
+        ],
+        "positions_count": 1,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Will ETH close above $4,000 this week?" in output
+    assert "Untitled Market" not in output
+
+
+def test_multiple_positions_show_correct_titles_consistently() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.51,
+                "size": 120.0,
+                "unrealized_pnl": 2.5,
+            },
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.53,
+                "size": 80.0,
+                "unrealized_pnl": -1.0,
+            },
+            {
+                "market_id": "mkt-sol-1",
+                "market_title": "Will SOL close above $300 this month?",
+                "side": "NO",
+                "entry_price": 0.35,
+                "size": 90.0,
+                "unrealized_pnl": 1.2,
+            },
+        ],
+        "positions_count": 3,
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("🎯 Position") == 3
+    assert output.count("Will BTC close above $100k this month?") >= 2
+    assert "Will SOL close above $300 this month?" in output
+
+
+def test_missing_title_falls_back_only_when_unresolvable(monkeypatch) -> None:
+    async def _stub_market_context(market_id: str) -> dict[str, str]:
+        if market_id == "mkt-resolve":
+            return {"question": "Resolved from cache title"}
+        return {}
+
+    original_get_market_context = ui_formatter.get_market_context
+    ui_formatter.get_market_context = _stub_market_context
+    try:
+        payload = {
+            "positions": [
+                {
+                    "market_id": "mkt-resolve",
+                    "market_title": "",
+                    "side": "YES",
+                    "entry_price": 0.5,
+                    "size": 50.0,
+                    "unrealized_pnl": 0.5,
+                },
+                {
+                    "market_id": "mkt-missing",
+                    "market_title": "",
+                    "side": "NO",
+                    "entry_price": 0.4,
+                    "size": 40.0,
+                    "unrealized_pnl": -0.5,
+                },
+            ]
+        }
+
+        output = _render_positions(payload)
+    finally:
+        ui_formatter.get_market_context = original_get_market_context
+
+    assert "Resolved from cache title" in output
+    assert output.count("Untitled Market") == 1
+
+
+def test_no_regression_positions_summary_and_render_count() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-a",
+                "market_title": "Market A",
+                "side": "YES",
+                "entry_price": 0.3,
+                "size": 25.0,
+                "unrealized_pnl": 0.1,
+            },
+            {
+                "market_id": "mkt-b",
+                "market_title": "Market B",
+                "side": "NO",
+                "entry_price": 0.7,
+                "size": 35.0,
+                "unrealized_pnl": -0.2,
+            },
+        ],
+        "positions_count": 1,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Open Positions: 2" in output
+    assert output.count("🎯 Position") == 2


### PR DESCRIPTION
### Motivation
- Operators saw `Untitled Market` in Telegram portfolio cards because `market_title` was dropped or mixed across layers instead of being preserved end-to-end.  
- The change standardizes on a single canonical field `market_title` across execution, payloads, portfolio normalization, and formatter to preserve market identity.  
- Reduce UI fallback noise by only showing the `Untitled Market` label when the title cannot be resolved at any layer and emit a warning instead of aggressive fallback logic.  

### Description
- Added `market_title` to the execution `Position` dataclass and to `ExecutionEngine.open_position(...)`, and included `market_title` in the exported execution payload (`projects/polymarket/polyquantbot/execution/models.py`, `projects/polymarket/polyquantbot/execution/engine.py`).
- Wired strategy-trigger metadata through to execution by returning a `market_title` from `_resolve_candidate_market_context(...)` and passing it into `open_position(...)` (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`).
- Normalized portfolio position schema and portfolio snapshot objects to include `market_title` so merge/update flows retain the canonical field (`projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`).
- Updated callback-router normalized payload to keep `market_title` for primary/rows and to populate payloads used by Telegram views (`projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`).
- View adapter row normalization was added to unify legacy keys into `market_title` before rendering (`projects/polymarket/polyquantbot/interface/telegram/view_handler.py`).
- Simplified formatter title-resolution to prefer `market_title`, then market-context lookup, and only fallback to `Untitled Market` while logging a warning (`telegram_market_title_missing_fallback`) when truly unresolved (`projects/polymarket/polyquantbot/interface/ui_formatter.py`).
- Added focused tests exercising execution export, portfolio payload builder, single/multiple positions rendering, same-market consistency, and missing-title fallback recovery (`projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py`).
- Added FORGE report and updated `PROJECT_STATE.md` with `Last Updated`, `Status`, completed item, in-progress handoff, next priority and known-issues entries (`projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`, `PROJECT_STATE.md`).

### Testing
- Static check: ran `python -m py_compile` across changed modules and test file; compilation succeeded.  
- Unit tests: ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` and all tests passed (`10 passed`); environment shows a non-blocking `asyncio_mode` pytest config warning.  
- Runtime proof: exercised `render_view('positions', ...)` for before/after/multiple payload examples and captured expected outputs in the forge report showing `Untitled Market` before and correct `market_title` rows after the fix (examples included in `projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d778e58ac0832eb911dfd2487a0f50)