### PR TITLE
P14: Post-trade analytics — FALCON attribution, deterministic buckets & bounded edge capture

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 14:30
-- Status        : FORGE-X completed P14.3 Falcon alpha strategy layer (smart-money + momentum + liquidity + S4 external weighting narrow integration); pending auto PR review and COMMANDER review.
+- Last Updated  : 2026-04-09 14:58
+- Status        : FORGE-X completed P14 post-trade analytics & attribution enhancement pass (FALCON attribution + deterministic buckets + bounded edge capture safety + expanded validation); pending auto PR review and COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P14 post-trade analytics & attribution enhancement pass (2026-04-09): added FALCON attribution normalization, deterministic strategy/regime baseline buckets, bounded edge-capture safety clamp with division-safe handling, and expanded focused tests for expectancy + edge safety + deterministic attribution outputs.
 - P14.3 Falcon alpha strategy layer (2026-04-09): implemented deterministic smart-money and momentum signal generation from Falcon datasets, liquidity scoring from orderbook spread/depth, bounded combined Falcon signal output, and narrow S4 integration via `external_signal_weight` with fallback-safe behavior and focused tests.
 - P14.2 external alpha ingestion (Falcon API) (2026-04-09): added bounded Falcon client for markets/trades/candles/orderbook retrieval (agent IDs 574/556/568/572), pagination-safe fetchers, deterministic normalization pipeline, basic smart-money/price/liquidity context extraction, and data-layer integration adapter with failure fallback plus focused runtime-proof tests.
 - SENTINEL validation complete for PR #336 — P14.1 optimization engine (2026-04-09): MAJOR hard-mode verification passed for bounded weighting/sizing/execution adjustments, negative-case resilience (noisy analytics, losing streak, false-positive strategy), feedback-loop safety (P9↔P14.1), break-test stress attempt, and execution-cap safety; verdict APPROVED with advisory smoothing recommendation.
@@ -129,7 +130,7 @@ Status:
 - COMMANDER final merge decision pending.
 
 ### P14 post-trade analytics & attribution handoff
-- STANDARD-tier narrow integration implementation is complete for trade lifecycle attribution, closed-trade storage enrichment, and in-memory analytics summary computation.
+- STANDARD-tier narrow integration enhancement is complete for FALCON attribution support, deterministic strategy/regime attribution buckets, bounded edge-capture safety, and focused runtime-proof tests.
 - Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P13 exit timing & trade management handoff
@@ -233,7 +234,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_29_p14_3_falcon_alpha_strategy_layer.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
@@ -241,7 +242,7 @@ Tier: STANDARD
 - P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces.
 - P14.2 Falcon ingestion is FOUNDATION claim-level only (data ingestion + normalization + adapter); broader runtime orchestration wiring remains out of scope.
 - P14.1 optimization output is currently narrow integration in strategy-trigger runtime path and is not yet propagated to external persistence/dashboard surfaces.
-- P14 analytics attribution is currently narrow integration in strategy-trigger to execution closed-trade path only and is not yet wired to external persistence or dashboard surfaces.
+- P14 analytics attribution (including FALCON attribution + bounded edge capture) is currently narrow integration in strategy-trigger to execution closed-trade path only and is not yet wired to external persistence or dashboard surfaces.
 - P13 exit management is currently narrow integration in strategy-trigger monitoring path only and is not yet propagated into broader runtime orchestration surfaces.
 - TG-2 + TG-3 trade history is currently narrow integration in Telegram portfolio rendering path only and is not yet surfaced in other non-portfolio historical analytics views.
 - P12 entry timing layer is currently narrow integration in strategy-trigger pre-execution path only and is not yet wired into broader runtime execution orchestration layers.

--- a/projects/polymarket/polyquantbot/execution/analytics.py
+++ b/projects/polymarket/polyquantbot/execution/analytics.py
@@ -36,7 +36,7 @@ class PerformanceTracker:
     @staticmethod
     def _normalize_strategy(raw: object) -> str:
         candidate = str(raw or "UNKNOWN").strip().upper()
-        return candidate if candidate in {"S1", "S2", "S3", "S5"} else "UNKNOWN"
+        return candidate if candidate in {"S1", "S2", "S3", "S5", "FALCON"} else "UNKNOWN"
 
     @staticmethod
     def _normalize_regime(raw: object) -> str:
@@ -122,8 +122,18 @@ class PerformanceTracker:
     def _group_label_value() -> dict[str, float]:
         return {"total_pnl": 0.0, "trades": 0.0, "wins": 0.0, "total_return": 0.0}
 
+    @staticmethod
+    def _default_group_labels(group_field: str) -> list[str]:
+        if group_field == "strategy_source":
+            return ["S1", "S2", "S3", "S5", "FALCON", "UNKNOWN"]
+        if group_field == "regime_at_entry":
+            return ["NEWS", "ARBITRAGE", "SMART_MONEY", "CHAOTIC"]
+        return []
+
     def _build_group_breakdown(self, group_field: str) -> dict[str, dict[str, float]]:
-        grouped: dict[str, dict[str, float]] = {}
+        grouped: dict[str, dict[str, float]] = {
+            label: self._group_label_value() for label in self._default_group_labels(group_field)
+        }
         for trade in self._trades:
             label = getattr(trade, group_field)
             row = grouped.setdefault(label, self._group_label_value())
@@ -174,7 +184,11 @@ class PerformanceTracker:
         gross_loss_abs = abs(sum(t.pnl for t in losses))
         profit_factor = gross_profit / gross_loss_abs if gross_loss_abs > 0 else (float("inf") if gross_profit > 0 else 0.0)
         expectancy = (win_rate * avg_win) - ((1.0 - win_rate) * avg_loss_abs)
-        edge_samples = [t.actual_return / t.theoretical_edge for t in self._trades if t.theoretical_edge > 1e-9]
+        edge_samples = [
+            self._clamp(t.actual_return / t.theoretical_edge, -3.0, 3.0)
+            for t in self._trades
+            if t.theoretical_edge > 1e-9
+        ]
         execution_quality_metrics = {
             "avg_slippage_impact": round(sum(t.slippage_impact for t in self._trades) / total_trades, 6),
             "avg_timing_effectiveness": round(sum(t.timing_effectiveness for t in self._trades) / total_trades, 6),

--- a/projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md
@@ -1,0 +1,83 @@
+# 24_30_p14_post_trade_analytics_attribution_enhancements
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - closed trade lifecycle
+  - analytics computation module
+  - attribution fields
+- Not in Scope:
+  - execution engine changes
+  - strategy logic changes
+  - optimization logic
+  - Telegram UI redesign
+  - ML models
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md`. Tier: STANDARD
+
+## 1. What was built
+- Extended trade-record enrichment normalization to accept `FALCON` as a valid `strategy_source` attribution value.
+- Hardened analytics attribution output by providing deterministic baseline buckets for all required strategy and regime groups:
+  - Strategy buckets: `S1`, `S2`, `S3`, `S5`, `FALCON`, `UNKNOWN`
+  - Regime buckets: `NEWS`, `ARBITRAGE`, `SMART_MONEY`, `CHAOTIC`
+- Added edge-capture safety bounding to prevent unstable extreme ratios while preserving sign (`[-3.0, 3.0]` clamp with division safety).
+- Expanded P14 test coverage with explicit expectancy validation and edge-capture safety proof scenario.
+
+## 2. Current system architecture
+- `execution/analytics.py`
+  - `PerformanceTracker.record_trade()` stores enriched close-trade context and normalizes strategy/regime attribution.
+  - `PerformanceTracker.summary()` computes core P14 metrics:
+    - `pnl.total_pnl`, `pnl.avg_pnl_per_trade`, `win_rate`, `profit_factor`
+    - `expectancy = (WR × avg_win) − ((1 − WR) × avg_loss)`
+    - `edge_captured` (division-safe + bounded)
+    - `strategy_breakdown`, `regime_breakdown`
+    - `execution_quality_metrics` (slippage/timing/exit)
+    - `risk_metrics` (max drawdown, avg drawdown, loss streak)
+- `tests/test_p14_post_trade_analytics_attribution_20260409.py`
+  - deterministic runtime simulation through `ExecutionEngine` close-trade path
+  - validates aggregation, attribution, expectancy, and bounded edge-capture behavior
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/analytics.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Metric definitions
+- `total_pnl`: sum of closed-trade PnL values.
+- `avg_pnl_per_trade`: `total_pnl / trades`.
+- `win_rate`: `winning_trades / total_trades`.
+- `profit_factor`: `gross_profit / abs(gross_loss)` with safe fallback rules.
+- `expectancy`: `E = (WR × avg_win) − ((1 − WR) × avg_loss)`.
+- `edge_captured`: average of per-trade `(actual_return / theoretical_edge)` for valid-edge trades, bounded to `[-3.0, 3.0]`.
+
+### Calculation examples
+- Closed-trade example set (`+10`, `-5`) yields:
+  - `total_pnl=5.0`, `avg_pnl_per_trade=2.5`, `win_rate=0.5`, `profit_factor=2.0`, `expectancy=2.5`.
+- Edge-capture safety example:
+  - one trade with `actual_return=0.4` and `theoretical_edge=0.0001` is clamped from `4000` to `3.0`.
+  - one trade with `theoretical_edge=0.0` is excluded from ratio computation (division-safe).
+
+### Attribution results
+- Strategy attribution example includes explicit `FALCON` bucket and deterministic zero-value buckets for non-participating strategies.
+- Regime attribution example includes all required regime buckets with populated and zero-baseline rows.
+
+### Validation evidence
+- `python -m py_compile projects/polymarket/polyquantbot/execution/analytics.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` ✅ (`8 passed`, warning: unknown `asyncio_mode`)
+- Runtime proof generated via local execution and printed:
+  - analytics summary output
+  - strategy breakdown example
+  - regime breakdown example
+
+## 5. Known issues
+- P14 analytics remains NARROW INTEGRATION in touched close-trade attribution and in-memory summary path only.
+- Existing pytest warning persists in environment: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Codex auto PR review for changed files + direct dependency checks.
+- COMMANDER review for merge/hold decision (STANDARD tier).
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
@@ -62,6 +62,52 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
     return list(engine._closed_trades), engine.get_analytics().summary()
 
 
+async def _build_edge_safety_trades() -> dict[str, object]:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+    position = await engine.open_position(
+        market="mkt-falcon-chaotic",
+        market_title="FALCON CHAOTIC",
+        side="YES",
+        price=0.50,
+        size=100.0,
+        position_id="p14-safety-1",
+        position_context={
+            "strategy_source": "FALCON",
+            "regime_at_entry": "LOW_ACTIVITY_CHAOTIC",
+            "entry_quality": "quality_enter",
+            "entry_timing": "timing_enter",
+            "theoretical_edge": 0.0001,
+            "slippage_impact": 0.01,
+            "timing_effectiveness": 0.6,
+        },
+    )
+    assert position is not None
+    await engine.close_position(
+        position,
+        0.90,
+        close_context={"exit_reason": "take_profit", "exit_efficiency": 0.8},
+    )
+
+    ignored = await engine.open_position(
+        market="mkt-safety-zero-edge",
+        market_title="ZERO EDGE",
+        side="YES",
+        price=0.50,
+        size=100.0,
+        position_id="p14-safety-2",
+        position_context={
+            "strategy_source": "S3",
+            "regime_at_entry": "SMART_MONEY_DOMINANT",
+            "entry_quality": "quality_enter",
+            "entry_timing": "timing_enter",
+            "theoretical_edge": 0.0,
+        },
+    )
+    assert ignored is not None
+    await engine.close_position(ignored, 0.60, close_context={"exit_reason": "take_profit", "exit_efficiency": 0.8})
+    return engine.get_analytics().summary()
+
+
 def test_correct_pnl_aggregation() -> None:
     _, summary = asyncio.run(_build_closed_trades())
 
@@ -93,6 +139,18 @@ def test_edge_captured_calculation_correct() -> None:
 
     # trade1: 0.10/0.05=2.0 ; trade2: -0.05/0.08=-0.625 ; avg=0.6875
     assert summary["edge_captured"] == 0.6875
+
+
+def test_expectancy_calculation_correct() -> None:
+    _, summary = asyncio.run(_build_closed_trades())
+    assert summary["expectancy"] == 2.5
+
+
+def test_edge_capture_safe_computation_bounded_and_division_safe() -> None:
+    summary = asyncio.run(_build_edge_safety_trades())
+    assert summary["edge_captured"] == 3.0
+    assert summary["strategy_breakdown"]["FALCON"]["pnl"] == 40.0
+    assert summary["regime_breakdown"]["CHAOTIC"]["pnl"] == 40.0
 
 
 def test_deterministic_output() -> None:


### PR DESCRIPTION
### Motivation
- Provide stable, deterministic post-trade analytics and attribution for closed trades so downstream optimization and reporting can consume consistent buckets and metrics.
- Accept external `FALCON` strategy source and ensure analytics handles extreme or zero theoretical-edge values safely.
- Surface core performance metrics and expectancy for per-strategy and per-regime attribution without introducing external persistence dependencies.

### Description
- Added `FALCON` to strategy normalization and introduced deterministic baseline buckets for strategy and regime groups in `projects/polymarket/polyquantbot/execution/analytics.py` so outputs always include `S1`, `S2`, `S3`, `S5`, `FALCON`, `UNKNOWN` and `NEWS`, `ARBITRAGE`, `SMART_MONEY`, `CHAOTIC` respectively.
- Hardened edge-capture calculation to be division-safe and bounded by `[-3.0, 3.0]` when computing per-trade `actual_return / theoretical_edge` to avoid unstable ratios for tiny theoretical edges.
- Ensured analytics summary includes core metrics required by P14: `total_pnl`, `avg_pnl_per_trade`, `win_rate`, `profit_factor`, `expectancy`, `edge_captured`, `strategy_breakdown`, `regime_breakdown`, `execution_quality_metrics`, and `risk_metrics`.
- Added focused tests and a FORGE report and updated `PROJECT_STATE.md` to document the change and handoff; modified files: `projects/polymarket/polyquantbot/execution/analytics.py`, `projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`, created `projects/polymarket/polyquantbot/reports/forge/24_30_p14_post_trade_analytics_attribution_enhancements.md`, and updated `PROJECT_STATE.md`.

### Testing
- Static compile check: ran `python -m py_compile projects/polymarket/polyquantbot/execution/analytics.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` and it passed.
- Unit tests: ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py` with result `8 passed, 1 warning` (warning: unknown `asyncio_mode`).
- Runtime proof: executed a local simulation that printed an `analytics_summary` plus `strategy_breakdown` and `regime_breakdown` examples confirming deterministic output and attribution buckets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bd840340832ebcd90afa9435bcf1)