### PR TITLE
P14.1: derive bounded optimization signals from P14 analytics and apply to S4/P7/P10/P12/P13

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 11:21
-- Status        : FORGE-X P14 post-trade analytics & attribution implementation complete (STANDARD, narrow integration) across closed-trade storage + analytics computation layer; awaiting Codex auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 12:43
+- Status        : FORGE-X P14.1 system optimization from analytics implementation complete (STANDARD, narrow integration) in analytics + strategy-trigger optimization-consumption path; awaiting Codex auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P14.1 system optimization from analytics (2026-04-09): implemented deterministic analytics-to-optimization output (`strategy_weights`/`regime_weights`/`execution_adjustments`/`risk_adjustments`) with bounded strategy/regime scoring, execution feedback tuning for P10/P12/P13, risk-pressure sizing/aggression reduction, strategy-trigger integration, and focused runtime-proof tests.
 - P14 post-trade analytics & attribution (2026-04-09): implemented closed-trade attribution persistence (`strategy_source`/`regime_at_entry`/`entry_quality`/`entry_timing`/`exit_reason`/`duration`), added analytics summary computation for profitability/expectancy/edge-captured/strategy+regime attribution/execution-quality/risk metrics, integrated strategy-trigger entry/exit context handoff into execution close path, and added deterministic runtime-proof tests.
 - P13 exit timing & trade management (2026-04-09): replaced static exit threshold behavior with adaptive deterministic exit decisioning (`EXIT_FULL`/`HOLD` + `exit_reason`/`pnl_snapshot`/`trade_duration`), added favorable-move momentum-weakening take-profit logic, bounded stop-loss + signal-invalidation exits, stale-trade timeout/hard-duration guards, and light adaptation using P9 performance feedback + P11 regime context with focused runtime-proof tests.
 - TG-2 + TG-3 open positions visibility & trade history (2026-04-09): implemented full open-position card rendering without truncation, added separate-card handling for same-market multi-position entries with per-position refs, added closed-trade history rendering with newest-first ordering and capped history display, integrated execution payload closed-trade persistence into portfolio state and Telegram callback payload path, and added focused formatter/view tests (including strict format and empty-state coverage).
@@ -110,6 +111,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P14.1 system optimization from analytics handoff
+- STANDARD-tier narrow integration implementation is complete for analytics output consumption + optimization decision layer + bounded config adjustment logic in touched S4/P7/P10/P12/P13 path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P14 post-trade analytics & attribution handoff
 - STANDARD-tier narrow integration implementation is complete for trade lifecycle attribution, closed-trade storage enrichment, and in-memory analytics summary computation.
@@ -216,11 +221,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Codex auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_26_p14_post_trade_analytics_attribution.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P14.1 optimization output is currently narrow integration in strategy-trigger runtime path and is not yet propagated to external persistence/dashboard surfaces.
 - P14 analytics attribution is currently narrow integration in strategy-trigger to execution closed-trade path only and is not yet wired to external persistence or dashboard surfaces.
 - P13 exit management is currently narrow integration in strategy-trigger monitoring path only and is not yet propagated into broader runtime orchestration surfaces.
 - TG-2 + TG-3 trade history is currently narrow integration in Telegram portfolio rendering path only and is not yet surfaced in other non-portfolio historical analytics views.

--- a/projects/polymarket/polyquantbot/execution/analytics.py
+++ b/projects/polymarket/polyquantbot/execution/analytics.py
@@ -199,6 +199,145 @@ class PerformanceTracker:
             "risk_metrics": self._compute_risk_metrics(),
         }
 
