### PR TITLE
[P13] Adaptive exit timing & trade management (STANDARD, narrow integration)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 11:12
-- Status        : FORGE-X TG-2 + TG-3 open positions visibility and trade history implementation complete (STANDARD, narrow integration) in Telegram portfolio view/formatter/storage path; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 11:52
+- Status        : FORGE-X P13 exit timing & trade management implementation complete (STANDARD, narrow integration) in strategy-trigger position monitoring + exit-decision path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P13 exit timing & trade management (2026-04-09): replaced static exit threshold behavior with adaptive deterministic exit decisioning (`EXIT_FULL`/`HOLD` + `exit_reason`/`pnl_snapshot`/`trade_duration`), added favorable-move momentum-weakening take-profit logic, bounded stop-loss + signal-invalidation exits, stale-trade timeout/hard-duration guards, and light adaptation using P9 performance feedback + P11 regime context with focused runtime-proof tests.
 - TG-2 + TG-3 open positions visibility & trade history (2026-04-09): implemented full open-position card rendering without truncation, added separate-card handling for same-market multi-position entries with per-position refs, added closed-trade history rendering with newest-first ordering and capped history display, integrated execution payload closed-trade persistence into portfolio state and Telegram callback payload path, and added focused formatter/view tests (including strict format and empty-state coverage).
 - P12 execution timing & entry optimization (2026-04-09): added pre-execution timing-aware gate with deterministic `ENTER_NOW`/`WAIT`/`SKIP` output contract, anti-chase spike delay/timeout skip handling, micro-pullback wait/re-evaluate/enter flow, bounded reevaluation windows, and timing-first coordination with existing P10 execution-quality gate plus focused deterministic tests.
 - TG-1 market-title merge-conflict fix (2026-04-09): enforced canonical `market_title` propagation in touched path (`execution.open_position` → execution position payload → portfolio snapshot → callback payload → Telegram view adapter → formatter), removed mixed-field priority in formatter/view path, and added focused regression tests proving no `Untitled Market` regression when title exists.
@@ -109,6 +110,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P13 exit timing & trade management handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger position monitoring and adaptive exit decisions with P9/P11 context shaping.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### TG-2 + TG-3 open positions + trade history handoff
 - STANDARD-tier narrow integration implementation is complete for Telegram positions-view rendering and history visibility in touched formatter/view/storage path.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -206,11 +211,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_24_tg2_tg3_open_positions_trade_history.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P13 exit management is currently narrow integration in strategy-trigger monitoring path only and is not yet propagated into broader runtime orchestration surfaces.
 - TG-2 + TG-3 trade history is currently narrow integration in Telegram portfolio rendering path only and is not yet surfaced in other non-portfolio historical analytics views.
 - P12 entry timing layer is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime execution orchestration layers.
 - P11 market regime detection is currently narrow integration in strategy-trigger S4 scoring path only and is not yet wired into broader runtime execution orchestration.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -50,6 +50,14 @@ class StrategyConfig:
     micro_pullback_improvement_ratio: float = 0.008
     timing_reevaluation_window_seconds: int = 15
     timing_max_wait_cycles: int = 2
+    stop_loss_ratio: float = 0.04
+    favorable_pnl_ratio: float = 0.015
+    momentum_weakening_ratio: float = 0.35
+    stale_trade_price_move_ratio: float = 0.003
+    max_trade_duration_seconds: int = 1800
+    hard_max_trade_duration_seconds: int = 3600
+    fast_exit_regime_factor: float = 0.75
+    slow_exit_regime_factor: float = 1.25
 
 
 @dataclass(frozen=True)
@@ -220,6 +228,14 @@ class EntryExecutionReadiness:
 
 
 @dataclass(frozen=True)
+class ExitDecision:
+    exit_decision: str
+    exit_reason: str
+    pnl_snapshot: float
+    trade_duration: int
+
+
+@dataclass(frozen=True)
 class StrategyPerformanceStats:
     strategy_name: str
     total_trades: int
@@ -286,6 +302,7 @@ class StrategyTrigger:
         )
         self._adaptive_confidence_bounds: tuple[float, float] = (0.55, 0.80)
         self._last_adjustment_explanation: str = "adaptive defaults active"
