### PR TITLE
Resolve market_title from market_id with cache and strict fallback

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 15:16
-- Status        : FORGE-X completed P14.3 Falcon alpha strategy layer safety refinement pass (insufficient-data fallback + noisy-trigger suppression + deterministic bounded external weighting) and is pending auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 15:37
+- Status        : FORGE-X completed market title resolution fix (market_id -> real market_title with strict fallback + cache) and is pending auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Market title resolution fix from market_id (2026-04-09): resolved real `market_title` via Falcon market metadata/cache in touched data-layer path, enforced strict placeholder fallback only when API unavailable with no cached title, and added focused regression tests for single/multi-market and fallback behavior.
 - P14.3 Falcon alpha strategy layer safety refinement (2026-04-09): added explicit insufficient-data fallback (`falcon_signal=None`), noisy-input neutralization (`external_signal_weight=1.0`), deterministic bounded aggregation behavior, and expanded focused tests for fallback/noise/runtime-proof examples.
 - P14 post-trade analytics & attribution enhancement pass (2026-04-09): added FALCON attribution normalization, deterministic strategy/regime baseline buckets, bounded edge-capture safety clamp with division-safe handling, and expanded focused tests for expectancy + edge safety + deterministic attribution outputs.
 - P14.3 Falcon alpha strategy layer (2026-04-09): implemented deterministic smart-money and momentum signal generation from Falcon datasets, liquidity scoring from orderbook spread/depth, bounded combined Falcon signal output, and narrow S4 integration via `external_signal_weight` with fallback-safe behavior and focused tests.
@@ -116,6 +117,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### Market title resolution handoff
+- STANDARD-tier NARROW INTEGRATION implementation is complete for market context builder + Falcon normalization + portfolio title payload source path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P14.3 Falcon alpha strategy layer handoff
 - STANDARD-tier narrow integration implementation is complete for Falcon-derived smart-money/momentum/liquidity signal generation and bounded S4 external weighting input path.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 15:37
-- Status        : FORGE-X completed market title resolution fix (market_id -> real market_title with strict fallback + cache) and is pending auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 15:52
+- Status        : FORGE-X completed market title resolution follow-up hardening for partial Falcon failure path and is pending auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Market title resolution follow-up hardening (2026-04-09): fixed partial Falcon failure path so successful markets title resolution is cached before downstream fetches, preventing fallback to numeric placeholder when later Falcon calls fail, and added focused regression coverage.
 - Market title resolution fix from market_id (2026-04-09): resolved real `market_title` via Falcon market metadata/cache in touched data-layer path, enforced strict placeholder fallback only when API unavailable with no cached title, and added focused regression tests for single/multi-market and fallback behavior.
 - P14.3 Falcon alpha strategy layer safety refinement (2026-04-09): added explicit insufficient-data fallback (`falcon_signal=None`), noisy-input neutralization (`external_signal_weight=1.0`), deterministic bounded aggregation behavior, and expanded focused tests for fallback/noise/runtime-proof examples.
 - P14 post-trade analytics & attribution enhancement pass (2026-04-09): added FALCON attribution normalization, deterministic strategy/regime baseline buckets, bounded edge-capture safety clamp with division-safe handling, and expanded focused tests for expectancy + edge safety + deterministic attribution outputs.
@@ -117,6 +118,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### Market title resolution follow-up handoff
+- STANDARD-tier NARROW INTEGRATION follow-up implementation is complete for Falcon partial-failure title fallback resilience in touched path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### Market title resolution handoff
 - STANDARD-tier NARROW INTEGRATION implementation is complete for market context builder + Falcon normalization + portfolio title payload source path.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 15:52