+    def optimization_output(self) -> dict[str, Any]:
+        """Convert analytics summary into bounded optimization signals."""
+        summary = self.summary()
+        strategy_keys = ("S1", "S2", "S3", "S5")
+        neutral_output = {
+            "strategy_weights": {key: 1.0 for key in strategy_keys},
+            "regime_weights": {"NEWS": 1.0, "ARBITRAGE": 1.0, "SMART_MONEY": 1.0, "CHAOTIC": 1.0},
+            "execution_adjustments": {
+                "p10_max_spread_multiplier": 1.0,
+                "p10_slippage_guard_multiplier": 1.0,
+                "p12_wait_cycle_bias": 0,
+                "p12_reevaluation_window_multiplier": 1.0,
+                "p13_exit_sensitivity_multiplier": 1.0,
+            },
+            "risk_adjustments": {
+                "aggression_multiplier": 1.0,
+                "size_multiplier": 1.0,
+            },
+            "fallback_to_neutral": False,
+        }
+        trades = int(summary.get("trades", 0))
+        if trades < 3:
+            neutral_output["fallback_to_neutral"] = True
+            return neutral_output
+
+        strategy_breakdown = summary.get("strategy_breakdown", {})
+        risk_metrics = summary.get("risk_metrics", {})
+        expectancy = float(summary.get("expectancy", 0.0))
+        strategy_weights: dict[str, float] = {key: 1.0 for key in strategy_keys}
+
+        scores: dict[str, float] = {}
+        max_abs_pnl = max(
+            (abs(float(row.get("pnl", 0.0))) for row in strategy_breakdown.values()),
+            default=1.0,
+        )
+        expectancy_norm = self._clamp(expectancy / 20.0, -1.0, 1.0)
+        global_drawdown = self._clamp(float(risk_metrics.get("max_drawdown", 0.0)), 0.0, 1.0)
+        drawdown_component = 1.0 - global_drawdown
+        for strategy_name in strategy_keys:
+            row = strategy_breakdown.get(strategy_name, {})
+            if not row:
+                continue
+            pnl = float(row.get("pnl", 0.0))
+            win_rate = self._clamp(float(row.get("win_rate", 0.0)), 0.0, 1.0)
+            avg_return = self._clamp(float(row.get("avg_return", 0.0)) / 0.10, -1.0, 1.0)
+            pnl_component = self._clamp((pnl / max(max_abs_pnl, 1e-6)), -1.0, 1.0)
+            score = (
+                (0.30 * ((pnl_component + 1.0) / 2.0))
+                + (0.30 * win_rate)
+                + (0.20 * ((avg_return + 1.0) / 2.0))
+                + (0.10 * ((expectancy_norm + 1.0) / 2.0))
+                + (0.10 * drawdown_component)
+            )
+            scores[strategy_name] = self._clamp(score, 0.0, 1.0)
+
+        if scores:
+            low = min(scores.values())
+            high = max(scores.values())
+            span = max(high - low, 1e-6)
+            for strategy_name, score in scores.items():
+                normalized = (score - low) / span if high > low else 0.5
+                if normalized >= 0.75:
+                    modifier = 1.08
+                elif normalized <= 0.15:
+                    modifier = 0.75
+                elif normalized <= 0.35:
+                    modifier = 0.90
+                else:
+                    modifier = 0.95 + (normalized - 0.35) * 0.20
+                strategy_weights[strategy_name] = round(self._clamp(modifier, 0.75, 1.15), 6)
+
+        regime_breakdown = summary.get("regime_breakdown", {})
+        regime_weights = {"NEWS": 1.0, "ARBITRAGE": 1.0, "SMART_MONEY": 1.0, "CHAOTIC": 1.0}
+        regime_scores: dict[str, float] = {}
+        max_abs_regime_pnl = max(
+            (abs(float(row.get("pnl", 0.0))) for row in regime_breakdown.values()),
+            default=1.0,
+        )
+        for regime_name, row in regime_breakdown.items():
+            pnl = float(row.get("pnl", 0.0))
+            win_rate = self._clamp(float(row.get("win_rate", 0.0)), 0.0, 1.0)
+            avg_return = self._clamp(float(row.get("avg_return", 0.0)) / 0.10, -1.0, 1.0)
+            pnl_component = self._clamp((pnl / max(max_abs_regime_pnl, 1e-6)), -1.0, 1.0)
+            regime_scores[regime_name] = self._clamp(
+                (0.45 * ((pnl_component + 1.0) / 2.0))
+                + (0.35 * win_rate)
+                + (0.20 * ((avg_return + 1.0) / 2.0)),
+                0.0,
+                1.0,
+            )
+        if regime_scores:
+            low = min(regime_scores.values())
+            high = max(regime_scores.values())
+            span = max(high - low, 1e-6)
+            for regime_name, score in regime_scores.items():
+                normalized = (score - low) / span if high > low else 0.5
+                regime_weights[regime_name] = round(self._clamp(0.85 + (normalized * 0.30), 0.85, 1.15), 6)
+
+        execution_metrics = summary.get("execution_quality_metrics", {})
+        avg_slippage_impact = self._clamp(float(execution_metrics.get("avg_slippage_impact", 0.0)), 0.0, 1.0)
+        avg_timing_effectiveness = self._clamp(float(execution_metrics.get("avg_timing_effectiveness", 0.0)), 0.0, 1.0)
+        avg_exit_efficiency = self._clamp(float(execution_metrics.get("avg_exit_efficiency", 0.0)), 0.0, 1.0)
+        p10_tighten = self._clamp((avg_slippage_impact - 0.02) / 0.06, 0.0, 1.0)
+        p12_timing_penalty = self._clamp((0.60 - avg_timing_effectiveness) / 0.40, 0.0, 1.0)
+        p13_exit_penalty = self._clamp((0.60 - avg_exit_efficiency) / 0.40, 0.0, 1.0)
+        execution_adjustments = {
+            "p10_max_spread_multiplier": round(self._clamp(1.0 - (0.15 * p10_tighten), 0.85, 1.0), 6),
+            "p10_slippage_guard_multiplier": round(self._clamp(1.0 - (0.20 * p10_tighten), 0.80, 1.0), 6),
+            "p12_wait_cycle_bias": int(round(self._clamp(p12_timing_penalty * 2.0, 0.0, 2.0))),
+            "p12_reevaluation_window_multiplier": round(self._clamp(1.0 + (0.20 * p12_timing_penalty), 1.0, 1.2), 6),
+            "p13_exit_sensitivity_multiplier": round(self._clamp(1.0 - (0.20 * p13_exit_penalty), 0.80, 1.0), 6),
+        }
+
+        loss_streak = int(risk_metrics.get("loss_streak", 0))
+        max_drawdown = self._clamp(float(risk_metrics.get("max_drawdown", 0.0)), 0.0, 1.0)
+        avg_drawdown = self._clamp(float(risk_metrics.get("avg_drawdown", 0.0)), 0.0, 1.0)
+        drawdown_pressure = self._clamp((max_drawdown - 0.04) / 0.20, 0.0, 1.0)
+        avg_drawdown_pressure = self._clamp((avg_drawdown - 0.02) / 0.10, 0.0, 1.0)
+        streak_pressure = self._clamp((loss_streak - 1) / 4.0, 0.0, 1.0)
+        risk_adjustments = {
+            "aggression_multiplier": round(
+                self._clamp(1.0 - (0.15 * max(drawdown_pressure, avg_drawdown_pressure)), 0.85, 1.0),
+                6,
+            ),
+            "size_multiplier": round(self._clamp(1.0 - (0.15 * streak_pressure), 0.85, 1.0), 6),
+        }
+
+        return {
+            "strategy_weights": strategy_weights,
+            "regime_weights": regime_weights,
+            "execution_adjustments": execution_adjustments,
+            "risk_adjustments": risk_adjustments,
+            "fallback_to_neutral": False,
+        }
+
+    @staticmethod
+    def _clamp(value: float, lower: float, upper: float) -> float:
+        return min(max(value, lower), upper)
+
     def _calculate_sharpe(self) -> float:
         """Placeholder for Sharpe ratio."""
         return 0.0

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -304,6 +304,22 @@ class StrategyTrigger:
         self._last_adjustment_explanation: str = "adaptive defaults active"
         self._position_peak_pnl: dict[str, float] = {}
         self._position_entry_context: dict[str, dict[str, object]] = {}
