### PR TITLE
P14.3 Falcon alpha strategy layer: smart‑money, momentum, liquidity + S4 external weighting

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 14:10
-- Status        : FORGE-X completed P14.2 external alpha ingestion (Falcon API) foundation pass with safe fallback + deterministic normalization; pending auto PR review and COMMANDER review.
+- Last Updated  : 2026-04-09 14:30
+- Status        : FORGE-X completed P14.3 Falcon alpha strategy layer (smart-money + momentum + liquidity + S4 external weighting narrow integration); pending auto PR review and COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P14.3 Falcon alpha strategy layer (2026-04-09): implemented deterministic smart-money and momentum signal generation from Falcon datasets, liquidity scoring from orderbook spread/depth, bounded combined Falcon signal output, and narrow S4 integration via `external_signal_weight` with fallback-safe behavior and focused tests.
 - P14.2 external alpha ingestion (Falcon API) (2026-04-09): added bounded Falcon client for markets/trades/candles/orderbook retrieval (agent IDs 574/556/568/572), pagination-safe fetchers, deterministic normalization pipeline, basic smart-money/price/liquidity context extraction, and data-layer integration adapter with failure fallback plus focused runtime-proof tests.
 - SENTINEL validation complete for PR #336 — P14.1 optimization engine (2026-04-09): MAJOR hard-mode verification passed for bounded weighting/sizing/execution adjustments, negative-case resilience (noisy analytics, losing streak, false-positive strategy), feedback-loop safety (P9↔P14.1), break-test stress attempt, and execution-cap safety; verdict APPROVED with advisory smoothing recommendation.
 - P14.1 system optimization from analytics (2026-04-09): implemented deterministic analytics-to-optimization output (`strategy_weights`/`regime_weights`/`execution_adjustments`/`risk_adjustments`) with bounded strategy/regime scoring, execution feedback tuning for P10/P12/P13, risk-pressure sizing/aggression reduction, strategy-trigger integration, and focused runtime-proof tests.
@@ -113,6 +114,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P14.3 Falcon alpha strategy layer handoff
+- STANDARD-tier narrow integration implementation is complete for Falcon-derived smart-money/momentum/liquidity signal generation and bounded S4 external weighting input path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P14.2 external alpha ingestion handoff
 - STANDARD-tier foundation implementation is complete for Falcon external data retrieval + normalization + data-layer adapter only (no strategy logic modifications).
@@ -228,11 +233,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_28_p14_2_external_alpha_ingestion_falcon.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces.
 - P14.2 Falcon ingestion is FOUNDATION claim-level only (data ingestion + normalization + adapter); broader runtime orchestration wiring remains out of scope.
 - P14.1 optimization output is currently narrow integration in strategy-trigger runtime path and is not yet propagated to external persistence/dashboard surfaces.
 - P14 analytics attribution is currently narrow integration in strategy-trigger to execution closed-trade path only and is not yet wired to external persistence or dashboard surfaces.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -9,6 +9,7 @@ import re
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
 from .trade_trace import TradeTraceEngine
+from ..strategy.falcon_alpha_strategy import FalconSignal
 
 log = structlog.get_logger(__name__)
 
@@ -177,6 +178,8 @@ class StrategyAggregationDecision:
     current_regime: str = "LOW_ACTIVITY_CHAOTIC"
     regime_confidence: float = 0.0
     strategy_weight_modifiers: dict[str, float] | None = None
+    external_signal_weight: float = 1.0
+    falcon_signal: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -930,6 +933,7 @@ class StrategyTrigger:
         s2_decision: CrossExchangeArbitrageDecision,
         s3_decision: SmartMoneyCopyTradingDecision,
         market_regime_inputs: MarketRegimeInputs | None = None,
