### PR TITLE
P15: strategy selection auto-weighting in S4 (STANDARD, narrow integration)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 15:16
-- Status        : FORGE-X completed P14.3 Falcon alpha strategy layer safety refinement pass (insufficient-data fallback + noisy-trigger suppression + deterministic bounded external weighting) and is pending auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 15:28
+- Status        : FORGE-X completed P15 strategy selection auto-weighting (analytics + regime-aware dynamic weighting in S4) and is pending auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P15 strategy selection & auto-weighting (2026-04-09): implemented deterministic analytics-driven strategy scoring (`pnl`/`win_rate`/`expectancy`/`edge_captured`), bounded and smoothed dynamic weights (`0.5..1.5`), regime-aware final weight adjustment in S4, and focused runtime-proof tests.
 - P14.3 Falcon alpha strategy layer safety refinement (2026-04-09): added explicit insufficient-data fallback (`falcon_signal=None`), noisy-input neutralization (`external_signal_weight=1.0`), deterministic bounded aggregation behavior, and expanded focused tests for fallback/noise/runtime-proof examples.
 - P14 post-trade analytics & attribution enhancement pass (2026-04-09): added FALCON attribution normalization, deterministic strategy/regime baseline buckets, bounded edge-capture safety clamp with division-safe handling, and expanded focused tests for expectancy + edge safety + deterministic attribution outputs.
 - P14.3 Falcon alpha strategy layer (2026-04-09): implemented deterministic smart-money and momentum signal generation from Falcon datasets, liquidity scoring from orderbook spread/depth, bounded combined Falcon signal output, and narrow S4 integration via `external_signal_weight` with fallback-safe behavior and focused tests.
@@ -116,6 +117,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P15 strategy selection & auto-weighting handoff
+- STANDARD-tier narrow integration implementation is complete for S4 dynamic weighting logic with P14 analytics + P11 regime context.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P14.3 Falcon alpha strategy layer handoff
 - STANDARD-tier narrow integration implementation is complete for Falcon-derived smart-money/momentum/liquidity signal generation and bounded S4 external weighting input path.
@@ -236,11 +241,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_31_p14_3_falcon_alpha_strategy_layer_signal_safety.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md
 Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P15 strategy weighting is currently narrow integration in S4 path only and is not yet wired into broader non-S4 runtime orchestration/telemetry surfaces.
 - P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces; insufficient-data fallback now prevents external weighting when Falcon evidence is unavailable.
 - P14.2 Falcon ingestion is FOUNDATION claim-level only (data ingestion + normalization + adapter); broader runtime orchestration wiring remains out of scope.
 - P14.1 optimization output is currently narrow integration in strategy-trigger runtime path and is not yet propagated to external persistence/dashboard surfaces.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -178,6 +178,7 @@ class StrategyAggregationDecision:
     current_regime: str = "LOW_ACTIVITY_CHAOTIC"
     regime_confidence: float = 0.0
     strategy_weight_modifiers: dict[str, float] | None = None
+    strategy_weights: dict[str, float] | None = None
     external_signal_weight: float = 1.0
     falcon_signal: dict[str, object] | None = None
 
@@ -323,10 +324,98 @@ class StrategyTrigger:
             },
             "fallback_to_neutral": True,
         }
+        self._last_dynamic_strategy_weights: dict[str, float] = self._default_dynamic_strategy_weights()
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
         return min(max(value, lower), upper)
