### PR TITLE
feat: implement P14 post-trade analytics & attribution layer

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 11:52
-- Status        : FORGE-X P13 exit timing & trade management implementation complete (STANDARD, narrow integration) in strategy-trigger position monitoring + exit-decision path; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 11:21
+- Status        : FORGE-X P14 post-trade analytics & attribution implementation complete (STANDARD, narrow integration) across closed-trade storage + analytics computation layer; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P14 post-trade analytics & attribution (2026-04-09): implemented closed-trade attribution persistence (`strategy_source`/`regime_at_entry`/`entry_quality`/`entry_timing`/`exit_reason`/`duration`), added analytics summary computation for profitability/expectancy/edge-captured/strategy+regime attribution/execution-quality/risk metrics, integrated strategy-trigger entry/exit context handoff into execution close path, and added deterministic runtime-proof tests.
 - P13 exit timing & trade management (2026-04-09): replaced static exit threshold behavior with adaptive deterministic exit decisioning (`EXIT_FULL`/`HOLD` + `exit_reason`/`pnl_snapshot`/`trade_duration`), added favorable-move momentum-weakening take-profit logic, bounded stop-loss + signal-invalidation exits, stale-trade timeout/hard-duration guards, and light adaptation using P9 performance feedback + P11 regime context with focused runtime-proof tests.
 - TG-2 + TG-3 open positions visibility & trade history (2026-04-09): implemented full open-position card rendering without truncation, added separate-card handling for same-market multi-position entries with per-position refs, added closed-trade history rendering with newest-first ordering and capped history display, integrated execution payload closed-trade persistence into portfolio state and Telegram callback payload path, and added focused formatter/view tests (including strict format and empty-state coverage).
 - P12 execution timing & entry optimization (2026-04-09): added pre-execution timing-aware gate with deterministic `ENTER_NOW`/`WAIT`/`SKIP` output contract, anti-chase spike delay/timeout skip handling, micro-pullback wait/re-evaluate/enter flow, bounded reevaluation windows, and timing-first coordination with existing P10 execution-quality gate plus focused deterministic tests.
@@ -110,6 +111,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P14 post-trade analytics & attribution handoff
+- STANDARD-tier narrow integration implementation is complete for trade lifecycle attribution, closed-trade storage enrichment, and in-memory analytics summary computation.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P13 exit timing & trade management handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger position monitoring and adaptive exit decisions with P9/P11 context shaping.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -211,11 +216,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P14 analytics attribution is currently narrow integration in strategy-trigger to execution closed-trade path only and is not yet wired to external persistence or dashboard surfaces.
 - P13 exit management is currently narrow integration in strategy-trigger monitoring path only and is not yet propagated into broader runtime orchestration surfaces.
 - TG-2 + TG-3 trade history is currently narrow integration in Telegram portfolio rendering path only and is not yet surfaced in other non-portfolio historical analytics views.
 - P12 entry timing layer is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime execution orchestration layers.

--- a/projects/polymarket/polyquantbot/execution/analytics.py
+++ b/projects/polymarket/polyquantbot/execution/analytics.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Dict, Optional
-import time
+from typing import Any
 import structlog
 
 log = structlog.get_logger(__name__)
@@ -11,62 +10,193 @@ log = structlog.get_logger(__name__)
 @dataclass
 class TradeRecord:
     position_id: str
-    entry_price: float
-    exit_price: float
     pnl: float
     duration: float
+    strategy_source: str
+    regime_at_entry: str
+    entry_quality: str
+    entry_timing: str
+    exit_reason: str
+    theoretical_edge: float
+    actual_return: float
+    slippage_impact: float
+    timing_effectiveness: float
+    exit_efficiency: float
 
 
 class PerformanceTracker:
-    def __init__(self):
-        self._trades: List[TradeRecord] = []
-        self._equity_curve: List[float] = []
+    def __init__(self) -> None:
+        self._trades: list[TradeRecord] = []
+        self._equity_curve: list[float] = []
 
