### PR TITLE
fix(tg-1): preserve market_title across execution → portfolio → Telegram formatter path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,13 +1,14 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 07:05
-- Status        : FORGE-X P12 execution timing & entry optimization implemented (STANDARD, narrow integration) in strategy-trigger pre-execution path; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 10:36
+- Status        : FORGE-X TG-1 market-title merge-conflict fix implemented (STANDARD, narrow integration) across execution→portfolio→Telegram formatter path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
 - P12 execution timing & entry optimization (2026-04-09): added pre-execution timing-aware gate with deterministic `ENTER_NOW`/`WAIT`/`SKIP` output contract, anti-chase spike delay/timeout skip handling, micro-pullback wait/re-evaluate/enter flow, bounded reevaluation windows, and timing-first coordination with existing P10 execution-quality gate plus focused deterministic tests.
+- TG-1 market-title merge-conflict fix (2026-04-09): enforced canonical `market_title` propagation in touched path (`execution.open_position` → execution position payload → portfolio snapshot → callback payload → Telegram view adapter → formatter), removed mixed-field priority in formatter/view path, and added focused regression tests proving no `Untitled Market` regression when title exists.
 - P11 market regime detection (2026-04-09): added deterministic regime classification (`NEWS_DRIVEN`/`ARBITRAGE_DOMINANT`/`SMART_MONEY_DOMINANT`/`LOW_ACTIVITY_CHAOTIC`) from social/dispersion/wallet/activity signals, integrated bounded regime-based S4 strategy weighting modifiers with neutral fallback behavior, and added focused deterministic regime/aggregation contract tests.
 - P10 execution quality & fill optimization (2026-04-09): added pre-execution execution-quality gate in strategy trigger with deterministic ENTER/SKIP/REDUCE contract (`final_decision`/`adjusted_size`/`expected_fill_price`/`expected_slippage`/`execution_quality_reason`), spread/depth/slippage checks, conservative fill-price discipline, and focused runtime-proof tests.
 - S5 settlement-gap scanner (2026-04-09): implemented Kalshi resolution detection + Polymarket equivalent-market matching + resolved-outcome underpricing check (`< 0.95`) with liquidity/open-market skip guards and deterministic ENTER/SKIP output contract (`decision`/`edge`/`reason`/`source="settlement_gap"`).
@@ -111,6 +112,10 @@ Status:
 - STANDARD-tier narrow integration implementation is complete for timing-aware pre-execution decisioning (`ENTER_NOW`/`WAIT`/`SKIP`) and bounded reevaluation behavior coordinated with P10 quality gating.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
+### TG-1 market-title merge-conflict handoff
+- STANDARD-tier narrow integration implementation is complete for market title preservation in execution-to-Telegram touched path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P11 market regime detection handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger regime classification and S4 score-weight adjustment context output.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -196,7 +201,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_22_p12_execution_timing_entry_optimization.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
@@ -223,3 +228,4 @@ Tier: STANDARD
 - MAJOR task `p5_execution_snapshot_contract_compatibility` awaits SENTINEL revalidation for merge eligibility.
 - Pytest environment still reports unknown `asyncio_mode` config warning; focused observability tests pass under synchronous `asyncio.run(...)` invocation.
 - Pytest environment still reports unknown `asyncio_mode` config warning on focused portfolio-render tests; tests pass despite the warning.
