### PR TITLE
fix: restart-safe global_trade_block persistence and terminal trace remediation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,14 +1,15 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 16:58
-- Status        : SENTINEL validated P16 execution validation & risk enforcement control-layer implementation as APPROVED (MAJOR gate satisfied).
+- Last Updated  : 2026-04-09 19:27
+- Status        : FORGE-X remediation complete for P16 restart-safe global risk block + terminal trace coverage; pending SENTINEL MAJOR revalidation before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
-- SENTINEL validation complete for P16 execution validation & risk enforcement layer (2026-04-09): verdict **APPROVED** after runtime verification of pre-trade blocking, execution truth capture, edge validation, risk global-block enforcement, interception chain, and end-to-end traceability in declared scope.
+- SENTINEL validation complete for P16 execution validation & risk enforcement layer (2026-04-09): verdict **APPROVED** for initial pass, now explicitly superseded by PR #348 blocked revalidation and remediation flow for restart-safe risk-block persistence + terminal trace authority.
 - P16 execution validation & risk enforcement layer (2026-04-09): implemented runtime pre-trade hard-block validation, execution truth capture, closed-trade edge validation, and global risk kill-switch enforcement in strategy-trigger execution path with focused MAJOR runtime-proof tests.
+- P16 restart-safe risk block + terminal trace remediation (2026-04-09): added persisted sticky global trade-block authority with restart rehydration and fail-safe load behavior in touched strategy-trigger runtime path; added authoritative terminal trace records for portfolio guard, timing gate, execution-quality gate, and execution-engine rejection outcomes with deterministic proof tests.
 - Market title resolution test hardening follow-up (2026-04-09): removed private cache mutation from Falcon title regression tests, seeded fallback cache through public normalization behavior, and preserved partial-failure/no-placeholder assertions.
 - Market title resolution follow-up hardening (2026-04-09): fixed partial Falcon failure path so successful markets title resolution is cached before downstream fetches, preventing fallback to numeric placeholder when later Falcon calls fail, and added focused regression coverage.
 - Market title resolution fix from market_id (2026-04-09): resolved real `market_title` via Falcon market metadata/cache in touched data-layer path, enforced strict placeholder fallback only when API unavailable with no cached title, and added focused regression tests for single/multi-market and fallback behavior.
@@ -123,9 +124,9 @@ Status:
 
 ## 🚧 IN PROGRESS
 
-### P16 execution validation & risk enforcement handoff
-- MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for strategy-trigger execution interception, execution-truth capture, edge validation, and global risk block enforcement in touched runtime path.
-- SENTINEL validation completed with verdict APPROVED; ready for COMMANDER merge decision.
+### P16 restart-safe risk block + terminal trace remediation handoff
+- MAJOR-tier NARROW INTEGRATION remediation is complete for touched strategy-trigger runtime path (`core/risk/risk_engine.py` + `execution/strategy_trigger.py`) with restart-safe persisted hard-block enforcement and authoritative terminal trace records on blocked/hold terminal outcomes.
+- SENTINEL MAJOR revalidation is required before merge for this remediation pass; prior approval history is superseded for this layer until revalidation verdict is issued.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
@@ -262,7 +263,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 SENTINEL validation required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md
 Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES

--- a/projects/polymarket/polyquantbot/core/risk/risk_engine.py
+++ b/projects/polymarket/polyquantbot/core/risk/risk_engine.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+
+import structlog
+
+
+log = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -23,9 +31,17 @@ class RiskEngine:
         *,
         max_drawdown_ratio: float = 0.08,
         daily_loss_limit: float = -2_000.0,
+        block_state_file: str | None = None,
     ) -> None:
         self._max_drawdown_ratio = max_drawdown_ratio
         self._daily_loss_limit = daily_loss_limit
+        self._block_state_file = Path(
+            block_state_file
+            or os.getenv(
+                "POLYQUANT_RISK_BLOCK_STATE_FILE",
+                "projects/polymarket/polyquantbot/infra/risk_global_block_state.json",
+            )
+        )
         self._peak_equity = 0.0
         self._equity = 0.0
         self._portfolio_pnl = 0.0
@@ -34,6 +50,9 @@ class RiskEngine:
         self._open_trades = 0
         self._correlated_exposure_ratio = 0.0
         self._global_trade_block = False
