### PR TITLE
Preserve market_title end-to-end for Telegram portfolio & execution payloads (TG-1)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,14 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 06:28
-- Status        : FORGE-X P11 market regime detection implemented (STANDARD, narrow integration) in strategy-trigger S4 scoring context layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 10:17
+- Status        : FORGE-X TG-1 market title resolution retry finalized (STANDARD, narrow integration) with backward-compatible execution API and passing focused regression suite; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- TG-1 retry addendum (2026-04-09): preserved backward compatibility for legacy execution callers that omit `market_title` while keeping canonical `market_title` export contract and refreshed focused test evidence.
+- TG-1 market title resolution fix (2026-04-09): preserved `market_title` across execution payload, portfolio normalization, callback payload builder, and Telegram formatter position rendering; reduced fallback-heavy title logic and added warning-only unresolved-title logging with focused regression tests.
 - P11 market regime detection (2026-04-09): added deterministic regime classification (`NEWS_DRIVEN`/`ARBITRAGE_DOMINANT`/`SMART_MONEY_DOMINANT`/`LOW_ACTIVITY_CHAOTIC`) from social/dispersion/wallet/activity signals, integrated bounded regime-based S4 strategy weighting modifiers with neutral fallback behavior, and added focused deterministic regime/aggregation contract tests.
 - P10 execution quality & fill optimization (2026-04-09): added pre-execution execution-quality gate in strategy trigger with deterministic ENTER/SKIP/REDUCE contract (`final_decision`/`adjusted_size`/`expected_fill_price`/`expected_slippage`/`execution_quality_reason`), spread/depth/slippage checks, conservative fill-price discipline, and focused runtime-proof tests.
 - S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
@@ -106,6 +108,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### TG-1 market title resolution handoff
+- STANDARD-tier narrow integration implementation is complete for market-title preservation in execution output mapping, portfolio payload normalization, and Telegram position formatting path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P11 market regime detection handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger regime classification and S4 score-weight adjustment context output.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -191,11 +197,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_21_p11_market_regime_detection.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- TG-1 title flow fix is narrow integration in Telegram-facing execution payload and formatter surfaces only; broader market metadata backfill outside active position paths remains out of scope.
 - P11 market regime detection is currently narrow integration in strategy-trigger S4 scoring path only and is not yet wired into broader runtime execution orchestration.
 - P10 execution quality gate is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into full runtime execution orchestration layers.
 - S5 settlement-gap scanner is currently narrow integration in strategy-trigger scope only and is not yet wired into full runtime execution orchestration.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 10:17
-- Status        : FORGE-X TG-1 market title resolution retry finalized (STANDARD, narrow integration) with backward-compatible execution API and passing focused regression suite; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 10:26
+- Status        : FORGE-X TG-1 merge-conflict resolution finalized (STANDARD, narrow integration) with canonical market_title preserved across execution→portfolio→Telegram formatter chain; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- TG-1 merge-conflict resolution (2026-04-09): re-applied canonical `market_title` flow across execution/portfolio/telegram formatter layers on dedicated conflict-fix branch and added deterministic formatting regression coverage.
 - TG-1 retry addendum (2026-04-09): preserved backward compatibility for legacy execution callers that omit `market_title` while keeping canonical `market_title` export contract and refreshed focused test evidence.
 - TG-1 market title resolution fix (2026-04-09): preserved `market_title` across execution payload, portfolio normalization, callback payload builder, and Telegram formatter position rendering; reduced fallback-heavy title logic and added warning-only unresolved-title logging with focused regression tests.
 - P11 market regime detection (2026-04-09): added deterministic regime classification (`NEWS_DRIVEN`/`ARBITRAGE_DOMINANT`/`SMART_MONEY_DOMINANT`/`LOW_ACTIVITY_CHAOTIC`) from social/dispersion/wallet/activity signals, integrated bounded regime-based S4 strategy weighting modifiers with neutral fallback behavior, and added focused deterministic regime/aggregation contract tests.
