### PR TITLE
P14.1: analytics-driven optimization layer for strategy / execution / risk tuning

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 11:52
-- Status        : FORGE-X P13 exit timing & trade management implementation complete (STANDARD, narrow integration) in strategy-trigger position monitoring + exit-decision path; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 12:35
+- Status        : FORGE-X P14 optimization from analytics implementation complete (STANDARD, narrow integration) in strategy-trigger analytics-consumption + optimization-decision path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P14 system optimization from analytics (2026-04-09): implemented analytics-driven optimization output (`strategy_weights`/`regime_weights`/`execution_adjustments`/`risk_adjustments`) with normalized strategy+regime scoring, bounded strategy/regime adjustment rules, execution feedback tuning for P10/P12/P13, and risk aggression/size reductions with deterministic bounded tests and runtime proof examples.
 - P13 exit timing & trade management (2026-04-09): replaced static exit threshold behavior with adaptive deterministic exit decisioning (`EXIT_FULL`/`HOLD` + `exit_reason`/`pnl_snapshot`/`trade_duration`), added favorable-move momentum-weakening take-profit logic, bounded stop-loss + signal-invalidation exits, stale-trade timeout/hard-duration guards, and light adaptation using P9 performance feedback + P11 regime context with focused runtime-proof tests.
 - TG-2 + TG-3 open positions visibility & trade history (2026-04-09): implemented full open-position card rendering without truncation, added separate-card handling for same-market multi-position entries with per-position refs, added closed-trade history rendering with newest-first ordering and capped history display, integrated execution payload closed-trade persistence into portfolio state and Telegram callback payload path, and added focused formatter/view tests (including strict format and empty-state coverage).
 - P12 execution timing & entry optimization (2026-04-09): added pre-execution timing-aware gate with deterministic `ENTER_NOW`/`WAIT`/`SKIP` output contract, anti-chase spike delay/timeout skip handling, micro-pullback wait/re-evaluate/enter flow, bounded reevaluation windows, and timing-first coordination with existing P10 execution-quality gate plus focused deterministic tests.
@@ -110,6 +111,10 @@ Status:
 
 ## 🚧 IN PROGRESS
 
+### P14 system optimization from analytics handoff
+- STANDARD-tier narrow integration implementation is complete for strategy-trigger analytics consumption, optimization decisioning, and bounded adjustment application to S4/P7/P10/P12/P13 touched paths.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
+
 ### P13 exit timing & trade management handoff
 - STANDARD-tier narrow integration implementation is complete for strategy-trigger position monitoring and adaptive exit decisions with P9/P11 context shaping.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
@@ -211,11 +216,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_25_p13_exit_timing_trade_management.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P14 optimization is currently narrow integration in strategy-trigger analytics/decision path only and is not yet wired into broader runtime orchestration surfaces.
 - P13 exit management is currently narrow integration in strategy-trigger monitoring path only and is not yet propagated into broader runtime orchestration surfaces.
 - TG-2 + TG-3 trade history is currently narrow integration in Telegram portfolio rendering path only and is not yet surfaced in other non-portfolio historical analytics views.
 - P12 entry timing layer is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime execution orchestration layers.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -273,6 +273,23 @@ class MarketRegimeClassification:
     strategy_weight_modifiers: dict[str, float]
 
 