+        self._position_peak_pnl: dict[str, float] = {}
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
@@ -1595,6 +1612,120 @@ class StrategyTrigger:
             expected_slippage=execution_quality.expected_slippage,
         )
 
+    def evaluate_exit_decision(
+        self,
+        *,
+        tracked_position: object,
+        market_context: dict[str, float | str | bool] | None = None,
+        aggregation_decision: StrategyAggregationDecision | None = None,
+        now_ts: float | None = None,
+    ) -> ExitDecision:
+        context = market_context or {}
+        current_time = time.time() if now_ts is None else now_ts
+        created_at = float(getattr(tracked_position, "created_at", current_time))
+        trade_duration = max(int(current_time - created_at), 0)
+        current_pnl = float(getattr(tracked_position, "pnl", 0.0))
+        entry_price = max(float(getattr(tracked_position, "entry_price", 0.0)), 1e-6)
+        current_price = max(float(getattr(tracked_position, "current_price", entry_price)), 0.0)
+        position_size = max(float(getattr(tracked_position, "size", 0.0)), 0.0)
+        position_id = str(getattr(tracked_position, "position_id", ""))
+
+        peak_pnl = max(self._position_peak_pnl.get(position_id, current_pnl), current_pnl)
+        self._position_peak_pnl[position_id] = peak_pnl
+
+        regime = (
+            aggregation_decision.current_regime
+            if aggregation_decision is not None
+            else str(context.get("current_regime", "LOW_ACTIVITY_CHAOTIC"))
+        )
+        adaptive_state = self.get_adaptive_adjustment_state()
+        avg_weight = (
+            sum(adaptive_state.strategy_weights.values()) / len(adaptive_state.strategy_weights)
+            if adaptive_state.strategy_weights
+            else 1.0
+        )
+
+        regime_factor = 1.0
+        if regime == "LOW_ACTIVITY_CHAOTIC":
+            regime_factor *= self._config.fast_exit_regime_factor
+        elif regime in {"NEWS_DRIVEN", "SMART_MONEY_DOMINANT"}:
+            regime_factor *= self._config.slow_exit_regime_factor
+
+        if avg_weight < 0.98:
+            regime_factor *= 0.9
+        elif avg_weight > 1.02:
+            regime_factor *= 1.1
+
+        bounded_factor = self._clamp(regime_factor, 0.65, 1.35)
+        stop_loss_limit = position_size * self._config.stop_loss_ratio * bounded_factor
+        favorable_threshold = max(
+            self._config.target_pnl * bounded_factor,
+            position_size * self._config.favorable_pnl_ratio * bounded_factor,
+        )
+        effective_max_duration = max(int(self._config.max_trade_duration_seconds * bounded_factor), 60)
+        effective_hard_max_duration = max(
+            int(self._config.hard_max_trade_duration_seconds * bounded_factor),
+            effective_max_duration,
+        )
+        stale_move_ratio = self._config.stale_trade_price_move_ratio * bounded_factor
+        price_move_ratio = abs(current_price - entry_price) / entry_price
+
+        if bool(context.get("signal_invalidated", False)):
+            return ExitDecision(
+                exit_decision="EXIT_FULL",
+                exit_reason="signal_invalidation",
+                pnl_snapshot=round(current_pnl, 6),
+                trade_duration=trade_duration,
+            )
+
+        if current_pnl <= -abs(stop_loss_limit):
+            return ExitDecision(
+                exit_decision="EXIT_FULL",
+                exit_reason="stop_loss_threshold_breached",
+                pnl_snapshot=round(current_pnl, 6),
+                trade_duration=trade_duration,
+            )
+
+        if trade_duration >= effective_hard_max_duration:
+            return ExitDecision(
+                exit_decision="EXIT_FULL",
+                exit_reason="max_duration_guard",
+                pnl_snapshot=round(current_pnl, 6),
+                trade_duration=trade_duration,
+            )
+
+        if trade_duration >= effective_max_duration and price_move_ratio <= stale_move_ratio:
+            return ExitDecision(
+                exit_decision="EXIT_FULL",
+                exit_reason="stale_trade_timeout",
+                pnl_snapshot=round(current_pnl, 6),
+                trade_duration=trade_duration,
+            )
+
+        if peak_pnl >= favorable_threshold:
+            pullback_from_peak = peak_pnl - current_pnl
+            weakening_threshold = peak_pnl * self._config.momentum_weakening_ratio
+            if pullback_from_peak >= weakening_threshold:
+                return ExitDecision(
+                    exit_decision="EXIT_FULL",
+                    exit_reason="momentum_weakened_after_favorable_move",
+                    pnl_snapshot=round(current_pnl, 6),
+                    trade_duration=trade_duration,
+                )
+            return ExitDecision(
+                exit_decision="HOLD",
+                exit_reason="favorable_momentum_intact",
+                pnl_snapshot=round(current_pnl, 6),
+                trade_duration=trade_duration,
+            )
+
+        return ExitDecision(
+            exit_decision="HOLD",
+            exit_reason="exit_conditions_not_met",
+            pnl_snapshot=round(current_pnl, 6),
+            trade_duration=trade_duration,
+        )
+
     def _select_best_cross_exchange_match(
         self,
         polymarket: CrossExchangeMarket,
@@ -1807,8 +1938,16 @@ class StrategyTrigger:
             await self._engine.update_mark_to_market({self._config.market_id: market_price})
             refreshed = await self._engine.snapshot()
             tracked = next((p for p in refreshed.positions if p.market_id == self._config.market_id), None)
-            if tracked is not None and tracked.pnl > self._config.target_pnl:
+            if tracked is not None:
+                exit_decision = self.evaluate_exit_decision(
+                    tracked_position=tracked,
+                    market_context=market_context,
+                    aggregation_decision=aggregation_decision,
+                )
+                if exit_decision.exit_decision == "HOLD":
+                    return "HOLD"
                 await self._engine.close_position(tracked, market_price)
+                self._position_peak_pnl.pop(str(getattr(tracked, "position_id", "")), None)
                 self._trace_engine.record_trace(
                     position_id=tracked.position_id,
                     market_id=self._config.market_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
@@ -1,0 +1,93 @@
+# 24_25_p13_exit_timing_trade_management
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - position monitoring loop in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - adaptive exit decision logic (`EXIT_FULL` / `HOLD`)
+  - integration points with P9 adaptive feedback and P11 regime context
+- Not in Scope:
+  - execution engine redesign
+  - strategy entry logic changes
+  - Telegram UI redesign
+  - external integrations
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md`. Tier: STANDARD
+
+## 1. What was built
+- Added adaptive exit-management configuration and deterministic `ExitDecision` contract in strategy trigger scope.
+- Implemented context-aware exit evaluator with required output fields:
+  - `exit_decision`
+  - `exit_reason`
+  - `pnl_snapshot`
+  - `trade_duration`
+- Implemented required exit logic:
+  1. **Take-profit management**: winners are held while momentum remains intact and exited when favorable move weakens.
+  2. **Stop-loss management**: immediate full-exit on adverse move beyond bounded loss threshold or signal invalidation.
+  3. **Time-based exit**: stale-trade timeout and hard max-duration guard to prevent infinite holding.
+- Integrated adaptive behavior (light):
+  - **P11 regime context** adjusts exit aggressiveness (`LOW_ACTIVITY_CHAOTIC` exits faster; strong regimes hold longer).
+  - **P9 performance feedback** (adaptive strategy-weight state) tightens/loosens exit factor based on recent strategy quality.
+- Wired exit decision into live position monitoring branch of `evaluate(...)` so the monitoring loop now closes based on adaptive exit decisions, not static fixed-PnL threshold only.
+
+## 2. Current system architecture
+- Entry-side flow from earlier tasks remains unchanged (P12 timing + P10 quality + P8/P7 sizing/exposure gating).
+- Position monitoring flow is now:
+  1. mark-to-market update
+  2. fetch tracked open position
+  3. call `evaluate_exit_decision(...)`
+  4. if `HOLD` -> keep position open
+  5. if `EXIT_FULL` -> close position and emit close trace
+- Exit evaluator inputs:
+  - position state (`pnl`, `entry_price`, `current_price`, `size`, `created_at`)
+  - P11 regime context (`aggregation_decision.current_regime` or context override)
+  - P9 adaptive state (`get_adaptive_adjustment_state()` average strategy-weight signal)
+- Safety controls:
+  - bounded thresholds via clamp
+  - hard max duration guard
+  - deterministic branch ordering and fixed reason strings
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests (all pass):
+1. profitable trade -> hold then exit on weakening momentum
+2. losing trade -> stop loss triggers
+3. stale trade -> time exit
+4. regime + feedback context affects exit behavior
+5. deterministic output for same input
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py projects/polymarket/polyquantbot/tests/test_p11_market_regime_detection_20260409.py` ✅ (17 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof:
+1) winning trade -> delayed exit
+```text
+winning trade hold: ExitDecision(exit_decision='HOLD', exit_reason='favorable_momentum_intact', pnl_snapshot=60.0, trade_duration=1000)
+winning trade delayed exit: ExitDecision(exit_decision='EXIT_FULL', exit_reason='momentum_weakened_after_favorable_move', pnl_snapshot=30.0, trade_duration=1010)
+```
+2) losing trade -> fast exit
+```text
+losing trade fast exit: ExitDecision(exit_decision='EXIT_FULL', exit_reason='stop_loss_threshold_breached', pnl_snapshot=-50.0, trade_duration=1020)
+```
+3) stale trade -> timeout exit
+```text
+stale trade timeout exit: ExitDecision(exit_decision='EXIT_FULL', exit_reason='stale_trade_timeout', pnl_snapshot=0.5, trade_duration=2000)
+```
+
+## 5. Known issues
+- P13 is intentionally narrow integration in strategy-trigger position monitoring path and is not yet generalized to other runtime orchestration surfaces.
+- `EXIT_PARTIAL` is intentionally not activated in this pass (optional output remains reserved).
+- Existing test environment warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.models import Position
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    positions: tuple[Position, ...]
+    cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    implied_prob: float
+    volatility: float
+
+
+class _NoopEngine:
+    max_total_exposure_ratio = 0.30
+    max_position_size_ratio = 0.10
+
+    async def snapshot(self):  # pragma: no cover - not used
+        return _Snapshot(
+            positions=tuple(),
+            cash=10_000.0,
+            equity=10_000.0,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.5,
+            volatility=0.1,
+        )
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_NoopEngine(),
+        config=StrategyConfig(
+            market_id="m-p13",
+            target_pnl=25.0,
+            stop_loss_ratio=0.04,
+            favorable_pnl_ratio=0.015,
+            momentum_weakening_ratio=0.35,
+            stale_trade_price_move_ratio=0.003,
+            max_trade_duration_seconds=1800,
+            hard_max_trade_duration_seconds=3600,
+        ),
+    )
+
+
+def _position(price: float, *, entry_price: float = 0.5, size: float = 1000.0, created_at: float = 0.0) -> Position:
+    position = Position(
+        market_id="m-p13",
+        market_title="P13 Market",
+        side="YES",
+        entry_price=entry_price,
+        current_price=entry_price,
+        size=size,
+        position_id="pos-p13",
+        created_at=created_at,
+    )
+    position.update_price(price)
+    return position
+
+
+def test_profitable_trade_holds_then_exits_on_momentum_weakening() -> None:
+    trigger = _make_trigger()
+    winning = _position(0.56)
+    hold_decision = trigger.evaluate_exit_decision(
+        tracked_position=winning,
+        market_context={"current_regime": "NEWS_DRIVEN"},
+        now_ts=1_000.0,
+    )
+
+    weakening = _position(0.53)
+    exit_decision = trigger.evaluate_exit_decision(
+        tracked_position=weakening,
+        market_context={"current_regime": "NEWS_DRIVEN"},
+        now_ts=1_010.0,
+    )
+
+    assert hold_decision.exit_decision == "HOLD"
+    assert hold_decision.exit_reason == "favorable_momentum_intact"
+    assert exit_decision.exit_decision == "EXIT_FULL"
+    assert exit_decision.exit_reason == "momentum_weakened_after_favorable_move"
+
+
+def test_losing_trade_triggers_stop_loss_fast() -> None:
+    trigger = _make_trigger()
+    losing = _position(0.45)
+
+    decision = trigger.evaluate_exit_decision(
+        tracked_position=losing,
+        market_context={"current_regime": "LOW_ACTIVITY_CHAOTIC"},
+        now_ts=900.0,
+    )
+
+    assert decision.exit_decision == "EXIT_FULL"
+    assert decision.exit_reason == "stop_loss_threshold_breached"
+
+
+def test_stale_trade_triggers_time_based_exit() -> None:
+    trigger = _make_trigger()
+    stale = _position(0.5005)
+
+    decision = trigger.evaluate_exit_decision(
+        tracked_position=stale,
+        market_context={"current_regime": "LOW_ACTIVITY_CHAOTIC"},
+        now_ts=2_000.0,
+    )
+
+    assert decision.exit_decision == "EXIT_FULL"
+    assert decision.exit_reason == "stale_trade_timeout"
+
+
+def test_regime_and_p9_feedback_adjust_exit_aggressiveness() -> None:
+    trigger = _make_trigger()
+    for _ in range(6):
+        trigger.record_trade_result(strategy_name="S1", pnl=-120.0, edge=0.02, position_size=900.0)
+        trigger.record_trade_result(strategy_name="S2", pnl=-80.0, edge=0.02, position_size=800.0)
+
+    borderline_loss = _position(0.465)
+
+    chaotic = trigger.evaluate_exit_decision(
+        tracked_position=borderline_loss,
+        market_context={"current_regime": "LOW_ACTIVITY_CHAOTIC"},
+        now_ts=1_100.0,
+    )
+    news = trigger.evaluate_exit_decision(
+        tracked_position=borderline_loss,
+        market_context={"current_regime": "NEWS_DRIVEN"},
+        now_ts=1_100.0,
+    )
+
+    assert chaotic.exit_decision == "EXIT_FULL"
+    assert news.exit_decision == "HOLD"
+
+
+def test_exit_decision_is_deterministic_for_same_inputs() -> None:
+    trigger_a = _make_trigger()
+    trigger_b = _make_trigger()
+    pos_a = _position(0.54)
+    pos_b = _position(0.54)
+
+    first = trigger_a.evaluate_exit_decision(
+        tracked_position=pos_a,
+        market_context={"current_regime": "SMART_MONEY_DOMINANT", "signal_invalidated": False},
+        now_ts=950.0,
+    )
+    second = trigger_b.evaluate_exit_decision(
+        tracked_position=pos_b,
+        market_context={"current_regime": "SMART_MONEY_DOMINANT", "signal_invalidated": False},
+        now_ts=950.0,
+    )
+
+    assert first == second


