### PR TITLE
SENTINEL: Approve P16 execution validation & risk enforcement layer (APPROVED)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 16:45
-- Status        : FORGE-X completed P16 execution validation & risk enforcement control-layer implementation and is pending SENTINEL validation before merge.
+- Last Updated  : 2026-04-09 16:58
+- Status        : SENTINEL validated P16 execution validation & risk enforcement control-layer implementation as APPROVED (MAJOR gate satisfied).
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- SENTINEL validation complete for P16 execution validation & risk enforcement layer (2026-04-09): verdict **APPROVED** after runtime verification of pre-trade blocking, execution truth capture, edge validation, risk global-block enforcement, interception chain, and end-to-end traceability in declared scope.
 - P16 execution validation & risk enforcement layer (2026-04-09): implemented runtime pre-trade hard-block validation, execution truth capture, closed-trade edge validation, and global risk kill-switch enforcement in strategy-trigger execution path with focused MAJOR runtime-proof tests.
 - Market title resolution test hardening follow-up (2026-04-09): removed private cache mutation from Falcon title regression tests, seeded fallback cache through public normalization behavior, and preserved partial-failure/no-placeholder assertions.
 - Market title resolution follow-up hardening (2026-04-09): fixed partial Falcon failure path so successful markets title resolution is cached before downstream fetches, preventing fallback to numeric placeholder when later Falcon calls fail, and added focused regression coverage.
@@ -124,7 +125,7 @@ Status:
 
 ### P16 execution validation & risk enforcement handoff
 - MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for strategy-trigger execution interception, execution-truth capture, edge validation, and global risk block enforcement in touched runtime path.