-    def record_trade(self, position: Dict) -> None:
+    @staticmethod
+    def _value(payload: dict[str, Any], key: str, default: Any) -> Any:
+        return payload.get(key, default)
+
+    @staticmethod
+    def _normalize_strategy(raw: object) -> str:
+        candidate = str(raw or "UNKNOWN").strip().upper()
+        return candidate if candidate in {"S1", "S2", "S3", "S5"} else "UNKNOWN"
+
+    @staticmethod
+    def _normalize_regime(raw: object) -> str:
+        normalized = str(raw or "").strip().upper()
+        mapping = {
+            "NEWS_DRIVEN": "NEWS",
+            "ARBITRAGE_DOMINANT": "ARBITRAGE",
+            "SMART_MONEY_DOMINANT": "SMART_MONEY",
+            "LOW_ACTIVITY_CHAOTIC": "CHAOTIC",
+        }
+        return mapping.get(normalized, normalized or "CHAOTIC")
+
+    def record_trade(self, trade: dict[str, Any]) -> None:
         """Store trade details, prevent duplicates and handle edge cases."""
-        if not position.get("position_id"):
+        position_id = str(self._value(trade, "position_id", "")).strip()
+        if not position_id:
             log.warning("analytics_skip", reason="missing_position_id")
             return
-        if position.get("size", 0) <= 0:
+        size = float(self._value(trade, "size", 0.0))
+        if size <= 0:
             log.warning("analytics_skip", reason="size_zero_or_negative")
             return
-        if any(t.position_id == position["position_id"] for t in self._trades):
+        if any(t.position_id == position_id for t in self._trades):
             return  # Skip duplicates
+        pnl = float(self._value(trade, "pnl", 0.0))
+        theoretical_edge = max(0.0, float(self._value(trade, "theoretical_edge", 0.0)))
+        actual_return = float(self._value(trade, "actual_return", pnl / size))
+        duration = max(0.0, float(self._value(trade, "duration", 0.0)))
         self._trades.append(
             TradeRecord(
-                position_id=position["position_id"],
-                entry_price=position["entry_price"],
-                exit_price=position.get("current_price", position["entry_price"]),
-                pnl=position["pnl"],
-                duration=time.time() - getattr(position, "created_at", time.time()),
+                position_id=position_id,
+                pnl=pnl,
+                duration=duration,
+                strategy_source=self._normalize_strategy(self._value(trade, "strategy_source", "UNKNOWN")),
+                regime_at_entry=self._normalize_regime(self._value(trade, "regime_at_entry", "CHAOTIC")),
+                entry_quality=str(self._value(trade, "entry_quality", "not_provided")),
+                entry_timing=str(self._value(trade, "entry_timing", "not_provided")),
+                exit_reason=str(self._value(trade, "exit_reason", "not_provided")),
+                theoretical_edge=theoretical_edge,
+                actual_return=actual_return,
+                slippage_impact=float(self._value(trade, "slippage_impact", 0.0)),
+                timing_effectiveness=float(self._value(trade, "timing_effectiveness", 0.0)),
+                exit_efficiency=float(self._value(trade, "exit_efficiency", 0.0)),
             )
         )
-        self._update_equity_curve(position["pnl"])
+        self._update_equity_curve(pnl)
 
-    def _update_equity_curve(self, pnl: float):
+    def _update_equity_curve(self, pnl: float) -> None:
         """Track equity for drawdown calculation."""
         self._equity_curve.append(self._equity_curve[-1] + pnl if self._equity_curve else pnl)
 