@@ -108,6 +109,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### TG-1 merge-conflict resolution handoff
+- STANDARD-tier narrow integration implementation is complete for canonical market-title continuity across execution payload, portfolio payload builder, Telegram adapter, and formatter layers.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### TG-1 market title resolution handoff
 - STANDARD-tier narrow integration implementation is complete for market-title preservation in execution output mapping, portfolio payload normalization, and Telegram position formatting path.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -197,11 +202,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- TG-1 merge-conflict fix remains narrow integration to target title-flow layers only; broader metadata consolidation outside the declared validation target remains out of scope.
 - TG-1 title flow fix is narrow integration in Telegram-facing execution payload and formatter surfaces only; broader market metadata backfill outside active position paths remains out of scope.
 - P11 market regime detection is currently narrow integration in strategy-trigger S4 scoring path only and is not yet wired into broader runtime execution orchestration.
 - P10 execution quality gate is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into full runtime execution orchestration layers.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -50,6 +50,7 @@ class ExecutionEngine:
         price: float,
         size: float,
         position_id: str | None = None,
+        market_title: str = "",
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
@@ -90,6 +91,7 @@ class ExecutionEngine:
 
             position = Position(
                 market_id=market,
+                market_title=str(market_title or "").strip(),
                 side=side.upper(),
                 entry_price=float(price),
                 current_price=float(price),
@@ -184,6 +186,7 @@ async def export_execution_payload() -> dict[str, Any]:
         "positions": [
             {
                 "market_id": pos.market_id,
+                "market_title": pos.market_title,
                 "side": pos.side,
                 "entry_price": pos.entry_price,
                 "current_price": pos.current_price,

--- a/projects/polymarket/polyquantbot/execution/models.py
+++ b/projects/polymarket/polyquantbot/execution/models.py
@@ -10,6 +10,7 @@ class Position:
     """Paper trading position state for execution engine."""
 
     market_id: str
+    market_title: str
     side: str
     entry_price: float
     current_price: float

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -1250,9 +1250,9 @@ class StrategyTrigger:
     def _resolve_candidate_market_context(
         self,
         selected_candidate: StrategyCandidateScore | None,
-    ) -> tuple[str, str | None]:
+    ) -> tuple[str, str | None, str]:
         if selected_candidate is None:
-            return self._config.market_id, None
+            return self._config.market_id, None, ""
         metadata = selected_candidate.market_metadata or {}
         raw_market_id = (
             metadata.get("market_id")
@@ -1266,8 +1266,15 @@ class StrategyTrigger:
             or metadata.get("event")
             or metadata.get("category")
         )
+        raw_market_title = (
+            metadata.get("market_title")
+            or metadata.get("question")
+            or metadata.get("title")
+            or metadata.get("name")
+        )
         theme = str(raw_theme).strip() if raw_theme is not None else None
-        return market_id, theme
+        market_title = str(raw_market_title).strip() if raw_market_title is not None else ""
+        return market_id, theme, market_title
 
     @staticmethod
     def _infer_position_theme(position: object) -> str:
@@ -1553,7 +1560,7 @@ class StrategyTrigger:
                     normalized_score=1.0,
                 )
             )
