### PR TITLE
fix: P16 sentinel remediation for restart-safe risk enforcement and blocked-path traceability

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 16:58
-- Status        : SENTINEL validated P16 execution validation & risk enforcement control-layer implementation as APPROVED (MAJOR gate satisfied).
+- Last Updated  : 2026-04-09 18:32
+- Status        : FORGE-X completed P16 Sentinel remediation for restart-safe hard-block enforcement and full blocked-path traceability in touched strategy-trigger runtime path; awaiting SENTINEL MAJOR revalidation.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P16 Sentinel remediation restart-safe risk enforcement + blocked-path traceability (2026-04-09): persisted and restored P16 hard-block state (`peak_equity`, daily PnL map, global block derivation), added fail-safe block on missing/corrupt persistence input after initialization, expanded terminal blocked trace outcomes across portfolio/timing/execution-quality/pre-trade/execution-engine failure exits, and added focused runtime-proof tests.
 - SENTINEL validation complete for P16 execution validation & risk enforcement layer (2026-04-09): verdict **APPROVED** after runtime verification of pre-trade blocking, execution truth capture, edge validation, risk global-block enforcement, interception chain, and end-to-end traceability in declared scope.
 - P16 execution validation & risk enforcement layer (2026-04-09): implemented runtime pre-trade hard-block validation, execution truth capture, closed-trade edge validation, and global risk kill-switch enforcement in strategy-trigger execution path with focused MAJOR runtime-proof tests.
 - Market title resolution test hardening follow-up (2026-04-09): removed private cache mutation from Falcon title regression tests, seeded fallback cache through public normalization behavior, and preserved partial-failure/no-placeholder assertions.
@@ -123,9 +124,9 @@ Status:
 
 ## 🚧 IN PROGRESS
 
-### P16 execution validation & risk enforcement handoff
-- MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for strategy-trigger execution interception, execution-truth capture, edge validation, and global risk block enforcement in touched runtime path.
-- SENTINEL validation completed with verdict APPROVED; ready for COMMANDER merge decision.
+### P16 sentinel remediation handoff
+- MAJOR-tier FULL RUNTIME INTEGRATION remediation implementation is complete for restart-safe hard-block persistence and full blocked-path traceability in touched strategy-trigger runtime path.
+- Fresh SENTINEL revalidation is required before merge decision for PR #346.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
@@ -262,12 +263,12 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 SENTINEL validation required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md
 Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
-- P16 control layer is currently integrated in strategy-trigger runtime path only; additional non-trigger execution entry surfaces (if introduced later) require separate wiring to inherit identical enforcement guarantees.
+- P16 control layer remains intentionally integrated in strategy-trigger runtime path only; additional non-trigger execution entry surfaces (if introduced later) still require separate wiring to inherit identical enforcement guarantees.
 - P15 strategy weighting is currently narrow integration in S4 path only and is not yet wired into broader non-S4 runtime orchestration/telemetry surfaces.
 - P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces; insufficient-data fallback now prevents external weighting when Falcon evidence is unavailable.
 - P14.2 Falcon ingestion is FOUNDATION claim-level only (data ingestion + normalization + adapter); broader runtime orchestration wiring remains out of scope.

--- a/projects/polymarket/polyquantbot/core/risk/risk_engine.py
+++ b/projects/polymarket/polyquantbot/core/risk/risk_engine.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -23,6 +30,8 @@ class RiskEngine:
         *,
         max_drawdown_ratio: float = 0.08,
         daily_loss_limit: float = -2_000.0,
+        state_file: str | None = None,
+        require_state_on_startup: bool = False,
     ) -> None:
         self._max_drawdown_ratio = max_drawdown_ratio
         self._daily_loss_limit = daily_loss_limit
@@ -34,6 +43,15 @@ class RiskEngine:
         self._open_trades = 0
         self._correlated_exposure_ratio = 0.0
         self._global_trade_block = False
+        self._persistence_block_reason: str | None = None
+        configured_path = state_file or os.getenv(
+            "POLYQUANT_RISK_ENGINE_STATE_FILE",
+            "projects/polymarket/polyquantbot/infra/risk_engine_state.json",
+        )
+        self._state_file = Path(configured_path)
+        self._state_marker_file = self._state_file.with_suffix(f"{self._state_file.suffix}.initialized")
+        self._require_state_on_startup = require_state_on_startup
+        self._load_state()
 
     def update_from_snapshot(
         self,
@@ -55,12 +73,14 @@ class RiskEngine:
         else:
             self._drawdown_ratio = 0.0
         self._refresh_global_block()
+        self._persist_state()
         return self.get_state()
 
     def record_trade_pnl(self, pnl: float) -> RiskState:
         today_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         self._daily_pnl_by_day[today_key] = self._daily_pnl_by_day.get(today_key, 0.0) + float(pnl)
         self._refresh_global_block()
+        self._persist_state()
         return self.get_state()
 
     def get_state(self) -> RiskState:
@@ -76,9 +96,9 @@ class RiskEngine:
             global_trade_block=self._global_trade_block,
         )
 
