### PR TITLE
Enforce centralized execution gateway for open-position flow

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 21:15
-- Status        : FORGE-X completed focused post-merge P16 smoke verification (restart-safe persistence, blocked terminal traceability, execution-truth success envelope) and cleaned stale validation-chain state references.
+- Last Updated  : 2026-04-09 22:03
+- Status        : FORGE-X completed P17 centralized execution entry gateway hardening in touched strategy-trigger/manual execution path, enforcing risk-before-open and direct-open fail-closed behavior.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P17 multi-entry protection gateway (2026-04-09): implemented centralized `ExecutionGateway` for open-position requests in touched strategy-trigger/manual path, enforced direct `ExecutionEngine.open_position` fail-closed outside gateway context, and added focused direct-block/gateway-pass/strategy-trigger regression coverage; report `projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md`.
 - P16 post-merge smoke-check cleanup (2026-04-09): verified touched runtime path remains stable after PR #350/#354 merge (restart-safe block persistence survives lifecycle, blocked terminal outcomes emit exactly one terminal trace each, successful path preserves `expected_price`/`actual_fill_price`/`slippage` execution-truth envelope fields), and retired stale P16 await-merge/await-SENTINEL state wording; report `projects/polymarket/polyquantbot/reports/forge/24_37_p16_post_merge_smoke_check_cleanup.md`.
 - FORGE-X P16 restart-safe risk traceability remediation (2026-04-09): implemented authoritative risk-state persistence/restore with fail-closed startup gating, added touched blocked-terminal trace writes, added focused restart/fail-safe/traceability tests, and generated report `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`.
 - SENTINEL revalidation for PR #347 P16 remediation (2026-04-09): verdict **BLOCKED** (score **49/100**) after runtime challenge confirmed restart can clear hard-block state in touched path and multiple blocked terminal outcomes are not trace-recorded; report saved at `projects/polymarket/polyquantbot/reports/sentinel/24_35_p16_remediation_revalidation_pr347.md`.
@@ -125,6 +126,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P17 multi-entry protection gateway handoff
+- STANDARD-tier NARROW INTEGRATION implementation is complete for centralized execution entry gating in touched strategy-trigger/manual open-position path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### Market title test-hardening handoff
 - STANDARD-tier NARROW INTEGRATION follow-up is complete for Falcon title-resolution regression test integrity in touched test scope.
@@ -260,12 +265,11 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_37_p16_post_merge_smoke_check_cleanup.md
-Tier: MINOR
+Auto PR review + COMMANDER review required. Source: projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 
+- P17 execution gateway enforcement is currently narrow integration in touched `ExecutionEngine`/`StrategyTrigger` open-position path and is not yet generalized to unrelated non-engine runtime execution stacks.
 - P16 control layer is currently integrated in strategy-trigger runtime path only; additional non-trigger execution entry surfaces (if introduced later) require separate wiring to inherit identical enforcement guarantees.
 - P15 strategy weighting is currently narrow integration in S4 path only and is not yet wired into broader non-S4 runtime orchestration/telemetry surfaces.
 - P14.3 Falcon strategy layer is currently narrow integration in S4 scoring path only and is not yet wired into broader non-S4 runtime orchestration surfaces; insufficient-data fallback now prevents external weighting when Falcon evidence is unavailable.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import statistics
@@ -14,6 +16,16 @@ from .analytics import PerformanceTracker
 from .trade_trace import TradeTraceEngine
 
 log = structlog.get_logger(__name__)
+_EXECUTION_GATEWAY_ACTIVE: ContextVar[bool] = ContextVar("_execution_gateway_active", default=False)
+
+
+@contextmanager
+def execution_gateway_context():
+    token = _EXECUTION_GATEWAY_ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        _EXECUTION_GATEWAY_ACTIVE.reset(token)
 
 
 @dataclass(frozen=True)