-            target_market_id, target_theme = self._resolve_candidate_market_context(selected_candidate)
+            target_market_id, target_theme, target_market_title = self._resolve_candidate_market_context(selected_candidate)
             portfolio_guard = self.evaluate_portfolio_exposure_and_correlation(
                 target_market_id=target_market_id,
                 target_theme=target_theme,
@@ -1583,6 +1590,7 @@ class StrategyTrigger:
             size = execution_quality.adjusted_size
             created = await self._engine.open_position(
                 market=target_market_id,
+                market_title=target_market_title,
                 side=self._config.side,
                 price=execution_quality.expected_fill_price,
                 size=size,

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -70,11 +70,29 @@ def safe_count(value: Any, default: int = 0) -> int:
 
 
 def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    def _normalize_rows(raw_rows: list[Any]) -> list[Mapping[str, Any]]:
+        normalized: list[Mapping[str, Any]] = []
+        for row in raw_rows:
+            if not isinstance(row, Mapping):
+                continue
+            row_dict = dict(row)
+            row_dict["market_title"] = _first_present(
+                row,
+                "market_title",
+                "market_question",
+                "question",
+                "title",
+                "name",
+                default="",
+            )
+            normalized.append(row_dict)
+        return normalized
+
     rows = _as_list(payload.get("positions"))
     if rows and isinstance(rows[0], Mapping):
-        return [row for row in rows if isinstance(row, Mapping)]
+        return _normalize_rows(rows)
     open_rows = _as_list(payload.get("open_positions"))
-    return [row for row in open_rows if isinstance(row, Mapping)]
+    return _normalize_rows(open_rows)
 
 
 def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -142,7 +160,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "confidence": payload.get("confidence", 0),
         "decision": payload.get("decision"),
         "operator_note": payload.get("operator_note"),
-        "market_title": _first_present(payload, "market_title", "market_name", "question", default=primary.get("market_title")),
+        "market_title": _first_present(payload, "market_title", default=primary.get("market_title")),
         "market_question": payload.get("question"),
         "market_id": _first_present(payload, "market_id", "market", default=primary.get("market_id")),
         "current": _first_present(payload, "current", "current_price", "last_price", default=primary.get("current_price")),

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
+import structlog
+
 from projects.polymarket.polyquantbot.data.market_context import get_market_context
+
+log = structlog.get_logger(__name__)
 
 VIEW_TITLE = {
     "home": "🏠 Home Command",
@@ -170,16 +174,18 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
 
     for candidate in (
         payload.get("market_title"),
-        payload.get("market_question"),
-        payload.get("market_name"),
         context.get("question"),
         context.get("name"),
-        payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
         if text and not _is_generic_label(text) and not _is_internal_fallback_label(text):
             return text
 
+    log.warning(
+        "telegram_market_title_missing_fallback",
+        market_id=_safe_text(payload.get("market_id"), ""),
+        fallback="Untitled Market",
+    )
     return "Untitled Market"
 
 
@@ -433,7 +439,7 @@ async def _render_position_cards(payload: Mapping[str, Any]) -> list[str]:
         row_payload.update(
             {
                 "market_id": row.get("market_id"),
-                "market_title": row.get("market_title", row.get("market_question")),
+                "market_title": row.get("market_title"),
                 "market_question": row.get("market_question"),
                 "side": row.get("side"),
                 "entry": row.get("entry_price", row.get("avg_price")),

--- a/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
@@ -1,0 +1,110 @@
+# 24_22_tg1_market_title_resolution
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - position data structure in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+  - execution output mapping in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - portfolio payload builder in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - Telegram formatter in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Not in Scope:
+  - execution engine strategy/risk decisions
+  - strategy logic/scoring changes
+  - sizing/risk constant changes
+  - Telegram layout redesign
+  - trade history features
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`. Tier: STANDARD
+
+## 1. What was built
+- Fixed Telegram portfolio title resolution by preserving `market_title` end-to-end across:
+  - execution position model + exported execution payload
+  - portfolio service normalized position schema
+  - callback-router normalized payload
+  - Telegram view payload normalization
+  - Telegram UI formatter position-card rendering
+- Replaced broad title fallback inputs with standardized `market_title` plus context lookup (`question` / `name`) only.
+- Added warning-only behavior when title is truly unresolved (`telegram_market_title_missing_fallback`) while keeping UI fallback only for genuinely unresolvable titles.
+- Added backward-compatible execution API behavior so `ExecutionEngine.open_position(...)` still works when legacy callers do not pass `market_title` (defaults to empty string).
+- Added focused TG-1 tests covering required scenarios and non-regression.
+
+Root cause:
+- `market_title` was dropped in callback-router normalization and execution export paths, while formatter relied on mixed field names/fallback-heavy logic. This broke identity continuity and produced `Untitled Market` for valid positions.
+
+## 2. Current system architecture
+- Flow now enforced:
+  - `ExecutionEngine.open_position(..., market_title=...)` stores title in `Position.market_title`
+  - `export_execution_payload()` emits `{market_id, market_title, ...}` per position
+  - portfolio service + callback router normalize and retain `market_title`
+  - view adapter normalizes any legacy row keys into `market_title`
+  - formatter displays `market_title` first, then market-context lookup, and falls back to `Untitled Market` only when both are unresolved
+- Claim level remains narrow integration in Telegram portfolio rendering surfaces; broader market metadata infrastructure is unchanged.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/models.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests implemented and passing:
+1. position with valid title -> displayed correctly
+2. multiple positions -> all show correct titles
+3. same market multiple positions -> consistent title
+4. missing title -> fallback only when truly absent (with cache/context recovery)
+5. no regression in portfolio rendering
+
+Additional mapping checks implemented and passing:
+- execution output payload includes `market_id` + `market_title`
+- portfolio payload builder keeps `market_title` from primary normalized position
+- legacy execution caller path (without `market_title`) remains functional and exports empty canonical title
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/models.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` ✅ (11 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof:
+1) Telegram output BEFORE fix behavior (missing title unresolved)
+```text
+🎯 Position
+├ Market: Untitled Market
+...
+```
+
+2) Telegram output AFTER fix behavior (resolved title displayed)
+```text
+🎯 Position
+├ Market: Will ETH close above $4,000 this week?
+...
+```
+
+3) Telegram output AFTER fix with multiple positions
+```text
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will SOL close above $300 this month?
+...
+```
+
+## 5. Known issues
+- When both payload `market_title` and market-context resolution are unavailable, UI still intentionally falls back to `Untitled Market` and logs a warning (expected safe fallback).
+- External market-context endpoint may be unreachable in container environments; fallback and warnings are expected in that case.
+- Existing pytest warning remains: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_22_tg1_market_title_resolution.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md
@@ -1,0 +1,117 @@
+# 24_23_tg1_merge_conflict_resolution
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - execution → position mapping in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/models.py` and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - portfolio payload builder in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py` and `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+  - Telegram view adapter in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+  - formatter layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Not in Scope:
+  - new feature development
+  - execution decision logic changes
+  - strategy changes
+  - sizing / risk changes
+  - UI redesign
+  - trade history implementation
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md`. Tier: STANDARD
+
+## 1. What was built
+- Resolved TG-1 merge-conflict path by reapplying the full market-title preservation changes on a clean branch while keeping `market_title` as the canonical field.
+- Preserved required end-to-end chain:
+  - execution -> position -> portfolio -> telegram -> formatter
+- Enforced canonical field usage:
+  - `market_title` remains the only authoritative title field in runtime payloads
+  - legacy fields (`question`/`title`/`name`) are only accepted as explicit input-mapping adapters into `market_title`, never as canonical downstream fields
+- Kept formatter fallback safe:
+  - title shows directly from `market_title`
+  - fallback to `Untitled Market` only when title truly cannot be resolved
+  - warning log emitted for unresolved path (`telegram_market_title_missing_fallback`)
+- Added deterministic-formatting regression test for fixed timestamp payloads.
+
+Root cause of merge conflict:
+- Previous PR conflicted with concurrent edits around Telegram/portfolio formatting and state/report updates. Conflict risk centered on title-field precedence (`market_title` vs `title`/`name`/`market_name`) and generated duplicate diff blocks.
+
+## 2. Current system architecture
+- Execution layer:
+  - `Position` contains required `market_title`
+  - `ExecutionEngine.open_position(...)` accepts explicit `market_title`
+  - exported payload emits `market_id` + `market_title`
+- Position/payload layers:
+  - portfolio service stores/normalizes `market_title`
+  - callback payload builder carries `market_title` to Telegram view payloads
+- Telegram layers:
+  - view adapter maps any legacy inbound aliases into canonical `market_title`
+  - formatter resolves label from `market_title` first, then context lookup, then safe fallback if unresolved
+- Field consistency validation:
+  - no runtime path uses `.title`/`.name`/`.market_name` as canonical output in target scope
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/models.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests covered and passing:
+1. position with valid title -> rendered correctly
+2. multiple positions -> all show correct titles
+3. same market multiple positions -> consistent title
+4. no regression to `Untitled Market` when title exists
+5. deterministic formatting with fixed timestamp payload
+
+Additional checks passing:
+- execution payload contains `market_id` + `market_title`
+- backward-compat execution call without explicit `market_title` remains safe and deterministic (`""`)
+- portfolio payload builder retains canonical `market_title`
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/models.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/interface/telegram/view_handler.py projects/polymarket/polyquantbot/interface/ui_formatter.py projects/polymarket/polyquantbot/telegram/handlers/callback_router.py projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` ✅ (12 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof:
+1) BEFORE (Untitled case; unresolved title)
+```text
+🎯 Position
+├ Market: Untitled Market
+...
+```
+
+2) AFTER (title preserved)
+```text
+🎯 Position
+├ Market: Will ETH close above $4,000 this week?
+...
+```
+
+3) AFTER (multi-position)
+```text
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will BTC close above $100k this month?
+...
+🎯 Position
+├ Market: Will SOL close above $300 this month?
+...
+```
+
+## 5. Known issues
+- If both canonical `market_title` and market-context lookup are absent, fallback label remains `Untitled Market` with warning log (expected safe behavior).
+- External market-context endpoint may be unreachable in container validation, producing warning logs.
+- Existing pytest warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_23_tg1_merge_conflict_resolution.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -347,6 +347,18 @@ class CallbackRouter:
             normalized.append(
                 {
                     "market_id": str(self._extract_field(pos, "market_id", "") or ""),
+                    "market_title": str(
+                        self._extract_field(
+                            pos,
+                            "market_title",
+                            self._extract_field(
+                                pos,
+                                "market_question",
+                                self._extract_field(pos, "question", ""),
+                            ),
+                        )
+                        or ""
+                    ).strip(),
                     "side": str(self._extract_field(pos, "side", "flat") or "flat"),
                     "entry_price": safe_number(
                         self._extract_field(
@@ -424,7 +436,7 @@ class CallbackRouter:
             "unrealized_pnl": unrealized_total,
             "exposure": exposure,
             "market_id": (primary or {}).get("market_id", ""),
-            "market_title": "",
+            "market_title": (primary or {}).get("market_title", ""),
             "side": (primary or {}).get("side", "flat"),
             "entry": safe_number((primary or {}).get("entry_price", 0.0)),
             "size": safe_number((primary or {}).get("size", 0.0)),

--- a/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
@@ -17,6 +17,7 @@ log = structlog.get_logger(__name__)
 @dataclass(frozen=True)
 class PortfolioPosition:
     market_id: str
+    market_title: str
     side: str
     avg_price: float
     size: float
@@ -85,6 +86,12 @@ class PortfolioService:
             normalized.append(
                 PortfolioPosition(
                     market_id=str(pos.get("market_id", "")),
+                    market_title=str(
+                        pos.get("market_title")
+                        or pos.get("market_question")
+                        or pos.get("question")
+                        or ""
+                    ).strip(),
                     side=str(pos.get("side", "")),
                     avg_price=self._safe_float(pos.get("entry_price", pos.get("avg_price", 0.0)), 0.0),
                     size=self._safe_float(pos.get("size", 0.0), 0.0),
@@ -173,6 +180,12 @@ class PortfolioService:
                 positions.append(
                     PortfolioPosition(
                         market_id=market_id,
+                        market_title=str(
+                            getattr(pos, "market_title", "")
+                            or getattr(pos, "market_question", "")
+                            or getattr(pos, "question", "")
+                            or ""
+                        ).strip(),
                         side=side,
                         avg_price=avg_price,
                         size=size,

--- a/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
@@ -236,3 +236,26 @@ def test_no_regression_positions_summary_and_render_count() -> None:
 
     assert "Open Positions: 2" in output
     assert output.count("🎯 Position") == 2
+
+
+def test_positions_rendering_is_deterministic_with_fixed_timestamp() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-det-1",
+                "market_title": "Will deterministic formatting hold?",
+                "side": "YES",
+                "entry_price": 0.33,
+                "size": 60.0,
+                "unrealized_pnl": 1.2,
+            }
+        ],
+        "positions_count": 1,
+        "updated_at": "2026-04-09T10:20:00+00:00",
+    }
+
+    first = _render_positions(payload)
+    second = _render_positions(payload)
+
+    assert first == second
+    assert "Will deterministic formatting hold?" in first

--- a/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution import engine as execution_engine_module
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, export_execution_payload
+from projects.polymarket.polyquantbot.interface import ui_formatter
+from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
+from projects.polymarket.polyquantbot.config.runtime_config import ConfigManager
+from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
+
+
+@dataclass(frozen=True)
+class _PortfolioStateStub:
+    positions: tuple[dict[str, object], ...]
+    equity: float
+    cash: float
+    pnl: float
+
+
+class _PortfolioServiceStub:
+    def __init__(self, state: _PortfolioStateStub) -> None:
+        self._state = state
+
+    def get_state(self) -> _PortfolioStateStub:
+        return self._state
+
+
+def _make_router() -> CallbackRouter:
+    command_handler = type("CommandHandlerStub", (), {"_runner": None, "_multi_metrics": None, "_allocator": None, "_risk_guard": None})()
+    return CallbackRouter(
+        tg_api="https://api.telegram.org/botTEST",
+        cmd_handler=command_handler,
+        state_manager=SystemStateManager(),
+        config_manager=ConfigManager(),
+        mode="PAPER",
+    )
+
+
+def _render_positions(payload: dict) -> str:
+    return asyncio.run(render_view("positions", payload))
+
+
+def test_execution_output_mapping_includes_market_title(monkeypatch) -> None:
+    isolated_engine = ExecutionEngine(starting_equity=10_000.0)
+    monkeypatch.setattr(execution_engine_module, "_engine_singleton", isolated_engine)
+
+    asyncio.run(
+        isolated_engine.open_position(
+            market="mkt-ev-1",
+            market_title="Will ETH close above $4,000 this week?",
+            side="YES",
+            price=0.45,
+            size=100.0,
+            position_id="tg1-1",
+        )
+    )
+
+    payload = asyncio.run(export_execution_payload())
+
+    assert payload["positions"][0]["market_id"] == "mkt-ev-1"
+    assert payload["positions"][0]["market_title"] == "Will ETH close above $4,000 this week?"
+
+
+def test_execution_open_position_backwards_compat_without_market_title(monkeypatch) -> None:
+    isolated_engine = ExecutionEngine(starting_equity=10_000.0)
+    monkeypatch.setattr(execution_engine_module, "_engine_singleton", isolated_engine)
+
+    asyncio.run(
+        isolated_engine.open_position(
+            market="mkt-legacy-2",
+            side="YES",
+            price=0.44,
+            size=75.0,
+            position_id="tg1-legacy",
+        )
+    )
+
+    payload = asyncio.run(export_execution_payload())
+
+    assert payload["positions"][0]["market_id"] == "mkt-legacy-2"
+    assert payload["positions"][0]["market_title"] == ""
+
+
+def test_portfolio_payload_builder_keeps_market_title(monkeypatch) -> None:
+    router = _make_router()
+    portfolio_state = _PortfolioStateStub(
+        positions=(
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.52,
+                "size": 150.0,
+                "unrealized_pnl": 12.5,
+            },
+        ),
+        equity=10_500.0,
+        cash=9_000.0,
+        pnl=12.5,
+    )
+    monkeypatch.setattr(
+        "projects.polymarket.polyquantbot.telegram.handlers.callback_router.get_portfolio_service",
+        lambda: _PortfolioServiceStub(portfolio_state),
+    )
+
+    payload = router._build_normalized_payload("positions")
+
+    assert payload["market_id"] == "mkt-btc-1"
+    assert payload["market_title"] == "Will BTC close above $100k this month?"
+
+
+def test_position_with_valid_title_displays_correctly() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-eth-1",
+                "market_title": "Will ETH close above $4,000 this week?",
+                "side": "YES",
+                "entry_price": 0.45,
+                "size": 100.0,
+                "unrealized_pnl": 4.0,
+            }
+        ],
+        "positions_count": 1,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Will ETH close above $4,000 this week?" in output
+    assert "Untitled Market" not in output
+
+
+def test_multiple_positions_show_correct_titles_consistently() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.51,
+                "size": 120.0,
+                "unrealized_pnl": 2.5,
+            },
+            {
+                "market_id": "mkt-btc-1",
+                "market_title": "Will BTC close above $100k this month?",
+                "side": "YES",
+                "entry_price": 0.53,
+                "size": 80.0,
+                "unrealized_pnl": -1.0,
+            },
+            {
+                "market_id": "mkt-sol-1",
+                "market_title": "Will SOL close above $300 this month?",
+                "side": "NO",
+                "entry_price": 0.35,
+                "size": 90.0,
+                "unrealized_pnl": 1.2,
+            },
+        ],
+        "positions_count": 3,
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("🎯 Position") == 3
+    assert output.count("Will BTC close above $100k this month?") >= 2
+    assert "Will SOL close above $300 this month?" in output
+
+
+def test_missing_title_falls_back_only_when_unresolvable(monkeypatch) -> None:
+    async def _stub_market_context(market_id: str) -> dict[str, str]:
+        if market_id == "mkt-resolve":
+            return {"question": "Resolved from cache title"}
+        return {}
+
+    original_get_market_context = ui_formatter.get_market_context
+    ui_formatter.get_market_context = _stub_market_context
+    try:
+        payload = {
+            "positions": [
+                {
+                    "market_id": "mkt-resolve",
+                    "market_title": "",
+                    "side": "YES",
+                    "entry_price": 0.5,
+                    "size": 50.0,
+                    "unrealized_pnl": 0.5,
+                },
+                {
+                    "market_id": "mkt-missing",
+                    "market_title": "",
+                    "side": "NO",
+                    "entry_price": 0.4,
+                    "size": 40.0,
+                    "unrealized_pnl": -0.5,
+                },
+            ]
+        }
+
+        output = _render_positions(payload)
+    finally:
+        ui_formatter.get_market_context = original_get_market_context
+
+    assert "Resolved from cache title" in output
+    assert output.count("Untitled Market") == 1
+
+
+def test_no_regression_positions_summary_and_render_count() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-a",
+                "market_title": "Market A",
+                "side": "YES",
+                "entry_price": 0.3,
+                "size": 25.0,
+                "unrealized_pnl": 0.1,
+            },
+            {
+                "market_id": "mkt-b",
+                "market_title": "Market B",
+                "side": "NO",
+                "entry_price": 0.7,
+                "size": 35.0,
+                "unrealized_pnl": -0.2,
+            },
+        ],
+        "positions_count": 1,
+    }
+
+    output = _render_positions(payload)
+
+    assert "Open Positions: 2" in output
+    assert output.count("🎯 Position") == 2


### PR DESCRIPTION
### Motivation
- Fix broken market title continuity which caused valid positions to render as `Untitled Market` by ensuring `market_title` is preserved across execution, portfolio normalization, callback payloads, and Telegram formatting. 
- Provide a backward-compatible execution API so legacy callers that omit `market_title` continue to function. 
- Reduce fallback-heavy title resolution logic and surface a warning when a title cannot be resolved rather than silently showing internal placeholders. 

### Description
- Added `market_title` field to `Position` in `projects/.../execution/models.py` and accepted a `market_title` parameter (default `""`) in `ExecutionEngine.open_position` in `projects/.../execution/engine.py`. 
- Included `market_title` in `export_execution_payload()` so execution payloads emit `{market_id, market_title, ...}`. 
- Propagated title resolution through `strategy_trigger.py` by extracting `market_title` from candidate metadata and passing it into `open_position`. 
- Normalized and preserved `market_title` in Telegram-facing code: `callback_router._normalize_positions`, `portfolio_service._normalize_positions`/`merge_execution_state`, `view_handler` row normalization, and `ui_formatter` label resolution (with a `telegram_market_title_missing_fallback` warning log). 
- Added focused TG-1 validation report and updated `PROJECT_STATE.md` to document the change and scope. 
- Added tests in `projects/.../tests/test_tg1_market_title_resolution_20260409.py` to cover execution export, backward-compat open, payload builder, rendering of single/multiple positions, missing-title fallback, and no-regression summary behavior. 

### Testing
- Per-file syntax checks with `python -m py_compile <modified files>`, which completed successfully. 
- Ran the focused test suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg1_market_title_resolution_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py`, resulting in all tests passing (11 passed) with an environment warning about unknown `asyncio_mode` only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d778e58ac0832eb911dfd2487a0f50)