-- SENTINEL validation is required before merge.
+- SENTINEL validation completed with verdict APPROVED; ready for COMMANDER merge decision.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_34_p16_execution_validation_risk_enforcement_layer_sentinel.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_34_p16_execution_validation_risk_enforcement_layer_sentinel.md
@@ -1,0 +1,95 @@
+# 24_34_p16_execution_validation_risk_enforcement_layer_sentinel
+
+## Validation Metadata
+- Task: P16 — Execution Validation & Risk Enforcement Layer
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Scope: runtime enforcement path in `execution/strategy_trigger.py` and supporting control-layer modules under `core/risk`, `core/execution`, and `core/analytics`.
+- Source Forge Report: `projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md`
+
+## Verdict
+- **APPROVED**
+
+Rationale:
+- All six validation targets were evidenced by code-path inspection plus runtime proof in the touched execution path.
+- No critical capital-safety contradiction was found in the declared validation target.
+
+## Validation Evidence
+
+### 1) Pre-Trade Hard Blocking (authoritative interception)
+Code evidence:
+- `PreTradeValidator.validate()` returns deterministic `BLOCK` reasons for all required gates: EV, edge, liquidity, spread, position sizing cap, concurrent trade cap, correlated exposure cap, daily-loss breach, drawdown breach, and global trade block. (`projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py`)
+- `StrategyTrigger.evaluate()` calls `PreTradeValidator` before `open_position`; if decision is not `ALLOW`, it writes traceability payload and returns `BLOCKED` (no execution call). (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`)
+
+Runtime evidence:
+- Dedicated runtime validation script asserted all required block reasons and verified blocked decisions produce zero opened positions.
+- Log evidence showed explicit block reason emission (e.g., `pre_trade_blocked reason=ev_non_positive` and `reason=global_trade_block_active`).
+
+Result: **PASS**
+
+### 2) Execution Truth Capture
+Code evidence:
+- `ExecutionTracker` records `expected_price`, `actual_fill_price`, `slippage`, `order_timestamp`, `fill_timestamp`, and `latency_ms` with non-null fill-time completion on successful execution. (`projects/polymarket/polyquantbot/core/execution/execution_tracker.py`)
+- `StrategyTrigger.evaluate()` records submission pre-open and fill post-open, then stores execution payload under trade traceability envelope.
+
+Runtime evidence:
+- Successful execution path created a trace with all execution-truth fields populated and consistent.
+
+Result: **PASS**
+
+### 3) Edge Validation
+Code evidence:
+- `TradeValidator.validate_closed_trade()` computes `expected_edge`, signed `actual_return`, `edge_captured = actual_return / expected_edge`, and sets degradation flag when `edge_captured < 0.5`. (`projects/polymarket/polyquantbot/core/analytics/trade_validator.py`)
+- `StrategyTrigger.evaluate()` invokes validator on close and persists output in `outcome_data`.
+
+Runtime evidence:
+- Forced close path (`signal_invalidated=True`) produced closed-trade outcome with computed `edge_captured`; assertion confirmed formula correctness and degradation flag trigger.
+
+Result: **PASS**
+
+### 4) Risk Engine Enforcement
+Code evidence:
+- `RiskEngine` tracks equity, portfolio PnL, drawdown, daily loss, open trades, correlated exposure, and computes `global_trade_block` when drawdown > 8% or daily loss <= -2000. (`projects/polymarket/polyquantbot/core/risk/risk_engine.py`)
+- `StrategyTrigger.evaluate()` refreshes risk state each cycle and feeds state into pre-trade validator gate.
+
+Runtime evidence:
+- Drawdown-breach and daily-loss-breach scenarios activated global trade block.
+- With `global_trade_block_active`, entry attempt was blocked and zero positions were opened.
+- Block remains active until state no longer breaches risk condition (condition-based reset).
+
+Result: **PASS**
+
+### 5) Execution Interception Chain
+Required chain:
+`decision_output → pre_trade_validator → execution → execution_tracker → trade_validator`
+
+Code/runtime evidence:
+- Entry path enforces pre-trade validation before execution.
+- Execution tracker wraps order submission/fill around open.
+- Close path routes to trade validator and updates lifecycle traceability object.
+- Negative test showed “no validation allow” leads to `BLOCKED` and no open position.
+
+Result: **PASS**
+
+### 6) End-to-End Traceability
+Required envelope keys:
+`trade_id`, `signal_data`, `decision_data`, `validation_result`, `execution_data`, `outcome_data`, `risk_state`
+
+Code/runtime evidence:
+- `StrategyTrigger` writes all required keys for blocked/opened/closed lifecycle updates.
+- Runtime checks confirmed key presence and lifecycle consistency (entry trace + close enrichment).
+
+Result: **PASS**
+
+## Commands Executed
+1. `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/execution/execution_tracker.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/analytics/trade_validator.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+3. `python - <<'PY' ... P16_SENTINEL_RUNTIME_VALIDATION ... PY`
+
+## Findings
+- No critical blocker in declared validation scope.
+- Existing pytest warning remains unrelated to this task objective: `Unknown config option: asyncio_mode`.
+
+## Decision
+- **APPROVED**
+- Merge gate (SENTINEL for MAJOR) is satisfied for P16 declared scope and claim level.


### PR DESCRIPTION
### Motivation
- Validate the FORGE-X P16 delivery that enforces pre-trade hard-blocking, execution truth capture, closed-trade edge validation, global risk enforcement, and an active execution-interception chain in the strategy-trigger runtime path.
- Produce an authoritative SENTINEL verdict and record state so the MAJOR-tier, FULL RUNTIME INTEGRATION gate can be progressed to COMMANDER for merge.

### Description
- Added the SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/24_34_p16_execution_validation_risk_enforcement_layer_sentinel.md` with an **APPROVED** verdict and detailed evidence for each validation target, and updated `PROJECT_STATE.md` to record SENTINEL approval and a refreshed timestamp. 
- Review focused on the runtime enforcement path and supporting modules: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `projects/polymarket/polyquantbot/core/risk/pre_trade_validator.py`, `projects/polymarket/polyquantbot/core/risk/risk_engine.py`, `projects/polymarket/polyquantbot/core/execution/execution_tracker.py`, and `projects/polymarket/polyquantbot/core/analytics/trade_validator.py`.

### Testing
- Ran compilation checks with `python -m py_compile` against the impacted modules and the test file, which completed successfully (`py_compile: PASS`).
- Executed the unit/runtime tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`, which passed (`3 passed`) with one unrelated pytest config warning.
- Executed additional runtime assertion scripts that exercised all required block reasons, verified no positions open on blocked decisions, confirmed full execution-trace fields on successful opens, validated closed-trade edge calculations and degradation flag, and confirmed `global_trade_block` behavior; these runtime checks passed and were recorded in the SENTINEL report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d95bda24832eba08fd0b5382e045)