### PR TITLE
Add P16 Execution Validation & Risk Enforcement Layer

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 16:03
-- Status        : FORGE-X completed market title resolution test hardening follow-up (private-cache-free regression coverage) and is pending auto PR review + COMMANDER review.
+- Last Updated  : 2026-04-09 16:45
+- Status        : FORGE-X completed P16 execution validation & risk enforcement control-layer implementation and is pending SENTINEL validation before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P16 execution validation & risk enforcement layer (2026-04-09): implemented runtime pre-trade hard-block validation, execution truth capture, closed-trade edge validation, and global risk kill-switch enforcement in strategy-trigger execution path with focused MAJOR runtime-proof tests.
 - Market title resolution test hardening follow-up (2026-04-09): removed private cache mutation from Falcon title regression tests, seeded fallback cache through public normalization behavior, and preserved partial-failure/no-placeholder assertions.
 - Market title resolution follow-up hardening (2026-04-09): fixed partial Falcon failure path so successful markets title resolution is cached before downstream fetches, preventing fallback to numeric placeholder when later Falcon calls fail, and added focused regression coverage.
 - Market title resolution fix from market_id (2026-04-09): resolved real `market_title` via Falcon market metadata/cache in touched data-layer path, enforced strict placeholder fallback only when API unavailable with no cached title, and added focused regression tests for single/multi-market and fallback behavior.
@@ -120,6 +121,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P16 execution validation & risk enforcement handoff
+- MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for strategy-trigger execution interception, execution-truth capture, edge validation, and global risk block enforcement in touched runtime path.
+- SENTINEL validation is required before merge.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
@@ -255,12 +260,13 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_32_p15_strategy_selection_auto_weighting.md
-Tier: STANDARD
+SENTINEL validation required before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- P16 control layer is currently integrated in strategy-trigger runtime path only; additional non-trigger execution entry surfaces (if introduced later) require separate wiring to inherit identical enforcement guarantees.
 - P15 strategy weighting is currently narrow integration in S4 path only and is not yet wired into broader non-S4 runtime orchestration/telemetry surfaces.
 - P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces; insufficient-data fallback now prevents external weighting when Falcon evidence is unavailable.
 - P14.2 Falcon ingestion is FOUNDATION claim-level only (data ingestion + normalization + adapter); broader runtime orchestration wiring remains out of scope.