-- Status        : FORGE-X completed market title resolution follow-up hardening for partial Falcon failure path and is pending auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 16:03
+- Status        : FORGE-X completed market title resolution test hardening follow-up (private-cache-free regression coverage) and is pending auto PR review + COMMANDER review.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Market title resolution test hardening follow-up (2026-04-09): removed private cache mutation from Falcon title regression tests, seeded fallback cache through public normalization behavior, and preserved partial-failure/no-placeholder assertions.
 - Market title resolution follow-up hardening (2026-04-09): fixed partial Falcon failure path so successful markets title resolution is cached before downstream fetches, preventing fallback to numeric placeholder when later Falcon calls fail, and added focused regression coverage.
 - Market title resolution fix from market_id (2026-04-09): resolved real `market_title` via Falcon market metadata/cache in touched data-layer path, enforced strict placeholder fallback only when API unavailable with no cached title, and added focused regression tests for single/multi-market and fallback behavior.
 - P14.3 Falcon alpha strategy layer safety refinement (2026-04-09): added explicit insufficient-data fallback (`falcon_signal=None`), noisy-input neutralization (`external_signal_weight=1.0`), deterministic bounded aggregation behavior, and expanded focused tests for fallback/noise/runtime-proof examples.
@@ -118,6 +119,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### Market title test-hardening handoff
+- STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### Market title resolution follow-up handoff
 - STANDARD-tier NARROW INTEGRATION follow-up implementation is complete for Falcon partial-failure title fallback resilience in touched path.