+        self._optimization_output: dict[str, object] = {
+            "strategy_weights": {"S1": 1.0, "S2": 1.0, "S3": 1.0, "S5": 1.0},
+            "regime_weights": {"NEWS": 1.0, "ARBITRAGE": 1.0, "SMART_MONEY": 1.0, "CHAOTIC": 1.0},
+            "execution_adjustments": {
+                "p10_max_spread_multiplier": 1.0,
+                "p10_slippage_guard_multiplier": 1.0,
+                "p12_wait_cycle_bias": 0,
+                "p12_reevaluation_window_multiplier": 1.0,
+                "p13_exit_sensitivity_multiplier": 1.0,
+            },
+            "risk_adjustments": {
+                "aggression_multiplier": 1.0,
+                "size_multiplier": 1.0,
+            },
+            "fallback_to_neutral": True,
+        }
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
@@ -457,6 +473,22 @@ class StrategyTrigger:
             confidence_threshold=round(self._adaptive_confidence_threshold, 6),
             explanation=self._last_adjustment_explanation,
         )
+
+    def refresh_optimization_output(self) -> dict[str, object]:
+        analytics_provider = getattr(self._engine, "get_analytics", None)
+        if callable(analytics_provider):
+            self._optimization_output = analytics_provider().optimization_output()
+        return dict(self._optimization_output)
+
+    @staticmethod
+    def _regime_output_key(regime_type: str) -> str:
+        mapping = {
+            "NEWS_DRIVEN": "NEWS",
+            "ARBITRAGE_DOMINANT": "ARBITRAGE",
+            "SMART_MONEY_DOMINANT": "SMART_MONEY",
+            "LOW_ACTIVITY_CHAOTIC": "CHAOTIC",
+        }
+        return mapping.get(regime_type, "CHAOTIC")
 
     def evaluate_breaking_news_momentum(
         self,
@@ -940,6 +972,24 @@ class StrategyTrigger:
                 regime_weight_modifier=regime.strategy_weight_modifiers.get("S3", 1.0),
             ),
         ]