-    def summary(self) -> Dict:
-        """Return performance metrics."""
+    def _compute_risk_metrics(self) -> dict[str, float | int]:
+        if not self._trades:
+            return {"max_drawdown": 0.0, "avg_drawdown": 0.0, "loss_streak": 0}
+        peaks: list[float] = []
+        drawdowns: list[float] = []
+        running_peak = float("-inf")
+        for equity in self._equity_curve:
+            running_peak = max(running_peak, equity)
+            peaks.append(running_peak)
+        for equity, peak in zip(self._equity_curve, peaks):
+            if peak <= 0:
+                drawdowns.append(0.0)
+            else:
+                drawdowns.append((peak - equity) / peak)
+        max_dd = max(drawdowns) if drawdowns else 0.0
+        avg_dd = sum(drawdowns) / len(drawdowns) if drawdowns else 0.0
+        streak = 0
+        max_streak = 0
+        for trade in self._trades:
+            if trade.pnl < 0:
+                streak += 1
+                max_streak = max(max_streak, streak)
+            else:
+                streak = 0
+        return {
+            "max_drawdown": round(max_dd, 6),
+            "avg_drawdown": round(avg_dd, 6),
+            "loss_streak": max_streak,
+        }
+
+    @staticmethod
+    def _group_label_value() -> dict[str, float]:
+        return {"total_pnl": 0.0, "trades": 0.0, "wins": 0.0, "total_return": 0.0}
+
+    def _build_group_breakdown(self, group_field: str) -> dict[str, dict[str, float]]:
+        grouped: dict[str, dict[str, float]] = {}
+        for trade in self._trades:
+            label = getattr(trade, group_field)
+            row = grouped.setdefault(label, self._group_label_value())
+            row["total_pnl"] += trade.pnl
+            row["trades"] += 1.0
+            row["wins"] += 1.0 if trade.pnl > 0 else 0.0
+            row["total_return"] += trade.actual_return
+        result: dict[str, dict[str, float]] = {}
+        for label in sorted(grouped):
+            row = grouped[label]
+            trades = row["trades"] if row["trades"] > 0 else 1.0
+            result[label] = {
+                "pnl": round(row["total_pnl"], 6),
+                "win_rate": round(row["wins"] / trades, 6),
+                "avg_return": round(row["total_return"] / trades, 6),
+            }
+        return result
+
+    def summary(self) -> dict[str, Any]:
+        """Return post-trade analytics summary."""
         if not self._trades:
             return {
+                "pnl": {"total_pnl": 0.0, "avg_pnl_per_trade": 0.0, "trades": 0},
                 "trades": 0,
                 "win_rate": 0.0,
                 "avg_pnl": 0.0,
                 "max_drawdown": 0.0,
-                "sharpe": 0.0,
+                "expectancy": 0.0,
+                "profit_factor": 0.0,
+                "edge_captured": 0.0,
+                "strategy_breakdown": {},
+                "regime_breakdown": {},
+                "execution_quality_metrics": {
+                    "avg_slippage_impact": 0.0,
+                    "avg_timing_effectiveness": 0.0,
+                    "avg_exit_efficiency": 0.0,
+                },
+                "risk_metrics": self._compute_risk_metrics(),
             }