### PR DESCRIPTION
### Motivation
- Replace static close-on-target behavior with adaptive, context-aware exit decisions to capture winners and cut losses deterministically. 
- Make exit decisions sensitive to short-term momentum, trade age, and external context signals (P9 performance feedback and P11 regime classification).

### Description
- Added bounded exit configuration fields to `StrategyConfig` (`stop_loss_ratio`, `favorable_pnl_ratio`, `momentum_weakening_ratio`, `stale_trade_price_move_ratio`, `max_trade_duration_seconds`, `hard_max_trade_duration_seconds`, `fast_exit_regime_factor`, `slow_exit_regime_factor`).
- Introduced a deterministic `ExitDecision` dataclass and implemented `evaluate_exit_decision(...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` which returns `EXIT_FULL` or `HOLD` with `exit_reason`, `pnl_snapshot`, and `trade_duration`.
- Exit rules implemented: signal invalidation immediate-exit, bounded stop-loss exits, momentum-weakening take-profit exit (holders until pullback threshold reached), time-based stale trade timeout and hard max-duration guard, and light adaptation using P9 (adaptive weights) and P11 (regime) via a bounded regime factor.
- Wired the new exit evaluator into the position-monitoring branch of `evaluate(...)` to replace the simple `pnl > target` close trigger, and added focused unit tests and a FORGE report; updated `PROJECT_STATE.md` accordingly.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py` which passed.
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py projects/polymarket/polyquantbot/tests/test_p11_market_regime_detection_20260409.py` which passed (17 passed, 1 environment warning about `asyncio_mode`).
- Executed a small runtime proof script that printed representative `ExitDecision` outputs demonstrating: winning trade held then exited on weakening, losing trade fast exit on stop-loss, and stale trade timeout exit (examples included in the forge report).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d785271b28832e88685cdfcc4d3da2)