+        regime_output_key = self._regime_output_key(regime.regime_type)
+        regime_perf_modifier = float(
+            (self._optimization_output.get("regime_weights", {}) or {}).get(regime_output_key, 1.0)
+        )
+        regime_perf_modifier = self._clamp(regime_perf_modifier, 0.85, 1.15)
+        if regime_perf_modifier != 1.0:
+            candidates = [
+                StrategyCandidateScore(
+                    strategy_name=item.strategy_name,
+                    decision=item.decision,
+                    reason=item.reason,
+                    edge=item.edge,
+                    confidence=item.confidence,
+                    score=round(item.score * regime_perf_modifier, 6),
+                    market_metadata=item.market_metadata,
+                )
+                for item in candidates
+            ]
         ranked_candidates = sorted(candidates, key=lambda item: (-item.score, item.strategy_name))
         enter_candidates = [candidate for candidate in ranked_candidates if candidate.decision == "ENTER"]
         top_score = ranked_candidates[0].score if ranked_candidates else 0.0
@@ -1070,8 +1120,12 @@ class StrategyTrigger:
         )
         score = round((0.7 * normalized_edge) + (0.3 * normalized_confidence), 6)
         adaptive_weight = self._adaptive_weights.get(strategy_name, 1.0)
+        optimization_weight = float(
+            (self._optimization_output.get("strategy_weights", {}) or {}).get(strategy_name, 1.0)
+        )
+        optimization_weight = self._clamp(optimization_weight, 0.75, 1.15)
         bounded_regime_modifier = self._clamp(regime_weight_modifier, 0.85, 1.20)