+        self._global_trade_block_reason = "not_blocked"
+        self._state_load_failed = False
+        self._load_persisted_block_state()
 
     def update_from_snapshot(
         self,
@@ -88,9 +107,69 @@ class RiskEngine:
             "global_trade_block": state.global_trade_block,
         }
 
+    def clear_global_trade_block(self) -> RiskState:
+        """Explicit operator-clear path for sticky global block state."""
+        self._global_trade_block = False
+        self._global_trade_block_reason = "manual_clear"
+        self._persist_block_state()
+        return self.get_state()
+
+    def _load_persisted_block_state(self) -> None:
+        try:
+            if not self._block_state_file.exists():
+                return
+            raw = self._block_state_file.read_text(encoding="utf-8")
+            payload = json.loads(raw)
+            persisted_block = bool(payload.get("global_trade_block", False))
+            persisted_reason = str(payload.get("reason", "persisted_block_active"))
+            if persisted_block:
+                self._global_trade_block = True
+                self._global_trade_block_reason = persisted_reason
+                log.warning(
+                    "risk_global_block_restored",
+                    path=str(self._block_state_file),
+                    reason=self._global_trade_block_reason,
+                )
+        except Exception as exc:  # noqa: BLE001
+            self._state_load_failed = True
+            self._global_trade_block = True
+            self._global_trade_block_reason = "block_state_load_failed"
+            log.error(
+                "risk_global_block_restore_failed",
+                path=str(self._block_state_file),
+                error=str(exc),
+            )
+
+    def _persist_block_state(self) -> None:
+        payload = {
+            "global_trade_block": self._global_trade_block,
+            "reason": self._global_trade_block_reason,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            self._block_state_file.parent.mkdir(parents=True, exist_ok=True)
+            self._block_state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            self._global_trade_block = True
+            self._global_trade_block_reason = "block_state_persist_failed"
+            log.error(
+                "risk_global_block_persist_failed",
+                path=str(self._block_state_file),
+                error=str(exc),
+            )
+
     def _refresh_global_block(self) -> None:
         state = self.get_state()
-        self._global_trade_block = (
-            state.drawdown_ratio > self._max_drawdown_ratio
-            or state.daily_loss <= self._daily_loss_limit
-        )
+        risk_breached = state.drawdown_ratio > self._max_drawdown_ratio or state.daily_loss <= self._daily_loss_limit
+        if self._state_load_failed:
+            self._global_trade_block = True
+            self._global_trade_block_reason = "block_state_load_failed"
+            self._persist_block_state()
+            return
+        if risk_breached:
+            self._global_trade_block = True
+            if state.drawdown_ratio > self._max_drawdown_ratio:
+                self._global_trade_block_reason = "max_drawdown_breached"
+            else:
+                self._global_trade_block_reason = "daily_loss_limit_breached"
+        self._persist_block_state()

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -2028,6 +2028,32 @@ class StrategyTrigger:
     def _tokenize(value: str) -> list[str]:
         return [token for token in re.split(r"[^a-z0-9]+", value.lower()) if len(token) >= 3]
 
+    def _record_terminal_trace(
+        self,
+        *,
+        trade_id: str,
+        signal_data: dict[str, object],
+        decision_data: dict[str, object],
+        validation_result: dict[str, object],
+        execution_data: dict[str, object],
+        outcome_data: dict[str, object],
+        terminal_status: str,
+        terminal_reason: str,
+    ) -> None:
+        self._trade_traceability[trade_id] = {
+            "trade_id": trade_id,
+            "signal_data": dict(signal_data),
+            "decision_data": dict(decision_data),
+            "validation_result": dict(validation_result),
+            "execution_data": dict(execution_data),
+            "outcome_data": {
+                **dict(outcome_data),
+                "terminal_status": terminal_status,
+                "terminal_reason": terminal_reason,
+            },
+            "risk_state": self._risk_engine.as_dict(),
+        }
+
     async def evaluate(
         self,
         market_price: float,
@@ -2067,6 +2093,7 @@ class StrategyTrigger:
 
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
             current_total_exposure = sum(position.exposure() for position in snapshot.positions)
+            trade_id = str(uuid.uuid4())
             selected_candidate = None
             if aggregation_decision is not None and aggregation_decision.selected_trade:
                 selected_candidate = next(
@@ -2099,11 +2126,33 @@ class StrategyTrigger:
                 open_positions=list(snapshot.positions),
                 total_capital=snapshot.equity,
             )
-            if portfolio_guard.final_decision == "SKIP":
-                return "BLOCKED"
+            selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             signal_edge = max(self._config.min_edge, 0.0)
             if selected_candidate is not None:
                 signal_edge = max(selected_candidate.edge, 0.0)
+            signal_data = {
+                "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
+                "edge": signal_edge,
+                "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                "spread": float((market_context or {}).get("spread", 0.0)),
+            }
+            decision_data = {
+                "position_size": portfolio_guard.adjusted_size,
+                "target_market_id": target_market_id,
+                "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+            }
+            if portfolio_guard.final_decision == "SKIP":
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "portfolio_guard_blocked", "checks": {}},
+                    execution_data={},
+                    outcome_data={"guard_reason": portfolio_guard.reason, "guard_flags": list(portfolio_guard.flags)},
+                    terminal_status="BLOCKED",
+                    terminal_reason="portfolio_guard",
+                )
+                return "BLOCKED"
             timing_wait_cycles = int((market_context or {}).get("timing_wait_cycles", 0.0))
             signal_reference_price = float((market_context or {}).get("signal_reference_price", market_price))
             readiness = self.evaluate_entry_execution_readiness(
@@ -2121,12 +2170,40 @@ class StrategyTrigger:
                     reference_price=readiness.reference_price,
                     reevaluation_window=readiness.reevaluation_window,
                 )
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data | {"position_size": readiness.adjusted_size},
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "timing_gate_wait", "checks": {}},
+                    execution_data={},
+                    outcome_data={
+                        "timing_decision": readiness.timing_decision,
+                        "timing_reason": readiness.timing_reason,
+                        "reevaluation_window": readiness.reevaluation_window,
+                    },
+                    terminal_status="HOLD",
+                    terminal_reason="timing_gate",
+                )
                 return "HOLD"
             if readiness.timing_decision == "SKIP":
                 log.info(
                     "entry_timing_skip",
                     timing_reason=readiness.timing_reason,
                     reference_price=readiness.reference_price,
+                )
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data | {"position_size": readiness.adjusted_size},
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "timing_gate_skip", "checks": {}},
+                    execution_data={},
+                    outcome_data={
+                        "timing_decision": readiness.timing_decision,
+                        "timing_reason": readiness.timing_reason,
+                        "reference_price": readiness.reference_price,
+                    },
+                    terminal_status="BLOCKED",
+                    terminal_reason="timing_gate",
                 )
                 return "BLOCKED"
             if not readiness.final_execution_readiness:
@@ -2136,10 +2213,23 @@ class StrategyTrigger:
                     expected_fill_price=readiness.expected_fill_price,
                     expected_slippage=readiness.expected_slippage,
                 )
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data | {"position_size": readiness.adjusted_size},
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "execution_quality_blocked", "checks": {}},
+                    execution_data={},
+                    outcome_data={
+                        "execution_quality_decision": readiness.execution_quality_decision,
+                        "execution_quality_reason": readiness.execution_quality_reason,
+                        "expected_fill_price": readiness.expected_fill_price,
+                        "expected_slippage": readiness.expected_slippage,
+                    },
+                    terminal_status="BLOCKED",
+                    terminal_reason="execution_quality_gate",
+                )
                 return "BLOCKED"
             size = readiness.adjusted_size
-            trade_id = str(uuid.uuid4())
-            selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             candidate_title = (
                 str(selected_metadata.get("title") or selected_metadata.get("market_title", ""))
                 if selected_candidate is not None
@@ -2147,36 +2237,27 @@ class StrategyTrigger:
                 and (selected_metadata.get("title") or selected_metadata.get("market_title"))
                 else target_market_id
             )
-            signal_data = {
-                "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
-                "edge": signal_edge,
-                "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
-                "spread": float((market_context or {}).get("spread", 0.0)),
-            }
-            decision_data = {
-                "position_size": size,
-                "target_market_id": target_market_id,
-                "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
-            }
+            decision_data = decision_data | {"position_size": size}
             validation_result = self._pre_trade_validator.validate(
                 signal_data=signal_data,
                 decision_data=decision_data,
                 risk_state=self._risk_engine.as_dict(),
             )
             if validation_result.decision != "ALLOW":