-        wins = sum(1 for t in self._trades if t.pnl > 0)
-        peak = max(self._equity_curve)
-        trough = min(self._equity_curve)
-        drawdown = (peak - trough) / peak if peak > 0 else 0
+        total_trades = len(self._trades)
+        total_pnl = sum(t.pnl for t in self._trades)
+        wins = [t for t in self._trades if t.pnl > 0]
+        losses = [t for t in self._trades if t.pnl < 0]
+        win_rate = len(wins) / total_trades
+        avg_win = sum(t.pnl for t in wins) / len(wins) if wins else 0.0
+        avg_loss_abs = abs(sum(t.pnl for t in losses) / len(losses)) if losses else 0.0
+        gross_profit = sum(t.pnl for t in wins)
+        gross_loss_abs = abs(sum(t.pnl for t in losses))
+        profit_factor = gross_profit / gross_loss_abs if gross_loss_abs > 0 else (float("inf") if gross_profit > 0 else 0.0)
+        expectancy = (win_rate * avg_win) - ((1.0 - win_rate) * avg_loss_abs)
+        edge_samples = [t.actual_return / t.theoretical_edge for t in self._trades if t.theoretical_edge > 1e-9]
+        execution_quality_metrics = {
+            "avg_slippage_impact": round(sum(t.slippage_impact for t in self._trades) / total_trades, 6),
+            "avg_timing_effectiveness": round(sum(t.timing_effectiveness for t in self._trades) / total_trades, 6),
+            "avg_exit_efficiency": round(sum(t.exit_efficiency for t in self._trades) / total_trades, 6),
+        }
         return {
-            "trades": len(self._trades),
-            "win_rate": wins / len(self._trades),
-            "avg_pnl": sum(t.pnl for t in self._trades) / len(self._trades),
-            "max_drawdown": drawdown,
-            "sharpe": self._calculate_sharpe(),
+            "pnl": {
+                "total_pnl": round(total_pnl, 6),
+                "avg_pnl_per_trade": round(total_pnl / total_trades, 6),
+                "trades": total_trades,
+            },
+            "trades": total_trades,
+            "win_rate": round(win_rate, 6),
+            "avg_pnl": round(total_pnl / total_trades, 6),
+            "max_drawdown": self._compute_risk_metrics()["max_drawdown"],
+            "expectancy": round(expectancy, 6),
+            "profit_factor": round(profit_factor, 6) if profit_factor != float("inf") else float("inf"),
+            "edge_captured": round(sum(edge_samples) / len(edge_samples), 6) if edge_samples else 0.0,
+            "strategy_breakdown": self._build_group_breakdown("strategy_source"),
+            "regime_breakdown": self._build_group_breakdown("regime_at_entry"),
+            "execution_quality_metrics": execution_quality_metrics,
+            "risk_metrics": self._compute_risk_metrics(),
         }
 
     def _calculate_sharpe(self) -> float:

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -44,6 +44,7 @@ class ExecutionEngine:
         self._analytics = PerformanceTracker()
         self._trace_engine = TradeTraceEngine()
         self._closed_trades: list[dict[str, Any]] = []
+        self._position_context: dict[str, dict[str, Any]] = {}
 
     async def open_position(
         self,
@@ -53,6 +54,7 @@ class ExecutionEngine:
         price: float,
         size: float,
         position_id: str | None = None,
+        position_context: dict[str, Any] | None = None,
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
@@ -102,6 +104,7 @@ class ExecutionEngine:
                 position_id=position_id
             )
             self._positions[market] = position
+            self._position_context[position.position_id] = dict(position_context or {})
             self._cash -= size
             self._implied_prob = max(0.01, min(0.99, float(price)))
             self._recalculate_unrealized()
@@ -109,7 +112,12 @@ class ExecutionEngine:
             log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
             return position
 
-    async def close_position(self, position: Position, price: float) -> float:
+    async def close_position(
+        self,
+        position: Position,
+        price: float,
+        close_context: dict[str, Any] | None = None,
+    ) -> float:
         """Close position, realize PnL, and update portfolio."""
         async with self._lock:
             live_position = self._positions.get(position.market_id)
@@ -120,7 +128,20 @@ class ExecutionEngine:
             realized_pnl = live_position.update_price(float(price))
             self._realized_pnl += realized_pnl
             self._cash += live_position.size + realized_pnl
-            self._analytics.record_trade(live_position)
+            entry_context = self._position_context.pop(live_position.position_id, {})
+            final_context = dict(entry_context)
+            final_context.update(dict(close_context or {}))
+            duration = max(0.0, (datetime.now(timezone.utc).timestamp() - live_position.created_at))
+            theoretical_edge = max(0.0, float(final_context.get("theoretical_edge", 0.0)))
+            actual_return = float(final_context.get("actual_return", realized_pnl / max(live_position.size, 1e-9)))
+            strategy_source = str(final_context.get("strategy_source", "UNKNOWN")).strip().upper() or "UNKNOWN"
+            regime_at_entry = str(final_context.get("regime_at_entry", "CHAOTIC")).strip().upper() or "CHAOTIC"
+            entry_quality = str(final_context.get("entry_quality", "not_provided"))
+            entry_timing = str(final_context.get("entry_timing", "not_provided"))
+            exit_reason = str(final_context.get("exit_reason", "not_provided"))
+            slippage_impact = float(final_context.get("slippage_impact", 0.0))
+            timing_effectiveness = float(final_context.get("timing_effectiveness", 0.0))
+            exit_efficiency = float(final_context.get("exit_efficiency", 0.0))
             closed_trade = {
                 "market_id": live_position.market_id,
                 "market_title": live_position.market_title,
@@ -131,7 +152,20 @@ class ExecutionEngine:
                 "result": "WIN" if realized_pnl >= 0 else "LOSS",
                 "closed_at": datetime.now(timezone.utc).isoformat(),
                 "position_id": live_position.position_id,
+                "size": live_position.size,
+                "duration": round(duration, 6),
+                "strategy_source": strategy_source,
+                "regime_at_entry": regime_at_entry,
+                "entry_quality": entry_quality,
+                "entry_timing": entry_timing,
+                "exit_reason": exit_reason,
+                "theoretical_edge": theoretical_edge,
+                "actual_return": actual_return,
+                "slippage_impact": slippage_impact,
+                "timing_effectiveness": timing_effectiveness,
+                "exit_efficiency": exit_efficiency,
             }
