### PR TITLE
fix: enforce authoritative position sizing at execution boundary

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 23:05
-- Status        : FORGE-X completed STANDARD-tier execution-boundary validation-proof enforcement in StrategyTrigger→ExecutionEngine path (signed proof required for every open_position call).
+- Last Updated  : 2026-04-10 00:10
+- Status        : FORGE-X completed STANDARD-tier execution-boundary position-sizing enforcement in StrategyTrigger→ExecutionEngine path (fail-closed boundary rejection for non-compliant requested size).
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P16 execution-boundary position-sizing enforcement (2026-04-10): enforced authoritative boundary sizing checks in `ExecutionEngine.open_position(...)` for non-positive/per-trade-cap/capital-risk-allowed size violations before mutation, preserved signed validation-proof enforcement, propagated structured rejection reason into StrategyTrigger blocked terminal trace, and added focused tests; report `projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`.
 - P16 execution-boundary validation-proof enforcement (2026-04-09): replaced trust-only execution entry assumption with signed `ExecutionValidationProof` contract at engine boundary, wired StrategyTrigger ALLOW path to pass proof payload, and added focused no-proof/fake-proof/pass-proof runtime tests; report `projects/polymarket/polyquantbot/reports/forge/24_38_execution_validation_proof_boundary_enforcement.md`.
 - P16 post-merge smoke-check cleanup (2026-04-09): verified touched runtime path remains stable after PR #350/#354 merge (restart-safe block persistence survives lifecycle, blocked terminal outcomes emit exactly one terminal trace each, successful path preserves `expected_price`/`actual_fill_price`/`slippage` execution-truth envelope fields), and retired stale P16 await-merge/await-SENTINEL state wording; report `projects/polymarket/polyquantbot/reports/forge/24_37_p16_post_merge_smoke_check_cleanup.md`.
 - FORGE-X P16 restart-safe risk traceability remediation (2026-04-09): implemented authoritative risk-state persistence/restore with fail-closed startup gating, added touched blocked-terminal trace writes, added focused restart/fail-safe/traceability tests, and generated report `projects/polymarket/polyquantbot/reports/forge/24_36_p16_restart_safe_risk_traceability_remediation.md`.
@@ -126,6 +127,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P16 execution-boundary position-sizing enforcement handoff
+- STANDARD-tier NARROW INTEGRATION implementation is complete for StrategyTrigger→ExecutionEngine boundary sizing enforcement + explicit rejection traceability in touched path.
+- Awaiting Codex auto PR review baseline and COMMANDER merge decision.
 
 ### P16 execution-boundary validation-proof enforcement handoff
 - STANDARD-tier NARROW INTEGRATION implementation is complete for StrategyTrigger→ExecutionEngine proof contract enforcement.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -61,6 +61,7 @@ class ExecutionEngine:
         self._closed_trades: list[dict[str, Any]] = []
         self._position_context: dict[str, dict[str, Any]] = {}
         self._validation_secret: str = secrets.token_hex(32)