-                self._trade_traceability[trade_id] = {
-                    "trade_id": trade_id,
-                    "signal_data": signal_data,
-                    "decision_data": decision_data,
-                    "validation_result": {
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
                         "decision": validation_result.decision,
                         "reason": validation_result.reason,
                         "checks": validation_result.checks,
                     },
-                    "execution_data": {},
-                    "outcome_data": {},
-                    "risk_state": self._risk_engine.as_dict(),
-                }
+                    execution_data={},
+                    outcome_data={},
+                    terminal_status="BLOCKED",
+                    terminal_reason="pre_trade_validator",
+                )
                 log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
                 return "BLOCKED"
             self._execution_tracker.record_order_submission(
@@ -2258,6 +2339,21 @@ class StrategyTrigger:
                     intelligence_reasons=entry_reasons,
                     decision_threshold=0.5,
                     action="OPEN",
+                )
+            if created is None:
+                self._record_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
+                        "decision": validation_result.decision,
+                        "reason": validation_result.reason,
+                        "checks": validation_result.checks,
+                    },
+                    execution_data=self._execution_tracker.get_execution_data(trade_id),
+                    outcome_data={"engine_result": "open_position_returned_none"},
+                    terminal_status="BLOCKED",
+                    terminal_reason="execution_engine_rejection",
                 )
             return "OPENED" if created is not None else "BLOCKED"
 