-    def as_dict(self) -> dict[str, float | int | bool]:
+    def as_dict(self) -> dict[str, float | int | bool | str]:
         state = self.get_state()
-        return {
+        payload: dict[str, float | int | bool | str] = {
             "equity": state.equity,
             "portfolio_pnl": state.portfolio_pnl,
             "drawdown_ratio": state.drawdown_ratio,
@@ -87,6 +107,9 @@ class RiskEngine:
             "correlated_exposure_ratio": state.correlated_exposure_ratio,
             "global_trade_block": state.global_trade_block,
         }
+        if self._persistence_block_reason is not None:
+            payload["persistence_block_reason"] = self._persistence_block_reason
+        return payload
 
     def _refresh_global_block(self) -> None:
         state = self.get_state()
@@ -94,3 +117,75 @@ class RiskEngine:
             state.drawdown_ratio > self._max_drawdown_ratio
             or state.daily_loss <= self._daily_loss_limit
         )
+        if self._persistence_block_reason is not None:
+            self._global_trade_block = True
+
+    def _load_state(self) -> None:
+        if not self._state_file.exists():
+            marker_exists = self._state_marker_file.exists()
+            if self._require_state_on_startup or marker_exists:
+                self._persistence_block_reason = "risk_state_missing_on_startup"
+                self._refresh_global_block()
+            return
+        try:
+            payload = json.loads(self._state_file.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            self._persistence_block_reason = "risk_state_unreadable_on_startup"
+            self._refresh_global_block()
+            log.error("risk_engine_restore_failed", state_file=str(self._state_file), error=str(exc))
+            return
+
+        if not isinstance(payload, dict):
+            self._persistence_block_reason = "risk_state_invalid_payload_on_startup"
+            self._refresh_global_block()
+            log.error(
+                "risk_engine_restore_failed",
+                state_file=str(self._state_file),
+                error="invalid_payload_type",
+            )
+            return
+
+        try:
+            self._peak_equity = max(float(payload.get("peak_equity", 0.0)), 0.0)
+            self._equity = float(payload.get("equity", 0.0))
+            self._portfolio_pnl = float(payload.get("portfolio_pnl", 0.0))
+            self._drawdown_ratio = max(float(payload.get("drawdown_ratio", 0.0)), 0.0)
+            self._daily_pnl_by_day = {
+                str(key): float(value)
+                for key, value in (payload.get("daily_pnl_by_day") or {}).items()
+            }
+            self._open_trades = max(int(payload.get("open_trades", 0)), 0)
+            self._correlated_exposure_ratio = max(float(payload.get("correlated_exposure_ratio", 0.0)), 0.0)
+            self._global_trade_block = bool(payload.get("global_trade_block", False))
+            self._persistence_block_reason = None
+            self._refresh_global_block()
+            log.info(
+                "risk_engine_state_restored",
+                state_file=str(self._state_file),
+                global_trade_block=self._global_trade_block,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._persistence_block_reason = "risk_state_corrupt_on_startup"
+            self._refresh_global_block()
+            log.error("risk_engine_restore_failed", state_file=str(self._state_file), error=str(exc))
+
+    def _persist_state(self) -> None:
+        payload = {
+            "peak_equity": self._peak_equity,
+            "equity": self._equity,
+            "portfolio_pnl": self._portfolio_pnl,
+            "drawdown_ratio": self._drawdown_ratio,
+            "daily_pnl_by_day": self._daily_pnl_by_day,
+            "open_trades": self._open_trades,
+            "correlated_exposure_ratio": self._correlated_exposure_ratio,
+            "global_trade_block": self._global_trade_block,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            self._state_file.parent.mkdir(parents=True, exist_ok=True)
+            self._state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            self._state_marker_file.write_text("initialized\n", encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            self._persistence_block_reason = "risk_state_persist_failed"
+            self._refresh_global_block()
+            log.error("risk_engine_persist_failed", state_file=str(self._state_file), error=str(exc))

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -2028,6 +2028,47 @@ class StrategyTrigger:
     def _tokenize(value: str) -> list[str]:
         return [token for token in re.split(r"[^a-z0-9]+", value.lower()) if len(token) >= 3]
 
+    def _init_trade_trace(
+        self,
+        *,
+        trade_id: str,
+        signal_data: dict[str, object],
+        decision_data: dict[str, object],
+        validation_result: dict[str, object] | None = None,
+    ) -> None:
+        self._trade_traceability[trade_id] = {
+            "trade_id": trade_id,
+            "signal_data": dict(signal_data),
+            "decision_data": dict(decision_data),
+            "validation_result": dict(validation_result or {}),
+            "execution_data": {},
+            "outcome_data": {},
+            "risk_state": self._risk_engine.as_dict(),
+        }
+
+    def _record_trade_terminal_outcome(
+        self,
+        *,
+        trade_id: str,
+        outcome_status: str,
+        outcome_reason: str,
+        execution_data: dict[str, object] | None = None,
+    ) -> None:
+        trace = self._trade_traceability.get(trade_id)
+        if trace is None:
+            return
+        outcome_data = trace.setdefault("outcome_data", {})
+        if isinstance(outcome_data, dict) and outcome_data.get("terminal", False):
+            return
+        trace["outcome_data"] = {
+            "terminal": True,
+            "status": outcome_status,
+            "reason": outcome_reason,
+        }
+        if execution_data is not None:
+            trace["execution_data"] = dict(execution_data)
+        trace["risk_state"] = self._risk_engine.as_dict()
+
     async def evaluate(
         self,
         market_price: float,
@@ -2067,6 +2108,7 @@ class StrategyTrigger:
 
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
             current_total_exposure = sum(position.exposure() for position in snapshot.positions)
+            trade_id = str(uuid.uuid4())
             selected_candidate = None
             if aggregation_decision is not None and aggregation_decision.selected_trade:
                 selected_candidate = next(
@@ -2099,8 +2141,6 @@ class StrategyTrigger:
                 open_positions=list(snapshot.positions),
                 total_capital=snapshot.equity,
             )
-            if portfolio_guard.final_decision == "SKIP":
-                return "BLOCKED"
             signal_edge = max(self._config.min_edge, 0.0)
             if selected_candidate is not None:
                 signal_edge = max(selected_candidate.edge, 0.0)
@@ -2114,31 +2154,7 @@ class StrategyTrigger:
                 market_context=market_context,
                 wait_cycles=timing_wait_cycles,
             )
-            if readiness.timing_decision == "WAIT":
-                log.info(
-                    "entry_timing_wait",
-                    timing_reason=readiness.timing_reason,
-                    reference_price=readiness.reference_price,
-                    reevaluation_window=readiness.reevaluation_window,
-                )
-                return "HOLD"
-            if readiness.timing_decision == "SKIP":
-                log.info(
-                    "entry_timing_skip",
-                    timing_reason=readiness.timing_reason,
-                    reference_price=readiness.reference_price,
-                )
-                return "BLOCKED"
-            if not readiness.final_execution_readiness:
-                log.info(
-                    "execution_quality_blocked",
-                    reason=readiness.execution_quality_reason,
-                    expected_fill_price=readiness.expected_fill_price,
-                    expected_slippage=readiness.expected_slippage,
-                )
-                return "BLOCKED"
             size = readiness.adjusted_size
-            trade_id = str(uuid.uuid4())
             selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             candidate_title = (
                 str(selected_metadata.get("title") or selected_metadata.get("market_title", ""))
@@ -2158,25 +2174,77 @@ class StrategyTrigger:
                 "target_market_id": target_market_id,
                 "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
             }
+            self._init_trade_trace(
+                trade_id=trade_id,
+                signal_data=signal_data,
+                decision_data=decision_data,
+                validation_result={
+                    "decision": "PENDING",
+                    "reason": "pre_trade_validation_not_run",
+                    "checks": {},
+                },
+            )
+            if portfolio_guard.final_decision == "SKIP":
+                self._record_trade_terminal_outcome(
+                    trade_id=trade_id,
+                    outcome_status="BLOCKED",
+                    outcome_reason=f"portfolio_guard:{portfolio_guard.reason}",
+                )
+                return "BLOCKED"
+            if readiness.timing_decision == "WAIT":
+                log.info(
+                    "entry_timing_wait",
+                    timing_reason=readiness.timing_reason,
+                    reference_price=readiness.reference_price,
+                    reevaluation_window=readiness.reevaluation_window,
+                )
+                self._record_trade_terminal_outcome(
+                    trade_id=trade_id,
+                    outcome_status="BLOCKED",
+                    outcome_reason=f"timing_gate_wait:{readiness.timing_reason}",
+                )
+                return "HOLD"
+            if readiness.timing_decision == "SKIP":
+                log.info(
+                    "entry_timing_skip",
+                    timing_reason=readiness.timing_reason,
+                    reference_price=readiness.reference_price,
+                )
+                self._record_trade_terminal_outcome(
+                    trade_id=trade_id,
+                    outcome_status="BLOCKED",
+                    outcome_reason=f"timing_gate_skip:{readiness.timing_reason}",
+                )
+                return "BLOCKED"
+            if not readiness.final_execution_readiness:
+                log.info(
+                    "execution_quality_blocked",
+                    reason=readiness.execution_quality_reason,
+                    expected_fill_price=readiness.expected_fill_price,
+                    expected_slippage=readiness.expected_slippage,
+                )
+                self._record_trade_terminal_outcome(
+                    trade_id=trade_id,
+                    outcome_status="BLOCKED",
+                    outcome_reason=f"execution_quality_gate:{readiness.execution_quality_reason}",
+                )
+                return "BLOCKED"
             validation_result = self._pre_trade_validator.validate(
                 signal_data=signal_data,
                 decision_data=decision_data,
                 risk_state=self._risk_engine.as_dict(),
             )
+            self._trade_traceability[trade_id]["validation_result"] = {
+                "decision": validation_result.decision,
+                "reason": validation_result.reason,
+                "checks": validation_result.checks,
+            }
             if validation_result.decision != "ALLOW":
-                self._trade_traceability[trade_id] = {
-                    "trade_id": trade_id,
-                    "signal_data": signal_data,
-                    "decision_data": decision_data,
-                    "validation_result": {
-                        "decision": validation_result.decision,
-                        "reason": validation_result.reason,
-                        "checks": validation_result.checks,
-                    },
-                    "execution_data": {},
-                    "outcome_data": {},
-                    "risk_state": self._risk_engine.as_dict(),
-                }
+                self._record_trade_terminal_outcome(
+                    trade_id=trade_id,
+                    outcome_status="BLOCKED",
+                    outcome_reason=f"pre_trade_validator:{validation_result.reason}",
+                )
                 log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
                 return "BLOCKED"
             self._execution_tracker.record_order_submission(
@@ -2211,55 +2279,51 @@ class StrategyTrigger:
                     "trade_id": trade_id,
                 },
             )
-            if created:
-                execution_data = self._execution_tracker.record_fill(
+            if created is None:
+                self._record_trade_terminal_outcome(
                     trade_id=trade_id,
-                    actual_fill_price=created.entry_price,
+                    outcome_status="BLOCKED",
+                    outcome_reason="execution_engine_open_rejected_or_failed",
+                    execution_data=self._execution_tracker.get_execution_data(trade_id),
                 )
-                self._position_entry_context[created.position_id] = {
-                    "strategy_source": (
-                        selected_candidate.strategy_name
-                        if selected_candidate is not None
-                        else "UNKNOWN"
-                    ),
-                    "regime_at_entry": (
-                        aggregation_decision.current_regime
-                        if aggregation_decision is not None
-                        else str((market_context or {}).get("current_regime", "LOW_ACTIVITY_CHAOTIC"))
-                    ),
-                    "entry_quality": readiness.execution_quality_reason,
-                    "entry_timing": readiness.timing_reason,
-                    "theoretical_edge": signal_edge,
-                    "slippage_impact": readiness.expected_slippage,
-                    "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
-                    "trade_id": trade_id,
-                }
-                self._trade_traceability[trade_id] = {
-                    "trade_id": trade_id,
-                    "signal_data": signal_data,
-                    "decision_data": decision_data,
-                    "validation_result": {
-                        "decision": validation_result.decision,
-                        "reason": validation_result.reason,
-                        "checks": validation_result.checks,
-                    },
-                    "execution_data": execution_data,
-                    "outcome_data": {},
-                    "risk_state": self._risk_engine.as_dict(),
-                }
-                self._trace_engine.record_trace(
-                    position_id=created.position_id,
-                    market_id=self._config.market_id,
-                    entry_price=market_price,
-                    exit_price=0.0,
-                    size=size,
-                    pnl=0.0,
-                    intelligence_score=entry_score,
-                    intelligence_reasons=entry_reasons,
-                    decision_threshold=0.5,
-                    action="OPEN",
-                )
-            return "OPENED" if created is not None else "BLOCKED"
+                return "BLOCKED"
+            execution_data = self._execution_tracker.record_fill(
+                trade_id=trade_id,
+                actual_fill_price=created.entry_price,
+            )
+            self._position_entry_context[created.position_id] = {
+                "strategy_source": (
+                    selected_candidate.strategy_name
+                    if selected_candidate is not None
+                    else "UNKNOWN"
+                ),
+                "regime_at_entry": (
+                    aggregation_decision.current_regime
+                    if aggregation_decision is not None
+                    else str((market_context or {}).get("current_regime", "LOW_ACTIVITY_CHAOTIC"))
+                ),
+                "entry_quality": readiness.execution_quality_reason,
+                "entry_timing": readiness.timing_reason,
+                "theoretical_edge": signal_edge,
+                "slippage_impact": readiness.expected_slippage,
+                "timing_effectiveness": 1.0 if readiness.timing_decision == "ENTER_NOW" else 0.0,
+                "trade_id": trade_id,
+            }
+            self._trade_traceability[trade_id]["execution_data"] = execution_data
+            self._trade_traceability[trade_id]["risk_state"] = self._risk_engine.as_dict()
+            self._trace_engine.record_trace(
+                position_id=created.position_id,
+                market_id=self._config.market_id,
+                entry_price=market_price,
+                exit_price=0.0,
+                size=size,
+                pnl=0.0,
+                intelligence_score=entry_score,
+                intelligence_reasons=entry_reasons,
+                decision_threshold=0.5,
+                action="OPEN",
+            )
+            return "OPENED"
 
         if open_pos is not None:
             await self._engine.update_mark_to_market({self._config.market_id: market_price})

--- a/projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md
@@ -1,0 +1,80 @@
+# 24_34_p16_sentinel_remediation_restart_safe_traceability
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  - P16 control layer in touched strategy-trigger runtime path only
+  - Restart-safe enforcement for risk state used by global hard-block logic
+  - Complete blocked-path traceability for touched execution interception chain
+  - Report accuracy alignment with actual runtime behavior
+- Not in Scope:
+  - New strategy logic (S1–S5)
+  - P15 weighting changes
+  - Dashboard / UI / Telegram UX
+  - Broad runtime orchestration outside touched strategy-trigger path
+  - Refactor of unrelated legacy entry surfaces
+  - New persistence architecture beyond minimum required for P16 hard-block correctness
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md`. Tier: MAJOR
+
+## 1. What was built
+- Added restart-safe persistence to `RiskEngine` for minimum authoritative hard-block state (`peak_equity`, daily PnL map, and derived global block status) with deterministic restore on startup.
+- Added fail-safe behavior for persistence contradictions in the touched path:
+  - missing risk state after prior initialization
+  - unreadable/corrupt risk state payload
+  - persistence write failure
+  In these conditions `global_trade_block` is forced active via persistent block reason.
+- Expanded strategy-trigger trade traceability for blocked terminal outcomes in touched execution interception chain:
+  - portfolio guard block
+  - timing gate block
+  - execution quality gate block
+  - pre-trade validator block
+  - execution-engine open rejection/failure
+- Added terminal outcome uniqueness guard to prevent duplicate terminal blocked writes per single attempt.
+- Preserved successful trade trace behavior and execution-truth fields.
+
+## 2. Current system architecture
+- `core/risk/risk_engine.py`
+  - persists and restores P16 risk state to `projects/polymarket/polyquantbot/infra/risk_engine_state.json` (or env override)
+  - loads persisted state at startup and recomputes hard-block conditions
+  - tracks initialization marker to distinguish first boot from restart/missing-state drift
+  - forces fail-safe global block if required persistence state is missing/corrupt/unwritable
+- `execution/strategy_trigger.py`
+  - initializes a deterministic trace envelope before gating exits
+  - records one authoritative terminal blocked outcome for each blocked attempt in touched scope
+  - maintains truthful execution_data on blocked outcomes (order submission present, fill absent when no open occurs)
+  - preserves successful OPENED and CLOSE flow trace behavior
+- `tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+  - includes focused runtime-proof coverage for restart-safe persistence and blocked-path traceability contracts
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Restart persistence for drawdown and daily-loss enforcement state is restored and re-enforced.
+- Global hard-block remains active after restart when breach state persists.
+- Missing/corrupt persistence inputs fail safe and keep trade block active in touched path.
+- Blocked execution exits in touched interception chain now emit terminal trace outcomes with machine-readable status/reason.
+- Successful trade path still captures execution truth fields without fake fill data.
+- Terminal blocked outcome emits once per attempt in touched scope.
+
+### Validation commands
+- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅ (`13 passed`)
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase14_market_paper_realism.py -k 'p16 or mp16'` ✅ (`14 passed, 29 deselected`)
+
+## 5. Known issues
+- `pytest` environment still emits `Unknown config option: asyncio_mode` warning.
+- `pytest` environment emits `PytestUnknownMarkWarning` for `@pytest.mark.asyncio` in existing phase14 realism test module.
+- Scope remains intentionally limited to touched strategy-trigger runtime path for this remediation.
+
+## 6. What is next
+- SENTINEL MAJOR revalidation of PR #346 against corrected restart-safe risk enforcement and blocked-path traceability behavior.
+- If SENTINEL approves, COMMANDER can proceed with merge decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
+import tempfile
 
+from projects.polymarket.polyquantbot.core.risk.risk_engine import RiskEngine
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
 from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    EntryExecutionReadiness,
+    PortfolioExposureDecision,
     StrategyAggregationDecision,
     StrategyCandidateScore,
     StrategyConfig,
@@ -30,88 +36,314 @@ def _build_aggregation(edge: float = 0.05) -> StrategyAggregationDecision:
     )
 
 
-def _build_trigger(starting_equity: float = 10_000.0) -> StrategyTrigger:
+def _build_trigger(
+    *,
+    state_file: Path,
+    starting_equity: float = 10_000.0,
+) -> StrategyTrigger:
     trigger = StrategyTrigger(
         engine=ExecutionEngine(starting_equity=starting_equity),
         config=StrategyConfig(market_id="MARKET-1", threshold=0.60, target_pnl=2.0),
     )
+    trigger._risk_engine = RiskEngine(state_file=str(state_file))  # noqa: SLF001
     trigger._cooldown_seconds = 0.0  # noqa: SLF001
     trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
     return trigger
 
 
-def test_p16_pre_trade_block_when_ev_non_positive() -> None:
+def _latest_trade_id(trigger: StrategyTrigger) -> str:
+    keys = list(trigger._trade_traceability.keys())  # noqa: SLF001
+    return keys[-1]
+
+
+def _default_market_context() -> dict[str, float]:
+    return {
+        "expected_value": 0.10,
+        "liquidity_usd": 50_000.0,
+        "spread": 0.01,
+        "best_bid": 0.445,
+        "best_ask": 0.455,
+        "signal_reference_price": 0.45,
+    }
+
+
+def test_p16_pre_trade_block_when_ev_non_positive_records_terminal_trace() -> None:
     async def _run() -> None:
-        trigger = _build_trigger()
-        decision = await trigger.evaluate(
-            market_price=0.45,
-            aggregation_decision=_build_aggregation(),
-            market_context={
-                "expected_value": 0.0,
-                "liquidity_usd": 20_000.0,
-                "spread": 0.01,
-                "best_bid": 0.44,
-                "best_ask": 0.46,
-            },
-        )
-        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
-        assert decision == "BLOCKED"
-        assert len(snapshot.positions) == 0
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            context = _default_market_context()
+            context["expected_value"] = 0.0
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=context,
+            )
+            snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+            trade_id = _latest_trade_id(trigger)
+            trace = trigger.get_trade_trace(trade_id)
+            assert decision == "BLOCKED"
+            assert len(snapshot.positions) == 0
+            assert trace["outcome_data"]["terminal"] is True
+            assert trace["outcome_data"]["status"] == "BLOCKED"
+            assert trace["outcome_data"]["reason"].startswith("pre_trade_validator:")
 
     asyncio.run(_run())
 
 
-def test_p16_successful_trade_records_execution_trace() -> None:
+def test_p16_successful_trade_records_execution_trace_regression() -> None:
     async def _run() -> None:
-        trigger = _build_trigger()
-        decision = await trigger.evaluate(
-            market_price=0.45,
-            aggregation_decision=_build_aggregation(),
-            market_context={
-                "expected_value": 0.10,
-                "liquidity_usd": 50_000.0,
-                "spread": 0.01,
-                "best_bid": 0.445,
-                "best_ask": 0.455,
-            },
-        )
-        assert decision == "OPENED"
-        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
-        assert len(snapshot.positions) == 1
-        trade_id = snapshot.positions[0].position_id
-        trace = trigger.get_trade_trace(trade_id)
-        assert trace["validation_result"]["decision"] == "ALLOW"
-        assert trace["execution_data"]["expected_price"] is not None
-        assert trace["execution_data"]["actual_fill_price"] is not None
-        assert trace["execution_data"]["latency_ms"] is not None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            assert decision == "OPENED"
+            snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+            assert len(snapshot.positions) == 1
+            trade_id = snapshot.positions[0].position_id
+            trace = trigger.get_trade_trace(trade_id)
+            assert trace["validation_result"]["decision"] == "ALLOW"
+            assert trace["execution_data"]["expected_price"] is not None
+            assert trace["execution_data"]["actual_fill_price"] is not None
+            assert trace["execution_data"]["latency_ms"] is not None
+            assert trace["outcome_data"] == {}
 
     asyncio.run(_run())
 
 
-def test_p16_risk_breach_triggers_global_block() -> None:
-    async def _run() -> None:
-        trigger = _build_trigger(starting_equity=10_000.0)
-        trigger._risk_engine.update_from_snapshot(  # noqa: SLF001
+def test_p16_restart_persistence_keeps_global_block_active() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        first = RiskEngine(state_file=str(state_path))
+        first.update_from_snapshot(
             equity=9_100.0,
             realized_pnl=-2_100.0,
             open_trades=0,
             correlated_exposure_ratio=0.0,
         )
-        trigger._risk_engine.record_trade_pnl(-2_100.0)  # noqa: SLF001
-        decision = await trigger.evaluate(
-            market_price=0.45,
-            aggregation_decision=_build_aggregation(),
-            market_context={
-                "expected_value": 0.12,
-                "liquidity_usd": 50_000.0,
-                "spread": 0.01,
-                "best_bid": 0.445,
-                "best_ask": 0.455,
-            },
+        first.record_trade_pnl(-2_100.0)
+        assert first.get_state().global_trade_block is True
+
+        second = RiskEngine(state_file=str(state_path))
+        restored = second.get_state()
+        assert restored.global_trade_block is True
+
+
+def test_p16_restart_missing_state_file_fails_safe() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        bootstrap = RiskEngine(state_file=str(state_path))
+        bootstrap.update_from_snapshot(
+            equity=10_000.0,
+            realized_pnl=0.0,
+            open_trades=0,
+            correlated_exposure_ratio=0.0,
         )
-        snapshot = await trigger._engine.snapshot()  # noqa: SLF001
-        assert decision == "BLOCKED"
-        assert trigger._risk_engine.get_state().global_trade_block is True  # noqa: SLF001
-        assert len(snapshot.positions) == 0
+        state_path.unlink()
+        restarted = RiskEngine(state_file=str(state_path))
+        state = restarted.get_state()
+        assert state.global_trade_block is True
+        assert restarted.as_dict().get("persistence_block_reason") == "risk_state_missing_on_startup"
+
+
+def test_p16_restart_corrupt_state_file_fails_safe() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text("{not-valid-json", encoding="utf-8")
+        marker = state_path.with_suffix(".json.initialized")
+        marker.write_text("initialized\n", encoding="utf-8")
+        restarted = RiskEngine(state_file=str(state_path))
+        state = restarted.get_state()
+        assert state.global_trade_block is True
+        assert restarted.as_dict().get("persistence_block_reason") == "risk_state_unreadable_on_startup"
+
+
+def test_p16_blocked_traceability_portfolio_guard_block() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            trigger.evaluate_portfolio_exposure_and_correlation = (  # type: ignore[assignment]
+                lambda **_: PortfolioExposureDecision(
+                    final_decision="SKIP",
+                    adjusted_size=0.0,
+                    reason="same_market_conflict",
+                    flags=("same_market",),
+                )
+            )
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            trace = trigger.get_trade_trace(_latest_trade_id(trigger))
+            assert decision == "BLOCKED"
+            assert trace["outcome_data"]["reason"].startswith("portfolio_guard:")
 
     asyncio.run(_run())
+
+
+def test_p16_blocked_traceability_timing_gate_block() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            trigger.evaluate_entry_execution_readiness = (  # type: ignore[assignment]
+                lambda **_: EntryExecutionReadiness(
+                    timing_decision="SKIP",
+                    timing_reason="anti_chase_timeout_skip",
+                    reference_price=0.45,
+                    reevaluation_window=10,
+                    final_execution_readiness=False,
+                    execution_quality_decision="NOT_EVALUATED",
+                    execution_quality_reason="timing_gate_blocked",
+                    adjusted_size=0.0,
+                    expected_fill_price=0.45,
+                    expected_slippage=0.0,
+                )
+            )
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            trace = trigger.get_trade_trace(_latest_trade_id(trigger))
+            assert decision == "BLOCKED"
+            assert trace["outcome_data"]["reason"].startswith("timing_gate_skip:")
+
+    asyncio.run(_run())
+
+
+def test_p16_blocked_traceability_execution_quality_block() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            trigger.evaluate_entry_execution_readiness = (  # type: ignore[assignment]
+                lambda **_: EntryExecutionReadiness(
+                    timing_decision="ENTER_NOW",
+                    timing_reason="stable_entry_window",
+                    reference_price=0.45,
+                    reevaluation_window=10,
+                    final_execution_readiness=False,
+                    execution_quality_decision="SKIP",
+                    execution_quality_reason="slippage_too_high",
+                    adjusted_size=100.0,
+                    expected_fill_price=0.46,
+                    expected_slippage=0.05,
+                )
+            )
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            trace = trigger.get_trade_trace(_latest_trade_id(trigger))
+            assert decision == "BLOCKED"
+            assert trace["outcome_data"]["reason"].startswith("execution_quality_gate:")
+
+    asyncio.run(_run())
+
+
+def test_p16_blocked_traceability_execution_engine_failure() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            async def _fail_open_position(**_: object) -> None:
+                return None
+
+            trigger._engine.open_position = _fail_open_position  # type: ignore[assignment] # noqa: SLF001
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            trace = trigger.get_trade_trace(_latest_trade_id(trigger))
+            assert decision == "BLOCKED"
+            assert trace["outcome_data"]["reason"] == "execution_engine_open_rejected_or_failed"
+            assert trace["execution_data"]["expected_price"] is not None
+            assert trace["execution_data"].get("actual_fill_price") is None
+
+    asyncio.run(_run())
+
+
+def test_p16_terminal_outcome_is_unique_for_single_attempt() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _build_trigger(state_file=Path(tmpdir) / "risk_state.json")
+            trigger.evaluate_portfolio_exposure_and_correlation = (  # type: ignore[assignment]
+                lambda **_: PortfolioExposureDecision(
+                    final_decision="SKIP",
+                    adjusted_size=0.0,
+                    reason="same_market_conflict",
+                    flags=("same_market",),
+                )
+            )
+            _ = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context=_default_market_context(),
+            )
+            trace = trigger.get_trade_trace(_latest_trade_id(trigger))
+            assert trace["outcome_data"]["terminal"] is True
+            assert set(trace["outcome_data"].keys()) == {"terminal", "status", "reason"}
+
+    asyncio.run(_run())
+
+
+def test_p16_daily_loss_persistence_restores_current_day_state() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        initial = RiskEngine(state_file=str(state_path))
+        initial.update_from_snapshot(
+            equity=10_000.0,
+            realized_pnl=0.0,
+            open_trades=0,
+            correlated_exposure_ratio=0.0,
+        )
+        initial.record_trade_pnl(-500.0)
+        initial.record_trade_pnl(-600.0)
+
+        restarted = RiskEngine(state_file=str(state_path))
+        assert restarted.get_state().daily_loss == -1_100.0
+
+
+def test_p16_drawdown_persistence_restores_peak_reference() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        initial = RiskEngine(state_file=str(state_path))
+        initial.update_from_snapshot(
+            equity=10_000.0,
+            realized_pnl=0.0,
+            open_trades=0,
+            correlated_exposure_ratio=0.0,
+        )
+        initial.update_from_snapshot(
+            equity=9_100.0,
+            realized_pnl=-900.0,
+            open_trades=0,
+            correlated_exposure_ratio=0.0,
+        )
+        first_drawdown = initial.get_state().drawdown_ratio
+        assert first_drawdown > 0.08
+
+        restarted = RiskEngine(state_file=str(state_path))
+        assert restarted.get_state().drawdown_ratio == first_drawdown
+
+
+def test_p16_risk_state_file_has_minimum_authoritative_fields() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_path = Path(tmpdir) / "risk_state.json"
+        risk_engine = RiskEngine(state_file=str(state_path))
+        risk_engine.update_from_snapshot(
+            equity=9_500.0,
+            realized_pnl=-500.0,
+            open_trades=1,
+            correlated_exposure_ratio=0.2,
+        )
+        risk_engine.record_trade_pnl(-400.0)
+
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        assert "peak_equity" in payload
+        assert "daily_pnl_by_day" in payload
+        assert "global_trade_block" in payload


### PR DESCRIPTION
### Motivation
- Address two blocking contradictions for PR #346: risk hard-blocks that are lost on process restart, and missing terminal trace records for blocked execution exits in the strategy-trigger path.
- Ensure the touched P16 control layer enforces global hard-blocks deterministically after restart and that every blocked outcome in the interception chain is captured exactly once for traceability.

### Description
- Persist and restore minimum authoritative risk state in `core/risk/risk_engine.py` (peak equity, daily PnL map, drawdown derivation and global block flag) with a state marker file and env override support, and force fail-safe global block on missing/corrupt/unwritable state after initialization.
- Add deterministic blocked-outcome trace helpers to `execution/strategy_trigger.py` (`_init_trade_trace` and `_record_trade_terminal_outcome`), wire them at all touched gated exits (portfolio guard, timing gate, execution-quality gate, pre-trade validator, execution-engine open failure), and enforce single authoritative terminal outcome per attempt while preserving successful-trade execution truth fields.
- Add focused runtime-proof tests in `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` covering restart persistence (daily-loss/drawdown), fail-safe missing/corrupt state, blocked-path traceability for each gated exit, terminal-event uniqueness, and successful-trade trace regression.
- Add FORGE-X report `projects/polymarket/polyquantbot/reports/forge/24_34_p16_sentinel_remediation_restart_safe_traceability.md` and update `PROJECT_STATE.md` to reflect remediation and next-step: SENTINEL MAJOR revalidation.

### Testing
- Ran `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — PASS.
- Ran focused tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — PASS (`13 passed`).
- Ran regression selection: `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase14_market_paper_realism.py -k 'p16 or mp16'` — PASS (`14 passed, 29 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ef212bbc832e976f57d94d064aa3)