@@ -57,6 +69,8 @@ class ExecutionEngine:
         position_context: dict[str, Any] | None = None,
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
+        if not _EXECUTION_GATEWAY_ACTIVE.get():
+            raise RuntimeError("execution_gateway_required_for_open_position")
         async with self._lock:
             size = float(size)
             if size <= 0:

--- a/projects/polymarket/polyquantbot/execution/gateway.py
+++ b/projects/polymarket/polyquantbot/execution/gateway.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from ..core.risk.pre_trade_validator import PreTradeValidator
+from ..core.risk.risk_engine import RiskEngine
+from .engine import ExecutionEngine, execution_gateway_context
+from .models import Position
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class GatewayExecutionResult:
+    position: Position | None
+    validation_decision: str
+    validation_reason: str
+    validation_checks: dict[str, bool]
+
+
+class ExecutionGateway:
+    """Centralized execution entry gateway for opening new positions."""
+
+    def __init__(
+        self,
+        *,
+        engine: ExecutionEngine,
+        pre_trade_validator: PreTradeValidator,
+        risk_engine: RiskEngine,
+    ) -> None:
+        self._engine = engine
+        self._pre_trade_validator = pre_trade_validator
+        self._risk_engine = risk_engine
+
+    async def open_validated_position(
+        self,
+        *,
+        market: str,
+        market_title: str,
+        side: str,
+        price: float,
+        size: float,
+        signal_data: dict[str, Any],
+        decision_data: dict[str, Any],
+        position_id: str | None = None,
+        position_context: dict[str, Any] | None = None,
+    ) -> GatewayExecutionResult:
+        validation = self._pre_trade_validator.validate(
+            signal_data=signal_data,
+            decision_data=decision_data,
+            risk_state=self._risk_engine.as_dict(),
+        )
+        if validation.decision != "ALLOW":
+            log.info(
+                "execution_gateway_blocked",
+                decision=validation.decision,
+                reason=validation.reason,
+                market=market,
+            )
+            return GatewayExecutionResult(
+                position=None,
+                validation_decision=validation.decision,
+                validation_reason=validation.reason,
+                validation_checks=validation.checks,
+            )
+
+        with execution_gateway_context():
+            created = await self._engine.open_position(
+                market=market,
+                market_title=market_title,
+                side=side,
+                price=price,
+                size=size,
+                position_id=position_id,
+                position_context=position_context,
+            )
+        return GatewayExecutionResult(
+            position=created,
+            validation_decision=validation.decision,
+            validation_reason=validation.reason,
+            validation_checks=validation.checks,
+        )

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from .engine import ExecutionEngine
+from .gateway import ExecutionGateway
 from .intelligence import ExecutionIntelligence, MarketSnapshot
 from .trade_trace import TradeTraceEngine
 from ..strategy.falcon_alpha_strategy import FalconSignal
@@ -318,6 +319,11 @@ class StrategyTrigger:
         self._execution_tracker = ExecutionTracker()
         self._trade_validator = TradeValidator()
         self._risk_engine = RiskEngine(persistence_path=self._config.risk_state_persistence_path)
+        self._execution_gateway = ExecutionGateway(
+            engine=self._engine,
+            pre_trade_validator=self._pre_trade_validator,
+            risk_engine=self._risk_engine,
+        )
         self._risk_restore_ready = False
         self._risk_restore_reason = "uninitialized"
         restored, restore_reason = self._risk_engine.restore_state()
@@ -2276,39 +2282,14 @@ class StrategyTrigger:
                 "target_market_id": target_market_id,
                 "strategy_source": selected_candidate.strategy_name if selected_candidate is not None else "UNKNOWN",
             }