--- a/projects/polymarket/polyquantbot/core/analytics/trade_validator.py
+++ b/projects/polymarket/polyquantbot/core/analytics/trade_validator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class TradeValidator:
+    """Validates realized outcomes against expected edge after trade close."""
+
+    def validate_closed_trade(
+        self,
+        *,
+        trade_id: str,
+        expected_edge: float,
+        entry_price: float,
+        exit_price: float,
+        side: str,
+        execution_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        entry = max(float(entry_price), 1e-9)
+        raw_return = (float(exit_price) - entry) / entry
+        direction = 1.0 if str(side).upper() == "YES" else -1.0
+        actual_return = raw_return * direction
+        expected = max(float(expected_edge), 0.0)
+        edge_captured = (actual_return / expected) if expected > 0.0 else 0.0
+        return {
+            "trade_id": trade_id,
+            "expected_edge": round(expected, 6),
+            "actual_return": round(actual_return, 6),
+            "edge_captured": round(edge_captured, 6),
+            "execution_degradation": edge_captured < 0.5,
+            "execution_data": dict(execution_data),
+        }

--- a/projects/polymarket/polyquantbot/core/execution/execution_tracker.py
+++ b/projects/polymarket/polyquantbot/core/execution/execution_tracker.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+class ExecutionTracker:
+    """Captures expected vs actual execution truth without changing execution behavior."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict[str, Any]] = {}
+
+    def record_order_submission(
+        self,
+        *,
+        trade_id: str,
+        expected_price: float,
+        signal_data: dict[str, Any],
+        decision_data: dict[str, Any],
+        order_timestamp: datetime | None = None,
+    ) -> None:
+        now = order_timestamp or datetime.now(timezone.utc)
+        self._records[trade_id] = {
+            "trade_id": trade_id,
+            "expected_price": float(expected_price),
+            "actual_fill_price": None,
+            "slippage": None,
+            "order_timestamp": now.isoformat(),
+            "fill_timestamp": None,
+            "latency_ms": None,
+            "signal_data": dict(signal_data),
+            "decision_data": dict(decision_data),
+        }
+
+    def record_fill(
+        self,
+        *,
+        trade_id: str,
+        actual_fill_price: float,
+        fill_timestamp: datetime | None = None,
+    ) -> dict[str, Any]:
+        record = self._records.get(trade_id)
+        if record is None:
+            raise ValueError(f"missing execution record for trade_id={trade_id}")
+        fill_ts = fill_timestamp or datetime.now(timezone.utc)
+        order_ts = datetime.fromisoformat(str(record["order_timestamp"]))
+        slippage = float(actual_fill_price) - float(record["expected_price"])
+        latency_ms = max((fill_ts - order_ts).total_seconds() * 1000.0, 0.0)
+        record["actual_fill_price"] = float(actual_fill_price)
+        record["slippage"] = round(slippage, 6)
+        record["fill_timestamp"] = fill_ts.isoformat()
+        record["latency_ms"] = round(latency_ms, 3)
+        return dict(record)
+
+    def get_execution_data(self, trade_id: str) -> dict[str, Any]:
+        record = self._records.get(trade_id)
+        if record is None:
+            raise ValueError(f"missing execution record for trade_id={trade_id}")
+        return dict(record)

--- a/projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py
+++ b/projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PreTradeValidationResult:
+    decision: str
+    reason: str
+    checks: dict[str, float | bool]
+
+
+class PreTradeValidator:
+    """Deterministic hard-block validator for execution readiness."""
+
+    def __init__(
+        self,
+        *,
+        min_liquidity_usd: float = 10_000.0,
+        max_spread: float = 0.04,
+        max_position_size_ratio: float = 0.10,
+        max_concurrent_trades: int = 5,
+        max_correlated_exposure_ratio: float = 0.40,
+        max_drawdown_ratio: float = 0.08,
+        daily_loss_limit: float = -2_000.0,
+    ) -> None:
+        self._min_liquidity_usd = min_liquidity_usd
+        self._max_spread = max_spread
+        self._max_position_size_ratio = max_position_size_ratio
+        self._max_concurrent_trades = max_concurrent_trades
+        self._max_correlated_exposure_ratio = max_correlated_exposure_ratio
+        self._max_drawdown_ratio = max_drawdown_ratio
+        self._daily_loss_limit = daily_loss_limit
+
+    def validate(
+        self,
+        *,
+        signal_data: dict[str, Any],
+        decision_data: dict[str, Any],
+        risk_state: dict[str, Any],
+    ) -> PreTradeValidationResult:
+        expected_value = float(signal_data.get("expected_value", 0.0))
+        edge = float(signal_data.get("edge", 0.0))
+        liquidity = float(signal_data.get("liquidity_usd", 0.0))
+        spread = float(signal_data.get("spread", 0.0))
+        position_size = max(float(decision_data.get("position_size", 0.0)), 0.0)
+        portfolio_equity = max(float(risk_state.get("equity", 0.0)), 0.0)
+        max_position_allowed = portfolio_equity * self._max_position_size_ratio
+        concurrent_trades = int(risk_state.get("open_trades", 0))
+        correlated_exposure = max(float(risk_state.get("correlated_exposure_ratio", 0.0)), 0.0)
+        drawdown_ratio = max(float(risk_state.get("drawdown_ratio", 0.0)), 0.0)
+        daily_loss = float(risk_state.get("daily_loss", 0.0))
+        global_trade_block = bool(risk_state.get("global_trade_block", False))
+
+        checks: dict[str, float | bool] = {
+            "expected_value": expected_value,
+            "edge": edge,
+            "liquidity_usd": liquidity,
+            "spread": spread,
+            "position_size": position_size,
+            "max_position_allowed": max_position_allowed,
+            "open_trades": concurrent_trades,
+            "correlated_exposure_ratio": correlated_exposure,
+            "drawdown_ratio": drawdown_ratio,
+            "daily_loss": daily_loss,
+            "global_trade_block": global_trade_block,
+        }
+
+        if global_trade_block:
+            return PreTradeValidationResult("BLOCK", "global_trade_block_active", checks)
+        if expected_value <= 0.0:
+            return PreTradeValidationResult("BLOCK", "ev_non_positive", checks)
+        if edge <= 0.0:
+            return PreTradeValidationResult("BLOCK", "edge_non_positive", checks)
+        if liquidity < self._min_liquidity_usd:
+            return PreTradeValidationResult("BLOCK", "liquidity_below_threshold", checks)
+        if spread > self._max_spread:
+            return PreTradeValidationResult("BLOCK", "spread_above_threshold", checks)
+        if position_size <= 0.0 or (max_position_allowed > 0.0 and position_size > max_position_allowed):
+            return PreTradeValidationResult("BLOCK", "position_size_limit_exceeded", checks)
+        if concurrent_trades >= self._max_concurrent_trades:
+            return PreTradeValidationResult("BLOCK", "max_concurrent_trades_exceeded", checks)
+        if correlated_exposure > self._max_correlated_exposure_ratio:
+            return PreTradeValidationResult("BLOCK", "correlated_exposure_exceeded", checks)
+        if daily_loss <= self._daily_loss_limit:
+            return PreTradeValidationResult("BLOCK", "daily_loss_limit_breached", checks)
+        if drawdown_ratio > self._max_drawdown_ratio:
+            return PreTradeValidationResult("BLOCK", "max_drawdown_breached", checks)
+        return PreTradeValidationResult("ALLOW", "passed", checks)

--- a/projects/polymarket/polyquantbot/core/risk/risk_engine.py
+++ b/projects/polymarket/polyquantbot/core/risk/risk_engine.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class RiskState:
+    equity: float
+    portfolio_pnl: float
+    drawdown_ratio: float
+    daily_loss: float
+    open_trades: int
+    correlated_exposure_ratio: float
+    global_trade_block: bool
+
+
+class RiskEngine:
+    """System-level risk state tracker with hard global block enforcement."""
+
+    def __init__(
+        self,
+        *,
+        max_drawdown_ratio: float = 0.08,
+        daily_loss_limit: float = -2_000.0,
+    ) -> None:
+        self._max_drawdown_ratio = max_drawdown_ratio
+        self._daily_loss_limit = daily_loss_limit
+        self._peak_equity = 0.0
+        self._equity = 0.0
+        self._portfolio_pnl = 0.0
+        self._drawdown_ratio = 0.0
+        self._daily_pnl_by_day: dict[str, float] = {}
+        self._open_trades = 0
+        self._correlated_exposure_ratio = 0.0
+        self._global_trade_block = False
+
+    def update_from_snapshot(
+        self,
+        *,
+        equity: float,
+        realized_pnl: float,
+        open_trades: int,
+        correlated_exposure_ratio: float,
+    ) -> RiskState:
+        self._equity = float(equity)
+        self._portfolio_pnl = float(realized_pnl)
+        self._open_trades = max(int(open_trades), 0)
+        self._correlated_exposure_ratio = max(float(correlated_exposure_ratio), 0.0)
+        if self._peak_equity <= 0.0:
+            self._peak_equity = self._equity
+        self._peak_equity = max(self._peak_equity, self._equity)
+        if self._peak_equity > 0.0:
+            self._drawdown_ratio = max((self._peak_equity - self._equity) / self._peak_equity, 0.0)
+        else:
+            self._drawdown_ratio = 0.0
+        self._refresh_global_block()
+        return self.get_state()
+
+    def record_trade_pnl(self, pnl: float) -> RiskState:
+        today_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        self._daily_pnl_by_day[today_key] = self._daily_pnl_by_day.get(today_key, 0.0) + float(pnl)
+        self._refresh_global_block()
+        return self.get_state()
+
+    def get_state(self) -> RiskState:
+        today_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        daily_loss = min(self._daily_pnl_by_day.get(today_key, 0.0), 0.0)
+        return RiskState(
+            equity=self._equity,
+            portfolio_pnl=self._portfolio_pnl,
+            drawdown_ratio=self._drawdown_ratio,
+            daily_loss=daily_loss,
+            open_trades=self._open_trades,
+            correlated_exposure_ratio=self._correlated_exposure_ratio,
+            global_trade_block=self._global_trade_block,
+        )
+
+    def as_dict(self) -> dict[str, float | int | bool]:
+        state = self.get_state()
+        return {
+            "equity": state.equity,
+            "portfolio_pnl": state.portfolio_pnl,
+            "drawdown_ratio": state.drawdown_ratio,
+            "daily_loss": state.daily_loss,
+            "open_trades": state.open_trades,
+            "correlated_exposure_ratio": state.correlated_exposure_ratio,
+            "global_trade_block": state.global_trade_block,
+        }
+
+    def _refresh_global_block(self) -> None:
+        state = self.get_state()
+        self._global_trade_block = (
+            state.drawdown_ratio > self._max_drawdown_ratio
+            or state.daily_loss <= self._daily_loss_limit
+        )

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -5,11 +5,16 @@ import time
 import structlog
 import uuid
 import re
+from typing import Any
 
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
 from .trade_trace import TradeTraceEngine
 from ..strategy.falcon_alpha_strategy import FalconSignal
+from ..core.analytics.trade_validator import TradeValidator
+from ..core.execution.execution_tracker import ExecutionTracker
+from ..core.risk.pre_trade_validator import PreTradeValidator
+from ..core.risk.risk_engine import RiskEngine
 
 log = structlog.get_logger(__name__)
 
@@ -308,6 +313,11 @@ class StrategyTrigger:
         self._last_adjustment_explanation: str = "adaptive defaults active"
         self._position_peak_pnl: dict[str, float] = {}
         self._position_entry_context: dict[str, dict[str, object]] = {}
+        self._pre_trade_validator = PreTradeValidator()
+        self._execution_tracker = ExecutionTracker()
+        self._trade_validator = TradeValidator()
+        self._risk_engine = RiskEngine()
+        self._trade_traceability: dict[str, dict[str, Any]] = {}
         self._optimization_output: dict[str, object] = {
             "strategy_weights": {"S1": 1.0, "S2": 1.0, "S3": 1.0, "S5": 1.0},
             "regime_weights": {"NEWS": 1.0, "ARBITRAGE": 1.0, "SMART_MONEY": 1.0, "CHAOTIC": 1.0},
@@ -2031,6 +2041,12 @@ class StrategyTrigger:
         self.refresh_optimization_output()
 
         snapshot = await self._engine.snapshot()
+        self._risk_engine.update_from_snapshot(
+            equity=snapshot.equity,
+            realized_pnl=snapshot.realized_pnl,
+            open_trades=len(snapshot.positions),
+            correlated_exposure_ratio=float((market_context or {}).get("correlated_exposure_ratio", 0.0)),
+        )
         open_pos = next((p for p in snapshot.positions if p.market_id == self._config.market_id), None)
 
         market_snapshot = MarketSnapshot(
@@ -2122,6 +2138,7 @@ class StrategyTrigger:
                 )
                 return "BLOCKED"
             size = readiness.adjusted_size
+            trade_id = str(uuid.uuid4())
             selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             candidate_title = (
                 str(selected_metadata.get("title") or selected_metadata.get("market_title", ""))
@@ -2130,13 +2147,51 @@ class StrategyTrigger:
                 and (selected_metadata.get("title") or selected_metadata.get("market_title"))
                 else target_market_id
             )
+            signal_data = {
+                "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
+                "edge": signal_edge,
+                "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                "spread": float((market_context or {}).get("spread", 0.0)),
+            }
+            decision_data = {
+                "position_size": size,
+                "target_market_id": target_market_id,
+                "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+            }
+            validation_result = self._pre_trade_validator.validate(
+                signal_data=signal_data,
+                decision_data=decision_data,
+                risk_state=self._risk_engine.as_dict(),
+            )
+            if validation_result.decision != "ALLOW":
+                self._trade_traceability[trade_id] = {
+                    "trade_id": trade_id,
+                    "signal_data": signal_data,
+                    "decision_data": decision_data,
+                    "validation_result": {
+                        "decision": validation_result.decision,
+                        "reason": validation_result.reason,
+                        "checks": validation_result.checks,
+                    },
+                    "execution_data": {},
+                    "outcome_data": {},
+                    "risk_state": self._risk_engine.as_dict(),
+                }
+                log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
+                return "BLOCKED"
+            self._execution_tracker.record_order_submission(
+                trade_id=trade_id,
+                expected_price=readiness.expected_fill_price,
+                signal_data=signal_data,
+                decision_data=decision_data,
+            )
             created = await self._engine.open_position(
                 market=target_market_id,
                 market_title=str(candidate_title),
                 side=self._config.side,
                 price=readiness.expected_fill_price,
                 size=size,
-                position_id=str(uuid.uuid4()),
+                position_id=trade_id,
                 position_context={
                     "strategy_source": (
                         selected_candidate.strategy_name
@@ -2153,9 +2208,14 @@ class StrategyTrigger:
                     "theoretical_edge": signal_edge,
                     "slippage_impact": readiness.expected_slippage,
                     "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
+                    "trade_id": trade_id,
                 },
             )
             if created:
+                execution_data = self._execution_tracker.record_fill(
+                    trade_id=trade_id,
+                    actual_fill_price=created.entry_price,
+                )
                 self._position_entry_context[created.position_id] = {
                     "strategy_source": (
                         selected_candidate.strategy_name
@@ -2172,6 +2232,20 @@ class StrategyTrigger:
                     "theoretical_edge": signal_edge,
                     "slippage_impact": readiness.expected_slippage,
                     "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
+                    "trade_id": trade_id,
+                }
+                self._trade_traceability[trade_id] = {
+                    "trade_id": trade_id,
+                    "signal_data": signal_data,
+                    "decision_data": decision_data,
+                    "validation_result": {
+                        "decision": validation_result.decision,
+                        "reason": validation_result.reason,
+                        "checks": validation_result.checks,
+                    },
+                    "execution_data": execution_data,
+                    "outcome_data": {},
+                    "risk_state": self._risk_engine.as_dict(),
                 }
                 self._trace_engine.record_trace(
                     position_id=created.position_id,
@@ -2200,6 +2274,7 @@ class StrategyTrigger:
                 if exit_decision.exit_decision == "HOLD":
                     return "HOLD"
                 entry_context = self._position_entry_context.pop(tracked.position_id, {})
+                trade_id = str(entry_context.get("trade_id", tracked.position_id))
                 exit_efficiency = 0.5
                 if exit_decision.exit_reason == "momentum_weakened_after_favorable_move":
                     exit_efficiency = 1.0
@@ -2214,6 +2289,24 @@ class StrategyTrigger:
                         "exit_efficiency": exit_efficiency,
                     },
                 )
+                validation_data = self._trade_validator.validate_closed_trade(
+                    trade_id=trade_id,
+                    expected_edge=float(entry_context.get("theoretical_edge", 0.0)),
+                    entry_price=tracked.entry_price,
+                    exit_price=market_price,
+                    side=tracked.side,
+                    execution_data=self._execution_tracker.get_execution_data(trade_id),
+                )
+                updated_risk_state = self._risk_engine.record_trade_pnl(tracked.pnl)
+                self._trade_traceability[trade_id] = {
+                    "trade_id": trade_id,
+                    "signal_data": self._trade_traceability.get(trade_id, {}).get("signal_data", {}),
+                    "decision_data": self._trade_traceability.get(trade_id, {}).get("decision_data", {}),
+                    "validation_result": self._trade_traceability.get(trade_id, {}).get("validation_result", {}),
+                    "execution_data": self._execution_tracker.get_execution_data(trade_id),
+                    "outcome_data": validation_data,
+                    "risk_state": self._risk_engine.as_dict() | {"global_trade_block": updated_risk_state.global_trade_block},
+                }
                 self._position_peak_pnl.pop(str(getattr(tracked, "position_id", "")), None)
                 self._trace_engine.record_trace(
                     position_id=tracked.position_id,
@@ -2230,3 +2323,9 @@ class StrategyTrigger:
                 return "CLOSED"
 
         return "HOLD"
+
+    def get_trade_trace(self, trade_id: str) -> dict[str, Any]:
+        trace = self._trade_traceability.get(trade_id)
+        if trace is None:
+            return {}
+        return dict(trace)

--- a/projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
@@ -1,0 +1,84 @@
+# 24_33_p16_execution_validation_risk_enforcement_layer
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  - Pre-trade hard blocking (`EV`, `edge`, liquidity, spread, position size, concurrent trades, correlated exposure, daily loss, drawdown)
+  - Execution truth capture (expected/actual/slippage/timestamps/latency)
+  - Closed-trade edge validation (`expected_edge`, `actual_return`, `edge_captured`, degradation flag)
+  - Runtime risk enforcement (`portfolio_pnl`, `drawdown`, `daily_loss`, `global_trade_block`)
+  - Execution interception chain: decision output → pre-trade validator → execution → execution tracker → trade validator
+- Not in Scope:
+  - Strategy logic (S1–S5)
+  - Weighting system (P15)
+  - UI/dashboard
+  - Arbitrage
+  - ML changes
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md`. Tier: MAJOR
+
+## 1. What was built
+- Added deterministic pre-trade hard-block validation layer in `core/risk/pre_trade_validator.py` with explicit `ALLOW` / `BLOCK` decisions and concrete reasons.
+- Added execution truth capture layer in `core/execution/execution_tracker.py` for expected price, actual fill, slippage, order/fill timestamps, and latency.
+- Added post-trade edge validation layer in `core/analytics/trade_validator.py` for `expected_edge`, `actual_return`, `edge_captured`, and degradation flag (`edge_captured < 0.5`).
+- Added global risk enforcement engine in `core/risk/risk_engine.py` tracking portfolio PnL, drawdown, daily loss, and global kill-switch (`global_trade_block`).
+- Integrated the control layer into `execution/strategy_trigger.py` so execution is blocked when pre-trade validation fails (no validation → no execution), execution truth is captured on open, and closed-trade outcomes are validated and attached to end-to-end traceability.
+
+## 2. Current system architecture
+- `execution/strategy_trigger.py`
+  - runtime orchestration now enforces: decision output → `PreTradeValidator` → execution (`ExecutionEngine.open_position`) → `ExecutionTracker` → `TradeValidator`.
+  - updates `RiskEngine` from runtime snapshot on each evaluation.
+  - blocks execution when validator decision is `BLOCK`.
+  - records per-trade traceability envelope with required fields:
+    - `trade_id`
+    - `signal_data`
+    - `decision_data`
+    - `validation_result`
+    - `execution_data`
+    - `outcome_data`
+    - `risk_state`
+- `core/risk/pre_trade_validator.py`
+  - deterministic hard checks with explicit reason mapping.
+- `core/execution/execution_tracker.py`
+  - passive execution recorder (non-mutating).
+- `core/analytics/trade_validator.py`
+  - closed-trade quality validator with degradation flag.
+- `core/risk/risk_engine.py`
+  - global block source of truth for drawdown / daily-loss breaches.
+
+## 3. Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/execution/execution_tracker.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/analytics/trade_validator.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Pre-trade blocking works for invalid EV and prevents execution.
+- Successful trade path records execution truth fields (`expected_price`, `actual_fill_price`, `slippage`, timestamps, latency).
+- Risk breach simulation activates global trade block and prevents new positions.
+- End-to-end trade trace envelope is populated and retrievable via `StrategyTrigger.get_trade_trace(trade_id)`.
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py projects/polymarket/polyquantbot/core/risk/risk_engine.py projects/polymarket/polyquantbot/core/execution/execution_tracker.py projects/polymarket/polyquantbot/core/analytics/trade_validator.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅ (`3 passed`)
+
+### Runtime-proof test coverage
+- ≥1 blocked trade test: covered (`test_p16_pre_trade_block_when_ev_non_positive`)
+- ≥1 successful tracked trade: covered (`test_p16_successful_trade_records_execution_trace`)
+- ≥1 risk breach simulation: covered (`test_p16_risk_breach_triggers_global_block`)
+- Control layer actively intercepts execution: verified via blocked decision with zero opened positions.
+
+## 5. Known issues
+- P16 is integrated in the strategy-trigger runtime path and is not yet propagated to every non-trigger execution entry surface (if any future alternate entry surfaces are introduced).
+- Existing pytest environment warning remains: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- SENTINEL validation required before merge (MAJOR tier).
+- Suggested next build step: P17 — Portfolio Intelligence Layer.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+def _build_aggregation(edge: float = 0.05) -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S1",
+        decision="ENTER",
+        reason="test_signal",
+        edge=edge,
+        confidence=0.9,
+        score=0.95,
+        market_metadata={"market_id": "MARKET-1", "title": "Test Market"},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S1",
+        ranked_candidates=[candidate],
+        selection_reason="highest_score",
+        top_score=0.95,
+        decision="ENTER",
+    )
+
+
+def _build_trigger(starting_equity: float = 10_000.0) -> StrategyTrigger:
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=starting_equity),
+        config=StrategyConfig(market_id="MARKET-1", threshold=0.60, target_pnl=2.0),
+    )
+    trigger._cooldown_seconds = 0.0  # noqa: SLF001
+    trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+    return trigger
+
+
+def test_p16_pre_trade_block_when_ev_non_positive() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.0,
+                "liquidity_usd": 20_000.0,
+                "spread": 0.01,
+                "best_bid": 0.44,
+                "best_ask": 0.46,
+            },
+        )
+        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+        assert decision == "BLOCKED"
+        assert len(snapshot.positions) == 0
+
+    asyncio.run(_run())
+
+
+def test_p16_successful_trade_records_execution_trace() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        assert decision == "OPENED"
+        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+        assert len(snapshot.positions) == 1
+        trade_id = snapshot.positions[0].position_id
+        trace = trigger.get_trade_trace(trade_id)
+        assert trace["validation_result"]["decision"] == "ALLOW"
+        assert trace["execution_data"]["expected_price"] is not None
+        assert trace["execution_data"]["actual_fill_price"] is not None
+        assert trace["execution_data"]["latency_ms"] is not None
+
+    asyncio.run(_run())
+
+
+def test_p16_risk_breach_triggers_global_block() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger(starting_equity=10_000.0)
+        trigger._risk_engine.update_from_snapshot(  # noqa: SLF001
+            equity=9_100.0,
+            realized_pnl=-2_100.0,
+            open_trades=0,
+            correlated_exposure_ratio=0.0,
+        )
+        trigger._risk_engine.record_trade_pnl(-2_100.0)  # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+        assert decision == "BLOCKED"
+        assert trigger._risk_engine.get_state().global_trade_block is True  # noqa: SLF001
+        assert len(snapshot.positions) == 0
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Implement a system-level control layer to enforce pre-trade risk rules, capture execution truth, validate realized edge, and provide a global kill switch as required by P16 (Validation Tier: MAJOR, Claim Level: FULL RUNTIME INTEGRATION). 
- Ensure `NO VALIDATION → NO EXECUTION` in the strategy-trigger path and provide end-to-end traceability for each trade.

### Description
- Added deterministic pre-trade hard-blocking logic in `projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py` that returns `ALLOW` / `BLOCK` with explicit reasons for `EV`, `edge`, liquidity, spread, position sizing, concurrency, correlated exposure, daily loss, and drawdown checks. 
- Implemented a runtime `RiskEngine` in `projects/polymarket/polyquantbot/core/risk/risk_engine.py` to track equity/PnL, drawdown, daily loss and to enforce `global_trade_block` when drawdown or daily-loss thresholds are breached. 
- Added a passive `ExecutionTracker` in `projects/polymarket/polyquantbot/core/execution/execution_tracker.py` to record `expected_price`, `actual_fill_price`, `slippage`, order/fill timestamps and latency, and a closed-trade `TradeValidator` in `projects/polymarket/polyquantbot/core/analytics/trade_validator.py` to compute `expected_edge`, `actual_return`, `edge_captured` and flag degradation when `edge_captured < 0.5`. 
- Integrated the chain into `projects/polymarket/polyquantbot/execution/strategy_trigger.py` so the flow is: decision output → `PreTradeValidator` → execution (`ExecutionEngine.open_position`) → `ExecutionTracker` → `TradeValidator`, and exposed per-trade trace envelopes containing `trade_id`, `signal_data`, `decision_data`, `validation_result`, `execution_data`, `outcome_data`, and `risk_state`. 
- Added focused runtime tests in `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` and a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md`, and updated `PROJECT_STATE.md` to hand off to SENTINEL.

### Testing
- Static compile check passed with `python -m py_compile` on all new/modified modules; command run: `python -m py_compile projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py projects/polymarket/polyquantbot/core/risk/risk_engine.py projects/polymarket/polyquantbot/core/execution/execution_tracker.py projects/polymarket/polyquantbot/core/analytics/trade_validator.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` (PASS). 
- Unit tests run with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` resulting in `3 passed` (covers blocked trade, successful tracked trade, and risk-breach global-block simulation). 
- No phase*/ structural violations were found and the change is ready for SENTINEL validation (MAJOR) before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d09fba34832e890d377a4495aa51)