### PR TITLE
Add execution proof lifecycle (TTL + replay safety, DB-backed, fail-closed)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-10 00:10
-- Status        : FORGE-X completed STANDARD-tier execution-boundary position-sizing enforcement in StrategyTrigger→ExecutionEngine path (fail-closed boundary rejection for non-compliant requested size).
+- Last Updated  : 2026-04-09 23:28
+- Status        : FORGE-X completed MAJOR-tier execution proof lifecycle (dynamic TTL + replay-safe single-use + persistent DB registry + fail-closed execution-boundary verification) in StrategyTrigger→ExecutionEngine path.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- P17 execution proof lifecycle (2026-04-09): implemented immutable validation proofs with dynamic TTL policy, DB-backed proof registry (`validation_proofs`), authoritative execution-boundary proof verification (existence/status/TTL/context/atomic consume), StrategyTrigger integration, and focused replay/expiry/context/restart/race/no-bypass tests; report `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`.
 - P16 execution-boundary position-sizing enforcement (2026-04-10): enforced authoritative boundary sizing checks in `ExecutionEngine.open_position(...)` for non-positive/per-trade-cap/capital-risk-allowed size violations before mutation, preserved signed validation-proof enforcement, propagated structured rejection reason into StrategyTrigger blocked terminal trace, and added focused tests; report `projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`.
 - P16 execution-boundary validation-proof enforcement (2026-04-09): replaced trust-only execution entry assumption with signed `ExecutionValidationProof` contract at engine boundary, wired StrategyTrigger ALLOW path to pass proof payload, and added focused no-proof/fake-proof/pass-proof runtime tests; report `projects/polymarket/polyquantbot/reports/forge/24_38_execution_validation_proof_boundary_enforcement.md`.
 - P16 post-merge smoke-check cleanup (2026-04-09): verified touched runtime path remains stable after PR #350/#354 merge (restart-safe block persistence survives lifecycle, blocked terminal outcomes emit exactly one terminal trace each, successful path preserves `expected_price`/`actual_fill_price`/`slippage` execution-truth envelope fields), and retired stale P16 await-merge/await-SENTINEL state wording; report `projects/polymarket/polyquantbot/reports/forge/24_37_p16_post_merge_smoke_check_cleanup.md`.
@@ -127,6 +128,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### P17 execution proof lifecycle handoff
+- MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for StrategyTrigger→ExecutionEngine proof lifecycle enforcement (dynamic TTL, replay safety, persistence, fail-closed verifier, atomic consume).
+- Awaiting SENTINEL validation before merge per MAJOR policy.
 
 ### P16 execution-boundary position-sizing enforcement handoff
 - STANDARD-tier NARROW INTEGRATION implementation is complete for StrategyTrigger→ExecutionEngine boundary sizing enforcement + explicit rejection traceability in touched path.
@@ -270,12 +275,14 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Auto PR review + COMMANDER review required before merge.
-Source: projects/polymarket/polyquantbot/reports/forge/24_38_execution_validation_proof_boundary_enforcement.md
-Tier: STANDARD
+SENTINEL validation required before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md
+Tier: MAJOR
 
 ## ⚠️ KNOWN ISSUES
 
+- P17 proof lifecycle currently uses lazy expiration enforcement at execution boundary; background cleanup of expired rows is deferred.
+- P17 TTL policy currently uses configurable baseline market-type ranges with optional volatility proxy scaling; advanced volatility-driven calibration remains out of scope for this phase.
 - P16 execution-boundary validation-proof enforcement is currently narrow integration in StrategyTrigger→ExecutionEngine path only; any future alternate execution entry surfaces must explicitly adopt the same proof contract.
 - P16 control layer is currently integrated in strategy-trigger runtime path only; additional non-trigger execution entry surfaces (if introduced later) require separate wiring to inherit identical enforcement guarantees.
 - P15 strategy weighting is currently narrow integration in S4 path only and is not yet wired into broader non-S4 runtime orchestration/telemetry surfaces.

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import hashlib
-import hmac
-import json
-import secrets
+import os
 import statistics
-import time
 from typing import Any
 import uuid
 
@@ -17,6 +13,13 @@ import structlog
 from .models import Position
 from .analytics import PerformanceTracker
 from .trade_trace import TradeTraceEngine