-            validation_result = self._pre_trade_validator.validate(
-                signal_data=signal_data,
-                decision_data=decision_data,
-                risk_state=self._risk_engine.as_dict(),
-            )
-            if validation_result.decision != "ALLOW":
-                self._record_blocked_terminal_trace(
-                    trade_id=trade_id,
-                    signal_data=signal_data,
-                    decision_data=decision_data,
-                    validation_result={
-                        "decision": validation_result.decision,
-                        "reason": validation_result.reason,
-                        "checks": validation_result.checks,
-                    },
-                    terminal_stage="pre_trade_validator_block",
-                    reason=validation_result.reason,
-                    terminal_outcome="BLOCKED",
-                )
-                log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
-                return "BLOCKED"
-            self._execution_tracker.record_order_submission(
-                trade_id=trade_id,
-                expected_price=readiness.expected_fill_price,
-                signal_data=signal_data,
-                decision_data=decision_data,
-            )
-            created = await self._engine.open_position(
+            gateway_result = await self._execution_gateway.open_validated_position(
                 market=target_market_id,
                 market_title=str(candidate_title),
                 side=self._config.side,
                 price=readiness.expected_fill_price,
                 size=size,
+                signal_data=signal_data,
+                decision_data=decision_data,
                 position_id=trade_id,
                 position_context={
                     "strategy_source": (
@@ -2329,6 +2310,32 @@ class StrategyTrigger:
                     "trade_id": trade_id,
                 },
             )
+            validation_decision = gateway_result.validation_decision
+            validation_reason = gateway_result.validation_reason
+            validation_checks = gateway_result.validation_checks
+            if validation_decision != "ALLOW":
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
+                        "decision": validation_decision,
+                        "reason": validation_reason,
+                        "checks": validation_checks,
+                    },
+                    terminal_stage="pre_trade_validator_block",
+                    reason=validation_reason,
+                    terminal_outcome="BLOCKED",
+                )
+                log.info("pre_trade_blocked", reason=validation_reason, trade_id=trade_id)
+                return "BLOCKED"
+            self._execution_tracker.record_order_submission(
+                trade_id=trade_id,
+                expected_price=readiness.expected_fill_price,
+                signal_data=signal_data,
+                decision_data=decision_data,
+            )
+            created = gateway_result.position
             if created:
                 execution_data = self._execution_tracker.record_fill(
                     trade_id=trade_id,
@@ -2357,9 +2364,9 @@ class StrategyTrigger:
                     "signal_data": signal_data,
                     "decision_data": decision_data,
                     "validation_result": {
-                        "decision": validation_result.decision,
-                        "reason": validation_result.reason,
-                        "checks": validation_result.checks,
+                        "decision": validation_decision,
+                        "reason": validation_reason,
+                        "checks": validation_checks,
                     },
                     "execution_data": execution_data,
                     "outcome_data": {},
@@ -2383,9 +2390,9 @@ class StrategyTrigger:
                     signal_data=signal_data,
                     decision_data=decision_data,
                     validation_result={
-                        "decision": validation_result.decision,
-                        "reason": validation_result.reason,
-                        "checks": validation_result.checks,
+                        "decision": validation_decision,
+                        "reason": validation_reason,
+                        "checks": validation_checks,
                     },
                     terminal_stage="execution_engine_rejected_open",
                     reason="execution_open_position_rejected",

--- a/projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md
@@ -1,0 +1,66 @@
+# 24_38_p17_multi_entry_protection_gateway
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Identify and enforce the touched execution-entry surfaces for strategy-trigger/manual command path so all open-position requests route through one gateway.
+  2. Introduce a centralized `ExecutionGateway` that performs pre-trade risk validation before opening positions.
+  3. Block direct `ExecutionEngine.open_position(...)` calls outside gateway context.
+  4. Verify strategy-trigger path remains functional after gateway enforcement.
+  5. Add focused negative/positive tests: direct call fails, gateway call passes, strategy-trigger still opens valid trades.
+- Not in Scope:
+  - Position sizing logic updates.
+  - Liquidity/slippage model changes.
+  - Strategy scoring/selection behavior changes.
+  - Duplicate prevention redesign.
+  - UI/Telegram UX changes.
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md`. Tier: STANDARD.
+
+## 1. What was built
+- Added centralized execution entry component `ExecutionGateway` in execution domain.
+- Refactored `StrategyTrigger` open-position path to call the gateway for risk validation + execution instead of calling engine directly.
+- Added execution guard at `ExecutionEngine.open_position(...)` boundary so direct calls outside gateway context raise `RuntimeError("execution_gateway_required_for_open_position")`.
+- Updated touched tests that previously opened positions directly so they now use gateway (except explicit negative test proving direct-call block).
+- Added focused P17 test module covering:
+  - direct execution call blocked,
+  - gateway execution allowed,
+  - strategy-trigger path still opens when valid.
+
+## 2. Current system architecture
+- Execution entry routing in touched runtime path now becomes:
+  `entry (strategy-trigger/manual path) -> ExecutionGateway -> PreTradeValidator + RiskEngine state -> ExecutionEngine.open_position`.
+- `ExecutionEngine.open_position` is now gateway-context protected and fail-closed on non-gateway calls.
+- Strategy-trigger keeps existing trade trace + execution tracker semantics while delegating pre-trade gate/execution open to gateway.
+- Manual trade command path remains strategy-trigger based; by routing strategy-trigger through gateway, manual command entry inherits the same centralized execution gate in this touched scope.
+
+## 3. Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/gateway.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py`
+
+## 4. What is working
+- Direct calls to `ExecutionEngine.open_position` outside gateway context now fail closed.
+- Gateway-based execution with valid risk/pre-trade inputs succeeds.
+- Strategy-trigger valid path still returns `OPENED` and records position/trace in touched scope.
+- Updated touched analytics/title/risk tests continue passing with gateway migration.
+
+### Validation commands
+- `python -m py_compile projects/polymarket/polyquantbot/execution/engine.py projects/polymarket/polyquantbot/execution/gateway.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py` ✅ (`23 passed`, warning: unknown pytest `asyncio_mode` config)
+
+## 5. Known issues
+- This STANDARD change is NARROW INTEGRATION in touched open-position execution path (`ExecutionEngine` + `StrategyTrigger` + touched tests) and does not yet rewire unrelated non-engine execution stacks (`core/pipeline` live executor path).
+- Pytest environment still emits `PytestConfigWarning: Unknown config option: asyncio_mode`; tests pass despite warning.
+
+## 6. What is next
+- Run Codex auto PR review for this STANDARD-tier change set.
+- COMMANDER review merge decision.
+- If approved, proceed to P17.2 (position sizing enforcement) using the centralized gateway baseline.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
@@ -3,17 +3,31 @@ from __future__ import annotations
 import asyncio
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.gateway import ExecutionGateway
+from projects.polymarket.polyquantbot.core.risk.pre_trade_validator import PreTradeValidator
+from projects.polymarket.polyquantbot.core.risk.risk_engine import RiskEngine
+
+
+def _gateway_for(engine: ExecutionEngine) -> ExecutionGateway:
+    return ExecutionGateway(
+        engine=engine,
+        pre_trade_validator=PreTradeValidator(),
+        risk_engine=RiskEngine(),
+    )
 
 
 async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, object]]:
     engine = ExecutionEngine(starting_equity=10_000.0)