+            self._analytics.record_trade(closed_trade)
             self._closed_trades.append(closed_trade)
             del self._positions[live_position.market_id]
             self._recalculate_unrealized()

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -303,6 +303,7 @@ class StrategyTrigger:
         self._adaptive_confidence_bounds: tuple[float, float] = (0.55, 0.80)
         self._last_adjustment_explanation: str = "adaptive defaults active"
         self._position_peak_pnl: dict[str, float] = {}
+        self._position_entry_context: dict[str, dict[str, object]] = {}
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
@@ -1918,8 +1919,42 @@ class StrategyTrigger:
                 price=readiness.expected_fill_price,
                 size=size,
                 position_id=str(uuid.uuid4()),
+                position_context={
+                    "strategy_source": (
+                        selected_candidate.strategy_name
+                        if selected_candidate is not None
+                        else "UNKNOWN"
+                    ),
+                    "regime_at_entry": (
+                        aggregation_decision.current_regime
+                        if aggregation_decision is not None
+                        else str((market_context or {}).get("current_regime", "LOW_ACTIVITY_CHAOTIC"))
+                    ),
+                    "entry_quality": readiness.execution_quality_reason,
+                    "entry_timing": readiness.timing_reason,
+                    "theoretical_edge": signal_edge,
+                    "slippage_impact": readiness.expected_slippage,
+                    "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
+                },
             )
             if created:
+                self._position_entry_context[created.position_id] = {
+                    "strategy_source": (
+                        selected_candidate.strategy_name
+                        if selected_candidate is not None
+                        else "UNKNOWN"
+                    ),
+                    "regime_at_entry": (
+                        aggregation_decision.current_regime
+                        if aggregation_decision is not None
+                        else str((market_context or {}).get("current_regime", "LOW_ACTIVITY_CHAOTIC"))
+                    ),
+                    "entry_quality": readiness.execution_quality_reason,
+                    "entry_timing": readiness.timing_reason,
+                    "theoretical_edge": signal_edge,
+                    "slippage_impact": readiness.expected_slippage,
+                    "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
+                }
                 self._trace_engine.record_trace(
                     position_id=created.position_id,
                     market_id=self._config.market_id,
@@ -1946,7 +1981,21 @@ class StrategyTrigger:
                 )
                 if exit_decision.exit_decision == "HOLD":
                     return "HOLD"