+        falcon_signal: FalconSignal | None = None,
     ) -> StrategyAggregationDecision:
         """
         Aggregate S1/S2/S3 strategy outputs and select one best trade candidate.
@@ -990,6 +994,28 @@ class StrategyTrigger:
                 )
                 for item in candidates
             ]
+        external_signal_weight = 1.0
+        falcon_signal_payload: dict[str, object] | None = None
+        if falcon_signal is not None:
+            external_signal_weight = self._clamp(float(falcon_signal.external_signal_weight), 0.90, 1.15)
+            falcon_signal_payload = {
+                "type": falcon_signal.signal_type,
+                "strength": round(self._clamp(falcon_signal.strength, 0.0, 1.0), 6),
+                "confidence": round(self._clamp(falcon_signal.confidence, 0.0, 1.0), 6),
+                "liquidity_score": round(self._clamp(falcon_signal.liquidity_score, 0.0, 1.0), 6),
+            }
+            candidates = [
+                StrategyCandidateScore(
+                    strategy_name=item.strategy_name,
+                    decision=item.decision,
+                    reason=item.reason,
+                    edge=item.edge,
+                    confidence=item.confidence,
+                    score=round(item.score * external_signal_weight, 6),
+                    market_metadata=item.market_metadata,
+                )
+                for item in candidates
+            ]
         ranked_candidates = sorted(candidates, key=lambda item: (-item.score, item.strategy_name))
         enter_candidates = [candidate for candidate in ranked_candidates if candidate.decision == "ENTER"]
         top_score = ranked_candidates[0].score if ranked_candidates else 0.0
@@ -1008,6 +1034,8 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                external_signal_weight=external_signal_weight,
+                falcon_signal=falcon_signal_payload,
             )
 
         if has_global_conflict_hold:
@@ -1020,6 +1048,8 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                external_signal_weight=external_signal_weight,
+                falcon_signal=falcon_signal_payload,
             )
 
         top_candidate = enter_candidates[0]
@@ -1033,6 +1063,8 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                external_signal_weight=external_signal_weight,
+                falcon_signal=falcon_signal_payload,
             )
 
         return StrategyAggregationDecision(
@@ -1044,6 +1076,8 @@ class StrategyTrigger:
             current_regime=regime.regime_type,
             regime_confidence=regime.confidence_score,
             strategy_weight_modifiers=regime.strategy_weight_modifiers,
+            external_signal_weight=external_signal_weight,
+            falcon_signal=falcon_signal_payload,
         )
 
     def detect_market_regime(

--- a/projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md
@@ -1,0 +1,79 @@
+# 24_29_p14_3_falcon_alpha_strategy_layer
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - signal generation layer
+  - S4 integration path (`aggregate_strategy_decisions` external weighting input)
+- Not in Scope:
+  - execution logic changes
+  - risk logic changes
+  - ML models
+  - Telegram UI
+- Suggested Next Step: Auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md`. Tier: STANDARD
+
+## 1. What was built
+- Added Falcon alpha strategy layer module at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py`.
+- Implemented required signal components:
+  - smart-money strategy from Falcon trades (large trade + repeated wallet detection)
+  - momentum strategy from Falcon candles (trend + acceleration)
+  - liquidity filter from Falcon orderbook (spread + depth scoring)
+  - deterministic signal aggregation output with bounded `external_signal_weight`
+- Added fallback-safe orchestration helper (`build_falcon_signal_context`) so missing Falcon inputs return neutral bounded outputs.
+- Integrated Falcon aggregated signal into S4 decision engine by extending `aggregate_strategy_decisions(..., falcon_signal=...)` and applying bounded external weighting (`0.90..1.15`) without overriding existing S1/S2/S3 strategy ranking semantics.
+
+## 2. Current system architecture
+- `strategy/falcon_alpha_strategy.py`
+  - `detect_smart_money_signal()`
+  - `detect_momentum_signal()`
+  - `compute_liquidity_score()`
+  - `aggregate_falcon_signal()`
+  - `build_falcon_signal_context()`
+- `execution/strategy_trigger.py`
+  - `StrategyAggregationDecision` now includes external alpha metadata (`external_signal_weight`, `falcon_signal`).
+  - `aggregate_strategy_decisions()` accepts optional `FalconSignal` and applies bounded score weighting in S4.
+
+## 3. Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Required tests
+- smart money detection works: pass
+- momentum detection works: pass
+- liquidity filter applied: pass
+- signals deterministic: pass
+- S4 integration correctness with bounded external weight: pass
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py` ✅ (`5 passed`)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅ (`11 passed`)
+
+### Runtime proof (required)
+1) Smart money example:
+- Input trades include repeated `0xsm1` wallet and multiple large trades (`>= 2600` size).
+- Output: `smart_money_signal = {"strength": 0.825, "confidence": 0.8}`
+
+2) Momentum example:
+- Input candles: `0.48 -> 0.50 -> 0.53 -> 0.56`
+- Output: `momentum_signal = {"direction": "UP", "strength": 0.166667}`
+
+3) Final combined signal:
+- `falcon_signal = {"type": "SMART_MONEY", "strength": 0.85125, "confidence": 0.839, "liquidity_score": 0.93, "external_signal_weight": 1.110363}`
+- S4 integration output includes `external_signal_weight` and `falcon_signal` payload while preserving selected trade ranking authority from existing S1/S2/S3 path.
+
+## 5. Known issues
+- External alpha strategy layer is NARROW integration in S4 scoring path only; full runtime orchestration beyond S4 remains out of scope.
+- Existing pytest warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Auto PR review + COMMANDER review required before merge.
+- If approved by COMMANDER, next increment can wire Falcon signal context deeper into non-S4 runtime surfaces where explicitly requested.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py
+++ b/projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SmartMoneySignal:
+    strength: float
+    confidence: float
+
+
+@dataclass(frozen=True)
+class MomentumSignal:
+    direction: str
+    strength: float
+
+
+@dataclass(frozen=True)
+class FalconSignal:
+    signal_type: str
+    strength: float
+    confidence: float
+    liquidity_score: float
+    external_signal_weight: float
+
+
+@dataclass(frozen=True)
+class FalconSignalContext:
+    smart_money_signal: SmartMoneySignal
+    momentum_signal: MomentumSignal
+    liquidity_score: float
+    falcon_signal: FalconSignal
+
+
+def detect_smart_money_signal(
+    trades: list[dict[str, Any]],
+    *,
+    large_trade_threshold: float = 1_500.0,
+    repeated_wallet_min_count: int = 2,
+) -> SmartMoneySignal:
+    if not trades:
+        return SmartMoneySignal(strength=0.0, confidence=0.0)
+
+    sizes = [max(0.0, _to_float(item.get("size") or item.get("amount"), default=0.0)) for item in trades]
+    large_trade_count = sum(1 for size in sizes if size >= large_trade_threshold)
+    large_trade_ratio = large_trade_count / max(len(sizes), 1)
+
+    wallets = [str(item.get("wallet") or item.get("wallet_address") or "") for item in trades]
+    wallet_counts = Counter(wallet for wallet in wallets if wallet)
+    repeated_wallet_count = sum(1 for count in wallet_counts.values() if count >= repeated_wallet_min_count)
+    repeated_wallet_ratio = repeated_wallet_count / max(len(wallet_counts), 1)
+
+    strength = _clamp((0.65 * large_trade_ratio) + (0.35 * repeated_wallet_ratio), 0.0, 1.0)
+    confidence = _clamp((0.60 * large_trade_ratio) + (0.40 * repeated_wallet_ratio), 0.0, 1.0)
+    return SmartMoneySignal(strength=round(strength, 6), confidence=round(confidence, 6))
+
+
+def detect_momentum_signal(candles: list[dict[str, Any]]) -> MomentumSignal:
+    closes = [_to_float(item.get("close"), default=0.0) for item in candles if item.get("close") is not None]
+    if len(closes) < 3:
+        return MomentumSignal(direction="NEUTRAL", strength=0.0)
+
+    start_price = closes[0]
+    end_price = closes[-1]
+    if start_price <= 0:
+        return MomentumSignal(direction="NEUTRAL", strength=0.0)
+
+    trend = (end_price - start_price) / start_price
+    latest_step = closes[-1] - closes[-2]
+    prev_step = closes[-2] - closes[-3]
+    acceleration = latest_step - prev_step
+
+    direction = "UP" if trend > 0 else "DOWN" if trend < 0 else "NEUTRAL"
+    strength = _clamp(abs(trend) + (abs(acceleration) / max(abs(start_price), 1e-6)), 0.0, 1.0)
+    return MomentumSignal(direction=direction, strength=round(strength, 6))
+
+
+def compute_liquidity_score(
+    orderbook: list[dict[str, Any]],
+    *,
+    target_depth_usd: float = 20_000.0,
+    max_acceptable_spread: float = 0.05,
+) -> float:
+    if not orderbook:
+        return 0.0
+
+    bids = [
+        _to_float(item.get("bid") if item.get("bid") is not None else item.get("price"), default=0.0)
+        for item in orderbook
+        if str(item.get("side", "")).lower() == "bid"
+    ]
+    asks = [
+        _to_float(item.get("ask") if item.get("ask") is not None else item.get("price"), default=0.0)
+        for item in orderbook
+        if str(item.get("side", "")).lower() == "ask"
+    ]
+
+    best_bid = max(bids) if bids else 0.0
+    best_ask = min(asks) if asks else 0.0
+    spread = max(0.0, best_ask - best_bid) if best_bid > 0.0 and best_ask > 0.0 else max_acceptable_spread
+
+    total_depth = sum(max(0.0, _to_float(item.get("depth") or item.get("size"), default=0.0)) for item in orderbook)
+    depth_score = _clamp(total_depth / max(target_depth_usd, 1.0), 0.0, 1.0)
+    spread_score = _clamp(1.0 - (spread / max(max_acceptable_spread, 1e-6)), 0.0, 1.0)
+    return round(_clamp((0.65 * depth_score) + (0.35 * spread_score), 0.0, 1.0), 6)
+
+
+def aggregate_falcon_signal(
+    *,
+    smart_money_signal: SmartMoneySignal,
+    momentum_signal: MomentumSignal,
+    liquidity_score: float,
+) -> FalconSignal:
+    bounded_liquidity = _clamp(liquidity_score, 0.0, 1.0)
+
+    smart_score = smart_money_signal.strength * smart_money_signal.confidence
+    momentum_confidence = 0.6 if momentum_signal.direction == "NEUTRAL" else 0.75
+    momentum_score = momentum_signal.strength * momentum_confidence
+
+    if smart_score >= momentum_score:
+        signal_type = "SMART_MONEY"
+        base_strength = smart_money_signal.strength
+        base_confidence = smart_money_signal.confidence
+    else:
+        signal_type = "MOMENTUM"
+        base_strength = momentum_signal.strength
+        base_confidence = momentum_confidence
+
+    strength = _clamp((0.75 * base_strength) + (0.25 * bounded_liquidity), 0.0, 1.0)
+    confidence = _clamp((0.70 * base_confidence) + (0.30 * bounded_liquidity), 0.0, 1.0)
+
+    # Bounded external influence, cannot override core S1/S2/S3 strategy scores.
+    external_signal_weight = round(_clamp(0.90 + (0.20 * confidence) + (0.05 * strength), 0.90, 1.15), 6)
+
+    return FalconSignal(
+        signal_type=signal_type,
+        strength=round(strength, 6),
+        confidence=round(confidence, 6),
+        liquidity_score=round(bounded_liquidity, 6),
+        external_signal_weight=external_signal_weight,
+    )
+
+
+def build_falcon_signal_context(
+    *,
+    trades: list[dict[str, Any]] | None,
+    candles: list[dict[str, Any]] | None,
+    orderbook: list[dict[str, Any]] | None,
+) -> FalconSignalContext:
+    safe_trades = trades or []
+    safe_candles = candles or []
+    safe_orderbook = orderbook or []
+
+    smart_money = detect_smart_money_signal(safe_trades)
+    momentum = detect_momentum_signal(safe_candles)
+    liquidity = compute_liquidity_score(safe_orderbook)
+    falcon_signal = aggregate_falcon_signal(
+        smart_money_signal=smart_money,
+        momentum_signal=momentum,
+        liquidity_score=liquidity,
+    )
+
+    return FalconSignalContext(
+        smart_money_signal=smart_money,
+        momentum_signal=momentum,
+        liquidity_score=liquidity,
+        falcon_signal=falcon_signal,
+    )
+
+
+def _to_float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))

--- a/projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeArbitrageDecision,
+    SmartMoneyCopyTradingDecision,
+    StrategyConfig,
+    StrategyDecision,
+    StrategyTrigger,
+)
+from projects.polymarket.polyquantbot.strategy.falcon_alpha_strategy import (
+    build_falcon_signal_context,
+)
+
+
+class _NoopEngine:
+    async def snapshot(self):  # pragma: no cover - not used in this suite
+        raise NotImplementedError
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(
+        engine=_NoopEngine(),
+        config=StrategyConfig(
+            market_id="m-p14-3-falcon-alpha",
+            min_edge=0.02,
+            min_liquidity_usd=10_000.0,
+        ),
+    )
+
+
+def test_smart_money_detection_works() -> None:
+    context = build_falcon_signal_context(
+        trades=[
+            {"wallet": "0xaaa", "size": 2500},
+            {"wallet": "0xaaa", "size": 2600},
+            {"wallet": "0xbbb", "size": 2100},
+            {"wallet": "0xaaa", "size": 2400},
+        ],
+        candles=[{"close": 0.49}, {"close": 0.50}, {"close": 0.52}],
+        orderbook=[
+            {"side": "bid", "price": 0.51, "depth": 12000},
+            {"side": "ask", "price": 0.52, "depth": 14000},
+        ],
+    )
+
+    assert context.smart_money_signal.strength > 0.6
+    assert context.smart_money_signal.confidence > 0.6
+
+
+def test_momentum_detection_works() -> None:
+    context = build_falcon_signal_context(
+        trades=[],
+        candles=[{"close": 0.40}, {"close": 0.43}, {"close": 0.47}, {"close": 0.54}],
+        orderbook=[],
+    )
+
+    assert context.momentum_signal.direction == "UP"
+    assert context.momentum_signal.strength > 0.0
+
+
+def test_liquidity_filter_applied() -> None:
+    rich_context = build_falcon_signal_context(
+        trades=[],
+        candles=[],
+        orderbook=[
+            {"side": "bid", "price": 0.61, "depth": 15000},
+            {"side": "ask", "price": 0.62, "depth": 15000},
+        ],
+    )
+    thin_context = build_falcon_signal_context(
+        trades=[],
+        candles=[],
+        orderbook=[
+            {"side": "bid", "price": 0.58, "depth": 500},
+            {"side": "ask", "price": 0.65, "depth": 500},
+        ],
+    )
+
+    assert rich_context.liquidity_score > thin_context.liquidity_score
+    assert 0.0 <= rich_context.liquidity_score <= 1.0
+
+
+def test_falcon_signals_are_deterministic() -> None:
+    payload = {
+        "trades": [
+            {"wallet": "0x111", "size": 1700},
+            {"wallet": "0x111", "size": 1900},
+            {"wallet": "0x222", "size": 900},
+        ],
+        "candles": [{"close": 0.50}, {"close": 0.53}, {"close": 0.55}],
+        "orderbook": [
+            {"side": "bid", "price": 0.54, "depth": 11000},
+            {"side": "ask", "price": 0.55, "depth": 13000},
+        ],
+    }
+
+    result_a = build_falcon_signal_context(**payload)
+    result_b = build_falcon_signal_context(**payload)
+
+    assert result_a == result_b
+
+
+def test_integration_with_s4_uses_external_signal_weight_without_override() -> None:
+    trigger = _make_trigger()
+    falcon_context = build_falcon_signal_context(
+        trades=[
+            {"wallet": "0xsm1", "size": 2800},
+            {"wallet": "0xsm1", "size": 3000},
+            {"wallet": "0xsm2", "size": 2600},
+        ],
+        candles=[{"close": 0.48}, {"close": 0.50}, {"close": 0.53}, {"close": 0.56}],
+        orderbook=[
+            {"side": "bid", "price": 0.55, "depth": 17000},
+            {"side": "ask", "price": 0.56, "depth": 18000},
+        ],
+    )
+
+    baseline = trigger.aggregate_strategy_decisions(
+        s1_decision=StrategyDecision(decision="ENTER", reason="news", edge=0.040),
+        s2_decision=CrossExchangeArbitrageDecision(
+            decision="ENTER",
+            reason="arb",
+            edge=0.030,
+            matched_markets_info={"exchange": "kalshi", "market_id": "k1"},
+        ),
+        s3_decision=SmartMoneyCopyTradingDecision(
+            decision="ENTER",
+            reason="wallet",
+            confidence=0.80,
+            wallet_info={"wallet": "0xsm1"},
+        ),
+    )
+
+    integrated = trigger.aggregate_strategy_decisions(
+        s1_decision=StrategyDecision(decision="ENTER", reason="news", edge=0.040),
+        s2_decision=CrossExchangeArbitrageDecision(
+            decision="ENTER",
+            reason="arb",
+            edge=0.030,
+            matched_markets_info={"exchange": "kalshi", "market_id": "k1"},
+        ),
+        s3_decision=SmartMoneyCopyTradingDecision(
+            decision="ENTER",
+            reason="wallet",
+            confidence=0.80,
+            wallet_info={"wallet": "0xsm1"},
+        ),
+        falcon_signal=falcon_context.falcon_signal,
+    )
+
+    # Existing strategy ranking remains authoritative and deterministic.
+    assert baseline.selected_trade == integrated.selected_trade == "S1"
+    assert 0.90 <= integrated.external_signal_weight <= 1.15
+    assert integrated.falcon_signal is not None
+    assert integrated.falcon_signal["type"] in {"SMART_MONEY", "MOMENTUM"}
+
+    # Runtime proof artifacts required by task.
+    assert falcon_context.smart_money_signal.strength > 0.0
+    assert falcon_context.momentum_signal.direction == "UP"
+    assert integrated.falcon_signal["liquidity_score"] > 0.0


### PR DESCRIPTION
### Motivation
- Convert normalized Falcon API data into bounded, deterministic trading signals (smart‑money, momentum, liquidity) so external alpha can inform S4 without overriding existing strategy authority. 
- Provide a narrow, safe integration point with fallback behavior to avoid runtime failures when Falcon data is missing. 

### Description
- Added new Falcon alpha strategy module `projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py` implementing `detect_smart_money_signal`, `detect_momentum_signal`, `compute_liquidity_score`, `aggregate_falcon_signal`, and `build_falcon_signal_context` that returns a bounded `FalconSignal` payload. 
- Integrated optional external signal into S4 by extending `aggregate_strategy_decisions(..., falcon_signal=...)` in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` and applying a clamped `external_signal_weight` (`0.90..1.15`) to candidate scores while preserving S1/S2/S3 ranking semantics. 
- Added focused tests at `projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py` covering smart‑money detection, momentum detection, liquidity scoring, determinism, and S4 integration behavior. 
- Created FORGE report `projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md` and updated `PROJECT_STATE.md` to record the STANDARD / NARROW_INTEGRATION handoff. 

### Testing
- Ran static checks with `python -m py_compile projects/polymarket/polyquantbot/strategy/falcon_alpha_strategy.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py` and it passed. 
- Executed unit tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_3_falcon_alpha_strategy_layer_20260409.py` which returned `5 passed`. 
- Verified no regressions by running `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` which returned `11 passed`; all automated checks passed (one non‑blocking pytest config warning remains).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b75a9c80832e86297e3f9e8bc4f4)