+    gateway = _gateway_for(engine)
 
-    first = await engine.open_position(
+    first = (await gateway.open_validated_position(
         market="mkt-s1-news",
         market_title="S1 NEWS",
         side="YES",
         price=0.50,
         size=100.0,
+        signal_data={"expected_value": 0.10, "edge": 0.05, "liquidity_usd": 20_000.0},
+        decision_data={"position_size": 100.0, "target_market_id": "mkt-s1-news", "strategy_source": "S1"},
         position_id="p14-1",
         position_context={
             "strategy_source": "S1",
@@ -24,7 +38,7 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
             "slippage_impact": 0.01,
             "timing_effectiveness": 0.90,
         },
-    )
+    )).position
     assert first is not None
     await engine.close_position(
         first,
@@ -32,12 +46,14 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
         close_context={"exit_reason": "momentum_weakened_after_favorable_move", "exit_efficiency": 0.95},
     )
 
-    second = await engine.open_position(
+    second = (await gateway.open_validated_position(
         market="mkt-s2-arb",
         market_title="S2 ARB",
         side="YES",
         price=0.60,
         size=100.0,
+        signal_data={"expected_value": 0.10, "edge": 0.08, "liquidity_usd": 20_000.0},
+        decision_data={"position_size": 100.0, "target_market_id": "mkt-s2-arb", "strategy_source": "S2"},
         position_id="p14-2",
         position_context={
             "strategy_source": "S2",
@@ -48,7 +64,7 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
             "slippage_impact": 0.03,
             "timing_effectiveness": 0.50,
         },
-    )
+    )).position
     assert second is not None
     await engine.close_position(
         second,
@@ -64,12 +80,15 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
 
 async def _build_edge_safety_trades() -> dict[str, object]:
     engine = ExecutionEngine(starting_equity=10_000.0)
-    position = await engine.open_position(
+    gateway = _gateway_for(engine)
+    position = (await gateway.open_validated_position(
         market="mkt-falcon-chaotic",
         market_title="FALCON CHAOTIC",
         side="YES",
         price=0.50,
         size=100.0,
+        signal_data={"expected_value": 0.10, "edge": 0.08, "liquidity_usd": 20_000.0},
+        decision_data={"position_size": 100.0, "target_market_id": "mkt-falcon-chaotic", "strategy_source": "FALCON"},
         position_id="p14-safety-1",
         position_context={
             "strategy_source": "FALCON",
@@ -80,7 +99,7 @@ async def _build_edge_safety_trades() -> dict[str, object]:
             "slippage_impact": 0.01,
             "timing_effectiveness": 0.6,
         },
-    )
+    )).position
     assert position is not None
     await engine.close_position(
         position,
@@ -88,12 +107,14 @@ async def _build_edge_safety_trades() -> dict[str, object]:
         close_context={"exit_reason": "take_profit", "exit_efficiency": 0.8},
     )
 
-    ignored = await engine.open_position(
+    ignored = (await gateway.open_validated_position(
         market="mkt-safety-zero-edge",
         market_title="ZERO EDGE",
         side="YES",
         price=0.50,
         size=100.0,
+        signal_data={"expected_value": 0.10, "edge": 0.08, "liquidity_usd": 20_000.0},
+        decision_data={"position_size": 100.0, "target_market_id": "mkt-safety-zero-edge", "strategy_source": "S3"},
         position_id="p14-safety-2",
         position_context={
             "strategy_source": "S3",
@@ -102,7 +123,7 @@ async def _build_edge_safety_trades() -> dict[str, object]:
             "entry_timing": "timing_enter",
             "theoretical_edge": 0.0,
         },
-    )
+    )).position
     assert ignored is not None
     await engine.close_position(ignored, 0.60, close_context={"exit_reason": "take_profit", "exit_efficiency": 0.8})
     return engine.get_analytics().summary()

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -192,13 +192,16 @@ def test_p16_blocked_terminal_traceability_has_single_terminal_trace_per_path() 
         assert len(pre_trade_traces) == 1
 
         portfolio_trigger = _build_trigger()
-        await portfolio_trigger._engine.open_position(  # noqa: SLF001
+        opened = await portfolio_trigger._execution_gateway.open_validated_position(  # noqa: SLF001
             market="MARKET-ALT",
             market_title="Alt",
             side="YES",
             price=0.5,
             size=100.0,
+            signal_data={"expected_value": 0.10, "edge": 0.05, "liquidity_usd": 20_000.0},
+            decision_data={"position_size": 100.0, "target_market_id": "MARKET-ALT", "strategy_source": "S1"},
         )
+        assert opened.position is not None
         decision = await portfolio_trigger.evaluate(
             market_price=0.45,
             aggregation_decision=StrategyAggregationDecision(
@@ -268,18 +271,25 @@ def test_p16_blocked_terminal_traceability_has_single_terminal_trace_per_path() 
         assert len(quality_traces) == 1
 
         engine_reject_trigger = _build_trigger()
-        original_open_position = engine_reject_trigger._engine.open_position  # noqa: SLF001
+        original_gateway_open = engine_reject_trigger._execution_gateway.open_validated_position  # noqa: SLF001
 
-        async def _reject_open(**_kwargs: object) -> None:
-            return None
+        async def _reject_open(**_kwargs: object):  # type: ignore[no-untyped-def]
+            from projects.polymarket.polyquantbot.execution.gateway import GatewayExecutionResult
 
-        engine_reject_trigger._engine.open_position = _reject_open  # type: ignore[assignment] # noqa: SLF001
+            return GatewayExecutionResult(
+                position=None,
+                validation_decision="ALLOW",
+                validation_reason="allowed",
+                validation_checks={"ev_positive": True},
+            )
+
+        engine_reject_trigger._execution_gateway.open_validated_position = _reject_open  # type: ignore[assignment] # noqa: SLF001
         decision = await engine_reject_trigger.evaluate(
             market_price=0.45,
             aggregation_decision=_build_aggregation(edge=0.06),
             market_context={"expected_value": 0.10, "liquidity_usd": 50_000.0, "spread": 0.01, "best_bid": 0.445, "best_ask": 0.455},
         )
-        engine_reject_trigger._engine.open_position = original_open_position  # type: ignore[assignment] # noqa: SLF001
+        engine_reject_trigger._execution_gateway.open_validated_position = original_gateway_open  # type: ignore[assignment] # noqa: SLF001
         assert decision == "BLOCKED"
         engine_traces = [
             trace for trace in engine_reject_trigger._trade_traceability.values()  # noqa: SLF001

--- a/projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from projects.polymarket.polyquantbot.core.risk.pre_trade_validator import PreTradeValidator
+from projects.polymarket.polyquantbot.core.risk.risk_engine import RiskEngine
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.gateway import ExecutionGateway
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+def _seed_risk_state_file(path: Path) -> None:
+    path.write_text(
+        (
+            '{"correlated_exposure_ratio":0.0,'
+            '"daily_pnl_by_day":{},'
+            '"drawdown_ratio":0.0,'
+            '"equity":10000.0,'
+            '"global_trade_block":false,'
+            '"open_trades":0,'
+            '"peak_equity":10000.0,'
+            '"portfolio_pnl":0.0,'
+            '"version":1}'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_aggregation() -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S1",
+        decision="ENTER",
+        reason="test_signal",
+        edge=0.05,
+        confidence=0.9,
+        score=0.95,
+        market_metadata={"market_id": "MARKET-1", "title": "Test Market"},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S1",
+        ranked_candidates=[candidate],
+        selection_reason="highest_score",
+        top_score=0.95,
+        decision="ENTER",
+    )
+
+
+def test_p17_direct_execution_open_position_is_blocked() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        try:
+            await engine.open_position(
+                market="MKT-DIRECT",
+                market_title="Direct Call",
+                side="YES",
+                price=0.50,
+                size=100.0,
+            )
+            raise AssertionError("Expected direct execution to fail.")
+        except RuntimeError as exc:
+            assert "execution_gateway_required_for_open_position" in str(exc)
+
+    asyncio.run(_run())
+
+
+def test_p17_execution_via_gateway_succeeds() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        gateway = ExecutionGateway(
+            engine=engine,
+            pre_trade_validator=PreTradeValidator(),
+            risk_engine=RiskEngine(),
+        )
+        result = await gateway.open_validated_position(
+            market="MKT-GATEWAY",
+            market_title="Gateway Call",
+            side="YES",
+            price=0.50,
+            size=100.0,
+            signal_data={"expected_value": 0.10, "edge": 0.05, "liquidity_usd": 20_000.0},
+            decision_data={"position_size": 100.0, "target_market_id": "MKT-GATEWAY", "strategy_source": "S1"},
+        )
+        assert result.validation_decision == "ALLOW"
+        assert result.position is not None
+
+    asyncio.run(_run())
+
+
+def test_p17_strategy_trigger_path_still_opens_via_gateway() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "risk_state.json"
+            _seed_risk_state_file(state_path)
+            trigger = StrategyTrigger(
+                engine=ExecutionEngine(starting_equity=10_000.0),
+                config=StrategyConfig(
+                    market_id="MARKET-1",
+                    threshold=0.60,
+                    target_pnl=2.0,
+                    risk_state_persistence_path=str(state_path),
+                ),
+            )
+            trigger._cooldown_seconds = 0.0  # noqa: SLF001
+            trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+            decision = await trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_build_aggregation(),
+                market_context={
+                    "expected_value": 0.10,
+                    "liquidity_usd": 50_000.0,
+                    "spread": 0.01,
+                    "best_bid": 0.445,
+                    "best_ask": 0.455,
+                },
+            )
+            assert decision == "OPENED"
+            snapshot = await trigger._engine.snapshot()  # noqa: SLF001
+            assert len(snapshot.positions) == 1
+
+    asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import asyncio
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, export_execution_payload
+from projects.polymarket.polyquantbot.execution.gateway import ExecutionGateway
 from projects.polymarket.polyquantbot.interface import ui_formatter
 from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+from projects.polymarket.polyquantbot.core.risk.pre_trade_validator import PreTradeValidator
+from projects.polymarket.polyquantbot.core.risk.risk_engine import RiskEngine
 
 
 async def _empty_context(_: str) -> dict[str, str]:
@@ -116,12 +119,19 @@ def test_rendering_is_deterministic_for_same_payload() -> None:
 def test_execution_to_payload_preserves_market_title() -> None:
     async def _run() -> dict[str, object]:
         engine = ExecutionEngine(starting_equity=1_000.0)
-        await engine.open_position(
+        gateway = ExecutionGateway(
+            engine=engine,
+            pre_trade_validator=PreTradeValidator(),
+            risk_engine=RiskEngine(),
+        )
+        await gateway.open_validated_position(
             market="mkt-exec-1",
             market_title="Will unemployment stay below 4% in Q3?",
             side="YES",
             price=0.49,
             size=50.0,
+            signal_data={"expected_value": 0.10, "edge": 0.04, "liquidity_usd": 20_000.0},
+            decision_data={"position_size": 50.0, "target_market_id": "mkt-exec-1", "strategy_source": "S1"},
             position_id="pos-1",
         )
         from projects.polymarket.polyquantbot.execution import engine as engine_module


### PR DESCRIPTION
### Motivation
- Prevent risk-bypass by requiring every open-position request to pass a single validated entry path before reaching the execution engine.
- Ensure pre-trade validation (risk checks) is always executed for strategy-trigger and manual/API/retry entry surfaces in the touched scope.

### Description
- Added a new `ExecutionGateway` (`projects/polymarket/polyquantbot/execution/gateway.py`) that runs `PreTradeValidator` + `RiskEngine` validation and opens positions only when allowed.
- Hardened the engine boundary by adding a gateway context guard in `ExecutionEngine.open_position(...)` using a `ContextVar` and `execution_gateway_context()` so direct calls outside the gateway raise `RuntimeError("execution_gateway_required_for_open_position")` (`projects/polymarket/polyquantbot/execution/engine.py`).
- Refactored `StrategyTrigger` to call `ExecutionGateway.open_validated_position(...)` and propagate validation decision/reason/checks into trade traceability instead of calling the engine directly (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`).
- Updated tests and test fixtures to use the gateway where they previously opened positions directly and added focused gateway tests (`projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py`), and added the FORGE report plus `PROJECT_STATE.md` update (`projects/polymarket/polyquantbot/reports/forge/24_38_p17_multi_entry_protection_gateway.md`, `PROJECT_STATE.md`).

### Testing
- Ran static compile checks with `python -m py_compile` against changed modules and related tests, which completed successfully.
- Ran targeted pytest: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p17_execution_gateway_20260410.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py` which passed (`23 passed`) with a non-blocking pytest config warning about `asyncio_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d821734f74832e809f9de076e24a51)