-                await self._engine.close_position(tracked, market_price)
+                entry_context = self._position_entry_context.pop(tracked.position_id, {})
+                exit_efficiency = 0.5
+                if exit_decision.exit_reason == "momentum_weakened_after_favorable_move":
+                    exit_efficiency = 1.0
+                elif exit_decision.exit_reason in {"stop_loss_threshold_breached", "signal_invalidation"}:
+                    exit_efficiency = 0.3
+                await self._engine.close_position(
+                    tracked,
+                    market_price,
+                    close_context={
+                        **entry_context,
+                        "exit_reason": exit_decision.exit_reason,
+                        "exit_efficiency": exit_efficiency,
+                    },
+                )
                 self._position_peak_pnl.pop(str(getattr(tracked, "position_id", "")), None)
                 self._trace_engine.record_trace(
                     position_id=tracked.position_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md
@@ -1,0 +1,139 @@
+# 24_26_p14_post_trade_analytics_attribution
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - trade lifecycle output in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - closed trade storage in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - analytics computation layer in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/analytics.py`
+- Not in Scope:
+  - execution engine architecture redesign
+  - strategy alpha/selection logic changes
+  - Telegram UI redesign
+  - external dashboards
+  - ML model training
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md`. Tier: STANDARD
+
+## 1. What was built
+- Implemented post-trade analytics and attribution computation in `PerformanceTracker.summary()` with required output contract:
+  - `pnl` (total + avg)
+  - `win_rate`
+  - `expectancy`
+  - `profit_factor`
+  - `edge_captured`
+  - `strategy_breakdown`
+  - `regime_breakdown`
+  - `execution_quality_metrics`
+  - `risk_metrics`
+- Extended closed-trade persistence to store attribution fields on every closed trade:
+  - `strategy_source`
+  - `regime_at_entry`
+  - `entry_quality`
+  - `entry_timing`
+  - `exit_reason`
+  - `duration`
+- Added strategy-trigger lifecycle wiring so entry/exit context is attached to closed trades:
+  - entry metadata from selected strategy/regime/P10/P12 context
+  - exit metadata from P13 exit decision reason + derived exit efficiency
+- Added deterministic test suite for P14 analytics attribution requirements.
+
+### Metrics Definitions
+- `total_pnl` = sum of realized PnL from closed trades.
+- `avg_pnl_per_trade` = `total_pnl / closed_trades`.
+- `win_rate` = wins / trades.
+- `profit_factor` = gross wins / abs(gross losses).
+- `expectancy` = `(WR × avg_win) − ((1 − WR) × avg_loss)`.
+- `edge_captured` = average of `actual_return / theoretical_edge` for trades with positive theoretical edge.
+- Risk:
+  - `max_drawdown`
+  - `avg_drawdown`
+  - `loss_streak`
+
+## 2. Current system architecture
+- Entry path (unchanged selection logic) now attaches P14 context at position creation:
+  - strategy source (`S1`/`S2`/`S3`/`S5`)
+  - regime at entry (P11 classification)
+  - execution quality reason + slippage (P10)
+  - timing reason + timing effectiveness (P12)
+  - theoretical edge (signal edge)
+- Exit path (P13) now forwards exit attribution to close operation:
+  - exit reason
+  - exit efficiency heuristic
+- Execution engine merges entry+exit context into the canonical closed-trade record, stores it in memory, and records it into analytics.
+- Analytics layer computes deterministic aggregate and grouped outputs for strategy/regime attribution, execution quality, and risk.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/analytics.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests implemented and passing:
+1. correct pnl aggregation
+2. strategy attribution correctness
+3. regime attribution correctness
+4. edge_captured calculation correct
+5. deterministic output
+
+Validation commands:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/analytics.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py` ✅ (11 passed, environment warning: unknown `asyncio_mode`)
+
+### Runtime Proof (required)
+1) Analytics summary example
+```text
+analytics_summary = {
+  'pnl': {'total_pnl': 5.0, 'avg_pnl_per_trade': 2.5, 'trades': 2},
+  'win_rate': 0.5,
+  'expectancy': 2.5,
+  'profit_factor': 2.0,
+  'edge_captured': 0.6875,
+  'strategy_breakdown': {...},
+  'regime_breakdown': {...},
+  'execution_quality_metrics': {'avg_slippage_impact': 0.02, 'avg_timing_effectiveness': 0.7, 'avg_exit_efficiency': 0.575},
+  'risk_metrics': {'max_drawdown': 0.5, 'avg_drawdown': 0.25, 'loss_streak': 1}
+}
+```
+
+2) Strategy breakdown example
+```text
+strategy_breakdown = {
+  'S1': {'pnl': 10.0, 'win_rate': 1.0, 'avg_return': 0.1},
+  'S2': {'pnl': -5.0, 'win_rate': 0.0, 'avg_return': -0.05}
+}
+```
+
+3) Regime breakdown example
+```text
+regime_breakdown = {
+  'ARBITRAGE': {'pnl': -5.0, 'win_rate': 0.0, 'avg_return': -0.05},
+  'NEWS': {'pnl': 10.0, 'win_rate': 1.0, 'avg_return': 0.1}
+}
+```
+
+### Attribution examples
+- Positive S1/NEWS trade persisted with entry-quality/timing context and favorable-move exit reason.
+- Negative S2/ARBITRAGE trade persisted with reduced quality/timing context and stop-loss exit reason.
+
+### Validation of calculations
+- PnL aggregation: `10 + (-5) = 5`.
+- Win rate: `1/2 = 0.5`.
+- Profit factor: `10 / 5 = 2.0`.
+- Expectancy: `(0.5 × 10) − (0.5 × 5) = 2.5`.
+- Edge captured: `((0.10/0.05) + (-0.05/0.08)) / 2 = 0.6875`.
+
+## 5. Known issues
+- P14 is intentionally narrow integration in touched strategy-trigger + execution closed-trade path and is not yet wired to external persistence/database backends.
+- Existing test environment warning persists: `Unknown config option: asyncio_mode`.
+- Regime labels are normalized to concise output buckets (`NEWS`, `ARBITRAGE`, `SMART_MONEY`, `CHAOTIC`) from internal P11 names.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+
+
+async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, object]]:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    first = await engine.open_position(
+        market="mkt-s1-news",
+        market_title="S1 NEWS",
+        side="YES",
+        price=0.50,
+        size=100.0,
+        position_id="p14-1",
+        position_context={
+            "strategy_source": "S1",
+            "regime_at_entry": "NEWS_DRIVEN",
+            "entry_quality": "quality_enter",
+            "entry_timing": "timing_enter",
+            "theoretical_edge": 0.05,
+            "slippage_impact": 0.01,
+            "timing_effectiveness": 0.90,
+        },
+    )
+    assert first is not None
+    await engine.close_position(
+        first,
+        0.60,
+        close_context={"exit_reason": "momentum_weakened_after_favorable_move", "exit_efficiency": 0.95},
+    )
+
+    second = await engine.open_position(
+        market="mkt-s2-arb",
+        market_title="S2 ARB",
+        side="YES",
+        price=0.60,
+        size=100.0,
+        position_id="p14-2",
+        position_context={
+            "strategy_source": "S2",
+            "regime_at_entry": "ARBITRAGE_DOMINANT",
+            "entry_quality": "quality_reduce",
+            "entry_timing": "timing_wait_then_enter",
+            "theoretical_edge": 0.08,
+            "slippage_impact": 0.03,
+            "timing_effectiveness": 0.50,
+        },
+    )
+    assert second is not None
+    await engine.close_position(
+        second,
+        0.55,
+        close_context={"exit_reason": "stop_loss_threshold_breached", "exit_efficiency": 0.20},
+    )
+
+    payload = await engine.snapshot()
+    assert round(payload.realized_pnl, 6) == 5.0
+
+    return list(engine._closed_trades), engine.get_analytics().summary()
+
+
+def test_correct_pnl_aggregation() -> None:
+    _, summary = asyncio.run(_build_closed_trades())
+
+    assert summary["pnl"]["total_pnl"] == 5.0
+    assert summary["pnl"]["avg_pnl_per_trade"] == 2.5
+    assert summary["win_rate"] == 0.5
+
+
+def test_strategy_attribution_correctness() -> None:
+    _, summary = asyncio.run(_build_closed_trades())
+
+    breakdown = summary["strategy_breakdown"]
+    assert breakdown["S1"]["pnl"] == 10.0
+    assert breakdown["S1"]["win_rate"] == 1.0
+    assert breakdown["S2"]["pnl"] == -5.0
+    assert breakdown["S2"]["win_rate"] == 0.0
+
+
+def test_regime_attribution_correctness() -> None:
+    _, summary = asyncio.run(_build_closed_trades())
+
+    regime = summary["regime_breakdown"]
+    assert regime["NEWS"]["pnl"] == 10.0
+    assert regime["ARBITRAGE"]["pnl"] == -5.0
+
+
+def test_edge_captured_calculation_correct() -> None:
+    _, summary = asyncio.run(_build_closed_trades())
+
+    # trade1: 0.10/0.05=2.0 ; trade2: -0.05/0.08=-0.625 ; avg=0.6875
+    assert summary["edge_captured"] == 0.6875
+
+
+def test_deterministic_output() -> None:
+    _, first = asyncio.run(_build_closed_trades())
+    _, second = asyncio.run(_build_closed_trades())
+
+    assert first == second
+
+
+def test_trade_lifecycle_output_contains_required_attribution_fields() -> None:
+    closed_trades, summary = asyncio.run(_build_closed_trades())
+
+    assert len(closed_trades) == 2
+    for trade in closed_trades:
+        assert set(
+            [
+                "strategy_source",
+                "regime_at_entry",
+                "entry_quality",
+                "entry_timing",
+                "exit_reason",
+                "duration",
+            ]
+        ).issubset(trade.keys())
+
+    assert summary["execution_quality_metrics"]["avg_slippage_impact"] == 0.02
+    assert summary["execution_quality_metrics"]["avg_timing_effectiveness"] == 0.7
+    assert summary["execution_quality_metrics"]["avg_exit_efficiency"] == 0.575


### PR DESCRIPTION
### Motivation
- Provide a deterministic post-trade analytics layer to measure realized edge, attribute PnL to strategies and regimes, and surface execution-quality and risk metrics for data-driven decisioning.
- Persist required attribution fields on every closed trade so downstream views and analytics can compute consistent breakdowns without external DBs.
- Deliver a narrow-integration analytics surface (trade lifecycle → closed-trade storage → analytics computation) to satisfy P14 requirements while keeping changes scoped to the execution/strategy surfaces.

### Description
- Added structured trade attribution and analytics: extended `TradeRecord` and `PerformanceTracker` in `projects/polymarket/polyquantbot/execution/analytics.py` to store attribution fields and compute `pnl`, `avg_pnl_per_trade`, `win_rate`, `expectancy`, `profit_factor`, `edge_captured`, `strategy_breakdown`, `regime_breakdown`, `execution_quality_metrics`, and `risk_metrics`.
- Persisted entry/exit context at close: extended `ExecutionEngine.open_position()` / `ExecutionEngine.close_position()` in `projects/polymarket/polyquantbot/execution/engine.py` to carry `position_context` and merge entry+exit context into canonical `closed_trade` records (fields include `strategy_source`, `regime_at_entry`, `entry_quality`, `entry_timing`, `exit_reason`, `duration`, `theoretical_edge`, `actual_return`, slippage/timing/exit metrics) and forward them to `PerformanceTracker.record_trade()`.
- Wired lifecycle context in strategy trigger: updated `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to attach entry metadata at open and forward exit_reason/exit_efficiency at close so attribution fields are available for closed-trade records.
- Tests and artifacts: added deterministic tests `projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`, created FORGE report `projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md`, and updated `PROJECT_STATE.md` to reflect P14 completion.
- Scope / docs: declared `Validation Tier: STANDARD` and `Claim Level: NARROW INTEGRATION` in the report and kept changes limited to trade lifecycle, closed-trade storage, and analytics computation (no external DBs, no strategy/engine redesign, no UI/dashboard changes).

### Testing
- Static check: `python -m py_compile projects/polymarket/polyquantbot/execution/analytics.py projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` — PASS.
- Unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py` — PASS (11 passed; environment warning: unknown `asyncio_mode`).
- Runtime proof: executed a short runtime check that prints the analytics summary and the `strategy_breakdown` / `regime_breakdown` examples used in the report; outputs match expected sample values included in the forge report.
- All automated tests added/modified for this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78a006a68832eba6fdbb29df0a000)