+
+    @staticmethod
+    def _default_dynamic_strategy_weights() -> dict[str, float]:
+        return {"S1": 1.0, "S2": 1.0, "S3": 1.0, "S5": 1.0, "FALCON": 1.0}
+
+    def _regime_strategy_modifiers(self, regime: MarketRegimeClassification) -> dict[str, float]:
+        modifiers: dict[str, float] = {
+            "S1": self._clamp(float(regime.strategy_weight_modifiers.get("S1", 1.0)), 0.85, 1.20),
+            "S2": self._clamp(float(regime.strategy_weight_modifiers.get("S2", 1.0)), 0.85, 1.20),
+            "S3": self._clamp(float(regime.strategy_weight_modifiers.get("S3", 1.0)), 0.85, 1.20),
+            "S5": 1.0,
+            "FALCON": 1.0,
+        }
+        if regime.confidence_score < 0.60:
+            return {key: 1.0 for key in modifiers}
+        if regime.regime_type == "NEWS_DRIVEN":
+            modifiers["S5"] = 1.05
+            modifiers["FALCON"] = 1.02
+        elif regime.regime_type == "ARBITRAGE_DOMINANT":
+            modifiers["S5"] = 1.10
+            modifiers["FALCON"] = 0.98
+        elif regime.regime_type == "SMART_MONEY_DOMINANT":
+            modifiers["S5"] = 1.00
+            modifiers["FALCON"] = 1.12
+        elif regime.regime_type == "LOW_ACTIVITY_CHAOTIC":
+            modifiers["S5"] = 0.95
+            modifiers["FALCON"] = 0.95
+        return {
+            key: round(self._clamp(value, 0.90, 1.20), 6)
+            for key, value in modifiers.items()
+        }
+
+    def _compute_dynamic_strategy_weights(self, regime: MarketRegimeClassification) -> dict[str, float]:
+        analytics_provider = getattr(self._engine, "get_analytics", None)
+        if not callable(analytics_provider):
+            return dict(self._last_dynamic_strategy_weights)
+        summary = analytics_provider().summary()
+        trades = int(summary.get("trades", 0))
+        if trades < 3:
+            self._last_dynamic_strategy_weights = self._default_dynamic_strategy_weights()
+            return dict(self._last_dynamic_strategy_weights)
+
+        strategy_breakdown = summary.get("strategy_breakdown", {}) or {}
+        strategy_keys = ("S1", "S2", "S3", "S5", "FALCON")
+        pnl_by_strategy = {
+            key: float((strategy_breakdown.get(key, {}) or {}).get("pnl", 0.0))
+            for key in strategy_keys
+        }
+        min_pnl = min(pnl_by_strategy.values(), default=0.0)
+        max_pnl = max(pnl_by_strategy.values(), default=0.0)
+        pnl_span = max(max_pnl - min_pnl, 1e-6)
+        expectancy_norm = self._clamp(float(summary.get("expectancy", 0.0)) / 20.0, -1.0, 1.0)
+        edge_norm = self._clamp(float(summary.get("edge_captured", 0.0)) / 2.0, -1.0, 1.0)
+
+        raw_scores: dict[str, float] = {}
+        for key in strategy_keys:
+            row = strategy_breakdown.get(key, {}) or {}
+            pnl_norm = self._clamp((pnl_by_strategy[key] - min_pnl) / pnl_span, 0.0, 1.0)
+            win_rate = self._clamp(float(row.get("win_rate", 0.5)), 0.0, 1.0)
+            raw_scores[key] = self._clamp(
+                (0.40 * pnl_norm)
+                + (0.30 * win_rate)
+                + (0.20 * ((expectancy_norm + 1.0) / 2.0))
+                + (0.10 * ((edge_norm + 1.0) / 2.0)),
+                0.0,
+                1.0,
+            )
+
+        low = min(raw_scores.values(), default=0.5)
+        high = max(raw_scores.values(), default=0.5)
+        span = max(high - low, 1e-6)
+        regime_modifiers = self._regime_strategy_modifiers(regime)
+        next_weights: dict[str, float] = {}
+        for key in strategy_keys:
+            normalized_score = (raw_scores[key] - low) / span if high > low else 0.5
+            base_weight = 0.5 + normalized_score
+            previous_weight = self._last_dynamic_strategy_weights.get(key, 1.0)
+            smooth_base = previous_weight + self._clamp(base_weight - previous_weight, -0.12, 0.12)
+            regime_modifier = regime_modifiers.get(key, 1.0)
+            adjusted_weight = self._clamp(smooth_base * regime_modifier, 0.5, 1.5)
+            if smooth_base < 1.0 and regime_modifier > 1.0:
+                adjusted_weight = min(adjusted_weight, 1.0)
+            smooth_final = previous_weight + self._clamp(adjusted_weight - previous_weight, -0.149, 0.149)
+            next_weights[key] = round(self._clamp(smooth_final, 0.5, 1.5), 6)
+
+        self._last_dynamic_strategy_weights = dict(next_weights)
+        return next_weights
 
     def record_trade_result(
         self,
@@ -947,6 +1036,7 @@ class StrategyTrigger:
                 strategy_weight_modifiers={"S1": 1.0, "S2": 1.0, "S3": 1.0},
             )
         )