+        self._last_open_rejection: dict[str, Any] | None = None
 
     def build_validation_proof(
         self,
@@ -102,9 +103,9 @@ class ExecutionEngine:
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
+            self._last_open_rejection = None
             if not self._is_validation_proof_allowed(validation_proof):
-                log.warning(
-                    "execution_engine_open_rejected",
+                self._record_open_rejection(
                     reason="validation_proof_required_or_invalid",
                     market=market,
                     position_id=position_id,
@@ -112,36 +113,51 @@ class ExecutionEngine:
                 return None
             size = float(size)
             if size <= 0:
-                log.warning("execution_engine_open_rejected", reason="size_non_positive", size=size)
+                self._record_open_rejection(
+                    reason="size_non_positive",
+                    market=market,
+                    position_id=position_id,
+                    requested_size=size,
+                )
                 return None
             if not position_id:
                 position_id = str(uuid.uuid4())
             equity_base = max(self._equity, 0.0)
             max_position_size = equity_base * self.max_position_size_ratio
             if size > max_position_size:
-                log.warning(
-                    "execution_engine_open_rejected",
+                self._record_open_rejection(
                     reason="max_position_size_exceeded",
-                    requested=size,
+                    market=market,
+                    position_id=position_id,
+                    requested_size=size,
                     limit=max_position_size,
                     equity=equity_base,
                 )
                 return None
-            if self._current_total_exposure() + size > equity_base * self.max_total_exposure_ratio:
-                log.warning(
-                    "execution_engine_open_rejected",
-                    reason="max_total_exposure_exceeded",
-                    requested=size,
-                    current_exposure=self._current_total_exposure(),
-                    limit=equity_base * self.max_total_exposure_ratio,
-                )
-                return None
-            if self._cash < size:
-                log.warning(
-                    "execution_engine_open_rejected",
-                    reason="insufficient_cash",
-                    requested=size,
-                    cash=self._cash,
+            current_exposure = self._current_total_exposure()
+            total_exposure_limit = equity_base * self.max_total_exposure_ratio
+            remaining_total_exposure = max(0.0, total_exposure_limit - current_exposure)
+            capital_risk_allowed_size = max(
+                0.0,
+                min(max_position_size, remaining_total_exposure, self._cash),
+            )
+            if size > capital_risk_allowed_size:
+                binding_constraint = "cash_available"
+                if remaining_total_exposure <= self._cash:
+                    binding_constraint = "remaining_total_exposure"
+                self._record_open_rejection(
+                    reason="capital_risk_allowed_size_exceeded",
+                    market=market,
+                    position_id=position_id,
+                    requested_size=size,
+                    capital_risk_allowed_size=capital_risk_allowed_size,
+                    binding_constraint=binding_constraint,
+                    cash_available=self._cash,
+                    current_exposure=current_exposure,
+                    remaining_total_exposure=remaining_total_exposure,
+                    total_exposure_limit=total_exposure_limit,
+                    max_position_size=max_position_size,
+                    equity=equity_base,
                 )
                 return None
 
@@ -163,6 +179,16 @@ class ExecutionEngine:
             self._refresh_equity()
             log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
             return position
+
+    def get_last_open_rejection(self) -> dict[str, Any] | None:
+        if self._last_open_rejection is None:
+            return None
+        return dict(self._last_open_rejection)
+
+    def _record_open_rejection(self, *, reason: str, **details: Any) -> None:
+        rejection_payload = {"reason": reason, **details}
+        self._last_open_rejection = rejection_payload
+        log.warning("execution_engine_open_rejected", **rejection_payload)
 
     def _is_validation_proof_allowed(self, proof: ExecutionValidationProof | None) -> bool:
         if not isinstance(proof, ExecutionValidationProof):

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -368,6 +368,7 @@ class StrategyTrigger:
         terminal_stage: str,
         reason: str,
         terminal_outcome: str,
+        extra_details: dict[str, Any] | None = None,
     ) -> None:
         existing = self._trade_traceability.get(trade_id, {})
         if existing.get("outcome_data", {}).get("terminal_stage"):
@@ -383,6 +384,7 @@ class StrategyTrigger:
                 "reason": reason,
                 "terminal_outcome": terminal_outcome,
                 "trace_count": 1,
+                **(extra_details or {}),
             },
             "risk_state": self._risk_engine.as_dict(),
         }
@@ -2385,6 +2387,8 @@ class StrategyTrigger:
                     action="OPEN",
                 )
             if created is None:
+                rejection_payload = self._engine.get_last_open_rejection() or {}
+                rejection_reason = str(rejection_payload.get("reason", "execution_open_position_rejected"))
                 self._record_blocked_terminal_trace(
                     trade_id=trade_id,
                     signal_data=signal_data,
@@ -2395,7 +2399,8 @@ class StrategyTrigger:
                         "checks": validation_result.checks,
                     },
                     terminal_stage="execution_engine_rejected_open",
-                    reason="execution_open_position_rejected",
+                    reason=rejection_reason,
+                    extra_details={"execution_rejection": rejection_payload},
                     terminal_outcome="BLOCKED",
                 )
                 return "BLOCKED"

