### PR TITLE
Restart-safe P16 risk persistence and blocked-terminal traceability remediation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 19:09
-- Status        : SENTINEL revalidation for PR #347 found critical P16 contradictions (restart-safe enforcement + blocked-path traceability) and set MAJOR verdict to BLOCKED.
+- Last Updated  : 2026-04-09 20:19
+- Status        : FORGE-X applied targeted P16 restart-safe risk persistence + blocked-terminal traceability remediation in touched strategy-trigger path; awaiting SENTINEL MAJOR revalidation before merge.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- FORGE-X P16 restart-safe risk traceability remediation (2026-04-09): implemented authoritative risk-state persistence/restore with fail-closed startup gating, added touched blocked-terminal trace writes, added focused restart/fail-safe/traceability tests, and generated report `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`.
 - SENTINEL revalidation for PR #347 P16 remediation (2026-04-09): verdict **BLOCKED** (score **49/100**) after runtime challenge confirmed restart can clear hard-block state in touched path and multiple blocked terminal outcomes are not trace-recorded; report saved at `projects/polymarket/polyquantbot/reports/sentinel/24_35_p16_remediation_revalidation_pr347.md`.
 - SENTINEL validation complete for P16 execution validation & risk enforcement layer (2026-04-09): verdict **APPROVED** after runtime verification of pre-trade blocking, execution truth capture, edge validation, risk global-block enforcement, interception chain, and end-to-end traceability in declared scope.
 - P16 execution validation & risk enforcement layer (2026-04-09): implemented runtime pre-trade hard-block validation, execution truth capture, closed-trade edge validation, and global risk kill-switch enforcement in strategy-trigger execution path with focused MAJOR runtime-proof tests.
@@ -125,8 +126,8 @@ Status:
 ## 🚧 IN PROGRESS
 
 ### P16 execution validation & risk enforcement handoff