+        dynamic_strategy_weights = self._compute_dynamic_strategy_weights(regime)
         candidates = [
             self._build_strategy_candidate_score(
                 strategy_name="S1",
@@ -956,6 +1046,7 @@ class StrategyTrigger:
                 confidence=None,
                 market_metadata={},
                 regime_weight_modifier=regime.strategy_weight_modifiers.get("S1", 1.0),
+                strategy_weight=dynamic_strategy_weights.get("S1", 1.0),
             ),
             self._build_strategy_candidate_score(
                 strategy_name="S2",
@@ -965,6 +1056,7 @@ class StrategyTrigger:
                 confidence=None,
                 market_metadata=s2_decision.matched_markets_info,
                 regime_weight_modifier=regime.strategy_weight_modifiers.get("S2", 1.0),
+                strategy_weight=dynamic_strategy_weights.get("S2", 1.0),
             ),
             self._build_strategy_candidate_score(
                 strategy_name="S3",
@@ -974,6 +1066,7 @@ class StrategyTrigger:
                 confidence=s3_decision.confidence,
                 market_metadata=s3_decision.wallet_info,
                 regime_weight_modifier=regime.strategy_weight_modifiers.get("S3", 1.0),
+                strategy_weight=dynamic_strategy_weights.get("S3", 1.0),
             ),
         ]
         regime_output_key = self._regime_output_key(regime.regime_type)
@@ -1034,6 +1127,7 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                strategy_weights=dynamic_strategy_weights,
                 external_signal_weight=external_signal_weight,
                 falcon_signal=falcon_signal_payload,
             )
@@ -1048,6 +1142,7 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                strategy_weights=dynamic_strategy_weights,
                 external_signal_weight=external_signal_weight,
                 falcon_signal=falcon_signal_payload,
             )
@@ -1063,6 +1158,7 @@ class StrategyTrigger:
                 current_regime=regime.regime_type,
                 regime_confidence=regime.confidence_score,
                 strategy_weight_modifiers=regime.strategy_weight_modifiers,
+                strategy_weights=dynamic_strategy_weights,
                 external_signal_weight=external_signal_weight,
                 falcon_signal=falcon_signal_payload,
             )
@@ -1076,6 +1172,7 @@ class StrategyTrigger:
             current_regime=regime.regime_type,
             regime_confidence=regime.confidence_score,
             strategy_weight_modifiers=regime.strategy_weight_modifiers,
+            strategy_weights=dynamic_strategy_weights,
             external_signal_weight=external_signal_weight,
             falcon_signal=falcon_signal_payload,
         )
@@ -1145,6 +1242,7 @@ class StrategyTrigger:
         confidence: float | None,
         market_metadata: dict[str, object],
         regime_weight_modifier: float = 1.0,
+        strategy_weight: float = 1.0,
     ) -> StrategyCandidateScore:
         normalized_edge = min(max(edge, 0.0) / 0.10, 1.0)
         normalized_confidence = (
@@ -1159,7 +1257,8 @@ class StrategyTrigger:
         )
         optimization_weight = self._clamp(optimization_weight, 0.75, 1.15)
         bounded_regime_modifier = self._clamp(regime_weight_modifier, 0.85, 1.20)