--- a/projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md
@@ -1,0 +1,63 @@
+# 24_39_execution_position_sizing_boundary_enforcement
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Add hard execution-boundary sizing enforcement in the touched `StrategyTrigger -> ExecutionEngine.open_position(...)` path.
+  2. Reject non-compliant open-size requests before any portfolio mutation (`size_non_positive`, per-trade cap breach, capital/risk-allowed max breach, touched-path constraint inconsistency).
+  3. Preserve fail-closed boundary behavior with existing validation-proof requirement.
+  4. Keep rejection outcomes explicit and structured for traceability in touched execution trace flow.
+  5. Add/update focused tests proving in-bounds pass and boundary rejects (including StrategyTrigger blocked-trace reason capture).
+- Not in Scope:
+  - Reworking strategy scoring or candidate selection.
+  - New sizing model research or Kelly redesign.
+  - Rollout beyond touched StrategyTrigger execution boundary path.
+  - Liquidity/slippage model changes, exit logic changes, UI/Telegram changes.
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`. Tier: STANDARD.
+
+## 1. What was built
+- Hardened `ExecutionEngine.open_position(...)` sizing checks so boundary rejection is authoritative before any state mutation.
+- Added combined capital/risk-allowed max-size computation (`min(per-trade cap, remaining total exposure, available cash)`) and fail-closed rejection when request exceeds that dynamic boundary.
+- Added structured rejection payload capture (`_record_open_rejection`) with `get_last_open_rejection()` so StrategyTrigger can persist exact boundary reason in blocked terminal trace outcomes.
+- Preserved existing validation-proof gate (no-proof/fake-proof still blocked) and integrated new sizing reason propagation in StrategyTrigger rejection trace path.
+- Expanded focused P16 test coverage for non-positive size, per-trade-cap breach, capital/risk-allowed breach, and StrategyTrigger blocked-trace reason capture.
+
+## 2. Current system architecture
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - remains authoritative execution boundary for `open_position(...)`.
+  - now stores explicit last-open rejection payload for trace consumers.
+  - enforces layered checks in order: validation proof, positive size, per-trade cap, capital/risk-allowed max-size.
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - unchanged gateway role for the touched path.
+  - on engine open rejection, now records explicit boundary reason/payload in blocked terminal trace (`execution_engine_rejected_open`).
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Execution boundary accepts valid in-bounds size requests and still requires signed validation proof.
+- Boundary rejects and logs explicit structured reason for:
+  - `size_non_positive`
+  - `max_position_size_exceeded`
+  - `capital_risk_allowed_size_exceeded`
+- StrategyTrigger blocked terminal trace now captures explicit execution rejection reason/payload when engine rejects size at boundary.
+
+### Validation commands
+- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` ✅ (`13 passed`; warning: unknown pytest `asyncio_mode` config)
+
+## 5. Known issues
+- Scope is intentionally NARROW INTEGRATION to StrategyTrigger-triggered opens; other execution entry surfaces are unchanged.
+- Pytest environment still reports `Unknown config option: asyncio_mode` warning (non-blocking).
+
+## 6. What is next
+- Run Codex auto PR review on touched files (STANDARD baseline).
+- COMMANDER review and merge decision.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -417,3 +417,104 @@ def test_p16_direct_engine_call_with_gateway_validation_proof_passes() -> None:
         assert created is not None
 
     asyncio.run(_run())