--- a/projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md
@@ -1,0 +1,85 @@
+# 24_35_risk_restart_trace_remediation
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - `projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+  - `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+  - `PROJECT_STATE.md`
+  - `projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md`
+- Not in Scope:
+  - full-system risk architecture redesign
+  - unrelated execution pipeline refactor
+  - new strategy logic
+  - UI/reporting improvements beyond required state/report consistency
+  - broad persistence framework redesign outside touched strategy-trigger runtime path
+  - merge decision
+- Suggested Next Step: SENTINEL validation required for restart-safe risk block + terminal trace remediation before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md`. Tier: MAJOR
+
+## 1. What was built
+- Added fail-safe persisted hard-block authority in `RiskEngine` so `global_trade_block` survives process restarts in the touched path.
+- Implemented startup rehydration for persisted block state with fail-safe behavior: if persisted block state cannot be loaded, runtime defaults to blocked (not tradable).
+- Added explicit terminal trace writing in `StrategyTrigger.evaluate()` for each terminal blocked/hold branch requested:
+  - `portfolio_guard`
+  - `timing_gate` (`WAIT`/`SKIP` terminals)
+  - `execution_quality_gate`
+  - `execution_engine_rejection`
+- Added focused deterministic tests proving restart-safe block restoration and per-branch authoritative terminal traces while preserving success-path trace behavior.
+- Updated `PROJECT_STATE.md` to explicitly mark earlier P16 approval history as superseded by blocked revalidation/remediation flow and set next handoff to SENTINEL MAJOR revalidation.
+
+### Root cause summary (from remediation target)
+- Restart bypass root cause: `global_trade_block` existed only in process-local memory and was recomputed from fresh in-memory state after restart, allowing blocked conditions to be silently cleared.
+- Missing terminal traceability root cause: several terminal return paths (`portfolio_guard`, timing gate, execution-quality gate, and `open_position` rejection) returned `BLOCKED`/`HOLD` before writing authoritative terminal trade-trace records.
+
+## 2. Current system architecture
+- `core/risk/risk_engine.py`
+  - Adds persisted block state file authority (`POLYQUANT_RISK_BLOCK_STATE_FILE` or default infra path).
+  - Rehydrates persisted block state at initialization.
+  - Uses sticky hard-block semantics for this touched path: risk breach or state-load failure latches hard block until explicit operator clear.
+  - Persists block status/reason/update time on state refresh for restart continuity.
+- `execution/strategy_trigger.py`
+  - Adds `_record_terminal_trace(...)` helper for authoritative terminal-path trace emission.
+  - Calls terminal trace helper on blocked/hold terminals in touched path before returning.
+  - Preserves success-path OPENED behavior and avoids false blocked traces on success.
+- `tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+  - Extends deterministic runtime-proof coverage for restart-safe enforcement and branch-level terminal trace evidence.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md`
+
+## 4. What is working
+- Hard-block persistence in touched runtime path is restart-safe and fail-safe:
+  - blocked before restart
+  - process restart simulated via fresh `StrategyTrigger`/`RiskEngine` instance with same persisted block file
+  - blocked state restored and enforced post-restart
+- Authoritative terminal trace records are emitted on actual terminal paths for:
+  - portfolio guard block
+  - timing gate hold
+  - execution-quality gate block
+  - execution engine rejection block
+- Successful OPENED path remains functional and does not emit false blocked terminal traces.
+
+### Runtime proof summary
+- Deterministic restart probe exists in test: risk breach activates block, persisted file is reused by fresh trigger instance, next entry attempt remains blocked.
+- Deterministic per-branch probe exists in tests for each requested blocked/hold terminal outcome with direct assertions over `outcome_data.terminal_status` + `outcome_data.terminal_reason`.
+
+### Validation commands
+- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅ (`7 passed`, warning: unknown `asyncio_mode` config)
+
+## 5. Known issues
+- Remediation is narrow integration in touched strategy-trigger runtime path only; additional future non-trigger execution entry surfaces will require explicit equivalent wiring.
+- Existing pytest warning remains in environment: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+- SENTINEL MAJOR revalidation required before merge/promotion for this remediation.
+- Validation should focus on restart-safe hard-block persistence and authoritative terminal traceability in the declared touched path.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
 from projects.polymarket.polyquantbot.execution.strategy_trigger import (
@@ -40,9 +41,18 @@ def _build_trigger(starting_equity: float = 10_000.0) -> StrategyTrigger:
     return trigger
 
 
-def test_p16_pre_trade_block_when_ev_non_positive() -> None:
+def _latest_terminal_trace(trigger: StrategyTrigger) -> dict[str, object]:
+    traces = trigger._trade_traceability  # noqa: SLF001
+    assert traces
+    latest_key = next(reversed(traces))
+    return trigger.get_trade_trace(latest_key)
+
+
+def test_p16_pre_trade_block_when_ev_non_positive(tmp_path: Path) -> None:
     async def _run() -> None:
+        state_file = tmp_path / "risk_block_state.json"
         trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = state_file  # noqa: SLF001
         decision = await trigger.evaluate(
             market_price=0.45,
             aggregation_decision=_build_aggregation(),
@@ -61,9 +71,10 @@ def test_p16_pre_trade_block_when_ev_non_positive() -> None:
     asyncio.run(_run())
 
 
-def test_p16_successful_trade_records_execution_trace() -> None:
+def test_p16_successful_trade_records_execution_trace(tmp_path: Path) -> None:
     async def _run() -> None:
         trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = tmp_path / "risk_block_state.json"  # noqa: SLF001
         decision = await trigger.evaluate(
             market_price=0.45,
             aggregation_decision=_build_aggregation(),
@@ -84,13 +95,16 @@ def test_p16_successful_trade_records_execution_trace() -> None:
         assert trace["execution_data"]["expected_price"] is not None
         assert trace["execution_data"]["actual_fill_price"] is not None
         assert trace["execution_data"]["latency_ms"] is not None
+        assert trace["outcome_data"] == {}
 
     asyncio.run(_run())
 
 
-def test_p16_risk_breach_triggers_global_block() -> None:
+def test_p16_risk_breach_triggers_global_block_restart_safe(tmp_path: Path) -> None:
     async def _run() -> None:
+        state_file = tmp_path / "risk_block_state.json"
         trigger = _build_trigger(starting_equity=10_000.0)
+        trigger._risk_engine._block_state_file = state_file  # noqa: SLF001
         trigger._risk_engine.update_from_snapshot(  # noqa: SLF001
             equity=9_100.0,
             realized_pnl=-2_100.0,
@@ -113,5 +127,128 @@ def test_p16_risk_breach_triggers_global_block() -> None:
         assert decision == "BLOCKED"
         assert trigger._risk_engine.get_state().global_trade_block is True  # noqa: SLF001
         assert len(snapshot.positions) == 0
+
+        restarted_trigger = _build_trigger(starting_equity=10_000.0)
+        restarted_trigger._risk_engine = restarted_trigger._risk_engine.__class__(  # noqa: SLF001
+            block_state_file=str(state_file)
+        )
+        restarted_decision = await restarted_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        restarted_snapshot = await restarted_trigger._engine.snapshot()  # noqa: SLF001
+        assert restarted_decision == "BLOCKED"
+        assert restarted_trigger._risk_engine.get_state().global_trade_block is True  # noqa: SLF001
+        assert len(restarted_snapshot.positions) == 0
+
+    asyncio.run(_run())
+
+
+def test_p16_terminal_trace_for_portfolio_guard_block(tmp_path: Path) -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = tmp_path / "risk_block_state.json"  # noqa: SLF001
+        trigger._engine.max_total_exposure_ratio = 0.0  # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        trace = _latest_terminal_trace(trigger)
+        assert decision == "BLOCKED"
+        assert trace["outcome_data"]["terminal_status"] == "BLOCKED"
+        assert trace["outcome_data"]["terminal_reason"] == "portfolio_guard"
+
+    asyncio.run(_run())
+
+
+def test_p16_terminal_trace_for_timing_gate_hold(tmp_path: Path) -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = tmp_path / "risk_block_state.json"  # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.49,
+            aggregation_decision=_build_aggregation(edge=0.06),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.40,
+                "best_ask": 0.60,
+                "signal_reference_price": 0.40,
+                "timing_wait_cycles": 0,
+            },
+        )
+        trace = _latest_terminal_trace(trigger)
+        assert decision == "HOLD"
+        assert trace["outcome_data"]["terminal_status"] == "HOLD"
+        assert trace["outcome_data"]["terminal_reason"] == "timing_gate"
+
+    asyncio.run(_run())
+
+
+def test_p16_terminal_trace_for_execution_quality_block(tmp_path: Path) -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = tmp_path / "risk_block_state.json"  # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.05),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.30,
+                "best_ask": 0.70,
+                "orderbook_depth_usd": 100_000.0,
+                "signal_reference_price": 0.45,
+                "timing_wait_cycles": 2,
+            },
+        )
+        trace = _latest_terminal_trace(trigger)
+        assert decision == "BLOCKED"
+        assert trace["outcome_data"]["terminal_status"] == "BLOCKED"
+        assert trace["outcome_data"]["terminal_reason"] == "execution_quality_gate"
+
+    asyncio.run(_run())
+
+
+def test_p16_terminal_trace_for_execution_engine_rejection(tmp_path: Path) -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._risk_engine._block_state_file = tmp_path / "risk_block_state.json"  # noqa: SLF001
+        async def _reject_open_position(**_: object) -> None:
+            return None
+
+        trigger._engine.open_position = _reject_open_position  # type: ignore[assignment] # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.05),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "signal_reference_price": 0.45,
+            },
+        )
+        trace = _latest_terminal_trace(trigger)
+        assert decision == "BLOCKED"
+        assert trace["outcome_data"]["terminal_status"] == "BLOCKED"
+        assert trace["outcome_data"]["terminal_reason"] == "execution_engine_rejection"
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Address the MAJOR blockers from revalidation (PR #348) where `global_trade_block` was stored only in-process and cleared on restart, and several terminal blocked/hold branches emitted no authoritative terminal trace evidence.
- Ensure that hard-block enforcement survives process restarts and that every terminal blocked/hold outcome in the touched strategy-trigger path is provably recorded for SENTINEL validation.
- Remove contradictory lifecycle status in project state so the remediation is explicitly handed off for revalidation before merge.

### Description
- Persisted sticky global block authority in `projects/polymarket/polyquantbot/core/risk/risk_engine.py` using a fail-safe file (`POLYQUANT_RISK_BLOCK_STATE_FILE` default) with startup rehydration, persistent writes on refresh, explicit manual-clear API (`clear_global_trade_block`), and load-failure safe-fail semantics (stay blocked if load fails).
- Added authoritative terminal trace helper `_record_terminal_trace(...)` and integrated terminal-path trace emission directly into `projects/polymarket/polyquantbot/execution/strategy_trigger.py` at the actual terminal points for `portfolio_guard`, `timing_gate` (WAIT/SKIP), `execution_quality_gate`, pre-trade validator blocks, and `execution_engine` rejection paths.
- Extended focused tests in `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` to prove restart-safe restoration/enforcement, per-branch terminal trace emission for the requested blocked/hold outcomes, and success-path non-regression.
- Updated `PROJECT_STATE.md` to mark prior P16 approval as superseded by the blocked revalidation/remediation flow and added the FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md` with scope/metadata.

### Testing
- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — PASS.
- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — PASS (`7 passed`) with one environment warning `Unknown config option: asyncio_mode` noted.
- Validation artifacts: added report `projects/polymarket/polyquantbot/reports/forge/24_35_risk_restart_trace_remediation.md` and updated `PROJECT_STATE.md` to request SENTINEL MAJOR revalidation as the next priority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fcb5c67c832eb9c7d9fc8c5d8432)