+- TG-1 market-title canonicalization is narrow integration in touched execution/portfolio/Telegram path; unrelated legacy views may still carry non-canonical labels until separately refactored.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -46,6 +46,7 @@ class ExecutionEngine:
     async def open_position(
         self,
         market: str,
+        market_title: str,
         side: str,
         price: float,
         size: float,
@@ -90,6 +91,7 @@ class ExecutionEngine:
 
             position = Position(
                 market_id=market,
+                market_title=market_title,
                 side=side.upper(),
                 entry_price=float(price),
                 current_price=float(price),
@@ -184,6 +186,7 @@ async def export_execution_payload() -> dict[str, Any]:
         "positions": [
             {
                 "market_id": pos.market_id,
+                "market_title": pos.market_title,
                 "side": pos.side,
                 "entry_price": pos.entry_price,
                 "current_price": pos.current_price,

--- a/projects/polymarket/polyquantbot/execution/models.py
+++ b/projects/polymarket/polyquantbot/execution/models.py
@@ -10,6 +10,7 @@ class Position:
     """Paper trading position state for execution engine."""
 
     market_id: str
+    market_title: str
     side: str
     entry_price: float
     current_price: float

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -1775,8 +1775,14 @@ class StrategyTrigger:
                 )
                 return "BLOCKED"
             size = readiness.adjusted_size
+            candidate_title = (
+                selected_candidate.title
+                if selected_candidate is not None and selected_candidate.title
+                else target_market_id
+            )
             created = await self._engine.open_position(
                 market=target_market_id,
+                market_title=str(candidate_title),
                 side=self._config.side,
                 price=readiness.expected_fill_price,
                 size=size,

--- a/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
+++ b/projects/polymarket/polyquantbot/interface/telegram/view_handler.py
@@ -72,13 +72,33 @@ def safe_count(value: Any, default: int = 0) -> int:
 def _position_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     rows = _as_list(payload.get("positions"))
     if rows and isinstance(rows[0], Mapping):
-        return [row for row in rows if isinstance(row, Mapping)]
+        return [_as_mapping(row) for row in rows if isinstance(row, Mapping)]
     open_rows = _as_list(payload.get("open_positions"))
-    return [row for row in open_rows if isinstance(row, Mapping)]
+    return [_as_mapping(row) for row in open_rows if isinstance(row, Mapping)]
+
+
+def _canonical_market_title(row: Mapping[str, Any]) -> str:
+    market_title = _first_present(
+        row,
+        "market_title",
+        "market_question",
+        "question",
+        "market_name",
+        "title",
+        default="",
+    )
+    return str(market_title or "").strip()
 
 
 def _derive_position_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
-    rows = _position_rows(payload)
+    raw_rows = _position_rows(payload)
+    rows = [
+        {
+            **dict(_as_mapping(row)),
+            "market_title": _canonical_market_title(_as_mapping(row)),
+        }
+        for row in raw_rows
+    ]
     primary = _as_mapping(rows[0]) if rows else {}
     unrealized_total = sum(
         safe_number(_as_mapping(row).get("unrealized_pnl", _as_mapping(row).get("pnl", 0.0)))
@@ -142,7 +162,7 @@ def _base_payload(mode: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         "confidence": payload.get("confidence", 0),
         "decision": payload.get("decision"),
         "operator_note": payload.get("operator_note"),
-        "market_title": _first_present(payload, "market_title", "market_name", "question", default=primary.get("market_title")),
+        "market_title": _first_present(payload, "market_title", default=primary.get("market_title")),
         "market_question": payload.get("question"),
         "market_id": _first_present(payload, "market_id", "market", default=primary.get("market_id")),
         "current": _first_present(payload, "current", "current_price", "last_price", default=primary.get("current_price")),

--- a/projects/polymarket/polyquantbot/interface/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/interface/ui_formatter.py
@@ -170,16 +170,14 @@ def _resolve_market_label(payload: Mapping[str, Any], context: Mapping[str, Any]
 
     for candidate in (
         payload.get("market_title"),
-        payload.get("market_question"),
-        payload.get("market_name"),
         context.get("question"),
-        context.get("name"),
-        payload.get("market"),
     ):
         text = _compact_text(candidate, "", max_len=86)
         if text and not _is_generic_label(text) and not _is_internal_fallback_label(text):
             return text
-
+    fallback_market_id = _safe_text(payload.get("market_id"), "")
+    if fallback_market_id:
+        return f"Market {fallback_market_id[:12]}"
     return "Untitled Market"
 
 
@@ -433,8 +431,7 @@ async def _render_position_cards(payload: Mapping[str, Any]) -> list[str]:
         row_payload.update(
             {
                 "market_id": row.get("market_id"),
-                "market_title": row.get("market_title", row.get("market_question")),
-                "market_question": row.get("market_question"),
+                "market_title": row.get("market_title"),
                 "side": row.get("side"),
                 "entry": row.get("entry_price", row.get("avg_price")),
                 "current": row.get("current_price", row.get("entry_price", row.get("avg_price"))),

--- a/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md
@@ -1,0 +1,111 @@
+# 24_23_tg1_market_title_merge_conflict
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - execution → position mapping
+  - portfolio payload builder
+  - Telegram view adapter
+  - formatter layer
+- Not in Scope:
+  - new feature development
+  - execution logic changes
+  - strategy changes
+  - sizing / risk changes
+  - UI redesign
+  - trade history implementation
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md`. Tier: STANDARD
+
+## 1. What was built
+- Resolved TG-1 merge-conflict behavior by enforcing `market_title` as canonical position title field across the touched pipeline path.
+- Extended execution `Position` contract and `ExecutionEngine.open_position(...)` to carry and persist `market_title` explicitly.
+- Ensured execution payload export includes `market_title` for every open position row.
+- Updated Telegram portfolio normalization and callback payload normalization to preserve `market_title` instead of dropping it.
+- Updated Telegram view adapter to canonicalize mixed legacy title fields into `market_title` once, then render from canonical key.
+- Tightened formatter title resolution to prioritize `market_title` and reduce aggressive fallback to `Untitled Market`.
+- Added focused regression tests for title preservation, multi-position behavior, deterministic formatting, and execution→payload propagation.
+
+## 2. Current system architecture
+Execution/path flow in touched scope now resolves as:
+1. `execution.strategy_trigger.evaluate(...)` computes selected candidate and passes explicit `market_title` to `ExecutionEngine.open_position(...)`.
+2. `execution.engine.Position` stores `market_title` as a first-class field.
+3. `execution.engine.export_execution_payload()` serializes `market_title` in each position object.
+4. `telegram.handlers.portfolio_service` keeps `market_title` in normalized `PortfolioPosition` snapshots.
+5. `telegram.handlers.callback_router` preserves `market_title` into callback payload.
+6. `interface.telegram.view_handler` canonicalizes legacy fields into `market_title` and forwards `position_rows` with canonical title.
+7. `interface.ui_formatter` renders market labels using canonical `market_title` first and only falls back when title is truly missing.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/models.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/telegram/view_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/interface/ui_formatter.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Root cause of merge conflict:
+- Conflicting field expectations (`market_title` vs `market_question`/`market_name`) caused title drops in intermediate payloads, which could drive formatter fallback behavior.
+- The position/payload path did not guarantee explicit `market_title` persistence from execution state.
+
+Field-consistency preservation:
+- Canonical field is now `market_title` in touched runtime path.
+- Legacy fields are only used as explicit one-time mapping inputs into canonical `market_title` in view adapter compatibility handling.
+- Formatter path no longer prioritizes mixed fields before canonical title.
+
+Required test coverage (all pass):
+1. position with valid title → rendered correctly
+2. multiple positions → all show correct titles
+3. same market multiple positions → consistent title
+4. no regression to `Untitled Market` when title exists
+5. deterministic formatting output for same payload
+6. execution→payload `market_title` propagation proof
+
+Runtime proof snapshots:
+
+1) BEFORE (title missing path)
+```text
+🎯 Position
+├ Market: Market legacy-1
+├ Side: 🟢 YES
+├ Entry: 45.00¢
+```
+
+2) AFTER (canonical title preserved)
+```text
+🎯 Position
+├ Market: Will Fed cut rates in June?
+├ Side: 🟢 YES
+├ Entry: 45.00¢
+```
+
+3) Multi-position example
+```text
+🎯 Position
+├ Market: ETH > 6k?
+...
+🎯 Position
+├ Market: SOL > 400?
+```
+
+Validation of no mixed field usage in touched path:
+- Execution position model/export: canonical `market_title` only.
+- Portfolio/callback payload: canonical `market_title` only.
+- View adapter explicitly maps legacy keys to canonical `market_title` before render.
+- Formatter consumes `market_title` as first source and only falls back when truly missing.
+
+## 5. Known issues
+- Legacy/non-canonical keys may still exist in unrelated modules outside this task’s validation target; touched path now canonicalizes them to `market_title` before rendering.
+- Existing pytest environment warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files and direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/callback_router.py
@@ -347,6 +347,7 @@ class CallbackRouter:
             normalized.append(
                 {
                     "market_id": str(self._extract_field(pos, "market_id", "") or ""),
+                    "market_title": str(self._extract_field(pos, "market_title", "") or ""),
                     "side": str(self._extract_field(pos, "side", "flat") or "flat"),
                     "entry_price": safe_number(
                         self._extract_field(
@@ -424,7 +425,7 @@ class CallbackRouter:
             "unrealized_pnl": unrealized_total,
             "exposure": exposure,
             "market_id": (primary or {}).get("market_id", ""),
-            "market_title": "",
+            "market_title": (primary or {}).get("market_title", ""),
             "side": (primary or {}).get("side", "flat"),
             "entry": safe_number((primary or {}).get("entry_price", 0.0)),
             "size": safe_number((primary or {}).get("size", 0.0)),

--- a/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
+++ b/projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py
@@ -17,6 +17,7 @@ log = structlog.get_logger(__name__)
 @dataclass(frozen=True)
 class PortfolioPosition:
     market_id: str
+    market_title: str
     side: str
     avg_price: float
     size: float
@@ -85,6 +86,7 @@ class PortfolioService:
             normalized.append(
                 PortfolioPosition(
                     market_id=str(pos.get("market_id", "")),
+                    market_title=str(pos.get("market_title", "")),
                     side=str(pos.get("side", "")),
                     avg_price=self._safe_float(pos.get("entry_price", pos.get("avg_price", 0.0)), 0.0),
                     size=self._safe_float(pos.get("size", 0.0), 0.0),
@@ -160,6 +162,7 @@ class PortfolioService:
         try:
             for pos in raw_positions:
                 market_id = str(getattr(pos, "market_id", ""))
+                market_title = str(getattr(pos, "market_title", ""))
                 side = str(getattr(pos, "side", ""))
                 size = self._safe_float(getattr(pos, "size", 0.0), 0.0)
                 avg_price = self._safe_float(
@@ -173,6 +176,7 @@ class PortfolioService:
                 positions.append(
                     PortfolioPosition(
                         market_id=market_id,
+                        market_title=market_title,
                         side=side,
                         avg_price=avg_price,
                         size=size,

--- a/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, export_execution_payload
+from projects.polymarket.polyquantbot.interface import ui_formatter
+from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+
+
+async def _empty_context(_: str) -> dict[str, str]:
+    return {}
+
+
+def _render_positions(payload: dict) -> str:
+    original = ui_formatter.get_market_context
+    ui_formatter.get_market_context = _empty_context
+    try:
+        return asyncio.run(render_view("positions", payload))
+    finally:
+        ui_formatter.get_market_context = original
+
+
+def test_position_with_valid_title_renders_market_title() -> None:
+    payload = {
+        "positions": [
+            {
+                "market_id": "mkt-1",
+                "market_title": "Will BTC close above $120k in 2026?",
+                "side": "YES",
+                "entry_price": 0.55,
+                "size": 100.0,
+                "unrealized_pnl": 6.5,
+            }
+        ]
+    }
+
+    output = _render_positions(payload)
+
+    assert "Will BTC close above $120k in 2026?" in output
+    assert "Untitled Market" not in output
+
+
+def test_multiple_positions_render_all_titles() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "a", "market_title": "ETH > 6k?", "side": "YES", "entry_price": 0.42, "size": 80.0, "unrealized_pnl": 1.2},
+            {"market_id": "b", "market_title": "SOL > 400?", "side": "NO", "entry_price": 0.38, "size": 60.0, "unrealized_pnl": -0.7},
+            {"market_id": "c", "market_title": "AVAX > 150?", "side": "YES", "entry_price": 0.31, "size": 40.0, "unrealized_pnl": 0.3},
+        ]
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("🎯 Position") == 3
+    assert "ETH > 6k?" in output
+    assert "SOL > 400?" in output
+    assert "AVAX > 150?" in output
+
+
+def test_same_market_multiple_positions_keep_consistent_title() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "btc-2026", "market_title": "Will BTC close above $120k in 2026?", "side": "YES", "entry_price": 0.50, "size": 90.0, "unrealized_pnl": 1.0},
+            {"market_id": "btc-2026", "market_title": "Will BTC close above $120k in 2026?", "side": "YES", "entry_price": 0.53, "size": 120.0, "unrealized_pnl": 2.0},
+        ]
+    }
+
+    output = _render_positions(payload)
+
+    assert output.count("Will BTC close above $120k in 2026?") >= 2
+    assert "Untitled Market" not in output
+
+
+def test_before_and_after_untitled_regression_proof() -> None:
+    before_payload = {
+        "positions": [
+            {"market_id": "legacy-1", "side": "YES", "entry_price": 0.45, "size": 50.0, "unrealized_pnl": 0.0}
+        ]
+    }
+    after_payload = {
+        "positions": [
+            {
+                "market_id": "legacy-1",
+                "market_question": "Will Fed cut rates in June?",
+                "side": "YES",
+                "entry_price": 0.45,
+                "size": 50.0,
+                "unrealized_pnl": 0.0,
+            }
+        ]
+    }
+
+    before_output = _render_positions(before_payload)
+    after_output = _render_positions(after_payload)
+
+    assert "Untitled Market" in before_output or "Market legacy-1" in before_output
+    assert "Will Fed cut rates in June?" in after_output
+    assert "Untitled Market" not in after_output
+
+
+def test_rendering_is_deterministic_for_same_payload() -> None:
+    payload = {
+        "positions": [
+            {"market_id": "det-1", "market_title": "Will CPI come under 2.5%?", "side": "NO", "entry_price": 0.41, "size": 77.0, "unrealized_pnl": 0.5}
+        ],
+        "positions_count": 1,
+        "updated_at": "2026-04-09T10:00:00+00:00",
+    }
+
+    first = _render_positions(payload)
+    second = _render_positions(payload)
+
+    assert first == second
+
+
+def test_execution_to_payload_preserves_market_title() -> None:
+    async def _run() -> dict[str, object]:
+        engine = ExecutionEngine(starting_equity=1_000.0)
+        await engine.open_position(
+            market="mkt-exec-1",
+            market_title="Will unemployment stay below 4% in Q3?",
+            side="YES",
+            price=0.49,
+            size=50.0,
+            position_id="pos-1",
+        )
+        from projects.polymarket.polyquantbot.execution import engine as engine_module
+
+        original = engine_module._engine_singleton
+        engine_module._engine_singleton = engine
+        try:
+            return await export_execution_payload()
+        finally:
+            engine_module._engine_singleton = original
+
+    payload = asyncio.run(_run())
+    positions = payload.get("positions", [])
+
+    assert isinstance(positions, list)
+    assert positions
+    row = positions[0]
+    assert row["market_title"] == "Will unemployment stay below 4% in Q3?"


### PR DESCRIPTION
### Motivation
- Resolve TG-1 merge conflict and prevent regressions where human-readable titles revert to placeholder text by making `market_title` the single canonical field across the touched pipeline. 
- Ensure execution-layer position creation and all downstream payloads always carry `market_title` so Telegram views never fall back to `Untitled Market` when a title exists.

### Description
- Add `market_title` as a first-class field on the execution `Position` model and extend `ExecutionEngine.open_position(...)` to accept and persist `market_title`, and include it in `export_execution_payload()` so execution→payload preserves title. (modified: `projects/polymarket/polyquantbot/execution/models.py`, `projects/polymarket/polyquantbot/execution/engine.py`)
- Wire `StrategyTrigger.evaluate(...)` to pass an explicit `market_title` when opening positions so the execution layer receives canonical title data. (modified: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`)
- Preserve `market_title` in portfolio normalization and callback payloads by adding it to `PortfolioPosition` and callback normalization, avoiding title drops during portfolio snapshot/telegram payload construction. (modified: `projects/polymarket/polyquantbot/telegram/handlers/portfolio_service.py`, `projects/polymarket/polyquantbot/telegram/handlers/callback_router.py`)
- Canonicalize legacy/alternate title keys in the Telegram view adapter and tighten formatter resolution to prefer `market_title` and only use market-id fallback when no title is present; update position-row handling to carry `market_title` end-to-end. (modified: `projects/polymarket/polyquantbot/interface/telegram/view_handler.py`, `projects/polymarket/polyquantbot/interface/ui_formatter.py`)
- Add focused regression tests exercising valid-title rendering, multi-position rendering, same-market consistency, deterministic formatting, and execution→payload title propagation. Also add a FORGE report and update `PROJECT_STATE.md`. (added: `projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py`; added: `projects/polymarket/polyquantbot/reports/forge/24_23_tg1_market_title_merge_conflict.md`; updated: `PROJECT_STATE.md`)

### Testing
- Ran `python -m py_compile` on modified modules and the new test file and it passed with no syntax errors. ✅
- Ran focused pytest: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py projects/polymarket/polyquantbot/tests/test_telegram_portfolio_position_render_mismatch_20260409.py` and all tests passed (10 passed) with one non-blocking pytest config warning (`Unknown config option: asyncio_mode`). ✅
- Performed runtime proof renders showing BEFORE (market-id fallback) and AFTER (canonical title preserved) outputs and execution→payload propagation checks, which succeeded and are included in the forge report. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77fe72fd8832ead59e977c497298c)