-        weighted_score = round(score * adaptive_weight * bounded_regime_modifier * optimization_weight, 6)
+        bounded_strategy_weight = self._clamp(strategy_weight, 0.5, 1.5)
+        weighted_score = round(score * adaptive_weight * bounded_regime_modifier * optimization_weight * bounded_strategy_weight, 6)
         return StrategyCandidateScore(
             strategy_name=strategy_name,
             decision=decision,

--- a/projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md
@@ -1,0 +1,78 @@
+# 24_32_p15_strategy_selection_auto_weighting
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - S4 decision weighting logic
+  - integration with P14 analytics
+- Not in Scope:
+  - execution logic changes
+  - risk model changes
+  - ML models
+  - external integrations
+- Suggested Next Step: Auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md`. Tier: STANDARD
+
+## 1. What was built
+- Implemented dynamic strategy auto-weighting in S4 path using post-trade analytics from P14 (`summary()` inputs + deterministic normalization).
+- Added scoring model `score = f(pnl, win_rate, expectancy, edge_captured)` and converted normalized scores into bounded base weights (`0.5` to `1.5`).
+- Added smoothing limits to prevent abrupt shifts (`±0.12` on base transition, `±0.149` on final transition).
+- Added regime-based adjustment layer (P11 context) applied as `final_weight = base_weight × regime_modifier` with confidence-gated neutral fallback.
+- Integrated weights into S4 candidate scoring as multiplicative influence only (does not bypass/override decision contract).
+- Exposed output `strategy_weights` in S4 aggregation decision payload with keys: `S1`, `S2`, `S3`, `S5`, `FALCON`.
+
+## 2. Current system architecture
+- `execution/strategy_trigger.py`
+  - New helpers for default weights, regime modifier map, and dynamic weight computation.
+  - Pulls analytics via `engine.get_analytics().summary()` (P14 integration source).
+  - Computes per-strategy raw score from normalized PnL + win rate + global expectancy + global edge-captured.
+  - Converts normalized scores to base weights (`0.5..1.5`), applies smoothing, then regime adjustment with bounded caps.
+  - Injects `strategy_weight` into `_build_strategy_candidate_score` so S4 final candidate score is influenced but still bounded and deterministic.
+- `tests/test_p15_strategy_auto_weighting_20260409.py`
+  - Focused STANDARD-tier tests validating strong/weak weighting, regime effects, deterministic output, and anti-jump safety.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Required tests
+- strong strategy gets higher weight: pass
+- weak strategy reduced: pass
+- regime modifies weights: pass
+- deterministic outputs: pass
+- no extreme jumps: pass
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py` ✅ (`5 passed`)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py` ✅ (`13 passed`)
+
+### Runtime proof (required)
+1) Weight distribution example
+- Baseline computed weights:
+  - `S1=1.12`, `S2=0.88`, `S3=1.109023`, `S5=1.078947`, `FALCON=1.12`
+
+2) Before/after comparison
+- Candidate score comparison (same S1/S2/S3 signals):
+  - Before (baseline weighting): `S1=0.4816`, `S2=0.3784`, `S3=0.365978`
+  - After (NEWS_DRIVEN regime weighting): `S1=0.643891`, `S2=0.29547`, `S3=0.323378`
+- Result: stronger analytics-aligned strategy receives higher influence while weak strategy influence is reduced.
+
+3) Regime-based adjustment example
+- `NEWS_DRIVEN`: `FALCON=1.207895`, `S5=1.132895`
+- `LOW_ACTIVITY_CHAOTIC`: `FALCON=1.125`, `S5=1.025`
+- Demonstrates P11 regime context modifying final weights while respecting smoothing and bounds.
+
+## 5. Known issues
+- P15 weighting is NARROW integration in S4 decision path only; it does not yet propagate to non-S4 orchestration/reporting surfaces.
+- Existing pytest warning remains in this environment: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Auto PR review + COMMANDER review required before merge.
+- Optional next increment (if requested): expose `strategy_weights` telemetry to monitoring/dashboard surfaces for operator observability.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.execution.analytics import PerformanceTracker
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    CrossExchangeArbitrageDecision,
+    MarketRegimeInputs,
+    SmartMoneyCopyTradingDecision,
+    StrategyConfig,
+    StrategyDecision,
+    StrategyTrigger,
+)
+
+
+def _build_tracker() -> PerformanceTracker:
+    tracker = PerformanceTracker()
+    rows = [
+        {"position_id": "s1-1", "size": 100.0, "pnl": 18.0, "strategy_source": "S1", "regime_at_entry": "NEWS_DRIVEN", "actual_return": 0.18, "theoretical_edge": 0.05},
+        {"position_id": "s1-2", "size": 100.0, "pnl": 12.0, "strategy_source": "S1", "regime_at_entry": "NEWS_DRIVEN", "actual_return": 0.12, "theoretical_edge": 0.04},
+        {"position_id": "s2-1", "size": 100.0, "pnl": -8.0, "strategy_source": "S2", "regime_at_entry": "ARBITRAGE_DOMINANT", "actual_return": -0.08, "theoretical_edge": 0.03},
+        {"position_id": "s3-1", "size": 100.0, "pnl": 4.0, "strategy_source": "S3", "regime_at_entry": "SMART_MONEY_DOMINANT", "actual_return": 0.04, "theoretical_edge": 0.03},
+        {"position_id": "s5-1", "size": 100.0, "pnl": 2.0, "strategy_source": "S5", "regime_at_entry": "ARBITRAGE_DOMINANT", "actual_return": 0.02, "theoretical_edge": 0.02},
+        {"position_id": "fal-1", "size": 100.0, "pnl": 9.0, "strategy_source": "FALCON", "regime_at_entry": "SMART_MONEY_DOMINANT", "actual_return": 0.09, "theoretical_edge": 0.04},
+    ]
+    for row in rows:
+        tracker.record_trade(row)
+    return tracker
+
+
+@dataclass(frozen=True)
+class _EngineStub:
+    max_total_exposure_ratio: float = 0.30
+    max_position_size_ratio: float = 0.10
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_analytics", _build_tracker())
+
+    def get_analytics(self) -> PerformanceTracker:
+        return self._analytics
+
+
+
+def _make_trigger() -> StrategyTrigger:
+    return StrategyTrigger(engine=_EngineStub(), config=StrategyConfig(market_id="m-p15"))
+
+
+
+def _run_aggregation(trigger: StrategyTrigger, regime_inputs: MarketRegimeInputs) -> dict[str, float]:
+    result = trigger.aggregate_strategy_decisions(
+        s1_decision=StrategyDecision(decision="ENTER", reason="s1", edge=0.04),
+        s2_decision=CrossExchangeArbitrageDecision(
+            decision="ENTER",
+            reason="s2",
+            edge=0.04,
+            matched_markets_info={"market": "k1"},
+        ),
+        s3_decision=SmartMoneyCopyTradingDecision(decision="ENTER", reason="s3", confidence=0.75, wallet_info={}),
+        market_regime_inputs=regime_inputs,
+    )
+    return result.strategy_weights or {}
+
+
+
+def test_strong_strategy_gets_higher_weight() -> None:
+    trigger = _make_trigger()
+    weights = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.80,
+            price_dispersion=0.20,
+            wallet_activity_strength=0.40,
+            trade_frequency=0.50,
+            volatility=0.40,
+        ),
+    )
+    assert weights["S1"] > weights["S2"]
+
+
+
+def test_weak_strategy_reduced() -> None:
+    trigger = _make_trigger()
+    weights = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.15,
+            price_dispersion=0.15,
+            wallet_activity_strength=0.15,
+            trade_frequency=0.90,
+            volatility=0.90,
+        ),
+    )
+    assert weights["S2"] < 1.0
+
+
+
+def test_regime_modifies_weights() -> None:
+    trigger = _make_trigger()
+    smart_money = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.30,
+            price_dispersion=0.30,
+            wallet_activity_strength=0.90,
+            trade_frequency=0.65,
+            volatility=0.55,
+        ),
+    )
+    chaotic = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.10,
+            price_dispersion=0.10,
+            wallet_activity_strength=0.10,
+            trade_frequency=0.95,
+            volatility=0.95,
+        ),
+    )
+    assert smart_money["FALCON"] > chaotic["FALCON"]
+
+
+
+def test_outputs_are_deterministic() -> None:
+    first_trigger = _make_trigger()
+    second_trigger = _make_trigger()
+    inputs = MarketRegimeInputs(
+        social_spike_intensity=0.75,
+        price_dispersion=0.20,
+        wallet_activity_strength=0.35,
+        trade_frequency=0.45,
+        volatility=0.45,
+    )
+    first = _run_aggregation(first_trigger, inputs)
+    second = _run_aggregation(second_trigger, inputs)
+    assert first == second
+
+
+
+def test_no_extreme_jumps_and_expected_keys_present() -> None:
+    trigger = _make_trigger()
+    first = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.85,
+            price_dispersion=0.15,
+            wallet_activity_strength=0.35,
+            trade_frequency=0.45,
+            volatility=0.35,
+        ),
+    )
+    second = _run_aggregation(
+        trigger,
+        MarketRegimeInputs(
+            social_spike_intensity=0.10,
+            price_dispersion=0.10,
+            wallet_activity_strength=0.10,
+            trade_frequency=0.90,
+            volatility=0.90,
+        ),
+    )
+    assert set(second.keys()) == {"S1", "S2", "S3", "S5", "FALCON"}
+    for strategy_name, weight in second.items():
+        assert 0.5 <= weight <= 1.5
+        assert abs(weight - first[strategy_name]) <= 0.15


### PR DESCRIPTION
### Motivation
- Add deterministic dynamic strategy weighting to S4 so the system can favor better-performing strategies using P14 analytics while respecting regime context from P11.
- Keep safety by bounding weights, smoothing transitions, and ensuring weighting is influence-only (does not override core strategy ranking/decision contract).

### Description
- Added dynamic-weighting helpers to `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, including `_default_dynamic_strategy_weights`, `_regime_strategy_modifiers`, and `_compute_dynamic_strategy_weights`, and stored last-computed weights for smooth updates.
- Integrated dynamic weights into the S4 aggregation flow by adding `strategy_weights` to `StrategyAggregationDecision` and passing a `strategy_weight` multiplier into `_build_strategy_candidate_score` so candidate scores are influenced multiplicatively and remain bounded (`0.5..1.5`).
- Implemented regime-aware adjustments (confidence-gated neutral fallback) and smoothing caps to prevent abrupt shifts (`±0.12` base / `±0.149` final transition) and deterministic normalization of analytics inputs (`pnl`, `win_rate`, `expectancy`, `edge_captured`).
- Added focused tests at `projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py` and a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md`, and updated `PROJECT_STATE.md` to record the P15 completion and handoff.

### Testing
- Ran compile check: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py` — PASS.
- Ran new tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p15_strategy_auto_weighting_20260409.py` — `5 passed` (warning about unknown `asyncio_mode` only, non-blocking).
- Verified existing related suites: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_s4_strategy_aggregation_prioritization_20260409.py projects/polymarket/polyquantbot/tests/test_p14_1_system_optimization_from_analytics_20260409.py` — `13 passed` (same non-blocking warning).
- All automated checks for the touched scope passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c48f58c8832e8864e6da405ace29)