+@dataclass(frozen=True)
+class AnalyticsPerformanceSnapshot:
+    pnl: float
+    win_rate: float
+    expectancy: float
+    drawdown: float
+    trades: int
+
+
+@dataclass(frozen=True)
+class OptimizationOutput:
+    strategy_weights: dict[str, float]
+    regime_weights: dict[str, float]
+    execution_adjustments: dict[str, float]
+    risk_adjustments: dict[str, float]
+
+
 class StrategyTrigger:
     """Strategy trigger with execution intelligence.
     
@@ -303,6 +320,24 @@ class StrategyTrigger:
         self._adaptive_confidence_bounds: tuple[float, float] = (0.55, 0.80)
         self._last_adjustment_explanation: str = "adaptive defaults active"
         self._position_peak_pnl: dict[str, float] = {}
+        self._optimization_strategy_modifiers: dict[str, float] = {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+        self._optimization_regime_modifiers: dict[str, float] = {
+            "NEWS_DRIVEN": 1.0,
+            "ARBITRAGE_DOMINANT": 1.0,
+            "SMART_MONEY_DOMINANT": 1.0,
+            "LOW_ACTIVITY_CHAOTIC": 1.0,
+        }
+        self._optimization_execution_adjustments: dict[str, float] = {
+            "p10_spread_tightening": 1.0,
+            "p12_wait_window_factor": 1.0,
+            "p13_exit_sensitivity_factor": 1.0,
+        }
+        self._optimization_risk_adjustments: dict[str, float] = {
+            "aggression_modifier": 1.0,
+            "size_modifier": 1.0,
+        }
+        self._optimization_step_limit: float = 0.04
+        self._optimization_adjustment_explanation: str = "optimization defaults active"
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
@@ -455,6 +490,182 @@ class StrategyTrigger:
             min_edge_threshold=round(self._adaptive_edge_threshold, 6),
             confidence_threshold=round(self._adaptive_confidence_threshold, 6),
             explanation=self._last_adjustment_explanation,
+        )
+
+    @staticmethod
+    def _safe_min_max_normalize(values: dict[str, float]) -> dict[str, float]:
+        if not values:
+            return {}
+        low = min(values.values())
+        high = max(values.values())
+        if high - low <= 1e-9:
+            return {key: 0.5 for key in values}
+        return {key: (value - low) / (high - low) for key, value in values.items()}
+
+    def _smooth_adjustment(
+        self,
+        *,
+        current: float,
+        target: float,
+        lower: float,
+        upper: float,
+    ) -> float:
+        bounded_target = self._clamp(target, lower, upper)
+        delta = self._clamp(
+            bounded_target - current,
+            -self._optimization_step_limit,
+            self._optimization_step_limit,
+        )
+        return round(self._clamp(current + delta, lower, upper), 6)
+
+    def apply_analytics_optimization(
+        self,
+        *,
+        strategy_analytics: dict[str, AnalyticsPerformanceSnapshot],
+        regime_analytics: dict[str, AnalyticsPerformanceSnapshot],
+        execution_analytics: dict[str, float],
+        risk_analytics: dict[str, float],
+    ) -> OptimizationOutput:
+        if not strategy_analytics or sum(item.trades for item in strategy_analytics.values()) < 6:
+            self._optimization_strategy_modifiers = {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+            self._optimization_regime_modifiers = {
+                "NEWS_DRIVEN": 1.0,
+                "ARBITRAGE_DOMINANT": 1.0,
+                "SMART_MONEY_DOMINANT": 1.0,
+                "LOW_ACTIVITY_CHAOTIC": 1.0,
+            }
+            self._optimization_execution_adjustments = {
+                "p10_spread_tightening": 1.0,
+                "p12_wait_window_factor": 1.0,
+                "p13_exit_sensitivity_factor": 1.0,
+            }
+            self._optimization_risk_adjustments = {
+                "aggression_modifier": 1.0,
+                "size_modifier": 1.0,
+            }
+            self._optimization_adjustment_explanation = "insufficient analytics; fallback to neutral modifiers"
+            return self.get_optimization_output()
+
+        pnl_values = {name: item.pnl for name, item in strategy_analytics.items()}
+        win_rate_values = {name: self._clamp(item.win_rate, 0.0, 1.0) for name, item in strategy_analytics.items()}
+        expectancy_values = {name: item.expectancy for name, item in strategy_analytics.items()}
+        inv_drawdown_values = {name: 1.0 - self._clamp(item.drawdown, 0.0, 1.0) for name, item in strategy_analytics.items()}
+
+        pnl_norm = self._safe_min_max_normalize(pnl_values)
+        win_rate_norm = self._safe_min_max_normalize(win_rate_values)
+        expectancy_norm = self._safe_min_max_normalize(expectancy_values)
+        drawdown_norm = self._safe_min_max_normalize(inv_drawdown_values)
+
+        for strategy_name, snapshot in strategy_analytics.items():
+            current = self._optimization_strategy_modifiers.get(strategy_name, 1.0)
+            score = (
+                (pnl_norm.get(strategy_name, 0.5) * 0.35)
+                + (win_rate_norm.get(strategy_name, 0.5) * 0.25)
+                + (expectancy_norm.get(strategy_name, 0.5) * 0.25)
+                + (drawdown_norm.get(strategy_name, 0.5) * 0.15)
+            )
+            target = 1.0
+            if score >= 0.67:
+                target = 1.08
+            elif score <= 0.30 and snapshot.pnl < 0.0 and snapshot.drawdown >= 0.18:
+                target = 0.88
+            elif score < 0.45:
+                target = 0.94
+            self._optimization_strategy_modifiers[strategy_name] = self._smooth_adjustment(
+                current=current,
+                target=target,
+                lower=0.85,
+                upper=1.15,
+            )
+
+        if regime_analytics:
+            regime_scores: dict[str, float] = {}
+            regime_pnl_norm = self._safe_min_max_normalize({name: item.pnl for name, item in regime_analytics.items()})
+            regime_win_norm = self._safe_min_max_normalize({name: item.win_rate for name, item in regime_analytics.items()})
+            regime_expectancy_norm = self._safe_min_max_normalize({name: item.expectancy for name, item in regime_analytics.items()})
+            regime_drawdown_norm = self._safe_min_max_normalize(
+                {name: 1.0 - self._clamp(item.drawdown, 0.0, 1.0) for name, item in regime_analytics.items()}
+            )
+            for regime_name in self._optimization_regime_modifiers:
+                if regime_name not in regime_analytics:
+                    continue
+                regime_scores[regime_name] = (
+                    (regime_pnl_norm.get(regime_name, 0.5) * 0.35)
+                    + (regime_win_norm.get(regime_name, 0.5) * 0.25)
+                    + (regime_expectancy_norm.get(regime_name, 0.5) * 0.25)
+                    + (regime_drawdown_norm.get(regime_name, 0.5) * 0.15)
+                )
+            if regime_scores:
+                best_regime = max(regime_scores, key=regime_scores.get)
+                worst_regime = min(regime_scores, key=regime_scores.get)
+                for regime_name, current in self._optimization_regime_modifiers.items():
+                    target = 1.0
+                    if regime_name == best_regime:
+                        target = 1.08
+                    elif regime_name == worst_regime and len(regime_scores) > 1:
+                        target = 0.92
+                    self._optimization_regime_modifiers[regime_name] = self._smooth_adjustment(
+                        current=current,
+                        target=target,
+                        lower=0.88,
+                        upper=1.12,
+                    )
+
+        slippage_ratio = self._clamp(float(execution_analytics.get("high_slippage_ratio", 0.0)), 0.0, 1.0)
+        poor_timing_ratio = self._clamp(float(execution_analytics.get("timing_wait_ratio", 0.0)), 0.0, 1.0)
+        poor_exit_ratio = self._clamp(float(execution_analytics.get("poor_exit_ratio", 0.0)), 0.0, 1.0)
+        self._optimization_execution_adjustments["p10_spread_tightening"] = self._smooth_adjustment(
+            current=self._optimization_execution_adjustments["p10_spread_tightening"],
+            target=0.94 if slippage_ratio >= 0.30 else 1.0,
+            lower=0.85,
+            upper=1.05,
+        )
+        self._optimization_execution_adjustments["p12_wait_window_factor"] = self._smooth_adjustment(
+            current=self._optimization_execution_adjustments["p12_wait_window_factor"],
+            target=0.92 if poor_timing_ratio >= 0.35 else 1.0,
+            lower=0.85,
+            upper=1.10,
+        )
+        self._optimization_execution_adjustments["p13_exit_sensitivity_factor"] = self._smooth_adjustment(
+            current=self._optimization_execution_adjustments["p13_exit_sensitivity_factor"],
+            target=0.92 if poor_exit_ratio >= 0.35 else 1.0,
+            lower=0.85,
+            upper=1.10,
+        )
+
+        current_drawdown = self._clamp(float(risk_analytics.get("current_drawdown", 0.0)), 0.0, 1.0)
+        drawdown_trend = float(risk_analytics.get("drawdown_trend", 0.0))
+        loss_streak = max(int(risk_analytics.get("loss_streak", 0.0)), 0)
+        risk_target_aggression = 1.0
+        if current_drawdown >= 0.05 and drawdown_trend > 0.0:
+            risk_target_aggression = 0.90
+        risk_target_size = 1.0
+        if loss_streak >= 3:
+            risk_target_size = 0.88
+
+        self._optimization_risk_adjustments["aggression_modifier"] = self._smooth_adjustment(
+            current=self._optimization_risk_adjustments["aggression_modifier"],
+            target=risk_target_aggression,
+            lower=0.80,
+            upper=1.05,
+        )
+        self._optimization_risk_adjustments["size_modifier"] = self._smooth_adjustment(
+            current=self._optimization_risk_adjustments["size_modifier"],
+            target=risk_target_size,
+            lower=0.80,
+            upper=1.05,
+        )
+        self._optimization_adjustment_explanation = (
+            "optimization update applied from analytics for strategy/regime/execution/risk layers"
+        )
+        return self.get_optimization_output()
+
+    def get_optimization_output(self) -> OptimizationOutput:
+        return OptimizationOutput(
+            strategy_weights=dict(self._optimization_strategy_modifiers),
+            regime_weights=dict(self._optimization_regime_modifiers),
+            execution_adjustments=dict(self._optimization_execution_adjustments),
+            risk_adjustments=dict(self._optimization_risk_adjustments),
         )
 
     def evaluate_breaking_news_momentum(
@@ -910,6 +1121,7 @@ class StrategyTrigger:
                 strategy_weight_modifiers={"S1": 1.0, "S2": 1.0, "S3": 1.0},
             )
         )
+        regime_performance_modifier = self._optimization_regime_modifiers.get(regime.regime_type, 1.0)
         candidates = [
             self._build_strategy_candidate_score(
                 strategy_name="S1",
@@ -918,7 +1130,7 @@ class StrategyTrigger:
                 edge=s1_decision.edge,
                 confidence=None,
                 market_metadata={},
-                regime_weight_modifier=regime.strategy_weight_modifiers.get("S1", 1.0),
+                regime_weight_modifier=regime.strategy_weight_modifiers.get("S1", 1.0) * regime_performance_modifier,
             ),
             self._build_strategy_candidate_score(
                 strategy_name="S2",
@@ -927,7 +1139,7 @@ class StrategyTrigger:
                 edge=s2_decision.edge,
                 confidence=None,
                 market_metadata=s2_decision.matched_markets_info,
-                regime_weight_modifier=regime.strategy_weight_modifiers.get("S2", 1.0),
+                regime_weight_modifier=regime.strategy_weight_modifiers.get("S2", 1.0) * regime_performance_modifier,
             ),
             self._build_strategy_candidate_score(
                 strategy_name="S3",
@@ -936,7 +1148,7 @@ class StrategyTrigger:
                 edge=max(0.0, s3_decision.confidence * self._config.min_edge),
                 confidence=s3_decision.confidence,
                 market_metadata=s3_decision.wallet_info,
-                regime_weight_modifier=regime.strategy_weight_modifiers.get("S3", 1.0),
+                regime_weight_modifier=regime.strategy_weight_modifiers.get("S3", 1.0) * regime_performance_modifier,
             ),
         ]
         ranked_candidates = sorted(candidates, key=lambda item: (-item.score, item.strategy_name))
@@ -1069,8 +1281,9 @@ class StrategyTrigger:
         )
         score = round((0.7 * normalized_edge) + (0.3 * normalized_confidence), 6)
         adaptive_weight = self._adaptive_weights.get(strategy_name, 1.0)
+        optimization_weight = self._optimization_strategy_modifiers.get(strategy_name, 1.0)
         bounded_regime_modifier = self._clamp(regime_weight_modifier, 0.85, 1.20)
-        weighted_score = round(score * adaptive_weight * bounded_regime_modifier, 6)
+        weighted_score = round(score * adaptive_weight * optimization_weight * bounded_regime_modifier, 6)
         return StrategyCandidateScore(
             strategy_name=strategy_name,
             decision=decision,
@@ -1154,7 +1367,9 @@ class StrategyTrigger:
         normalized_score = min(max(base_score * conservative_multiplier, 0.0), 1.0)
         scaled_score = normalized_score ** 2
         raw_position_size = safe_capital * self._config.max_position_size_ratio * scaled_score
-        raw_position_size *= self._adaptive_sizing_modifier
+        aggression_modifier = self._optimization_risk_adjustments["aggression_modifier"]
+        size_modifier = self._optimization_risk_adjustments["size_modifier"]
+        raw_position_size *= self._adaptive_sizing_modifier * aggression_modifier * size_modifier
         position_size = raw_position_size
 
         if position_size > max_position_size:
@@ -1354,6 +1569,9 @@ class StrategyTrigger:
     ) -> ExecutionQualityDecision:
         context = market_context or {}
         size = max(0.0, proposed_size)
+        spread_tightening = self._optimization_execution_adjustments["p10_spread_tightening"]
+        max_execution_spread = self._config.max_execution_spread * spread_tightening
+        borderline_execution_spread = self._config.borderline_execution_spread * spread_tightening
         if size <= 0.0:
             return ExecutionQualityDecision(
                 final_decision="SKIP",
@@ -1370,7 +1588,7 @@ class StrategyTrigger:
         ask = float(context.get("best_ask", min(1.0, market_price + (spread_val / 2.0))))
         observed_spread = max(0.0, ask - bid, spread_val)
 
-        if observed_spread >= self._config.max_execution_spread:
+        if observed_spread >= max_execution_spread:
             expected_fill_price = round(max(market_price, ask), 6)
             expected_slippage = round(max(expected_fill_price - market_price, 0.0), 6)
             return ExecutionQualityDecision(
@@ -1382,7 +1600,7 @@ class StrategyTrigger:
             )
 
         reduced = False
-        if observed_spread >= self._config.borderline_execution_spread:
+        if observed_spread >= borderline_execution_spread:
             size *= self._config.execution_reduction_factor
             reduced = True
 
@@ -1478,7 +1696,12 @@ class StrategyTrigger:
         normalized_wait_cycles = max(wait_cycles, 0)
         reference_price = signal_reference_price if signal_reference_price > 0.0 else market_price
         reference_price = max(reference_price, 0.0)
-        reevaluation_window = max(self._config.timing_reevaluation_window_seconds, 1)
+        wait_window_factor = self._optimization_execution_adjustments["p12_wait_window_factor"]
+        reevaluation_window = max(int(self._config.timing_reevaluation_window_seconds * wait_window_factor), 1)
+        max_wait_cycles = max(
+            int(round(self._config.timing_max_wait_cycles * wait_window_factor)),
+            1,
+        )
 
         bid = float(context.get("best_bid", market_price))
         ask = float(context.get("best_ask", market_price))
@@ -1503,7 +1726,7 @@ class StrategyTrigger:
             and spread_ratio >= self._config.anti_chase_spread_ratio
         )
         if chase_detected:
-            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+            if normalized_wait_cycles >= max_wait_cycles:
                 return EntryTimingDecision(
                     timing_decision="SKIP",
                     timing_reason="anti_chase_timeout_skip",
@@ -1528,7 +1751,7 @@ class StrategyTrigger:
                     reevaluation_window=0,
                     final_execution_readiness=True,
                 )
-            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+            if normalized_wait_cycles >= max_wait_cycles:
                 return EntryTimingDecision(
                     timing_decision="SKIP",
                     timing_reason="micro_pullback_timeout_skip",
@@ -1657,6 +1880,8 @@ class StrategyTrigger:
             regime_factor *= 1.1
 
         bounded_factor = self._clamp(regime_factor, 0.65, 1.35)
+        exit_sensitivity_factor = self._optimization_execution_adjustments["p13_exit_sensitivity_factor"]
+        bounded_factor = self._clamp(bounded_factor * exit_sensitivity_factor, 0.60, 1.40)
         stop_loss_limit = position_size * self._config.stop_loss_ratio * bounded_factor
         favorable_threshold = max(
             self._config.target_pnl * bounded_factor,
@@ -1704,7 +1929,7 @@ class StrategyTrigger:
 
         if peak_pnl >= favorable_threshold:
             pullback_from_peak = peak_pnl - current_pnl
-            weakening_threshold = peak_pnl * self._config.momentum_weakening_ratio
+            weakening_threshold = peak_pnl * self._config.momentum_weakening_ratio * exit_sensitivity_factor
             if pullback_from_peak >= weakening_threshold:
                 return ExitDecision(
                     exit_decision="EXIT_FULL",

--- a/projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md
@@ -1,0 +1,104 @@
+# 24_26_p14_system_optimization_from_analytics
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - analytics output consumption in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - optimization decision layer for strategy/regime/execution/risk modifiers
+  - bounded config adjustment logic feeding S4 weighting, P7 sizing, and P10/P12/P13 tuning
+- Not in Scope:
+  - execution engine redesign
+  - ML model training
+  - external data sources
+  - Telegram UI changes
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md`. Tier: STANDARD
+
+## 1. What was built
+- Added analytics-driven optimization contracts:
+  - `AnalyticsPerformanceSnapshot` for normalized scoring inputs (`pnl`, `win_rate`, `expectancy`, `drawdown`, `trades`).
+  - `OptimizationOutput` payload with required output structure:
+    - `strategy_weights`
+    - `regime_weights`
+    - `execution_adjustments`
+    - `risk_adjustments`
+- Implemented `apply_analytics_optimization(...)` to consume strategy/regime/execution/risk analytics and produce deterministic bounded adjustments.
+- Implemented strategy scoring and adjustment rules:
+  - normalized multi-factor score = `f(pnl, win_rate, expectancy, drawdown)`
+  - strong strategy -> slight boost
+  - weak strategy -> reduction
+  - consistently bad strategy -> soft disable (bounded modifier floor, never hard-off)
+- Implemented regime performance scoring and weighting:
+  - regime comparative ranking from normalized score
+  - best regime receives bounded boost
+  - worst regime receives bounded reduction
+- Implemented execution feedback adjustments:
+  - high slippage tightens P10 spread thresholds
+  - poor timing tightens P12 wait-window behavior
+  - poor exits increase P13 exit sensitivity
+- Implemented risk adjustments:
+  - increasing drawdown reduces aggression
+  - loss streak reduces size
+- Added fallback + safety behavior:
+  - insufficient data -> neutral modifiers
+  - step-limited smoothing (`_optimization_step_limit`) to prevent jumps
+  - strict bounds per modifier group
+
+## 2. Current system architecture
+- Optimization layer lives in strategy-trigger scope and updates internal optimization state.
+- Integration points in touched runtime path:
+  1. **S4 weighting**: `_build_strategy_candidate_score(...)` now multiplies base score by adaptive + optimization strategy modifiers.
+  2. **Regime weighting**: `aggregate_strategy_decisions(...)` applies current regime performance modifier in addition to regime-classification weight.
+  3. **P7 sizing**: `_compute_position_size(...)` applies risk aggression/size modifiers on top of adaptive sizing.
+  4. **P10 execution quality**: `evaluate_execution_quality(...)` applies optimization-based spread tightening.
+  5. **P12 timing logic**: `evaluate_entry_timing(...)` scales reevaluation window and max wait cycles using timing adjustment factor.
+  6. **P13 exits**: `evaluate_exit_decision(...)` applies exit sensitivity factor to bounded exit behavior.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required tests (all pass):
+1. strong strategy -> weight increases
+2. weak strategy -> weight decreases (soft disable, bounded)
+3. high drawdown -> risk reduced
+4. deterministic adjustments
+5. no extreme jumps
+
+Additional safety validation:
+- insufficient analytics -> neutral fallback output
+- adjustment values remain bounded across strategy/regime/execution/risk output groups
+
+Test evidence:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py` ✅ (39 passed, environment warning: unknown `asyncio_mode`)
+
+Runtime proof:
+1) before/after weight changes
+```text
+before strategy_weights: {'S1': 1.0, 'S2': 1.0, 'S3': 1.0}
+after strategy_weights:  {'S1': 1.04, 'S2': 1.0, 'S3': 0.96}
+```
+2) strategy ranking example
+```text
+strategy ranking: [('S1', 1.04), ('S2', 1.0), ('S3', 0.96)]
+```
+3) risk adjustment example
+```text
+risk_adjustments: {'aggression_modifier': 0.96, 'size_modifier': 0.96}
+```
+
+## 5. Known issues
+- P14 optimization is intentionally narrow integration in strategy-trigger scope and is not yet wired into other runtime orchestration surfaces.
+- Optimization uses analytics snapshots supplied by caller; end-to-end analytics collection/orchestration outside strategy-trigger remains out of scope.
+- Existing test environment warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review on changed files + direct dependencies.
+- COMMANDER review for STANDARD-tier merge/hold decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    AnalyticsPerformanceSnapshot,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    positions: tuple[object, ...]
+    cash: float
+    equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    implied_prob: float
+    volatility: float
+
+
+class _Engine:
+    def __init__(self) -> None:
+        self.max_total_exposure_ratio = 0.30
+        self.max_position_size_ratio = 0.10
+        self._snapshot = _Snapshot(
+            positions=tuple(),
+            cash=10_000.0,
+            equity=10_000.0,
+            realized_pnl=0.0,
+            unrealized_pnl=0.0,
+            implied_prob=0.50,
+            volatility=0.10,
+        )
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_Engine(),
+        config=StrategyConfig(market_id="m-p14-optimization", min_edge=0.02),
+    )
+
+
+def _strategy_analytics() -> dict[str, AnalyticsPerformanceSnapshot]:
+    return {
+        "S1": AnalyticsPerformanceSnapshot(pnl=420.0, win_rate=0.72, expectancy=0.18, drawdown=0.06, trades=18),
+        "S2": AnalyticsPerformanceSnapshot(pnl=90.0, win_rate=0.51, expectancy=0.04, drawdown=0.12, trades=16),
+        "S3": AnalyticsPerformanceSnapshot(pnl=-210.0, win_rate=0.32, expectancy=-0.08, drawdown=0.25, trades=17),
+    }
+
+
+def _regime_analytics() -> dict[str, AnalyticsPerformanceSnapshot]:
+    return {
+        "NEWS_DRIVEN": AnalyticsPerformanceSnapshot(pnl=260.0, win_rate=0.66, expectancy=0.11, drawdown=0.09, trades=14),
+        "ARBITRAGE_DOMINANT": AnalyticsPerformanceSnapshot(
+            pnl=120.0,
+            win_rate=0.58,
+            expectancy=0.07,
+            drawdown=0.12,
+            trades=12,
+        ),
+        "SMART_MONEY_DOMINANT": AnalyticsPerformanceSnapshot(
+            pnl=-40.0,
+            win_rate=0.46,
+            expectancy=-0.01,
+            drawdown=0.17,
+            trades=11,
+        ),
+        "LOW_ACTIVITY_CHAOTIC": AnalyticsPerformanceSnapshot(
+            pnl=-180.0,
+            win_rate=0.33,
+            expectancy=-0.05,
+            drawdown=0.22,
+            trades=10,
+        ),
+    }
+
+
+def test_strong_strategy_weight_increases_and_ranking_example() -> None:
+    trigger = _make_trigger()
+
+    before = trigger.get_optimization_output().strategy_weights
+    after = trigger.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.18, "timing_wait_ratio": 0.22, "poor_exit_ratio": 0.18},
+        risk_analytics={"current_drawdown": 0.03, "drawdown_trend": -0.01, "loss_streak": 1},
+    ).strategy_weights
+
+    assert before["S1"] == 1.0
+    assert after["S1"] > before["S1"]
+    ranked = sorted(after.items(), key=lambda item: item[1], reverse=True)
+    assert ranked[0][0] == "S1"
+
+
+def test_weak_strategy_weight_decreases_and_soft_disable_not_hard_off() -> None:
+    trigger = _make_trigger()
+
+    output = trigger.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.40, "timing_wait_ratio": 0.20, "poor_exit_ratio": 0.20},
+        risk_analytics={"current_drawdown": 0.02, "drawdown_trend": 0.0, "loss_streak": 1},
+    )
+
+    assert output.strategy_weights["S3"] < 1.0
+    assert output.strategy_weights["S3"] > 0.0
+
+
+def test_high_drawdown_and_loss_streak_reduce_risk() -> None:
+    trigger = _make_trigger()
+
+    before = trigger.get_optimization_output().risk_adjustments
+    after = trigger.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.20, "timing_wait_ratio": 0.20, "poor_exit_ratio": 0.20},
+        risk_analytics={"current_drawdown": 0.09, "drawdown_trend": 0.02, "loss_streak": 4},
+    ).risk_adjustments
+
+    assert before["aggression_modifier"] == 1.0
+    assert before["size_modifier"] == 1.0
+    assert after["aggression_modifier"] < 1.0
+    assert after["size_modifier"] < 1.0
+
+
+def test_adjustments_are_deterministic_for_same_inputs() -> None:
+    trigger_a = _make_trigger()
+    trigger_b = _make_trigger()
+
+    output_a = trigger_a.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.35, "timing_wait_ratio": 0.38, "poor_exit_ratio": 0.41},
+        risk_analytics={"current_drawdown": 0.08, "drawdown_trend": 0.01, "loss_streak": 3},
+    )
+    output_b = trigger_b.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.35, "timing_wait_ratio": 0.38, "poor_exit_ratio": 0.41},
+        risk_analytics={"current_drawdown": 0.08, "drawdown_trend": 0.01, "loss_streak": 3},
+    )
+
+    assert output_a == output_b
+
+
+def test_no_extreme_jumps_and_bounds_enforced() -> None:
+    trigger = _make_trigger()
+
+    first = trigger.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.95, "timing_wait_ratio": 0.95, "poor_exit_ratio": 0.95},
+        risk_analytics={"current_drawdown": 0.20, "drawdown_trend": 0.04, "loss_streak": 8},
+    )
+    second = trigger.apply_analytics_optimization(
+        strategy_analytics=_strategy_analytics(),
+        regime_analytics=_regime_analytics(),
+        execution_analytics={"high_slippage_ratio": 0.95, "timing_wait_ratio": 0.95, "poor_exit_ratio": 0.95},
+        risk_analytics={"current_drawdown": 0.20, "drawdown_trend": 0.04, "loss_streak": 8},
+    )
+
+    assert abs(first.strategy_weights["S1"] - 1.0) <= 0.041
+    assert abs(second.strategy_weights["S1"] - first.strategy_weights["S1"]) <= 0.041
+    assert 0.85 <= second.strategy_weights["S3"] <= 1.15
+    assert 0.88 <= second.regime_weights["LOW_ACTIVITY_CHAOTIC"] <= 1.12
+    assert 0.80 <= second.risk_adjustments["size_modifier"] <= 1.05
+    assert 0.85 <= second.execution_adjustments["p10_spread_tightening"] <= 1.05
+
+
+def test_insufficient_data_falls_back_to_neutral() -> None:
+    trigger = _make_trigger()
+
+    output = trigger.apply_analytics_optimization(
+        strategy_analytics={
+            "S1": AnalyticsPerformanceSnapshot(pnl=10.0, win_rate=0.6, expectancy=0.01, drawdown=0.03, trades=1)
+        },
+        regime_analytics={},
+        execution_analytics={"high_slippage_ratio": 0.90, "timing_wait_ratio": 0.90, "poor_exit_ratio": 0.90},
+        risk_analytics={"current_drawdown": 0.15, "drawdown_trend": 0.03, "loss_streak": 5},
+    )
+
+    assert output.strategy_weights == {"S1": 1.0, "S2": 1.0, "S3": 1.0}
+    assert output.execution_adjustments == {
+        "p10_spread_tightening": 1.0,
+        "p12_wait_window_factor": 1.0,
+        "p13_exit_sensitivity_factor": 1.0,
+    }


### PR DESCRIPTION
### Motivation
- Convert P14 analytics into actionable optimization signals that tune S4 strategy weighting, P7 sizing, and P10/P12/P13 execution/exit parameters. 
- Ensure adjustments are deterministic, bounded, step-smoothed, and fallback to neutral when analytics are insufficient. 
- Provide a narrow-integration optimization decision layer inside the strategy-trigger path to improve runtime adaptability without redesigning core engines.

### Description
- Added typed contracts `AnalyticsPerformanceSnapshot` and `OptimizationOutput` and implemented `apply_analytics_optimization(...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to consume analytics and produce `strategy_weights`, `regime_weights`, `execution_adjustments`, and `risk_adjustments`.
- Implemented normalized multi-factor scoring (`pnl`, `win_rate`, `expectancy`, `drawdown`), regime comparative ranking, step-limited smoothing (`_optimization_step_limit`), and strict bounds to prevent extreme jumps or hard disables.
- Integrated optimization outputs into narrow runtime surfaces: S4 candidate scoring (`_build_strategy_candidate_score`), regime weighting in `aggregate_strategy_decisions`, P7 sizing (`_compute_position_size` uses aggression/size modifiers), P10 execution-quality spread tightening, P12 timing wait-window/cycle tuning, and P13 exit sensitivity adjustments.
- Added focused unit tests `projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_26_p14_system_optimization_from_analytics.md`, and updated `PROJECT_STATE.md` to reflect the change.

### Testing
- Ran syntax check: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py` — PASS.
- Ran unit test suite (focused integration): `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_system_optimization_from_analytics_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py projects/polymarket/polyquantbot/tests/test_p9_performance_feedback_loop_20260409.py` — `39 passed` (one environment warning: `Unknown config option: asyncio_mode`).
- Verified no forbidden `phase*/` folders present with `find` checks and validated created report and `PROJECT_STATE.md` update.
- All implemented tests for required cases (strong/weak strategy weight changes, risk reduction on drawdown, deterministic adjustments, bounded behavior, insufficient-data fallback) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d795f4bd84832ebd68d415588885ff)