+from .proof_lifecycle import (
+    ProofVerifier,
+    TTLResolver,
+    ValidationProof,
+    ValidationProofRegistry,
+    new_validation_proof,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -32,20 +35,18 @@ class ExecutionSnapshot:
     volatility: float
 
 
-@dataclass(frozen=True)
-class ExecutionValidationProof:
-    validation_id: str
-    validation_decision: str
-    validation_reason: str
-    validation_checks_hash: str
-    issued_at_unix: float
-    signature: str
+ExecutionValidationProof = ValidationProof
 
 
 class ExecutionEngine:
     """Paper-only execution engine with sizing, PnL tracking, and performance analytics."""
 
-    def __init__(self, starting_equity: float = 10_000.0) -> None:
+    def __init__(
+        self,
+        starting_equity: float = 10_000.0,
+        proof_registry_path: str | None = None,
+        ttl_resolver: TTLResolver | None = None,
+    ) -> None:
         self._lock = asyncio.Lock()
         self._positions: dict[str, Position] = {}
         self._cash: float = float(starting_equity)
@@ -60,35 +61,50 @@ class ExecutionEngine:
         self._trace_engine = TradeTraceEngine()
         self._closed_trades: list[dict[str, Any]] = []
         self._position_context: dict[str, dict[str, Any]] = {}
-        self._validation_secret: str = secrets.token_hex(32)
+        resolved_registry_path = proof_registry_path or os.environ.get(
+            "VALIDATION_PROOF_DB_PATH",
+            "/tmp/polyquantbot_validation_proofs.db",
+        )
+        self._proof_registry = ValidationProofRegistry(db_path=resolved_registry_path)
+        self._proof_registry.initialize()
+        self._proof_verifier = ProofVerifier(self._proof_registry)
+        self._ttl_resolver = ttl_resolver or TTLResolver()
         self._last_open_rejection: dict[str, Any] | None = None
 
     def build_validation_proof(
         self,
         *,
-        validation_id: str,
-        validation_decision: str,
-        validation_reason: str,
-        validation_checks: dict[str, bool] | None,
-    ) -> ExecutionValidationProof:
-        """Create a signed execution validation proof for trusted gateway paths."""
-        checks_hash = self._hash_validation_checks(validation_checks or {})
-        issued_at_unix = time.time()
-        signature = self._sign_validation_fields(
-            validation_id=validation_id,
-            validation_decision=validation_decision,
-            validation_reason=validation_reason,
-            validation_checks_hash=checks_hash,
-            issued_at_unix=issued_at_unix,
+        condition_id: str,
+        side: str,
+        price_snapshot: float,
+        size: float,
+        market_type: str = "normal",
+        volatility_proxy: float | None = None,
+        created_at: float | None = None,
+    ) -> ValidationProof:
+        """Create and persist an immutable execution validation proof."""
+        ttl_seconds = self._ttl_resolver.resolve(
+            market_type=market_type,
+            volatility_proxy=volatility_proxy,
         )
-        return ExecutionValidationProof(
-            validation_id=validation_id,
-            validation_decision=validation_decision,
-            validation_reason=validation_reason,
-            validation_checks_hash=checks_hash,
-            issued_at_unix=issued_at_unix,
-            signature=signature,
+        proof = new_validation_proof(
+            condition_id=condition_id,
+            side=side,
+            price_snapshot=price_snapshot,
+            size=size,
+            ttl_seconds=ttl_seconds,
+            created_at=created_at,
         )
+        self._proof_registry.store(proof)
+        log.info(
+            "execution_validation_proof_created",
+            proof_id=proof.proof_id,
+            condition_id=proof.condition_id,
+            side=proof.side,
+            ttl_seconds=proof.ttl_seconds,
+            expires_at=proof.expires_at,
+        )
+        return proof
 
     async def open_position(
         self,
@@ -99,16 +115,31 @@ class ExecutionEngine:
         size: float,
         position_id: str | None = None,
         position_context: dict[str, Any] | None = None,
-        validation_proof: ExecutionValidationProof | None = None,
+        validation_proof: ValidationProof | None = None,
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
             self._last_open_rejection = None
-            if not self._is_validation_proof_allowed(validation_proof):
+            if not isinstance(validation_proof, ValidationProof):
                 self._record_open_rejection(
                     reason="validation_proof_required_or_invalid",
                     market=market,
                     position_id=position_id,
+                )
+                return None
+            proof_ok, proof_reason = self._proof_verifier.verify_and_consume(
+                proof_id=validation_proof.proof_id,
+                condition_id=str(market),
+                side=str(side),
+                price_snapshot=float(price),
+                size=float(size),
+            )
+            if not proof_ok:
+                self._record_open_rejection(
+                    reason=f"validation_proof_{proof_reason}",
+                    market=market,
+                    position_id=position_id,
+                    proof_id=validation_proof.proof_id,
                 )
                 return None
             size = float(size)
@@ -189,55 +220,6 @@ class ExecutionEngine:
         rejection_payload = {"reason": reason, **details}
         self._last_open_rejection = rejection_payload
         log.warning("execution_engine_open_rejected", **rejection_payload)
-
-    def _is_validation_proof_allowed(self, proof: ExecutionValidationProof | None) -> bool:
-        if not isinstance(proof, ExecutionValidationProof):
-            return False
-        if not proof.validation_id.strip():
-            return False
-        if proof.validation_decision != "ALLOW":
-            return False
-        if not proof.validation_checks_hash.strip() or len(proof.validation_checks_hash) != 64:
-            return False
-        if not isinstance(proof.issued_at_unix, float):
-            return False
-        expected_signature = self._sign_validation_fields(
-            validation_id=proof.validation_id,
-            validation_decision=proof.validation_decision,
-            validation_reason=proof.validation_reason,
-            validation_checks_hash=proof.validation_checks_hash,
-            issued_at_unix=proof.issued_at_unix,
-        )
-        return hmac.compare_digest(expected_signature, proof.signature)
-
-    def _sign_validation_fields(
-        self,
-        *,
-        validation_id: str,
-        validation_decision: str,
-        validation_reason: str,
-        validation_checks_hash: str,
-        issued_at_unix: float,
-    ) -> str:
-        payload = "|".join(
-            [
-                validation_id.strip(),
-                validation_decision.strip().upper(),
-                validation_reason.strip(),
-                validation_checks_hash.strip(),
-                f"{issued_at_unix:.6f}",
-            ]
-        )
-        return hmac.new(
-            self._validation_secret.encode("utf-8"),
-            payload.encode("utf-8"),
-            digestmod=hashlib.sha256,
-        ).hexdigest()
-
-    @staticmethod
-    def _hash_validation_checks(validation_checks: dict[str, bool]) -> str:
-        normalized = json.dumps(validation_checks, sort_keys=True, separators=(",", ":"))
-        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
     async def close_position(
         self,

--- a/projects/polymarket/polyquantbot/execution/proof_lifecycle.py
+++ b/projects/polymarket/polyquantbot/execution/proof_lifecycle.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+import json
+import os
+import sqlite3
+import time
+import uuid
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ValidationProof:
+    proof_id: str
+    condition_id: str
+    side: str
+    price_snapshot: float
+    size: float
+    created_at: float
+    ttl_seconds: int
+    expires_at: float
+    context_hash: str
+    status: str
+
+
+@dataclass(frozen=True)
+class TTLResolver:
+    fast_min_seconds: int = 5
+    fast_max_seconds: int = 10
+    normal_min_seconds: int = 15
+    normal_max_seconds: int = 30
+    volatility_anchor: float = 0.10
+
+    def resolve(self, *, market_type: str, volatility_proxy: float | None = None) -> int:
+        normalized_market_type = str(market_type).strip().lower()
+        if normalized_market_type == "fast":
+            min_seconds = self.fast_min_seconds
+            max_seconds = self.fast_max_seconds
+        else:
+            min_seconds = self.normal_min_seconds
+            max_seconds = self.normal_max_seconds
+        if max_seconds < min_seconds:
+            max_seconds = min_seconds
+        if volatility_proxy is None:
+            return int(max_seconds)
+        bounded_proxy = max(0.0, float(volatility_proxy))
+        anchor = max(self.volatility_anchor, 1e-6)
+        ratio = max(0.0, min(1.0, bounded_proxy / anchor))
+        ttl_window = max_seconds - min_seconds
+        ttl = int(round(max_seconds - (ttl_window * ratio)))
+        return max(min_seconds, min(max_seconds, ttl))
+
+
+class ValidationProofRegistry:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._initialized = False
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        parent = os.path.dirname(self._db_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS validation_proofs (
+                    proof_id TEXT PRIMARY KEY,
+                    condition_id TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    price_snapshot REAL NOT NULL,
+                    size REAL NOT NULL,
+                    created_at REAL NOT NULL,
+                    ttl_seconds INTEGER NOT NULL,
+                    expires_at REAL NOT NULL,
+                    context_hash TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    consumed_at REAL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_validation_proofs_expires_at ON validation_proofs (expires_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_validation_proofs_status ON validation_proofs (status)"
+            )
+            conn.commit()
+        self._initialized = True
+
+    def store(self, proof: ValidationProof) -> None:
+        self.initialize()
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO validation_proofs (
+                    proof_id,
+                    condition_id,
+                    side,
+                    price_snapshot,
+                    size,
+                    created_at,
+                    ttl_seconds,
+                    expires_at,
+                    context_hash,
+                    status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    proof.proof_id,
+                    proof.condition_id,
+                    proof.side,
+                    float(proof.price_snapshot),
+                    float(proof.size),
+                    float(proof.created_at),
+                    int(proof.ttl_seconds),
+                    float(proof.expires_at),
+                    proof.context_hash,
+                    proof.status,
+                ),
+            )
+            conn.commit()
+
+    def get(self, proof_id: str) -> ValidationProof | None:
+        self.initialize()
+        with sqlite3.connect(self._db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT proof_id, condition_id, side, price_snapshot, size, created_at,
+                       ttl_seconds, expires_at, context_hash, status
+                FROM validation_proofs
+                WHERE proof_id = ?
+                """,
+                (proof_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return ValidationProof(
+            proof_id=str(row[0]),
+            condition_id=str(row[1]),
+            side=str(row[2]),
+            price_snapshot=float(row[3]),
+            size=float(row[4]),
+            created_at=float(row[5]),
+            ttl_seconds=int(row[6]),
+            expires_at=float(row[7]),
+            context_hash=str(row[8]),
+            status=str(row[9]),
+        )
+
+    def mark_expired_if_created(self, proof_id: str) -> bool:
+        return self._update_status_if_created(proof_id=proof_id, next_status="EXPIRED")
+
+    def consume_if_created(self, proof_id: str) -> bool:
+        self.initialize()
+        with sqlite3.connect(self._db_path, timeout=5.0, isolation_level="IMMEDIATE") as conn:
+            cursor = conn.execute(
+                """
+                UPDATE validation_proofs
+                SET status = 'CONSUMED', consumed_at = ?
+                WHERE proof_id = ? AND status = 'CREATED'
+                """,
+                (time.time(), proof_id),
+            )
+            conn.commit()
+            return cursor.rowcount == 1
+
+    def _update_status_if_created(self, *, proof_id: str, next_status: str) -> bool:
+        self.initialize()
+        with sqlite3.connect(self._db_path, timeout=5.0, isolation_level="IMMEDIATE") as conn:
+            cursor = conn.execute(
+                """
+                UPDATE validation_proofs
+                SET status = ?
+                WHERE proof_id = ? AND status = 'CREATED'
+                """,
+                (next_status, proof_id),
+            )
+            conn.commit()
+            return cursor.rowcount == 1
+
+
+class ProofVerifier:
+    def __init__(self, registry: ValidationProofRegistry) -> None:
+        self._registry = registry
+
+    def verify_and_consume(
+        self,
+        *,
+        proof_id: str,
+        condition_id: str,
+        side: str,
+        price_snapshot: float,
+        size: float,
+        now_ts: float | None = None,
+    ) -> tuple[bool, str]:
+        proof = self._registry.get(proof_id)
+        if proof is None:
+            return False, "not_found"
+        if proof.status != "CREATED":
+            return False, f"status_{proof.status.lower()}"
+
+        current_time = float(now_ts) if now_ts is not None else time.time()
+        if current_time > proof.expires_at:
+            self._registry.mark_expired_if_created(proof.proof_id)
+            return False, "expired"
+
+        normalized_side = str(side).strip().upper()
+        if (
+            proof.condition_id != condition_id
+            or proof.side != normalized_side
+            or abs(proof.price_snapshot - float(price_snapshot)) > 1e-9
+            or abs(proof.size - float(size)) > 1e-9
+        ):
+            return False, "context_mismatch"
+
+        expected_context_hash = compute_context_hash(
+            condition_id=condition_id,
+            side=normalized_side,
+            price_snapshot=float(price_snapshot),
+            size=float(size),
+            created_at=proof.created_at,
+        )
+        if not hmac.compare_digest(proof.context_hash, expected_context_hash):
+            return False, "context_hash_mismatch"
+
+        if not self._registry.consume_if_created(proof.proof_id):
+            return False, "already_consumed"
+        return True, "verified"
+
+
+def compute_context_hash(
+    *,
+    condition_id: str,
+    side: str,
+    price_snapshot: float,
+    size: float,
+    created_at: float,
+) -> str:
+    payload = json.dumps(
+        {
+            "condition_id": condition_id,
+            "side": str(side).strip().upper(),
+            "price_snapshot": round(float(price_snapshot), 10),
+            "size": round(float(size), 10),
+            "created_at": round(float(created_at), 6),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def new_validation_proof(
+    *,
+    condition_id: str,
+    side: str,
+    price_snapshot: float,
+    size: float,
+    ttl_seconds: int,
+    created_at: float | None = None,
+    proof_id: str | None = None,
+) -> ValidationProof:
+    issued_at = float(created_at) if created_at is not None else time.time()
+    normalized_side = str(side).strip().upper()
+    resolved_proof_id = str(proof_id or uuid.uuid4())
+    context_hash = compute_context_hash(
+        condition_id=condition_id,
+        side=normalized_side,
+        price_snapshot=float(price_snapshot),
+        size=float(size),
+        created_at=issued_at,
+    )
+    return ValidationProof(
+        proof_id=resolved_proof_id,
+        condition_id=condition_id,
+        side=normalized_side,
+        price_snapshot=float(price_snapshot),
+        size=float(size),
+        created_at=issued_at,
+        ttl_seconds=int(ttl_seconds),
+        expires_at=issued_at + int(ttl_seconds),
+        context_hash=context_hash,
+        status="CREATED",
+    )

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -2299,11 +2299,17 @@ class StrategyTrigger:
                 )
                 log.info("pre_trade_blocked", reason=validation_result.reason, trade_id=trade_id)
                 return "BLOCKED"
+            market_type = str((market_context or {}).get("market_type", "normal")).strip().lower()
+            if market_type not in {"fast", "normal"}:
+                market_type = "fast" if float((market_context or {}).get("spread", 0.0)) >= 0.03 else "normal"
+            volatility_proxy = (market_context or {}).get("volatility")
             validation_proof = self._engine.build_validation_proof(
-                validation_id=trade_id,
-                validation_decision=validation_result.decision,
-                validation_reason=validation_result.reason,
-                validation_checks=validation_result.checks,
+                condition_id=target_market_id,
+                side=self._config.side,
+                price_snapshot=readiness.expected_fill_price,
+                size=size,
+                market_type=market_type,
+                volatility_proxy=float(volatility_proxy) if volatility_proxy is not None else None,
             )
             self._execution_tracker.record_order_submission(
                 trade_id=trade_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md
@@ -1,0 +1,71 @@
+# 24_40_execution_proof_lifecycle_ttl_replay_safety
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  1. Validate immutable `ValidationProof` lifecycle (`CREATED -> CONSUMED/EXPIRED`) with dynamic TTL.
+  2. Verify DB-backed proof persistence (`validation_proofs` table + primary/status/expiry indexes) and restart survival.
+  3. Verify fail-closed execution-boundary `ProofVerifier` checks (existence, status, TTL, context hash, atomic consume).
+  4. Verify replay rejection, expired-proof rejection, context-mismatch rejection, restart persistence, race-safe single-consume behavior, and no-bypass enforcement in touched runtime path.
+  5. Verify StrategyTrigger -> ExecutionEngine integration now issues dynamic-TTL proofs bound to execution context.
+- Not in Scope:
+  - Execution-time price deviation drift guard.
+  - Liquidity revalidation at boundary.
+  - Cross-market correlation logic changes.
+  - Advanced volatility-model TTL policy beyond baseline configurable range logic.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`. Tier: MAJOR.
+
+## 1. What was built
+- Added a new proof lifecycle module implementing immutable `ValidationProof`, configurable `TTLResolver`, persistent `ValidationProofRegistry` (SQLite-backed), and authoritative `ProofVerifier` with fail-closed, single-use consume semantics.
+- Replaced trust-only signed proof acceptance with strict execution-boundary verification/consumption flow in `ExecutionEngine.open_position(...)`.
+- Updated proof issuance path in `ExecutionEngine.build_validation_proof(...)` to produce context-bound proofs and persist them immediately.
+- Integrated dynamic TTL proof issuance in `StrategyTrigger.evaluate(...)` before execution (market-type aware + optional volatility proxy input).
+- Updated existing proof-dependent tests and added a new focused lifecycle test suite covering replay, expiry, context mismatch, restart persistence, race-safe consume, and no-bypass behavior.
+
+## 2. Current system architecture
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/proof_lifecycle.py`
+  - New authoritative proof lifecycle components:
+    - `ValidationProof` immutable model.
+    - `TTLResolver` dynamic TTL policy.
+    - `ValidationProofRegistry` DB persistence (`validation_proofs` + indexes).
+    - `ProofVerifier` execution-boundary gate with atomic consume.
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+  - Proof creation now persists immutable proof records.
+  - `open_position(...)` now hard-blocks unless `ProofVerifier.verify_and_consume(...)` passes.
+  - Replay/stale/context mismatch enforcement is now execution-authoritative.
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+  - Touched runtime path now builds context-bound proofs using market context (market type + optional volatility proxy) right before engine execution.
+
+## 3. Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/proof_lifecycle.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4. What is working
+- Execution rejects proofs that are missing, unknown, expired, already consumed, or context-mismatched.
+- Replay attempts using the same `proof_id` fail after first successful consume.
+- Proof status transitions persist across engine restarts via DB-backed storage.
+- Atomic consume (`UPDATE ... WHERE status='CREATED'`) allows only one consumer in double-execution race attempts.
+- StrategyTrigger issues context-bound proofs with configurable dynamic TTL ranges.
+
+### Validation commands
+- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/proof_lifecycle.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py` ✅
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py` ✅ (`34 passed`; warning: unknown pytest `asyncio_mode` config)
+
+## 5. Known issues
+- Background cleanup of expired proof rows is intentionally not implemented in this phase (lazy expiry at verification boundary only).
+- TTL policy currently uses baseline market-type + optional volatility proxy scaling and does not yet include advanced volatility model calibrations.
+
+## 6. What is next
+- Run SENTINEL MAJOR validation against lifecycle claims and declared target checks before merge.
+- Continue to P17.4 execution drift guard after SENTINEL verdict.
+
+Report: projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md
+State: PROJECT_STATE.md updated

--- a/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py
@@ -5,12 +5,20 @@ import asyncio
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
 
 
-def _gateway_validation_proof(engine: ExecutionEngine, validation_id: str) -> object:
+def _gateway_validation_proof(
+    engine: ExecutionEngine,
+    *,
+    market: str,
+    side: str,
+    price: float,
+    size: float,
+) -> object:
     return engine.build_validation_proof(
-        validation_id=validation_id,
-        validation_decision="ALLOW",
-        validation_reason="passed",
-        validation_checks={"ev_positive": True, "edge_positive": True},
+        condition_id=market,
+        side=side,
+        price_snapshot=price,
+        size=size,
+        market_type="normal",
     )
 
 
@@ -33,7 +41,7 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
             "slippage_impact": 0.01,
             "timing_effectiveness": 0.90,
         },
-        validation_proof=_gateway_validation_proof(engine, "p14-1"),
+        validation_proof=_gateway_validation_proof(engine, market="mkt-s1-news", side="YES", price=0.50, size=100.0),
     )
     assert first is not None
     await engine.close_position(
@@ -58,7 +66,7 @@ async def _build_closed_trades() -> tuple[list[dict[str, object]], dict[str, obj
             "slippage_impact": 0.03,
             "timing_effectiveness": 0.50,
         },
-        validation_proof=_gateway_validation_proof(engine, "p14-2"),
+        validation_proof=_gateway_validation_proof(engine, market="mkt-s2-arb", side="YES", price=0.60, size=100.0),
     )
     assert second is not None
     await engine.close_position(
@@ -91,7 +99,7 @@ async def _build_edge_safety_trades() -> dict[str, object]:
             "slippage_impact": 0.01,
             "timing_effectiveness": 0.6,
         },
-        validation_proof=_gateway_validation_proof(engine, "p14-safety-1"),
+        validation_proof=_gateway_validation_proof(engine, market="mkt-falcon-chaotic", side="YES", price=0.50, size=100.0),
     )
     assert position is not None
     await engine.close_position(
@@ -114,7 +122,7 @@ async def _build_edge_safety_trades() -> dict[str, object]:
             "entry_timing": "timing_enter",
             "theoretical_edge": 0.0,
         },
-        validation_proof=_gateway_validation_proof(engine, "p14-safety-2"),
+        validation_proof=_gateway_validation_proof(engine, market="mkt-safety-zero-edge", side="YES", price=0.50, size=100.0),
     )
     assert ignored is not None
     await engine.close_position(ignored, 0.60, close_context={"exit_reason": "take_profit", "exit_efficiency": 0.8})

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -70,17 +70,20 @@ def _build_trigger(
     return trigger
 
 
-def _build_gateway_validation_proof(engine: ExecutionEngine, validation_id: str = "test-trade") -> ExecutionValidationProof:
+def _build_gateway_validation_proof(
+    engine: ExecutionEngine,
+    *,
+    market: str,
+    side: str,
+    price: float,
+    size: float,
+) -> ExecutionValidationProof:
     return engine.build_validation_proof(
-        validation_id=validation_id,
-        validation_decision="ALLOW",
-        validation_reason="passed",
-        validation_checks={
-            "ev_positive": True,
-            "edge_positive": True,
-            "liquidity_ok": True,
-            "spread_ok": True,
-        },
+        condition_id=market,
+        side=side,
+        price_snapshot=price,
+        size=size,
+        market_type="normal",
     )
 
 
@@ -214,7 +217,10 @@ def test_p16_blocked_terminal_traceability_has_single_terminal_trace_per_path() 
             size=100.0,
             validation_proof=_build_gateway_validation_proof(
                 portfolio_trigger._engine,  # noqa: SLF001
-                validation_id="seed-position",
+                market="MARKET-ALT",
+                side="YES",
+                price=0.5,
+                size=100.0,
             ),
         )
         decision = await portfolio_trigger.evaluate(
@@ -383,12 +389,16 @@ def test_p16_direct_engine_call_with_fake_validation_proof_fails() -> None:
     async def _run() -> None:
         engine = ExecutionEngine(starting_equity=10_000.0)
         fake = ExecutionValidationProof(
-            validation_id="fake-trade",
-            validation_decision="ALLOW",
-            validation_reason="passed",
-            validation_checks_hash="0" * 64,
-            issued_at_unix=1.0,
-            signature="fake-signature",
+            proof_id="fake-trade",
+            condition_id="MARKET-1",
+            side="YES",
+            price_snapshot=0.45,
+            size=100.0,
+            created_at=1.0,
+            ttl_seconds=20,
+            expires_at=21.0,
+            context_hash="0" * 64,
+            status="CREATED",
         )
         created = await engine.open_position(
             market="MARKET-1",
@@ -412,7 +422,7 @@ def test_p16_direct_engine_call_with_gateway_validation_proof_passes() -> None:
             side="YES",
             price=0.45,
             size=100.0,
-            validation_proof=_build_gateway_validation_proof(engine),
+            validation_proof=_build_gateway_validation_proof(engine, market="MARKET-1", side="YES", price=0.45, size=100.0),
         )
         assert created is not None
 
@@ -428,7 +438,7 @@ def test_p16_direct_engine_open_rejects_non_positive_size() -> None:
             side="YES",
             price=0.45,
             size=0.0,
-            validation_proof=_build_gateway_validation_proof(engine, validation_id="zero-size"),
+            validation_proof=_build_gateway_validation_proof(engine, market="MARKET-1", side="YES", price=0.45, size=0.0),
         )
         assert created is None
         rejection = engine.get_last_open_rejection()
@@ -447,7 +457,7 @@ def test_p16_direct_engine_open_rejects_size_above_per_trade_cap() -> None:
             side="YES",
             price=0.45,
             size=1_500.0,
-            validation_proof=_build_gateway_validation_proof(engine, validation_id="over-cap"),
+            validation_proof=_build_gateway_validation_proof(engine, market="MARKET-1", side="YES", price=0.45, size=1_500.0),
         )
         assert created is None
         rejection = engine.get_last_open_rejection()
@@ -468,7 +478,7 @@ def test_p16_direct_engine_open_rejects_capital_risk_allowed_size_boundary() -> 
             side="YES",
             price=0.40,
             size=1_000.0,
-            validation_proof=_build_gateway_validation_proof(engine, validation_id="seed-position"),
+            validation_proof=_build_gateway_validation_proof(engine, market="MARKET-SEED", side="YES", price=0.40, size=1_000.0),
         )
         assert seed_created is not None
         created = await engine.open_position(
@@ -477,7 +487,7 @@ def test_p16_direct_engine_open_rejects_capital_risk_allowed_size_boundary() -> 
             side="YES",
             price=0.45,
             size=750.0,
-            validation_proof=_build_gateway_validation_proof(engine, validation_id="over-risk-cap"),
+            validation_proof=_build_gateway_validation_proof(engine, market="MARKET-2", side="YES", price=0.45, size=750.0),
         )
         assert created is None
         rejection = engine.get_last_open_rejection()

--- a/projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+
+
+def test_p17_replay_attempt_fails_single_use_proof() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            engine = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            proof = engine.build_validation_proof(
+                condition_id="MARKET-1",
+                side="YES",
+                price_snapshot=0.45,
+                size=100.0,
+                market_type="normal",
+            )
+            first = await engine.open_position(
+                market="MARKET-1",
+                market_title="M1",
+                side="YES",
+                price=0.45,
+                size=100.0,
+                position_id="first",
+                validation_proof=proof,
+            )
+            assert first is not None
+
+            second = await engine.open_position(
+                market="MARKET-1",
+                market_title="M1",
+                side="YES",
+                price=0.45,
+                size=100.0,
+                position_id="second",
+                validation_proof=proof,
+            )
+            assert second is None
+            rejection = engine.get_last_open_rejection()
+            assert rejection is not None
+            assert rejection["reason"] == "validation_proof_status_consumed"
+
+    asyncio.run(_run())
+
+
+def test_p17_expired_proof_is_rejected() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            engine = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            stale_proof = engine.build_validation_proof(
+                condition_id="MARKET-2",
+                side="YES",
+                price_snapshot=0.44,
+                size=80.0,
+                market_type="normal",
+                created_at=1.0,
+            )
+            created = await engine.open_position(
+                market="MARKET-2",
+                market_title="M2",
+                side="YES",
+                price=0.44,
+                size=80.0,
+                position_id="expired",
+                validation_proof=stale_proof,
+            )
+            assert created is None
+            rejection = engine.get_last_open_rejection()
+            assert rejection is not None
+            assert rejection["reason"] == "validation_proof_expired"
+
+    asyncio.run(_run())
+
+
+def test_p17_modified_context_fails_verification() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            engine = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            proof = engine.build_validation_proof(
+                condition_id="MARKET-3",
+                side="YES",
+                price_snapshot=0.52,
+                size=90.0,
+                market_type="normal",
+            )
+            created = await engine.open_position(
+                market="MARKET-3",
+                market_title="M3",
+                side="YES",
+                price=0.52,
+                size=120.0,
+                position_id="mismatch",
+                validation_proof=proof,
+            )
+            assert created is None
+            rejection = engine.get_last_open_rejection()
+            assert rejection is not None
+            assert rejection["reason"] == "validation_proof_context_mismatch"
+
+    asyncio.run(_run())
+
+
+def test_p17_proof_survives_restart_and_enforces_status() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            engine_a = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            proof = engine_a.build_validation_proof(
+                condition_id="MARKET-4",
+                side="YES",
+                price_snapshot=0.48,
+                size=100.0,
+                market_type="normal",
+            )
+
+            engine_b = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            opened = await engine_b.open_position(
+                market="MARKET-4",
+                market_title="M4",
+                side="YES",
+                price=0.48,
+                size=100.0,
+                position_id="restart-ok",
+                validation_proof=proof,
+            )
+            assert opened is not None
+
+            replay = await engine_b.open_position(
+                market="MARKET-4",
+                market_title="M4",
+                side="YES",
+                price=0.48,
+                size=100.0,
+                position_id="restart-replay",
+                validation_proof=proof,
+            )
+            assert replay is None
+            rejection = engine_b.get_last_open_rejection()
+            assert rejection is not None
+            assert rejection["reason"] == "validation_proof_status_consumed"
+
+    asyncio.run(_run())
+
+
+def test_p17_race_condition_allows_only_one_consumer() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            producer = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            proof = producer.build_validation_proof(
+                condition_id="MARKET-RACE",
+                side="YES",
+                price_snapshot=0.51,
+                size=100.0,
+                market_type="normal",
+            )
+            engine_a = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            engine_b = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+
+            first, second = await asyncio.gather(
+                engine_a.open_position(
+                    market="MARKET-RACE",
+                    market_title="Race",
+                    side="YES",
+                    price=0.51,
+                    size=100.0,
+                    position_id="race-a",
+                    validation_proof=proof,
+                ),
+                engine_b.open_position(
+                    market="MARKET-RACE",
+                    market_title="Race",
+                    side="YES",
+                    price=0.51,
+                    size=100.0,
+                    position_id="race-b",
+                    validation_proof=proof,
+                ),
+            )
+            success_count = int(first is not None) + int(second is not None)
+            assert success_count == 1
+
+    asyncio.run(_run())
+
+
+def test_p17_no_execution_path_bypasses_proof_verifier() -> None:
+    async def _run() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = str(Path(temp_dir) / "proofs.db")
+            engine = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+            opened = await engine.open_position(
+                market="MARKET-NO-PROOF",
+                market_title="No Proof",
+                side="YES",
+                price=0.49,
+                size=100.0,
+                position_id="no-proof",
+            )
+            assert opened is None
+            rejection = engine.get_last_open_rejection()
+            assert rejection is not None
+            assert rejection["reason"] == "validation_proof_required_or_invalid"
+
+    asyncio.run(_run())
+
+
+def test_p17_ttl_resolver_respects_fast_and_normal_ranges() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = str(Path(temp_dir) / "proofs.db")
+        engine = ExecutionEngine(starting_equity=10_000.0, proof_registry_path=db_path)
+        fast = engine.build_validation_proof(
+            condition_id="MARKET-FAST",
+            side="YES",
+            price_snapshot=0.4,
+            size=50.0,
+            market_type="fast",
+            created_at=100.0,
+        )
+        normal = engine.build_validation_proof(
+            condition_id="MARKET-NORMAL",
+            side="YES",
+            price_snapshot=0.4,
+            size=50.0,
+            market_type="normal",
+            created_at=100.0,
+        )
+        assert 5 <= fast.ttl_seconds <= 10
+        assert 15 <= normal.ttl_seconds <= 30

--- a/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py
@@ -117,10 +117,11 @@ def test_execution_to_payload_preserves_market_title() -> None:
     async def _run() -> dict[str, object]:
         engine = ExecutionEngine(starting_equity=1_000.0)
         proof = engine.build_validation_proof(
-            validation_id="pos-1",
-            validation_decision="ALLOW",
-            validation_reason="passed",
-            validation_checks={"ev_positive": True, "edge_positive": True},
+            condition_id="mkt-exec-1",
+            side="YES",
+            price_snapshot=0.49,
+            size=50.0,
+            market_type="normal",
         )
         await engine.open_position(
             market="mkt-exec-1",


### PR DESCRIPTION
### Motivation
- Close a critical safety gap by preventing replay, stale, or cross-context proof reuse at the execution boundary. 
- Provide restart-survivable, single-use proof records with configurable TTL so execution gating is authoritative and fail-closed. 

### Description
- Added a new proof lifecycle module `projects/polymarket/polyquantbot/execution/proof_lifecycle.py` implementing `ValidationProof`, `TTLResolver`, `ValidationProofRegistry` (SQLite-backed), and `ProofVerifier` with `validation_proofs` table and indexes on `proof_id` (PK), `expires_at`, and `status`.
- Integrated lifecycle into `ExecutionEngine` by replacing the previous trust-only signed proof flow with `build_validation_proof(...)` that persists immutable proof records and by enforcing `ProofVerifier.verify_and_consume(...)` inside `open_position(...)`, which performs existence/status/TTL/context-hash checks and an atomic `UPDATE ... WHERE status = 'CREATED'` consume to guarantee single-use.
- Updated `StrategyTrigger` to issue context-bound proofs (fields: `condition_id`, `side`, `price_snapshot`, `size`) using dynamic TTL inputs (`market_type` + optional `volatility`) and pass persisted proofs to the engine before order placement (fail-closed on any verification failure).
- Tests and repo hygiene: added `projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py`, updated related proof-dependent tests, added forge report `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`, and updated `PROJECT_STATE.md` to declare MAJOR handoff and SENTINEL next step.

### Testing
- Static/compile check: ran `python -m py_compile` on changed modules and new test file (success) ✅.
- Unit suite: ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p17_execution_proof_lifecycle_20260410.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py projects/polymarket/polyquantbot/tests/test_p14_post_trade_analytics_attribution_20260409.py projects/polymarket/polyquantbot/tests/test_tg_market_title_merge_conflict_20260409.py` which passed (`34 passed`) with a non-blocking pytest `asyncio_mode` config warning. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d834e87cd8832eb449dea4830a9d13)