-        weighted_score = round(score * adaptive_weight * bounded_regime_modifier, 6)
+        weighted_score = round(score * adaptive_weight * bounded_regime_modifier * optimization_weight, 6)
         return StrategyCandidateScore(
             strategy_name=strategy_name,
             decision=decision,
@@ -1156,6 +1210,10 @@ class StrategyTrigger:
         scaled_score = normalized_score ** 2
         raw_position_size = safe_capital * self._config.max_position_size_ratio * scaled_score
         raw_position_size *= self._adaptive_sizing_modifier
+        risk_adjustments = self._optimization_output.get("risk_adjustments", {}) or {}
+        aggression_multiplier = self._clamp(float(risk_adjustments.get("aggression_multiplier", 1.0)), 0.85, 1.0)
+        size_multiplier = self._clamp(float(risk_adjustments.get("size_multiplier", 1.0)), 0.85, 1.0)
+        raw_position_size *= aggression_multiplier * size_multiplier
         position_size = raw_position_size
 
         if position_size > max_position_size:
@@ -1370,8 +1428,17 @@ class StrategyTrigger:
         bid = float(context.get("best_bid", max(0.0, market_price - (spread_val / 2.0))))
         ask = float(context.get("best_ask", min(1.0, market_price + (spread_val / 2.0))))
         observed_spread = max(0.0, ask - bid, spread_val)
+        execution_adjustments = self._optimization_output.get("execution_adjustments", {}) or {}
+        max_spread_multiplier = self._clamp(float(execution_adjustments.get("p10_max_spread_multiplier", 1.0)), 0.85, 1.0)
+        slippage_guard_multiplier = self._clamp(
+            float(execution_adjustments.get("p10_slippage_guard_multiplier", 1.0)),
+            0.80,
+            1.0,
+        )
+        adjusted_max_execution_spread = self._config.max_execution_spread * max_spread_multiplier
+        adjusted_borderline_execution_spread = self._config.borderline_execution_spread * max_spread_multiplier
 
-        if observed_spread >= self._config.max_execution_spread:
+        if observed_spread >= adjusted_max_execution_spread:
             expected_fill_price = round(max(market_price, ask), 6)
             expected_slippage = round(max(expected_fill_price - market_price, 0.0), 6)
             return ExecutionQualityDecision(
@@ -1383,7 +1450,7 @@ class StrategyTrigger:
             )
 
         reduced = False
-        if observed_spread >= self._config.borderline_execution_spread:
+        if observed_spread >= adjusted_borderline_execution_spread:
             size *= self._config.execution_reduction_factor
             reduced = True
 
@@ -1434,7 +1501,7 @@ class StrategyTrigger:
         if (
             safe_signal_edge <= 0.0
             or expected_slippage >= safe_signal_edge
-            or expected_slippage >= (safe_signal_edge * self._config.max_slippage_edge_consumption_ratio)
+            or expected_slippage >= (safe_signal_edge * self._config.max_slippage_edge_consumption_ratio * slippage_guard_multiplier)
         ):
             return ExecutionQualityDecision(
                 final_decision="SKIP",
@@ -1447,7 +1514,7 @@ class StrategyTrigger:
         if (
             not reduced
             and expected_slippage
-            >= (safe_signal_edge * self._config.borderline_slippage_edge_consumption_ratio)
+            >= (safe_signal_edge * self._config.borderline_slippage_edge_consumption_ratio * slippage_guard_multiplier)
         ):
             size *= self._config.execution_reduction_factor
             reduced = True
@@ -1479,7 +1546,15 @@ class StrategyTrigger:
         normalized_wait_cycles = max(wait_cycles, 0)
         reference_price = signal_reference_price if signal_reference_price > 0.0 else market_price
         reference_price = max(reference_price, 0.0)
-        reevaluation_window = max(self._config.timing_reevaluation_window_seconds, 1)
+        execution_adjustments = self._optimization_output.get("execution_adjustments", {}) or {}
+        wait_cycle_bias = int(self._clamp(float(execution_adjustments.get("p12_wait_cycle_bias", 0)), 0.0, 2.0))
+        reevaluation_multiplier = self._clamp(
+            float(execution_adjustments.get("p12_reevaluation_window_multiplier", 1.0)),
+            1.0,
+            1.2,
+        )
+        adjusted_max_wait_cycles = self._config.timing_max_wait_cycles + wait_cycle_bias
+        reevaluation_window = max(int(round(self._config.timing_reevaluation_window_seconds * reevaluation_multiplier)), 1)
 
         bid = float(context.get("best_bid", market_price))
         ask = float(context.get("best_ask", market_price))
@@ -1504,7 +1579,7 @@ class StrategyTrigger:
             and spread_ratio >= self._config.anti_chase_spread_ratio
         )
         if chase_detected:
-            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+            if normalized_wait_cycles >= adjusted_max_wait_cycles:
                 return EntryTimingDecision(
                     timing_decision="SKIP",
                     timing_reason="anti_chase_timeout_skip",
@@ -1529,7 +1604,7 @@ class StrategyTrigger:
                     reevaluation_window=0,
                     final_execution_readiness=True,
                 )
-            if normalized_wait_cycles >= self._config.timing_max_wait_cycles:
+            if normalized_wait_cycles >= adjusted_max_wait_cycles:
                 return EntryTimingDecision(
                     timing_decision="SKIP",
                     timing_reason="micro_pullback_timeout_skip",
@@ -1705,7 +1780,13 @@ class StrategyTrigger:
 
         if peak_pnl >= favorable_threshold:
             pullback_from_peak = peak_pnl - current_pnl
-            weakening_threshold = peak_pnl * self._config.momentum_weakening_ratio
+            execution_adjustments = self._optimization_output.get("execution_adjustments", {}) or {}
+            exit_sensitivity_multiplier = self._clamp(
+                float(execution_adjustments.get("p13_exit_sensitivity_multiplier", 1.0)),
+                0.80,
+                1.0,
+            )
+            weakening_threshold = peak_pnl * self._config.momentum_weakening_ratio * exit_sensitivity_multiplier
             if pullback_from_peak >= weakening_threshold:
                 return ExitDecision(
                     exit_decision="EXIT_FULL",
@@ -1814,6 +1895,7 @@ class StrategyTrigger:
         if self._last_trigger_time and (now - self._last_trigger_time) < self._cooldown_seconds:
             return "COOLDOWN"
         self._last_trigger_time = now
+        self.refresh_optimization_output()
 
         snapshot = await self._engine.snapshot()
         open_pos = next((p for p in snapshot.positions if p.market_id == self._config.market_id), None)
@@ -1907,9 +1989,12 @@ class StrategyTrigger:
                 )
                 return "BLOCKED"
             size = readiness.adjusted_size
+            selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             candidate_title = (
-                selected_candidate.title
-                if selected_candidate is not None and selected_candidate.title
+                str(selected_metadata.get("title") or selected_metadata.get("market_title", ""))
+                if selected_candidate is not None
+                and isinstance(selected_metadata, dict)
+                and (selected_metadata.get("title") or selected_metadata.get("market_title"))
                 else target_market_id
             )
             created = await self._engine.open_position(

--- a/projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md
@@ -1,0 +1,100 @@
+# 24_27_p14_1_system_optimization_from_analytics
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - analytics output consumption
+  - optimization decision layer
+  - config adjustment logic (S4/P7/P10/P12/P13 touched path)
+- Not in Scope:
+  - execution engine redesign
+  - ML model training
+  - external data sources
+  - Telegram UI changes
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md`. Tier: STANDARD
+
+## 1. What was built
+- Added deterministic P14.1 optimization generation in `PerformanceTracker.optimization_output()` that converts analytics into bounded optimization signals:
+  - `strategy_weights`
+  - `regime_weights`
+  - `execution_adjustments`
+  - `risk_adjustments`
+- Implemented strategy/regime performance scoring with normalization and bounded modifier rules (boost/penalize/soft-disable behavior).
+- Implemented execution feedback rules:
+  - high slippage tightens P10 spread/slippage guards
+  - weak timing adjusts P12 wait behavior and reevaluation window
+  - weak exits adjusts P13 exit sensitivity
+- Implemented risk adjustments from drawdown/loss-streak pressure to reduce aggression and position size safely.
+- Integrated optimization output consumption in strategy-trigger runtime path:
+  - refresh optimization output on evaluation
+  - apply strategy weights to S4 candidate score weighting
+  - apply regime weights to current regime score scaling
+  - apply risk adjustments to P7 sizing result
+  - apply execution adjustments to P10/P12/P13 decision thresholds
+
+## 2. Current system architecture
+- `execution/analytics.py`
+  - analytics summary remains authoritative source
+  - new optimization layer derives bounded action signals from summary metrics
+  - neutral fallback if insufficient trade data
+- `execution/strategy_trigger.py`
+  - runtime refreshes optimization output from engine analytics
+  - S4 path: candidate score uses adaptive weights × strategy weight modifiers × regime modifiers
+  - P7 path: position size multiplied by bounded risk adjustment multipliers
+  - P10 path: spread/slippage gates tightened using execution feedback multipliers
+  - P12 path: wait-cycle and reevaluation behavior tuned from timing feedback
+  - P13 path: exit weakening threshold tuned from exit quality feedback
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/analytics.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+Required behavior tests implemented and passing:
+1. strong strategy → weight increases
+2. weak strategy → weight decreases
+3. high drawdown → risk reduced
+4. deterministic adjustments
+5. no extreme jumps
+
+Focused runtime/integration checks passing:
+- optimization signals consumed in strategy-trigger scoring/tuning path
+- no hard off behavior; weak strategy uses soft-disable bounds
+- fallback remains neutral for insufficient data
+
+Validation commands:
+- `python -m py_compile projects/polymarket/polyquantbot/execution/analytics.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_p10_execution_quality_fill_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p12_execution_timing_entry_optimization_20260409.py projects/polymarket/polyquantbot/tests/test_p13_exit_timing_trade_management_20260409.py projects/polymarket/polyquantbot/tests/test_p7_capital_allocation_position_sizing_20260409.py projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py` ✅ (45 passed, warning: unknown `asyncio_mode`)
+
+### Runtime proof (required)
+1) Before/after weight changes (example)
+- Before (neutral): `S1=1.0, S2=1.0, S3=1.0`
+- After optimization: `S1=1.08, S2=0.75, S3=1.027333`
+
+2) Strategy ranking example
+- Input set with equal raw edge on S1/S2 and lower-confidence S3.
+- After optimization refresh:
+  - S1 score increases versus baseline
+  - S2 score decreases versus baseline
+  - ranking reflects strategy-performance-aware weighting
+
+3) Risk adjustment example
+- Example output under drawdown/loss-streak pressure:
+  - `aggression_multiplier=0.85`
+  - `size_multiplier=0.9625`
+- P7 sizing now applies these multipliers as bounded risk reductions.
+
+## 5. Known issues
+- P14.1 remains narrow integration in touched strategy-trigger pipeline path only; no external persistence/UI exposure for optimization output yet.
+- Existing pytest warning remains in environment: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review for changed files + direct dependencies.
+- COMMANDER review for merge/hold decision (STANDARD tier).
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.analytics import PerformanceTracker
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeArbitrageDecision,
+    SmartMoneyCopyTradingDecision,
+    StrategyConfig,
+    StrategyDecision,
+    StrategyTrigger,
+)
+
+
+def _build_tracker_with_mixed_results() -> PerformanceTracker:
+    tracker = PerformanceTracker()
+    rows = [
+        {"position_id": "t1", "size": 100.0, "pnl": 12.0, "strategy_source": "S1", "regime_at_entry": "NEWS_DRIVEN", "actual_return": 0.12, "theoretical_edge": 0.04, "slippage_impact": 0.01, "timing_effectiveness": 0.80, "exit_efficiency": 0.80},
+        {"position_id": "t2", "size": 100.0, "pnl": 8.0, "strategy_source": "S1", "regime_at_entry": "NEWS_DRIVEN", "actual_return": 0.08, "theoretical_edge": 0.03, "slippage_impact": 0.01, "timing_effectiveness": 0.75, "exit_efficiency": 0.70},
+        {"position_id": "t3", "size": 100.0, "pnl": -7.0, "strategy_source": "S2", "regime_at_entry": "ARBITRAGE_DOMINANT", "actual_return": -0.07, "theoretical_edge": 0.03, "slippage_impact": 0.05, "timing_effectiveness": 0.35, "exit_efficiency": 0.40},
+        {"position_id": "t4", "size": 100.0, "pnl": -9.0, "strategy_source": "S2", "regime_at_entry": "ARBITRAGE_DOMINANT", "actual_return": -0.09, "theoretical_edge": 0.04, "slippage_impact": 0.05, "timing_effectiveness": 0.30, "exit_efficiency": 0.35},
+        {"position_id": "t5", "size": 100.0, "pnl": 3.0, "strategy_source": "S3", "regime_at_entry": "SMART_MONEY_DOMINANT", "actual_return": 0.03, "theoretical_edge": 0.03, "slippage_impact": 0.02, "timing_effectiveness": 0.60, "exit_efficiency": 0.60},
+    ]
+    for row in rows:
+        tracker.record_trade(row)
+    return tracker
+
+
+def test_strong_strategy_weight_increases() -> None:
+    optimization = _build_tracker_with_mixed_results().optimization_output()
+    assert optimization["strategy_weights"]["S1"] > 1.0
+
+
+def test_weak_strategy_weight_decreases() -> None:
+    optimization = _build_tracker_with_mixed_results().optimization_output()
+    assert optimization["strategy_weights"]["S2"] < 1.0
+
+
+def test_high_drawdown_reduces_risk_aggression() -> None:
+    tracker = PerformanceTracker()
+    for idx, pnl in enumerate([8.0, -12.0, -13.0, -9.0, -7.0], start=1):
+        tracker.record_trade(
+            {
+                "position_id": f"dd-{idx}",
+                "size": 100.0,
+                "pnl": pnl,
+                "strategy_source": "S3",
+                "regime_at_entry": "LOW_ACTIVITY_CHAOTIC",
+                "actual_return": pnl / 100.0,
+                "theoretical_edge": 0.04,
+            }
+        )
+    optimization = tracker.optimization_output()
+    assert optimization["risk_adjustments"]["aggression_multiplier"] < 1.0
+    assert optimization["risk_adjustments"]["size_multiplier"] < 1.0
+
+
+def test_adjustments_are_deterministic() -> None:
+    first = _build_tracker_with_mixed_results().optimization_output()
+    second = _build_tracker_with_mixed_results().optimization_output()
+    assert first == second
+
+
+def test_all_adjustments_are_bounded_no_extreme_jumps() -> None:
+    optimization = _build_tracker_with_mixed_results().optimization_output()
+    for modifier in optimization["strategy_weights"].values():
+        assert 0.75 <= modifier <= 1.15
+    for modifier in optimization["regime_weights"].values():
+        assert 0.85 <= modifier <= 1.15
+    assert 0.85 <= optimization["risk_adjustments"]["aggression_multiplier"] <= 1.0
+    assert 0.85 <= optimization["risk_adjustments"]["size_multiplier"] <= 1.0
+    assert 0.85 <= optimization["execution_adjustments"]["p10_max_spread_multiplier"] <= 1.0
+    assert 0.80 <= optimization["execution_adjustments"]["p10_slippage_guard_multiplier"] <= 1.0
+    assert 0 <= optimization["execution_adjustments"]["p12_wait_cycle_bias"] <= 2
+    assert 1.0 <= optimization["execution_adjustments"]["p12_reevaluation_window_multiplier"] <= 1.2
+    assert 0.80 <= optimization["execution_adjustments"]["p13_exit_sensitivity_multiplier"] <= 1.0
+
+
+@dataclass(frozen=True)
+class _EngineStub:
+    max_total_exposure_ratio: float = 0.30
+    max_position_size_ratio: float = 0.10
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_analytics", _build_tracker_with_mixed_results())
+
+    def get_analytics(self) -> PerformanceTracker:
+        return self._analytics
+
+
+def test_before_after_weight_changes_and_strategy_ranking_example() -> None:
+    trigger = StrategyTrigger(engine=_EngineStub(), config=StrategyConfig(market_id="m-p14-1"))
+    baseline = trigger.aggregate_strategy_decisions(
+        s1_decision=StrategyDecision(decision="ENTER", reason="s1", edge=0.04),
+        s2_decision=CrossExchangeArbitrageDecision(decision="ENTER", reason="s2", edge=0.04, matched_markets_info={}),
+        s3_decision=SmartMoneyCopyTradingDecision(decision="ENTER", reason="s3", confidence=0.4, wallet_info={}),
+    )
+    trigger.refresh_optimization_output()
+    optimized = trigger.aggregate_strategy_decisions(
+        s1_decision=StrategyDecision(decision="ENTER", reason="s1", edge=0.04),
+        s2_decision=CrossExchangeArbitrageDecision(decision="ENTER", reason="s2", edge=0.04, matched_markets_info={}),
+        s3_decision=SmartMoneyCopyTradingDecision(decision="ENTER", reason="s3", confidence=0.4, wallet_info={}),
+    )
+    baseline_scores = {item.strategy_name: item.score for item in baseline.ranked_candidates}
+    optimized_scores = {item.strategy_name: item.score for item in optimized.ranked_candidates}
+    assert optimized_scores["S1"] > baseline_scores["S1"]
+    assert optimized_scores["S2"] < baseline_scores["S2"]


### PR DESCRIPTION
### Motivation
- Convert P14 post-trade analytics into actionable, bounded optimization signals to automatically tune strategy weighting, regime preference, execution thresholds, and risk sizing.
- Narrowly integrate the optimization consumer into the strategy-trigger path so S4/P7/P10/P12/P13 can react to recent performance without changing core execution architecture.
- Ensure safety via clamped multipliers and a neutral fallback when data is insufficient to avoid extreme or hard-disable behavior.

### Description
- Added `PerformanceTracker.optimization_output()` in `projects/polymarket/polyquantbot/execution/analytics.py` to emit `strategy_weights`, `regime_weights`, `execution_adjustments`, and `risk_adjustments` from the analytics summary with normalization, clamping, and fallback logic.  
- Integrated optimization consumption in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` by calling `refresh_optimization_output()` during `evaluate()` and applying the signals to S4 scoring (strategy + regime modifiers), P7 sizing (risk multipliers), P10 execution quality gates (spread/slippage multipliers), P12 timing/reevaluation windows, and P13 exit sensitivity; also added a safe metadata-based `candidate_title` fallback path.  
- Added deterministic unit tests `projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py` verifying strong/weak strategy weight adjustments, drawdown-driven risk reductions, determinism, and bounded modifiers.  
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/24_27_p14_1_system_optimization_from_analytics.md` and updated `PROJECT_STATE.md` to reflect the P14.1 handoff (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION). 

### Testing
- Performed static compile checks with `python -m py_compile` against the changed modules and test file, which passed.  
- Ran the focused pytest command `PYTHONPATH=/workspace/walker-ai-team pytest -q` for the new P14.1 tests plus related integration tests, resulting in `45 passed` with a single environment warning (`Unknown config option: asyncio_mode`) that does not affect correctness.  
- New unit tests added passed and demonstrate the runtime-proof examples (before/after weights, strategy ranking changes, and risk adjustment examples).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d79da2543c832eb17516e8860c207f)