-- MAJOR-tier revalidation for PR #347 is BLOCKED: restart-safe enforcement and blocked-path terminal traceability remain contradictory to FULL RUNTIME INTEGRATION claim in touched strategy-trigger scope.
-- Targeted FORGE-X remediation required before merge decision; source: `projects/polymarket/polyquantbot/reports/sentinel/24_35_p16_remediation_revalidation_pr347.md`.
+- FORGE-X remediation for PR #347 BLOCKED findings is complete in touched strategy-trigger path (restart-safe persistence/restore + blocked-terminal traceability + focused tests).
+- Awaiting SENTINEL MAJOR revalidation for updated evidence; source: `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
@@ -263,7 +264,7 @@ Status:
 ## 🎯 NEXT PRIORITY
 
 SENTINEL validation required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_33_p16_execution_validation_risk_enforcement_layer.md
+Source: projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md
 Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES

--- a/projects/polymarket/polyquantbot/core/risk/risk_engine.py
+++ b/projects/polymarket/polyquantbot/core/risk/risk_engine.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -23,9 +26,11 @@ class RiskEngine:
         *,
         max_drawdown_ratio: float = 0.08,
         daily_loss_limit: float = -2_000.0,
+        persistence_path: str | None = None,
     ) -> None:
         self._max_drawdown_ratio = max_drawdown_ratio
         self._daily_loss_limit = daily_loss_limit
+        self._persistence_path = Path(persistence_path) if persistence_path else None
         self._peak_equity = 0.0
         self._equity = 0.0
         self._portfolio_pnl = 0.0
@@ -55,12 +60,14 @@ class RiskEngine:
         else:
             self._drawdown_ratio = 0.0
         self._refresh_global_block()
+        self.persist_state()
         return self.get_state()
 
     def record_trade_pnl(self, pnl: float) -> RiskState:
         today_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         self._daily_pnl_by_day[today_key] = self._daily_pnl_by_day.get(today_key, 0.0) + float(pnl)
         self._refresh_global_block()
+        self.persist_state()
         return self.get_state()
 
     def get_state(self) -> RiskState:
@@ -94,3 +101,96 @@ class RiskEngine:
             state.drawdown_ratio > self._max_drawdown_ratio
             or state.daily_loss <= self._daily_loss_limit
         )
+
+    def persist_state(self) -> tuple[bool, str]:
+        if self._persistence_path is None:
+            return True, "persistence_disabled"
+        payload = self._serialize_state()
+        temporary_path = self._persistence_path.with_suffix(f"{self._persistence_path.suffix}.tmp")
+        try:
+            self._persistence_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            temporary_path.replace(self._persistence_path)
+            return True, "persisted"
+        except OSError as exc:
+            return False, f"persist_write_error:{exc.__class__.__name__}"
+
+    def restore_state(self) -> tuple[bool, str]:
+        if self._persistence_path is None:
+            return False, "persistence_path_missing"
+        try:
+            content = self._persistence_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return False, "persistence_missing"
+        except OSError as exc:
+            return False, f"persistence_unreadable:{exc.__class__.__name__}"
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError:
+            return False, "persistence_corrupt_json"
+        validated = self._validate_payload(payload)
+        if validated is None:
+            return False, "persistence_invalid_structure"
+        self._peak_equity = validated["peak_equity"]
+        self._equity = validated["equity"]
+        self._portfolio_pnl = validated["portfolio_pnl"]
+        self._drawdown_ratio = validated["drawdown_ratio"]
+        self._daily_pnl_by_day = validated["daily_pnl_by_day"]
+        self._open_trades = validated["open_trades"]
+        self._correlated_exposure_ratio = validated["correlated_exposure_ratio"]
+        self._global_trade_block = validated["global_trade_block"]
+        self._refresh_global_block()
+        return True, "restored"
+
+    def _serialize_state(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "peak_equity": self._peak_equity,
+            "equity": self._equity,
+            "portfolio_pnl": self._portfolio_pnl,
+            "drawdown_ratio": self._drawdown_ratio,
+            "daily_pnl_by_day": dict(self._daily_pnl_by_day),
+            "open_trades": self._open_trades,
+            "correlated_exposure_ratio": self._correlated_exposure_ratio,
+            "global_trade_block": self._global_trade_block,
+        }
+
+    def _validate_payload(self, payload: object) -> dict[str, Any] | None:
+        if not isinstance(payload, dict):
+            return None
+        required_scalar_fields = (
+            "peak_equity",
+            "equity",
+            "portfolio_pnl",
+            "drawdown_ratio",
+            "open_trades",
+            "correlated_exposure_ratio",
+            "global_trade_block",
+        )
+        for field in required_scalar_fields:
+            if field not in payload:
+                return None
+        daily_pnl_by_day = payload.get("daily_pnl_by_day")
+        if not isinstance(daily_pnl_by_day, dict):
+            return None
+        validated_daily: dict[str, float] = {}
+        for day_key, day_value in daily_pnl_by_day.items():
+            if not isinstance(day_key, str):
+                return None
+            try:
+                validated_daily[day_key] = float(day_value)
+            except (TypeError, ValueError):
+                return None
+        try:
+            return {
+                "peak_equity": float(payload["peak_equity"]),
+                "equity": float(payload["equity"]),
+                "portfolio_pnl": float(payload["portfolio_pnl"]),
+                "drawdown_ratio": float(payload["drawdown_ratio"]),
+                "daily_pnl_by_day": validated_daily,
+                "open_trades": int(payload["open_trades"]),
+                "correlated_exposure_ratio": float(payload["correlated_exposure_ratio"]),
+                "global_trade_block": bool(payload["global_trade_block"]),
+            }
+        except (TypeError, ValueError):
+            return None

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -64,6 +64,7 @@ class StrategyConfig:
     hard_max_trade_duration_seconds: int = 3600
     fast_exit_regime_factor: float = 0.75
     slow_exit_regime_factor: float = 1.25
+    risk_state_persistence_path: str = "/tmp/polyquantbot_p16_risk_state.json"
 
 
 @dataclass(frozen=True)
@@ -316,7 +317,14 @@ class StrategyTrigger:
         self._pre_trade_validator = PreTradeValidator()
         self._execution_tracker = ExecutionTracker()
         self._trade_validator = TradeValidator()
-        self._risk_engine = RiskEngine()
+        self._risk_engine = RiskEngine(persistence_path=self._config.risk_state_persistence_path)
+        self._risk_restore_ready = False
+        self._risk_restore_reason = "uninitialized"
+        restored, restore_reason = self._risk_engine.restore_state()
+        self._risk_restore_ready = restored
+        self._risk_restore_reason = restore_reason
+        if not restored:
+            log.error("risk_state_restore_failed_fail_closed", reason=restore_reason)
         self._trade_traceability: dict[str, dict[str, Any]] = {}
         self._optimization_output: dict[str, object] = {
             "strategy_weights": {"S1": 1.0, "S2": 1.0, "S3": 1.0, "S5": 1.0},
@@ -343,6 +351,41 @@ class StrategyTrigger:
     @staticmethod
     def _default_dynamic_strategy_weights() -> dict[str, float]:
         return {"S1": 1.0, "S2": 1.0, "S3": 1.0, "S5": 1.0, "FALCON": 1.0}
+
+    def get_risk_restore_status(self) -> dict[str, str | bool]:
+        return {
+            "ready": self._risk_restore_ready,
+            "reason": self._risk_restore_reason,
+        }
+
+    def _record_blocked_terminal_trace(
+        self,
+        *,
+        trade_id: str,
+        signal_data: dict[str, Any],
+        decision_data: dict[str, Any],
+        validation_result: dict[str, Any],
+        terminal_stage: str,
+        reason: str,
+        terminal_outcome: str,
+    ) -> None:
+        existing = self._trade_traceability.get(trade_id, {})
+        if existing.get("outcome_data", {}).get("terminal_stage"):
+            return
+        self._trade_traceability[trade_id] = {
+            "trade_id": trade_id,
+            "signal_data": signal_data,
+            "decision_data": decision_data,
+            "validation_result": validation_result,
+            "execution_data": existing.get("execution_data", {}),
+            "outcome_data": {
+                "terminal_stage": terminal_stage,
+                "reason": reason,
+                "terminal_outcome": terminal_outcome,
+                "trace_count": 1,
+            },
+            "risk_state": self._risk_engine.as_dict(),
+        }
 
     def _regime_strategy_modifiers(self, regime: MarketRegimeClassification) -> dict[str, float]:
         modifiers: dict[str, float] = {
@@ -2034,6 +2077,9 @@ class StrategyTrigger:
         aggregation_decision: StrategyAggregationDecision | None = None,
         market_context: dict[str, float] | None = None,
     ) -> str:
+        if not self._risk_restore_ready:
+            log.warning("risk_state_not_restored_fail_closed", reason=self._risk_restore_reason)
+            return "BLOCKED"
         now = time.time()
         if self._last_trigger_time and (now - self._last_trigger_time) < self._cooldown_seconds:
             return "COOLDOWN"
@@ -2067,6 +2113,7 @@ class StrategyTrigger:
 
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
             current_total_exposure = sum(position.exposure() for position in snapshot.positions)
+            trade_id = str(uuid.uuid4())
             selected_candidate = None
             if aggregation_decision is not None and aggregation_decision.selected_trade:
                 selected_candidate = next(
@@ -2100,6 +2147,24 @@ class StrategyTrigger:
                 total_capital=snapshot.equity,
             )
             if portfolio_guard.final_decision == "SKIP":
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data={
+                        "expected_value": float((market_context or {}).get("expected_value", 0.0)),
+                        "edge": 0.0,
+                        "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                        "spread": float((market_context or {}).get("spread", 0.0)),
+                    },
+                    decision_data={
+                        "position_size": sizing.position_size,
+                        "target_market_id": target_market_id,
+                        "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+                    },
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "portfolio_guard_blocked", "checks": {}},
+                    terminal_stage="portfolio_guard_block",
+                    reason=portfolio_guard.reason,
+                    terminal_outcome="BLOCKED",
+                )
                 return "BLOCKED"
             signal_edge = max(self._config.min_edge, 0.0)
             if selected_candidate is not None:
@@ -2121,12 +2186,48 @@ class StrategyTrigger:
                     reference_price=readiness.reference_price,
                     reevaluation_window=readiness.reevaluation_window,
                 )
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data={
+                        "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
+                        "edge": signal_edge,
+                        "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                        "spread": float((market_context or {}).get("spread", 0.0)),
+                    },
+                    decision_data={
+                        "position_size": portfolio_guard.adjusted_size,
+                        "target_market_id": target_market_id,
+                        "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+                    },
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "timing_gate_wait", "checks": {}},
+                    terminal_stage="timing_gate_block",
+                    reason=readiness.timing_reason,
+                    terminal_outcome="HOLD",
+                )
                 return "HOLD"
             if readiness.timing_decision == "SKIP":
                 log.info(
                     "entry_timing_skip",
                     timing_reason=readiness.timing_reason,
                     reference_price=readiness.reference_price,
+                )
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data={
+                        "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
+                        "edge": signal_edge,
+                        "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                        "spread": float((market_context or {}).get("spread", 0.0)),
+                    },
+                    decision_data={
+                        "position_size": portfolio_guard.adjusted_size,
+                        "target_market_id": target_market_id,
+                        "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+                    },
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "timing_gate_skip", "checks": {}},
+                    terminal_stage="timing_gate_block",
+                    reason=readiness.timing_reason,
+                    terminal_outcome="BLOCKED",
                 )
                 return "BLOCKED"
             if not readiness.final_execution_readiness:
@@ -2136,9 +2237,26 @@ class StrategyTrigger:
                     expected_fill_price=readiness.expected_fill_price,
                     expected_slippage=readiness.expected_slippage,
                 )
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data={
+                        "expected_value": float((market_context or {}).get("expected_value", signal_edge)),
+                        "edge": signal_edge,
+                        "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                        "spread": float((market_context or {}).get("spread", 0.0)),
+                    },
+                    decision_data={
+                        "position_size": portfolio_guard.adjusted_size,
+                        "target_market_id": target_market_id,
+                        "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
+                    },
+                    validation_result={"decision": "NOT_EVALUATED", "reason": "execution_quality_blocked", "checks": {}},
+                    terminal_stage="execution_quality_gate_block",
+                    reason=readiness.execution_quality_reason,
+                    terminal_outcome="BLOCKED",
+                )
                 return "BLOCKED"
             size = readiness.adjusted_size
-            trade_id = str(uuid.uuid4())
             selected_metadata = selected_candidate.market_metadata if selected_candidate is not None else {}
             candidate_title = (
                 str(selected_metadata.get("title") or selected_metadata.get("market_title", ""))
@@ -2164,19 +2282,19 @@ class StrategyTrigger:
                 risk_state=self._risk_engine.as_dict(),
             )
             if validation_result.decision != "ALLOW":
-                self._trade_traceability[trade_id] = {
-                    "trade_id": trade_id,
-                    "signal_data": signal_data,
-                    "decision_data": decision_data,
-                    "validation_result": {
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
                         "decision": validation_result.decision,
                         "reason": validation_result.reason,
                         "checks": validation_result.checks,
                     },
-                    "execution_data": {},
-                    "outcome_data": {},
-                    "risk_state": self._risk_engine.as_dict(),
-                }
+                    terminal_stage="pre_trade_validator_block",
+                    reason=validation_result.reason,
+                    terminal_outcome="BLOCKED",
+                )
                 log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
                 return "BLOCKED"
             self._execution_tracker.record_order_submission(
@@ -2259,7 +2377,22 @@ class StrategyTrigger:
                     decision_threshold=0.5,
                     action="OPEN",
                 )
-            return "OPENED" if created is not None else "BLOCKED"
+            if created is None:
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
+                        "decision": validation_result.decision,
+                        "reason": validation_result.reason,
+                        "checks": validation_result.checks,
+                    },
+                    terminal_stage="execution_engine_rejected_open",
+                    reason="execution_open_position_rejected",
+                    terminal_outcome="BLOCKED",
+                )
+                return "BLOCKED"
+            return "OPENED"
 
         if open_pos is not None:
             await self._engine.update_mark_to_market({self._config.market_id: market_price})

--- a/projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md
@@ -1,0 +1,72 @@
+# 24_36_p16_restart_safe_risk_traceability_remediation
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Authoritative restart-safe persistence and restore for touched P16 hard-block controls in strategy-trigger runtime path.
+  2. Fail-safe blocked behavior when risk persistence is missing/corrupt/unreadable/invalid.
+  3. Exactly one terminal blocked trace record for touched terminal blocked outcomes (pre-trade validator, portfolio guard, timing gate, execution-quality gate, execution-engine rejected open).
+  4. Preserve successful-path execution-truth fields (`expected_price`, `actual_fill_price`, `slippage`, latency envelope fields).
+  5. Correct implementation truthfulness for touched scope only.
+- Not in Scope:
+  - New strategy design.
+  - Broad persistence redesign outside touched P16 strategy-trigger path.
+  - Non-trigger execution entry surfaces.
+  - Telegram/UI/dashboard or BRIEFER artifacts.
+  - P15 weighting changes.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`. Tier: MAJOR
+
+## 1. What was built
+- Implemented authoritative risk-state persistence and restore support in `RiskEngine` with structural validation, atomic write, and explicit restore status reasons.
+- Integrated fail-closed startup gating in `StrategyTrigger` so trading decisions are blocked until risk state restore succeeds.
+- Added terminal blocked trace recording helper in `StrategyTrigger` and wired it to touched blocked terminal exits:
+  - pre-trade validator block
+  - portfolio guard block
+  - timing gate block
+  - execution-quality gate block
+  - execution-engine rejected open path
+- Preserved successful-path execution-truth behavior (order submission + fill recording + traceability envelope fields).
+- Added focused P16 tests for restart safety, fail-safe persistence restore behavior, and one-terminal-trace-per-blocked-outcome coverage.
+
+## 2. Current system architecture
+- `projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+  - owns risk-state persistence (`persist_state`) and restore (`restore_state`) with payload validation and explicit failure reasons.
+  - persists after snapshot updates and post-trade pnl updates.
+- `projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - constructs `RiskEngine` with configured persistence path.
+  - enforces fail-closed behavior before any evaluate/open decision when restore failed.
+  - writes one authoritative terminal blocked trace payload for each touched blocked terminal outcome.
+- `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+  - validates restart-safe block continuity after re-instantiation.
+  - validates fail-closed behavior + explicit reason for missing/corrupt/invalid persistence payloads.
+  - validates touched blocked terminal outcomes each emit exactly one terminal trace record.
+  - validates successful path still records execution truth fields.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/core/risk/risk_engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Restart-safe hard-block continuity now persists and restores in the touched strategy-trigger path.
+- Restore failure states are fail-closed with explicit status reasons (`persistence_missing`, `persistence_corrupt_json`, `persistence_invalid_structure`, unreadable error class).
+- Touched blocked terminal outcomes now have one terminal trace record each and no touched blocked exit remains zero-trace in focused coverage.
+- Successful-path execution-truth capture remains intact (`expected_price`, `actual_fill_price`, `slippage`, `latency_ms`).
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/core/risk/risk_engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅ (`6 passed`, warning: unknown pytest `asyncio_mode` config)
+
+## 5. Known issues
+- This remediation is NARROW INTEGRATION in the touched strategy-trigger path only; non-trigger execution entry surfaces remain out of scope.
+- Pytest emits existing environment warning for unknown `asyncio_mode` option; focused tests still pass.
+
+## 6. What is next
+- Run SENTINEL MAJOR revalidation on the same touched P16 target path before merge decision.
+- If SENTINEL approves, proceed to COMMANDER merge decision for PR flow.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
+from pathlib import Path
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
 from projects.polymarket.polyquantbot.execution.strategy_trigger import (
@@ -30,10 +32,38 @@ def _build_aggregation(edge: float = 0.05) -> StrategyAggregationDecision:
     )
 
 
-def _build_trigger(starting_equity: float = 10_000.0) -> StrategyTrigger:
+def _seed_risk_state_file(path: Path) -> None:
+    path.write_text(
+        (
+            '{"correlated_exposure_ratio":0.0,'
+            '"daily_pnl_by_day":{},'
+            '"drawdown_ratio":0.0,'
+            '"equity":10000.0,'
+            '"global_trade_block":false,'
+            '"open_trades":0,'
+            '"peak_equity":10000.0,'
+            '"portfolio_pnl":0.0,'
+            '"version":1}'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_trigger(
+    starting_equity: float = 10_000.0,
+    risk_state_path: str | None = None,
+) -> StrategyTrigger:
+    state_file = Path(risk_state_path) if risk_state_path else Path(tempfile.mkstemp(suffix="_p16_risk_state.json")[1])
+    if not state_file.exists() or state_file.stat().st_size == 0:
+        _seed_risk_state_file(state_file)
     trigger = StrategyTrigger(
         engine=ExecutionEngine(starting_equity=starting_equity),
-        config=StrategyConfig(market_id="MARKET-1", threshold=0.60, target_pnl=2.0),
+        config=StrategyConfig(
+            market_id="MARKET-1",
+            threshold=0.60,
+            target_pnl=2.0,
+            risk_state_persistence_path=str(state_file),
+        ),
     )
     trigger._cooldown_seconds = 0.0  # noqa: SLF001
     trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
@@ -57,6 +87,205 @@ def test_p16_pre_trade_block_when_ev_non_positive() -> None:
         snapshot = await trigger._engine.snapshot()  # noqa: SLF001
         assert decision == "BLOCKED"
         assert len(snapshot.positions) == 0
+
+    asyncio.run(_run())
+
+
+def test_p16_restart_safe_hard_block_persists_after_restart() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "risk_state.json"
+            _seed_risk_state_file(state_path)
+            trigger = _build_trigger(risk_state_path=str(state_path))
+            trigger._risk_engine.update_from_snapshot(  # noqa: SLF001
+                equity=9_100.0,
+                realized_pnl=-2_100.0,
+                open_trades=0,
+                correlated_exposure_ratio=0.0,
+            )
+            trigger._risk_engine.record_trade_pnl(-2_100.0)  # noqa: SLF001
+            restarted = _build_trigger(risk_state_path=str(state_path))
+            decision = await restarted.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context={
+                    "expected_value": 0.12,
+                    "liquidity_usd": 50_000.0,
+                    "spread": 0.01,
+                    "best_bid": 0.445,
+                    "best_ask": 0.455,
+                },
+            )
+            assert decision == "BLOCKED"
+            assert restarted._risk_engine.get_state().global_trade_block is True  # noqa: SLF001
+
+    asyncio.run(_run())
+
+
+def test_p16_missing_corrupt_or_invalid_risk_state_fails_closed_with_reason() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        missing_state_path = Path(temp_dir) / "missing.json"
+        missing_trigger = StrategyTrigger(
+            engine=ExecutionEngine(starting_equity=10_000.0),
+            config=StrategyConfig(
+                market_id="MARKET-1",
+                threshold=0.60,
+                target_pnl=2.0,
+                risk_state_persistence_path=str(missing_state_path),
+            ),
+        )
+        missing_trigger._cooldown_seconds = 0.0  # noqa: SLF001
+        missing_trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+        assert missing_trigger.get_risk_restore_status()["ready"] is False
+        assert missing_trigger.get_risk_restore_status()["reason"] == "persistence_missing"
+        decision_missing = asyncio.run(
+            missing_trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context={"expected_value": 0.10, "liquidity_usd": 50_000.0, "spread": 0.01, "best_bid": 0.445, "best_ask": 0.455},
+            )
+        )
+        assert decision_missing == "BLOCKED"
+
+        corrupt_state_path = Path(temp_dir) / "corrupt.json"
+        corrupt_state_path.write_text("{not-json", encoding="utf-8")
+        corrupt_trigger = StrategyTrigger(
+            engine=ExecutionEngine(starting_equity=10_000.0),
+            config=StrategyConfig(
+                market_id="MARKET-1",
+                threshold=0.60,
+                target_pnl=2.0,
+                risk_state_persistence_path=str(corrupt_state_path),
+            ),
+        )
+        assert corrupt_trigger.get_risk_restore_status()["ready"] is False
+        assert corrupt_trigger.get_risk_restore_status()["reason"] == "persistence_corrupt_json"
+
+        invalid_state_path = Path(temp_dir) / "invalid.json"
+        invalid_state_path.write_text('{"version":1,"equity":10000}', encoding="utf-8")
+        invalid_trigger = StrategyTrigger(
+            engine=ExecutionEngine(starting_equity=10_000.0),
+            config=StrategyConfig(
+                market_id="MARKET-1",
+                threshold=0.60,
+                target_pnl=2.0,
+                risk_state_persistence_path=str(invalid_state_path),
+            ),
+        )
+        assert invalid_trigger.get_risk_restore_status()["ready"] is False
+        assert invalid_trigger.get_risk_restore_status()["reason"] == "persistence_invalid_structure"
+
+
+def test_p16_blocked_terminal_traceability_has_single_terminal_trace_per_path() -> None:
+    async def _run() -> None:
+        pre_trade_trigger = _build_trigger()
+        decision = await pre_trade_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={"expected_value": 0.0, "liquidity_usd": 20_000.0, "spread": 0.01, "best_bid": 0.44, "best_ask": 0.46},
+        )
+        assert decision == "BLOCKED"
+        pre_trade_traces = [
+            trace for trace in pre_trade_trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "pre_trade_validator_block"
+        ]
+        assert len(pre_trade_traces) == 1
+
+        portfolio_trigger = _build_trigger()
+        await portfolio_trigger._engine.open_position(  # noqa: SLF001
+            market="MARKET-ALT",
+            market_title="Alt",
+            side="YES",
+            price=0.5,
+            size=100.0,
+        )
+        decision = await portfolio_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=StrategyAggregationDecision(
+                selected_trade="S1",
+                ranked_candidates=[
+                    StrategyCandidateScore(
+                        strategy_name="S1",
+                        decision="ENTER",
+                        reason="portfolio_guard_test",
+                        edge=0.05,
+                        confidence=0.9,
+                        score=0.95,
+                        market_metadata={"market_id": "MARKET-ALT", "title": "Alt Market"},
+                    )
+                ],
+                selection_reason="portfolio_guard_test",
+                top_score=0.95,
+                decision="ENTER",
+            ),
+            market_context={"expected_value": 0.10, "liquidity_usd": 50_000.0, "spread": 0.01, "best_bid": 0.445, "best_ask": 0.455},
+        )
+        assert decision == "BLOCKED"
+        portfolio_traces = [
+            trace for trace in portfolio_trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "portfolio_guard_block"
+        ]
+        assert len(portfolio_traces) == 1
+
+        timing_trigger = _build_trigger()
+        decision = await timing_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.06),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "timing_wait_cycles": 3,
+                "signal_reference_price": 0.40,
+            },
+        )
+        assert decision == "BLOCKED"
+        timing_traces = [
+            trace for trace in timing_trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "timing_gate_block"
+        ]
+        assert len(timing_traces) == 1
+
+        quality_trigger = _build_trigger()
+        decision = await quality_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.06),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.40,
+                "best_ask": 0.50,
+            },
+        )
+        assert decision == "BLOCKED"
+        quality_traces = [
+            trace for trace in quality_trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "execution_quality_gate_block"
+        ]
+        assert len(quality_traces) == 1
+
+        engine_reject_trigger = _build_trigger()
+        original_open_position = engine_reject_trigger._engine.open_position  # noqa: SLF001
+
+        async def _reject_open(**_kwargs: object) -> None:
+            return None
+
+        engine_reject_trigger._engine.open_position = _reject_open  # type: ignore[assignment] # noqa: SLF001
+        decision = await engine_reject_trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.06),
+            market_context={"expected_value": 0.10, "liquidity_usd": 50_000.0, "spread": 0.01, "best_bid": 0.445, "best_ask": 0.455},
+        )
+        engine_reject_trigger._engine.open_position = original_open_position  # type: ignore[assignment] # noqa: SLF001
+        assert decision == "BLOCKED"
+        engine_traces = [
+            trace for trace in engine_reject_trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "execution_engine_rejected_open"
+        ]
+        assert len(engine_traces) == 1
 
     asyncio.run(_run())
 


### PR DESCRIPTION
### Motivation
- Fix SENTINEL BLOCKED findings showing restart cleared P16 hard-block state and multiple blocked-terminal exits returned with `trace_count=0` for the touched strategy-trigger path.
- Ensure authoritative, restart-surviving risk-state for P16 hard-block controls so a process restart cannot reopen blocked trading paths. 
- Provide one authoritative trace record per touched blocked terminal outcome to restore blocked-path forensic traceability and correct report/state truthfulness.

### Description
- Added persistent state support to `RiskEngine` with `persist_state()` and `restore_state()` including atomic tmp-write, JSON schema validation, explicit restore failure reasons, and persistence on snapshot/update and post-trade updates (`projects/polymarket/polyquantbot/core/risk/risk_engine.py`).
- Wired authoritative restore into `StrategyTrigger` initialization by constructing `RiskEngine(persistence_path=...)`, exposing restore status via `get_risk_restore_status()`, and enforcing fail-closed startup gating so `evaluate()` returns `BLOCKED` until restore is validated (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`).
- Added single-authoritative blocked-terminal trace helper `_record_blocked_terminal_trace()` and invoked it on the touched terminal blocked exits: pre-trade validator, portfolio guard, timing gate (wait/skip), execution-quality gate, and execution-engine rejected open; ensured no duplicate terminal traces for the same trade id while preserving successful-path trace envelope fields (expected/actual/slippage/latency). (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`).
- Added focused tests and test harness wiring to cover restart-safety, fail-safe restore, blocked-terminal single-trace semantics, and no regression of successful-path execution-truth; added a new FORGE report and updated `PROJECT_STATE.md` to reflect the remediation and next-step handoff. (`projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`, `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`, `PROJECT_STATE.md`).

### Testing
- Performed static compile: `python -m py_compile projects/polymarket/polyquantbot/core/risk/risk_engine.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — passed. 
- Ran focused test suite: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` — all focused tests passed (`6 passed`), with a non-blocking pytest config warning about unknown `asyncio_mode`.
- Validation Tier: `MAJOR`; Claim Level: `NARROW INTEGRATION` — next step: request SENTINEL MAJOR revalidation on the same touched P16 path before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80839d6fc832ea15e640550c496c0)