--- a/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py
+++ b/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py
@@ -248,19 +248,14 @@ async def fetch_external_alpha_with_fallback(
 
     Returns deterministic fallback payload when Falcon is unavailable.
     """
-    fallback_title = get_cached_market_title(market_id) or f"Market {market_id}"
-    fallback = {
-        "market_id": market_id,
-        "market_title": fallback_title,
-        "price": 0.0,
-        "volume": 0.0,
-        "momentum": 0.0,
-        "liquidity": 0.0,
-        "smart_money_indicator": 0.0,
-        "volatility_snapshot": 0.0,
-    }
+    cached_title = get_cached_market_title(market_id)
     try:
         markets = await fetch_markets(client, params={"market_id": market_id})
+        if markets:
+            resolved_title = _resolve_market_title(markets[0])
+            if resolved_title:
+                _cache_market_title(market_id, resolved_title)
+                cached_title = resolved_title
         trades = await fetch_trades(client, params={"market_id": market_id})
         candles = await fetch_candles(client, params={"token_id": token_id})
         orderbook = await fetch_orderbook(client, params={"token_id": token_id})
@@ -273,7 +268,16 @@ async def fetch_external_alpha_with_fallback(
         )
     except Exception as exc:
         log.warning("falcon_external_alpha_fallback", market_id=market_id, error=str(exc))
-        return fallback
+        return {
+            "market_id": market_id,
+            "market_title": cached_title or f"Market {market_id}",
+            "price": 0.0,
+            "volume": 0.0,
+            "momentum": 0.0,
+            "liquidity": 0.0,
+            "smart_money_indicator": 0.0,
+            "volatility_snapshot": 0.0,
+        }
 
 def get_cached_market_title(market_id: str) -> str:
     """Return cached market title for market_id, if available."""

--- a/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py
+++ b/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py
@@ -20,6 +20,8 @@ import structlog
 
 log = structlog.get_logger(__name__)
 
+_market_title_cache: dict[str, str] = {}
+
 _FALCON_BASE_URL = "https://narrative.agent.heisenberg.so"
 _FALCON_ENDPOINT = "/api/v2/semantic/retrieve/parameterized"
 _FALCON_AGENT_MARKETS = 574
@@ -191,6 +193,11 @@ def normalize_external_signal(
     orderbook: list[dict[str, Any]],
 ) -> dict[str, float | str]:
     """Convert Falcon raw rows into deterministic internal alpha payload."""
+    market_id = str(market.get("market_id") or market.get("id") or "")
+    market_title = _resolve_market_title(market)
+    if market_id and market_title:
+        _cache_market_title(market_id, market_title)
+
     price = _to_float(market.get("price"), default=0.0)
     volume = _to_float(market.get("volume"), default=0.0)
     momentum, volatility = _compute_price_context(candles)
@@ -198,8 +205,8 @@ def normalize_external_signal(
     smart_money_score = _compute_smart_money_score(trades)
 
     return {
-        "market_id": str(market.get("market_id") or market.get("id") or ""),
-        "market_title": str(market.get("market_title") or market.get("title") or ""),
+        "market_id": market_id,
+        "market_title": market_title,
         "price": round(price, 6),
         "volume": round(volume, 2),
         "momentum": round(momentum, 6),
@@ -241,9 +248,10 @@ async def fetch_external_alpha_with_fallback(
 
     Returns deterministic fallback payload when Falcon is unavailable.
     """
+    fallback_title = get_cached_market_title(market_id) or f"Market {market_id}"
     fallback = {
         "market_id": market_id,
-        "market_title": "",
+        "market_title": fallback_title,
         "price": 0.0,
         "volume": 0.0,
         "momentum": 0.0,
@@ -266,6 +274,25 @@ async def fetch_external_alpha_with_fallback(
     except Exception as exc:
         log.warning("falcon_external_alpha_fallback", market_id=market_id, error=str(exc))
         return fallback
+
+def get_cached_market_title(market_id: str) -> str:
+    """Return cached market title for market_id, if available."""
+    return _market_title_cache.get(str(market_id), "")
+
+
+def _cache_market_title(market_id: str, market_title: str) -> None:
+    safe_market_id = str(market_id).strip()
+    safe_title = str(market_title).strip()
+    if safe_market_id and safe_title:
+        _market_title_cache[safe_market_id] = safe_title
+
+
+def _resolve_market_title(market: dict[str, Any]) -> str:
+    for key in ("market_title", "title", "question", "name"):
+        value = market.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
 
 
 def _extract_rows(response: dict[str, Any]) -> list[dict[str, Any]]:

--- a/projects/polymarket/polyquantbot/data/market_context.py
+++ b/projects/polymarket/polyquantbot/data/market_context.py
@@ -4,11 +4,16 @@ from typing import Any
 
 import structlog
 
-from .ingestion.falcon_alpha import FalconAPIClient, fetch_external_alpha_with_fallback
+from .ingestion.falcon_alpha import (
+    FalconAPIClient,
+    fetch_external_alpha_with_fallback,
+    get_cached_market_title,
+)
 from .polymarket_api import fetch_market_details
 
 log = structlog.get_logger(__name__)
 market_cache: dict[str, dict[str, Any]] = {}
+market_title_cache: dict[str, str] = {}
 
 
 async def get_market_context(market_id: str) -> dict[str, Any]:
@@ -28,10 +33,11 @@ async def get_market_context(market_id: str) -> dict[str, Any]:
 
     try:
         raw = await fetch_market_details(market_id) or {}
-        q = raw.get("question", "")
-        name = q if isinstance(q, str) and q else f"Market #{market_id}"
+        resolved_title = _resolve_market_title(raw) or market_title_cache.get(market_id, "")
+        if resolved_title:
+            market_title_cache[market_id] = resolved_title
         context = {
-            "name": name,
+            "name": resolved_title,
             "category": raw.get("category") or "unknown",
             "resolution": raw.get("end_date_iso", raw.get("end_date", "N/A")),
         }
@@ -39,8 +45,9 @@ async def get_market_context(market_id: str) -> dict[str, Any]:
         return context
     except Exception as exc:
         log.warning("market_context_api_failed", market_id=market_id, error=str(exc))
+        cached_title = market_title_cache.get(market_id) or get_cached_market_title(market_id)
         return {
-            "name": f"Market #{market_id}",
+            "name": cached_title or f"Market {market_id}",
             "category": "unknown",
             "resolution": "N/A",
         }
@@ -64,7 +71,7 @@ async def get_market_context_with_external_alpha(
     return {
         **internal,
         "market_id": market_id,
-        "market_title": external.get("market_title") or internal.get("name", ""),
+        "market_title": external.get("market_title") or internal.get("name", "") or market_title_cache.get(market_id, ""),
         "price": float(external.get("price", 0.0)),
         "volume": float(external.get("volume", 0.0)),
         "momentum": float(external.get("momentum", 0.0)),
@@ -73,3 +80,11 @@ async def get_market_context_with_external_alpha(
         "smart_money_score": float(external.get("smart_money_indicator", 0.0)),
         "volatility": float(external.get("volatility_snapshot", 0.0)),
     }
+
+
+def _resolve_market_title(raw_market: dict[str, Any]) -> str:
+    for key in ("question", "market_title", "title", "name"):
+        value = raw_market.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""

--- a/projects/polymarket/polyquantbot/reports/forge/24_32_fix_market_title_resolution_from_id.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_32_fix_market_title_resolution_from_id.md
@@ -1,0 +1,68 @@
+# 24_32_fix_market_title_resolution_from_id
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - market context builder
+  - Falcon ingestion normalization
+  - portfolio payload title field source (`market_title`)
+- Not in Scope:
+  - execution logic
+  - strategy logic
+  - Telegram layout changes
+  - analytics
+- Suggested Next Step: Auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_32_fix_market_title_resolution_from_id.md`. Tier: STANDARD
+
+## 1. What was built
+- Implemented deterministic market title resolution from `market_id` in Falcon ingestion normalization so title derives from Falcon market metadata fields (`market_title` / `title` / `question` / `name`) instead of staying empty.
+- Added safe in-memory `market_id -> market_title` cache in Falcon ingestion to avoid repeated fallback misses and improve repeated resolution stability.
+- Updated market-context builder fallback behavior:
+  - Uses cached title first when API fails.
+  - Uses strict placeholder `Market {id}` only when API fails and no cache title exists.
+- Preserved portfolio payload field contract (`market_title`) without formatter/layout changes.
+
+## 2. Current system architecture
+1. `data/ingestion/falcon_alpha.py`
+   - Falcon fetchers retrieve market/trade/candle/orderbook rows.
+   - Normalizer now resolves and persists `market_title` from market metadata and caches by `market_id`.
+   - Fallback payload now carries cached title or strict placeholder only on API failure.
+2. `data/market_context.py`
+   - Internal market context attempts direct Polymarket title resolution.
+   - On failure, returns cached title from local/Falcon cache before placeholder.
+   - `get_market_context_with_external_alpha` keeps `market_title` authoritative for downstream portfolio payload.
+3. Portfolio payload path remains unchanged structurally; it receives improved upstream `market_title` value.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/data/market_context.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_32_fix_market_title_resolution_from_id.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Required tests
+1. valid `market_id` resolves correct title: pass
+2. multiple markets resolve all correct titles: pass
+3. fallback placeholder only when API unavailable and no cached title: pass
+4. no regression to numeric-only display contract in resolved payload path: pass
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/data/market_context.py projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅ (`7 passed`)
+
+### Runtime proof
+- BEFORE: `Market 540816`
+- AFTER: `Will BTC close above $120k in 2026?`
+- MULTI: `m100 -> Will ETH close above $6k? | m200 -> Will SOL close above $300?`
+
+## 5. Known issues
+- Environment-level pytest warning persists: `Unknown config option: asyncio_mode`.
+- Runtime proof script in this environment logs Polymarket network unavailability warning before Falcon title resolution fallback path completes.
+
+## 6. What is next
+- Auto PR review + COMMANDER review required before merge.
+- Optional next increment (only if requested): centralize title cache between Polymarket and Falcon sources behind one typed cache adapter.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_32_fix_market_title_resolution_from_id.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/reports/forge/24_33_market_title_resolution_followup_partial_failure.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_33_market_title_resolution_followup_partial_failure.md
@@ -1,0 +1,62 @@
+# 24_33_market_title_resolution_followup_partial_failure
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - Falcon ingestion normalization
+  - market-title fallback path on partial Falcon failure
+  - portfolio payload title source safety
+- Not in Scope:
+  - execution logic
+  - strategy logic
+  - Telegram layout changes
+  - analytics
+- Suggested Next Step: Auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_33_market_title_resolution_followup_partial_failure.md`. Tier: STANDARD
+
+## 1. What was built
+- Applied follow-up hardening to market-title fallback flow to address review feedback on partial Falcon failures.
+- Updated `fetch_external_alpha_with_fallback(...)` to cache market title immediately after successful markets endpoint response (before other Falcon calls).
+- Ensured fallback payload prefers this freshly-resolved title if later Falcon calls fail, preventing numeric placeholder regression in mixed-success scenarios.
+- Added focused regression test for partial-failure case (`markets` success + subsequent request failure).
+
+## 2. Current system architecture
+1. Falcon ingestion now resolves/caches title in two places:
+   - during normalization (`normalize_external_signal`) for full-success path,
+   - immediately after markets fetch in `fetch_external_alpha_with_fallback` for partial-failure resilience.
+2. Fallback contract remains strict:
+   - use cached/just-resolved title when available,
+   - use `Market {id}` only if API path fails and no cached title exists.
+3. Portfolio payload path remains unchanged structurally and consumes improved `market_title` input.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_33_market_title_resolution_followup_partial_failure.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Required tests
+1. valid market_id resolves correct title: pass
+2. multiple markets resolve correct titles: pass
+3. fallback only when unavailable + no cache: pass
+4. no regression to numeric-only display on partial Falcon failure: pass
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅ (`8 passed`)
+
+### Runtime proof
+- BEFORE: `Market 540816`
+- AFTER: `Will BTC close above $120k in 2026?`
+- MULTI: `m100 -> Will ETH close above $6k? | m200 -> Will SOL close above $300?`
+- PARTIAL FAILURE: `m900 -> Will Fed cut rates in June?` (no numeric placeholder)
+
+## 5. Known issues
+- Environment-level pytest warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Auto PR review + COMMANDER review required before merge.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_33_market_title_resolution_followup_partial_failure.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/reports/forge/24_34_market_title_resolution_test_hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_34_market_title_resolution_test_hardening.md
@@ -1,0 +1,48 @@
+# 24_34_market_title_resolution_test_hardening
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - Falcon title-resolution regression tests
+  - fallback behavior verification path
+- Not in Scope:
+  - execution logic
+  - strategy logic
+  - Telegram layout changes
+  - analytics
+- Suggested Next Step: Auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_34_market_title_resolution_test_hardening.md`. Tier: STANDARD
+
+## 1. What was built
+- Addressed follow-up review feedback in tests by removing direct test mutation of private cache internals.
+- Updated fallback-cache test to seed cache through public behavior (`normalize_external_signal`) rather than private dictionary access.
+- Kept partial-failure and market-title regression coverage intact.
+
+## 2. Current system architecture
+1. Runtime code path unchanged from previous follow-up (`24_33`).
+2. Test path now validates through public ingestion contracts and avoids private state coupling.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_34_market_title_resolution_test_hardening.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+### Required tests
+1. valid market_id resolves correct title: pass
+2. multiple markets resolve correct titles: pass
+3. fallback only when unavailable + no cache: pass
+4. no regression to numeric-only display on partial Falcon failure: pass
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` ✅ (`8 passed`)
+
+## 5. Known issues
+- Environment-level pytest warning persists: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- Auto PR review + COMMANDER review required before merge.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_34_market_title_resolution_test_hardening.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
@@ -221,3 +221,21 @@ def test_fallback_uses_cached_title_when_api_unavailable() -> None:
         assert alpha["market_title"] != "Market m500"
 
     asyncio.run(_run())
+
+
+def test_partial_falcon_failure_uses_resolved_market_title_not_numeric_placeholder() -> None:
+    async def _run() -> None:
+        falcon_alpha._market_title_cache.clear()
+
+        transport = _CaptureTransport(
+            responses=[
+                {"data": [{"market_id": "m900", "question": "Will Fed cut rates in June?", "price": 0.52, "volume": 88000}]},
+            ]
+        )
+        client = FalconAPIClient(transport=transport)
+        alpha = await fetch_external_alpha_with_fallback(client, market_id="m900", token_id="t900")
+
+        assert alpha["market_title"] == "Will Fed cut rates in June?"
+        assert alpha["market_title"] != "Market m900"
+
+    asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from projects.polymarket.polyquantbot.data import market_context
+from projects.polymarket.polyquantbot.data.ingestion import falcon_alpha
 from projects.polymarket.polyquantbot.data.ingestion.falcon_alpha import (
     FalconAPIClient,
     FalconPagination,
@@ -102,7 +104,7 @@ def test_failure_fallback_and_context_integration() -> None:
         alpha = await fetch_external_alpha_with_fallback(client, market_id="m3", token_id="t3")
         assert alpha == {
             "market_id": "m3",
-            "market_title": "",
+            "market_title": "Market m3",
             "price": 0.0,
             "volume": 0.0,
             "momentum": 0.0,
@@ -147,5 +149,75 @@ def test_runtime_proof_samples_market_trade_and_normalized_output() -> None:
         assert context["liquidity_usd"] == 23000.0
         assert context["smart_money_score"] > 0.0
         assert context["momentum"] > 0.0
+
+    asyncio.run(_run())
+
+
+def test_market_id_only_resolves_real_title_and_portfolio_context() -> None:
+    async def _run() -> None:
+        falcon_alpha._market_title_cache.clear()
+        market_context.market_cache.clear()
+        market_context.market_title_cache.clear()
+
+        transport = _CaptureTransport(
+            responses=[
+                {"data": [{"market_id": "540816", "question": "Will BTC close above $120k in 2026?", "price": 0.61, "volume": 90000}]},
+                {"data": [{"wallet": "0x1", "size": 2100}]},
+                {"data": [{"close": 0.58}, {"close": 0.60}, {"close": 0.61}]},
+                {"data": [{"side": "bid", "price": 0.60, "depth": 11000}, {"side": "ask", "price": 0.62, "depth": 12000}]},
+            ]
+        )
+        client = FalconAPIClient(transport=transport)
+
+        context = await get_market_context_with_external_alpha(
+            market_id="540816",
+            token_id="t540816",
+            falcon_client=client,
+        )
+
+        assert context["market_title"] == "Will BTC close above $120k in 2026?"
+        assert context["market_title"] != "Market 540816"
+
+    asyncio.run(_run())
+
+
+def test_multiple_market_ids_resolve_all_titles() -> None:
+    async def _run() -> None:
+        falcon_alpha._market_title_cache.clear()
+        market_context.market_cache.clear()
+        market_context.market_title_cache.clear()
+
+        m1 = normalize_external_signal(
+            market={"market_id": "m100", "question": "Will ETH close above $6k?", "price": 0.44, "volume": 120000},
+            trades=[{"wallet": "0xaaa", "size": 1500}],
+            candles=[{"close": 0.40}, {"close": 0.42}],
+            orderbook=[{"side": "bid", "price": 0.41, "depth": 12000}, {"side": "ask", "price": 0.42, "depth": 13000}],
+        )
+        m2 = normalize_external_signal(
+            market={"market_id": "m200", "title": "Will SOL close above $300?", "price": 0.54, "volume": 110000},
+            trades=[{"wallet": "0xbbb", "size": 2500}],
+            candles=[{"close": 0.50}, {"close": 0.53}],
+            orderbook=[{"side": "bid", "price": 0.52, "depth": 15000}, {"side": "ask", "price": 0.53, "depth": 14000}],
+        )
+
+        assert m1["market_title"] == "Will ETH close above $6k?"
+        assert m2["market_title"] == "Will SOL close above $300?"
+
+    asyncio.run(_run())
+
+
+def test_fallback_uses_cached_title_when_api_unavailable() -> None:
+    async def _run() -> None:
+        falcon_alpha._market_title_cache.clear()
+        falcon_alpha._market_title_cache["m500"] = "Will CPI print under 2.5%?"
+
+        async def failing_transport(_: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("falcon_down")
+
+        client = FalconAPIClient(transport=failing_transport)
+        alpha = await fetch_external_alpha_with_fallback(client, market_id="m500", token_id="t500")
+
+        assert alpha["market_title"] == "Will CPI print under 2.5%?"
+        assert alpha["market_title"] != "Market m500"
 
     asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from projects.polymarket.polyquantbot.data import market_context
-from projects.polymarket.polyquantbot.data.ingestion import falcon_alpha
 from projects.polymarket.polyquantbot.data.ingestion.falcon_alpha import (
     FalconAPIClient,
     FalconPagination,
@@ -155,10 +153,6 @@ def test_runtime_proof_samples_market_trade_and_normalized_output() -> None:
 
 def test_market_id_only_resolves_real_title_and_portfolio_context() -> None:
     async def _run() -> None:
-        falcon_alpha._market_title_cache.clear()
-        market_context.market_cache.clear()
-        market_context.market_title_cache.clear()
-
         transport = _CaptureTransport(
             responses=[
                 {"data": [{"market_id": "540816", "question": "Will BTC close above $120k in 2026?", "price": 0.61, "volume": 90000}]},
@@ -183,10 +177,6 @@ def test_market_id_only_resolves_real_title_and_portfolio_context() -> None:
 
 def test_multiple_market_ids_resolve_all_titles() -> None:
     async def _run() -> None:
-        falcon_alpha._market_title_cache.clear()
-        market_context.market_cache.clear()
-        market_context.market_title_cache.clear()
-
         m1 = normalize_external_signal(
             market={"market_id": "m100", "question": "Will ETH close above $6k?", "price": 0.44, "volume": 120000},
             trades=[{"wallet": "0xaaa", "size": 1500}],
@@ -208,8 +198,12 @@ def test_multiple_market_ids_resolve_all_titles() -> None:
 
 def test_fallback_uses_cached_title_when_api_unavailable() -> None:
     async def _run() -> None:
-        falcon_alpha._market_title_cache.clear()
-        falcon_alpha._market_title_cache["m500"] = "Will CPI print under 2.5%?"
+        normalize_external_signal(
+            market={"market_id": "m500", "question": "Will CPI print under 2.5%?"},
+            trades=[],
+            candles=[],
+            orderbook=[],
+        )
 
         async def failing_transport(_: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError("falcon_down")
@@ -225,8 +219,6 @@ def test_fallback_uses_cached_title_when_api_unavailable() -> None:
 
 def test_partial_falcon_failure_uses_resolved_market_title_not_numeric_placeholder() -> None:
     async def _run() -> None:
-        falcon_alpha._market_title_cache.clear()
-
         transport = _CaptureTransport(
             responses=[
                 {"data": [{"market_id": "m900", "question": "Will Fed cut rates in June?", "price": 0.52, "volume": 88000}]},


### PR DESCRIPTION
### Motivation
- Fix cases where views fell back to numeric placeholders like `Market {id}` by ensuring `market_title` is resolved from external metadata when only `market_id` is present.
- Prefer authoritative title sources (Falcon markets endpoint or cached metadata) and only use the `Market {id}` placeholder if the API fails and no cached title exists.
- Make normalization deterministic by guaranteeing `market_title` is populated in Falcon normalization (data-layer) so downstream Telegram/portfolio payloads render human-readable titles.

### Description
- Added an in-memory title cache and helper functions in `projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py`: `_market_title_cache`, `get_cached_market_title`, `_cache_market_title`, and `_resolve_market_title`, and populated the cache during `normalize_external_signal` when a real title is present.
- Changed `fetch_external_alpha_with_fallback` to return `market_title` from the cache or `Market {id}` only as a strict last-resort fallback.
- Updated `projects/polymarket/polyquantbot/data/market_context.py` to prefer resolved titles and consult the Falcon cache when the Polymarket API is unavailable, and to keep `market_title` authoritative in `get_market_context_with_external_alpha` merged payloads.
- Added focused tests and a FORGE report and updated `PROJECT_STATE.md`; modified `projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` to cover single/multi-market resolution and cached-fallback behavior.

### Testing
- Ran static compile checks with `python -m py_compile projects/polymarket/polyquantbot/data/market_context.py projects/polymarket/polyquantbot/data/ingestion/falcon_alpha.py projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py` and it passed.
- Ran unit tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p14_2_external_alpha_ingestion_falcon_20260409.py projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py` and all tests passed (`13 passed`, one pytest config warning about `asyncio_mode`).
- Executed a runtime proof script that demonstrates the BEFORE/AFTER examples: `BEFORE: Market 540816` → `AFTER: Will BTC close above $120k in 2026?` and multi-market examples (`m100 -> Will ETH close above $6k? | m200 -> Will SOL close above $300?`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c6b9048c832e8244f61043026b96)