+
+
+def test_p16_direct_engine_open_rejects_non_positive_size() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        created = await engine.open_position(
+            market="MARKET-1",
+            market_title="Test Market",
+            side="YES",
+            price=0.45,
+            size=0.0,
+            validation_proof=_build_gateway_validation_proof(engine, validation_id="zero-size"),
+        )
+        assert created is None
+        rejection = engine.get_last_open_rejection()
+        assert rejection is not None
+        assert rejection["reason"] == "size_non_positive"
+
+    asyncio.run(_run())
+
+
+def test_p16_direct_engine_open_rejects_size_above_per_trade_cap() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        created = await engine.open_position(
+            market="MARKET-1",
+            market_title="Test Market",
+            side="YES",
+            price=0.45,
+            size=1_500.0,
+            validation_proof=_build_gateway_validation_proof(engine, validation_id="over-cap"),
+        )
+        assert created is None
+        rejection = engine.get_last_open_rejection()
+        assert rejection is not None
+        assert rejection["reason"] == "max_position_size_exceeded"
+        assert rejection["limit"] == 1_000.0
+
+    asyncio.run(_run())
+
+
+def test_p16_direct_engine_open_rejects_capital_risk_allowed_size_boundary() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        engine.max_total_exposure_ratio = 0.15
+        seed_created = await engine.open_position(
+            market="MARKET-SEED",
+            market_title="Seed Position",
+            side="YES",
+            price=0.40,
+            size=1_000.0,
+            validation_proof=_build_gateway_validation_proof(engine, validation_id="seed-position"),
+        )
+        assert seed_created is not None
+        created = await engine.open_position(
+            market="MARKET-2",
+            market_title="Test Market 2",
+            side="YES",
+            price=0.45,
+            size=750.0,
+            validation_proof=_build_gateway_validation_proof(engine, validation_id="over-risk-cap"),
+        )
+        assert created is None
+        rejection = engine.get_last_open_rejection()
+        assert rejection is not None
+        assert rejection["reason"] == "capital_risk_allowed_size_exceeded"
+        assert rejection["capital_risk_allowed_size"] == 500.0
+        assert rejection["binding_constraint"] == "remaining_total_exposure"
+
+    asyncio.run(_run())
+
+
+def test_p16_strategy_trigger_records_execution_rejection_reason_for_sizing_block() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._engine.max_position_size_ratio = 0.01  # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(edge=0.06),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        assert decision == "BLOCKED"
+        trace = next(
+            (
+                record
+                for record in trigger._trade_traceability.values()  # noqa: SLF001
+                if record.get("outcome_data", {}).get("terminal_stage") == "execution_engine_rejected_open"
+            ),
+            None,
+        )
+        assert trace is not None
+        assert trace["outcome_data"]["reason"] == "max_position_size_exceeded"
+        assert trace["outcome_data"]["execution_rejection"]["reason"] == "max_position_size_exceeded"
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Ensure the execution engine is the authoritative fail-closed gate for position sizing so no open request can mutate portfolio state when it violates sizing or capital/risk constraints. 
- Make rejection outcomes explicit and traceable so the gateway (`StrategyTrigger`) records the exact engine-side reason when opens are blocked. 

### Description
- Hardened `ExecutionEngine.open_position(...)` to perform ordered, pre-mutation checks: validation-proof, positive `size`, per-trade cap, and a computed `capital_risk_allowed_size` (= min(per-trade cap, remaining total exposure, available cash)), and reject when any check fails. 
- Added structured rejection capture via `_record_open_rejection(...)` and `get_last_open_rejection()` to expose the engine's rejection payload. 
- Propagated engine rejection payload into gateway traces by having `StrategyTrigger` read `get_last_open_rejection()` and include the payload in the blocked terminal trace (`execution_engine_rejected_open`). 
- Added focused unit tests covering non-positive size, per-trade-cap exceed, capital/risk-allowed exceed, and StrategyTrigger blocked-trace reason capture, and created a FORGE report and `PROJECT_STATE.md` update for traceability. 
- Files changed: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`, `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`, `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`, and `/workspace/walker-ai-team/PROJECT_STATE.md`. 

### Testing
- Ran `python -m py_compile` over the touched modules which completed successfully. 
- Ran targeted tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` and all tests passed (`13 passed`) with a non-blocking pytest config warning (`Unknown config option: asyncio_mode`). 
- Confirmed no forbidden `phase*/` folders exist in the repo and updated the forge report at `projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md` and `PROJECT_STATE.md` to reflect the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d830101624832ea5a403820635b346)