### PR TITLE
fix: harden P17.4 execution-boundary drift guard market-data authority

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,25 +1,27 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 01:14
-🔄 Status       : P17.4 infra/path remediation complete — active project-root artifact alignment restored for validation tooling.
+📅 Last Updated : 2026-04-10 01:38
+🔄 Status       : P17.4 execution-boundary drift guard authority remediation implemented under MAJOR tier with fail-closed market-data validation.
 
 ✅ COMPLETED
-- P17.4 infra alignment fix completed after SENTINEL drift detection context:
-  - Aligned artifact paths under active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`.
-  - Created `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/drift_guard.py`.
-  - Created `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py`.
-  - Restored `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_42_p17_4_execution_drift_guard_remediation.md`.
-  - Added forge alignment report `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_43_p17_4_infra_artifact_alignment_fix.md`.
-  - Active-root compile/test command resolution confirmed from `/workspace/walker-ai-team/projects/polymarket/polyquantbot`.
+- P17.4 boundary authority hardening completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
+  - Added strict execution boundary market-data validation (missing/malformed/incomplete data now rejected).
+  - Added snapshot timestamp age enforcement with deterministic `stale_data` rejection.
+  - Enforced authoritative reference price derivation from orderbook executable levels (no caller `reference_price` trust).
+  - Removed permissive market-data fallback behavior (no silent `model_probability` defaults).
+  - Preserved proof/drift separation: immutable proof snapshot verification remains separate from runtime drift validation.
+  - Added focused P17.4 tests for invalid/stale data, direct engine-entry guard enforcement, and existing rejection-path continuity.
+- FORGE report added:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
 
 🔧 IN PROGRESS
-- COMMANDER review queue for STANDARD-tier P17.4 infra artifact alignment PR.
-
-📋 NOT STARTED
 - None.
 
+📋 NOT STARTED
+- SENTINEL MAJOR validation for P17.4 remediation.
+
 🎯 NEXT PRIORITY
-- Codex auto PR review + COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_43_p17_4_infra_artifact_alignment_fix.md. Tier: STANDARD
+- SENTINEL validation required for p17-4-drift-guard-market-data-authority-remediation before merge. Source: reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this infra alignment task).
+- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).

--- a/projects/polymarket/polyquantbot/execution/drift_guard.py
+++ b/projects/polymarket/polyquantbot/execution/drift_guard.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -10,6 +12,17 @@ class DriftCheckResult:
     allowed: bool
     drift_ratio: float
     max_drift_ratio: float
+
+
+@dataclass(frozen=True)
+class MarketDataValidationResult:
+    """Validation outcome for execution-boundary market data."""
+
+    allowed: bool
+    reason: str | None
+    details: dict[str, Any]
+    reference_price: float | None
+    model_probability: float | None
 
 
 def evaluate_execution_price_drift(
@@ -34,3 +47,198 @@ def evaluate_execution_price_drift(
         drift_ratio=drift_ratio,
         max_drift_ratio=float(max_drift_ratio),
     )
+
+
+def validate_execution_market_data(
+    *,
+    execution_market_data: dict[str, Any] | None,
+    side: str,
+    now_ts: float,
+    max_age_seconds: float,
+) -> MarketDataValidationResult:
+    """Validate execution market data and derive authoritative reference price."""
+    if execution_market_data is None:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "execution_market_data", "issue": "missing"},
+            reference_price=None,
+            model_probability=None,
+        )
+    if not isinstance(execution_market_data, dict):
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "execution_market_data", "issue": "not_dict"},
+            reference_price=None,
+            model_probability=None,
+        )
+
+    snapshot_ts_raw = execution_market_data.get("timestamp")
+    snapshot_ts = _parse_timestamp(snapshot_ts_raw)
+    if snapshot_ts is None:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "timestamp", "value": snapshot_ts_raw, "issue": "invalid_or_missing"},
+            reference_price=None,
+            model_probability=None,
+        )
+    age_seconds = float(now_ts) - snapshot_ts
+    if age_seconds < 0.0:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "timestamp", "issue": "future_timestamp", "age_seconds": age_seconds},
+            reference_price=None,
+            model_probability=None,
+        )
+    if age_seconds > float(max_age_seconds):
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="stale_data",
+            details={
+                "snapshot_timestamp": snapshot_ts,
+                "current_timestamp": float(now_ts),
+                "age_seconds": age_seconds,
+                "threshold_seconds": float(max_age_seconds),
+            },
+            reference_price=None,
+            model_probability=None,
+        )
+
+    model_probability_raw = execution_market_data.get("model_probability")
+    model_probability = _parse_probability(model_probability_raw)
+    if model_probability is None:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "model_probability", "value": model_probability_raw, "issue": "invalid_or_missing"},
+            reference_price=None,
+            model_probability=None,
+        )
+
+    orderbook = execution_market_data.get("orderbook")
+    if not isinstance(orderbook, dict):
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "missing_or_not_dict"},
+            reference_price=None,
+            model_probability=model_probability,
+        )
+
+    bids = _normalize_levels(orderbook.get("bids"))
+    asks = _normalize_levels(orderbook.get("asks"))
+    if bids is None or asks is None:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "malformed_levels"},
+            reference_price=None,
+            model_probability=model_probability,
+        )
+
+    normalized_side = str(side).strip().upper()
+    if normalized_side in {"YES", "BUY", "LONG"}:
+        reference_price = _best_ask_price(asks)
+    elif normalized_side in {"NO", "SELL", "SHORT"}:
+        reference_price = _best_bid_price(bids)
+    else:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "side", "issue": "unsupported_value", "value": side},
+            reference_price=None,
+            model_probability=model_probability,
+        )
+    if reference_price is None:
+        return MarketDataValidationResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            details={"field": "orderbook", "issue": "no_executable_levels", "side": normalized_side},
+            reference_price=None,
+            model_probability=model_probability,
+        )
+
+    return MarketDataValidationResult(
+        allowed=True,
+        reason=None,
+        details={
+            "snapshot_timestamp": snapshot_ts,
+            "current_timestamp": float(now_ts),
+            "age_seconds": age_seconds,
+            "threshold_seconds": float(max_age_seconds),
+        },
+        reference_price=reference_price,
+        model_probability=model_probability,
+    )
+
+
+def _normalize_levels(raw_levels: Any) -> list[tuple[float, float]] | None:
+    if not isinstance(raw_levels, list):
+        return None
+    normalized: list[tuple[float, float]] = []
+    for item in raw_levels:
+        if isinstance(item, dict):
+            price_raw = item.get("price")
+            size_raw = item.get("size")
+        elif isinstance(item, (list, tuple)) and len(item) >= 2:
+            price_raw = item[0]
+            size_raw = item[1]
+        else:
+            return None
+        try:
+            price = float(price_raw)
+            size = float(size_raw)
+        except (TypeError, ValueError):
+            return None
+        if price <= 0.0 or price >= 1.0:
+            continue
+        if size <= 0.0:
+            continue
+        normalized.append((price, size))
+    return normalized
+
+
+def _best_ask_price(asks: list[tuple[float, float]]) -> float | None:
+    if not asks:
+        return None
+    return min(price for price, _ in asks)
+
+
+def _best_bid_price(bids: list[tuple[float, float]]) -> float | None:
+    if not bids:
+        return None
+    return max(price for price, _ in bids)
+
+
+def _parse_probability(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0.0 or parsed > 1.0:
+        return None
+    return parsed
+
+
+def _parse_timestamp(raw_value: Any) -> float | None:
+    if isinstance(raw_value, (int, float)):
+        timestamp = float(raw_value)
+        return timestamp if timestamp > 0.0 else None
+    if isinstance(raw_value, str):
+        candidate = raw_value.strip()
+        if not candidate:
+            return None
+        try:
+            return float(candidate)
+        except ValueError:
+            try:
+                parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
+    return None

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import os
 import statistics
+import time
 from typing import Any
 import uuid
 
@@ -20,6 +21,7 @@ from .proof_lifecycle import (
     ValidationProofRegistry,
     new_validation_proof,
 )
+from .drift_guard import evaluate_execution_price_drift, validate_execution_market_data
 
 log = structlog.get_logger(__name__)
 
@@ -46,6 +48,8 @@ class ExecutionEngine:
         starting_equity: float = 10_000.0,
         proof_registry_path: str | None = None,
         ttl_resolver: TTLResolver | None = None,
+        max_market_data_age_seconds: float = 5.0,
+        max_execution_price_drift_ratio: float = 0.02,
     ) -> None:
         self._lock = asyncio.Lock()
         self._positions: dict[str, Position] = {}
@@ -70,6 +74,8 @@ class ExecutionEngine:
         self._proof_verifier = ProofVerifier(self._proof_registry)
         self._ttl_resolver = ttl_resolver or TTLResolver()
         self._last_open_rejection: dict[str, Any] | None = None
+        self._max_market_data_age_seconds = float(max_market_data_age_seconds)
+        self._max_execution_price_drift_ratio = float(max_execution_price_drift_ratio)
 
     def build_validation_proof(
         self,
@@ -116,10 +122,76 @@ class ExecutionEngine:
         position_id: str | None = None,
         position_context: dict[str, Any] | None = None,
         validation_proof: ValidationProof | None = None,
+        execution_market_data: dict[str, Any] | None = None,
     ) -> Position | None:
         """Create position object and update paper portfolio if risk allows."""
         async with self._lock:
             self._last_open_rejection = None
+            market_data_validation = validate_execution_market_data(
+                execution_market_data=execution_market_data,
+                side=side,
+                now_ts=time.time(),
+                max_age_seconds=self._max_market_data_age_seconds,
+            )
+            if not market_data_validation.allowed:
+                self._record_open_rejection(
+                    reason=str(market_data_validation.reason or "invalid_market_data"),
+                    market=market,
+                    position_id=position_id,
+                    **market_data_validation.details,
+                )
+                return None
+            if market_data_validation.reference_price is None or market_data_validation.model_probability is None:
+                self._record_open_rejection(
+                    reason="invalid_market_data",
+                    market=market,
+                    position_id=position_id,
+                    issue="reference_price_or_model_probability_missing_after_validation",
+                )
+                return None
+
+            drift_result = evaluate_execution_price_drift(
+                expected_price=market_data_validation.reference_price,
+                execution_price=float(price),
+                max_drift_ratio=self._max_execution_price_drift_ratio,
+            )
+            if not drift_result.allowed:
+                self._record_open_rejection(
+                    reason="price_deviation",
+                    market=market,
+                    position_id=position_id,
+                    reference_price=market_data_validation.reference_price,
+                    execution_price=float(price),
+                    drift_ratio=drift_result.drift_ratio,
+                    max_drift_ratio=drift_result.max_drift_ratio,
+                )
+                return None
+
+            normalized_side = str(side).strip().upper()
+            if normalized_side in {"YES", "BUY", "LONG"}:
+                expected_value = float(market_data_validation.model_probability) - float(market_data_validation.reference_price)
+            elif normalized_side in {"NO", "SELL", "SHORT"}:
+                expected_value = (1.0 - float(market_data_validation.model_probability)) - float(market_data_validation.reference_price)
+            else:
+                self._record_open_rejection(
+                    reason="invalid_market_data",
+                    market=market,
+                    position_id=position_id,
+                    field="side",
+                    issue="unsupported_value",
+                    value=side,
+                )
+                return None
+            if expected_value <= 0.0:
+                self._record_open_rejection(
+                    reason="ev_negative",
+                    market=market,
+                    position_id=position_id,
+                    expected_value=expected_value,
+                    reference_price=market_data_validation.reference_price,
+                    model_probability=market_data_validation.model_probability,
+                )
+                return None
             if not isinstance(validation_proof, ValidationProof):
                 self._record_open_rejection(
                     reason="validation_proof_required_or_invalid",
@@ -131,7 +203,7 @@ class ExecutionEngine:
                 proof_id=validation_proof.proof_id,
                 condition_id=str(market),
                 side=str(side),
-                price_snapshot=float(price),
+                price_snapshot=float(validation_proof.price_snapshot),
                 size=float(size),
             )
             if not proof_ok:

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -2324,6 +2324,11 @@ class StrategyTrigger:
                 price=readiness.expected_fill_price,
                 size=size,
                 position_id=trade_id,
+                execution_market_data={
+                    "timestamp": (market_context or {}).get("timestamp"),
+                    "model_probability": (market_context or {}).get("model_probability"),
+                    "orderbook": (market_context or {}).get("orderbook"),
+                },
                 position_context={
                     "strategy_source": (
                         selected_candidate.strategy_name

--- a/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md
@@ -1,0 +1,100 @@
+# 24_44_p17_4_drift_guard_market_data_authority_remediation
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: FULL RUNTIME INTEGRATION
+- Validation Target:
+  1. `ExecutionEngine.open_position(...)` remains final authority for execution-boundary drift enforcement.
+  2. Boundary guard fails closed for missing, malformed, incomplete, or stale market data.
+  3. Reference execution price for EV/drift is derived from authoritative orderbook levels (not caller-injected `reference_price`).
+  4. Missing/invalid `model_probability` and invalid orderbook data cannot silently degrade to permissive defaults.
+  5. StrategyTrigger path and direct `ExecutionEngine.open_position(...)` entry path share the same rejection authority.
+  6. Structured rejection reasons/details remain available via `get_last_open_rejection()` for blocked trace handling.
+- Not in Scope:
+  - Volatility-adaptive drift thresholding.
+  - ML slippage prediction.
+  - Cross-market liquidity modeling.
+  - Telegram/UI/reporting UX changes.
+  - Broad execution architecture redesign outside boundary path.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`. Tier: MAJOR.
+
+## 1. What was built
+- Hardened execution-boundary market data guard in `ExecutionEngine.open_position(...)` with fail-closed validation before proof consumption and before capital mutation.
+- Added strict market-data validation contract in `execution/drift_guard.py`:
+  - required `execution_market_data` object
+  - required/valid timestamp parsing
+  - snapshot freshness max-age enforcement
+  - required/valid model probability
+  - required/valid orderbook structure
+  - side-specific executable price derivation from orderbook levels
+- Removed permissive fallback behavior by design:
+  - no `model_probability = 0.5` fallback
+  - no external `reference_price` trust path
+  - no synthetic fallback reference when side-specific executable level is unavailable
+- Preserved proof-vs-drift separation:
+  - proof verification uses immutable proof snapshot (`validation_proof.price_snapshot`)
+  - drift check evaluates runtime execution deviation against authoritative orderbook-derived reference.
+- Wired `StrategyTrigger` to pass boundary payload (`timestamp`, `model_probability`, `orderbook`) while preserving engine-side authority.
+
+## 2. Current system architecture
+- Authority location remains execution boundary:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py` (`open_position`)
+- Validation flow in `open_position(...)`:
+  1. Validate boundary market-data structure/completeness/freshness.
+  2. Derive side-specific authoritative reference price from orderbook.
+  3. Evaluate execution price drift against max drift ratio.
+  4. Evaluate EV sign using model probability + authoritative reference price.
+  5. Verify/consume immutable validation proof.
+  6. Apply exposure/capital checks and open position only if all checks pass.
+- Price derivation rule (deterministic):
+  - YES / BUY / LONG → best ask (minimum executable ask)
+  - NO / SELL / SHORT → best bid (maximum executable bid)
+- Freshness rule:
+  - reject `stale_data` when `age_seconds > threshold_seconds`
+  - reject `invalid_market_data` for missing/invalid/future timestamps.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/drift_guard.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Fail-closed rejection reasons now deterministic at execution boundary:
+  - `invalid_market_data`
+  - `stale_data`
+  - `liquidity_insufficient`
+  - `price_deviation`
+  - `ev_negative`
+- Direct engine-entry calls cannot bypass stale/invalid market-data checks.
+- StrategyTrigger path is subject to the same open-position authority checks.
+- Structured rejection payload details are recorded and retrievable for blocked traces.
+
+### Commands run (active project root)
+Run location:
+`/workspace/walker-ai-team/projects/polymarket/polyquantbot`
+
+1) Compile command
+- Command:
+  `python -m py_compile execution/drift_guard.py execution/engine.py execution/strategy_trigger.py tests/test_p17_4_execution_drift_guard_20260410.py`
+- Result: ✅ success (no compile errors)
+
+2) Pytest command
+- Command:
+  `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py`
+- Result: ✅ `9 passed, 1 warning in 0.40s`
+- Warning detail: unknown config option `asyncio_mode` in current environment.
+
+## 5. Known issues
+- Repository-level pytest warning for `asyncio_mode` remains present in this environment (non-blocking for this remediation scope).
+
+## 6. What is next
+- MAJOR-tier handoff to SENTINEL for authoritative validation before merge.
+- SENTINEL should validate the declared boundary authority contract and rejection semantics against this report.
+
+## 7. Validation handoff summary
+- Report path: `projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
+- State path: `projects/polymarket/polyquantbot/PROJECT_STATE.md`
+- Required gate: SENTINEL MAJOR validation before merge decision.

--- a/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
@@ -1,29 +1,237 @@
 from __future__ import annotations
 
-from execution.drift_guard import evaluate_execution_price_drift
+import asyncio
+import time
+
 from execution.engine import ExecutionEngine
 
 
-def test_p17_4_drift_guard_allows_price_within_threshold() -> None:
-    result = evaluate_execution_price_drift(
-        expected_price=0.50,
-        execution_price=0.505,
-        max_drift_ratio=0.02,
+def _build_market_data(*, ts: float, model_probability: float | object = 0.60, orderbook: object | None = None) -> dict[str, object]:
+    resolved_orderbook = orderbook
+    if resolved_orderbook is None:
+        resolved_orderbook = {
+            "bids": [{"price": 0.49, "size": 1000.0}],
+            "asks": [{"price": 0.51, "size": 1000.0}],
+        }
+    return {
+        "timestamp": ts,
+        "model_probability": model_probability,
+        "orderbook": resolved_orderbook,
+    }
+
+
+def _open_with_boundary_data(
+    *,
+    engine: ExecutionEngine,
+    side: str = "YES",
+    price: float = 0.51,
+    size: float = 100.0,
+    execution_market_data: dict[str, object] | None = None,
+):
+    proof = engine.build_validation_proof(
+        condition_id="mkt-1",
+        side=side,
+        price_snapshot=0.50,
+        size=size,
+        market_type="normal",
+        created_at=time.time(),
     )
-    assert result.allowed is True
-    assert result.drift_ratio > 0.0
-
-
-def test_p17_4_drift_guard_rejects_price_over_threshold() -> None:
-    result = evaluate_execution_price_drift(
-        expected_price=0.50,
-        execution_price=0.55,
-        max_drift_ratio=0.02,
+    return asyncio.run(
+        engine.open_position(
+            market="mkt-1",
+            market_title="market",
+            side=side,
+            price=price,
+            size=size,
+            validation_proof=proof,
+            execution_market_data=execution_market_data,
+        )
     )
-    assert result.allowed is False
-    assert result.drift_ratio > result.max_drift_ratio
 
 
-def test_p17_4_import_alignment_engine_and_drift_guard_from_active_root() -> None:
+def _snapshot(engine: ExecutionEngine):
+    return asyncio.run(engine.snapshot())
+
+
+def test_p17_4_missing_execution_market_data_rejected_invalid_market_data() -> None:
     engine = ExecutionEngine(starting_equity=10_000.0)
-    assert engine is not None
+
+    created = _open_with_boundary_data(engine=engine, execution_market_data=None)
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "invalid_market_data"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_missing_model_probability_rejected_invalid_market_data() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data=_build_market_data(ts=time.time(), model_probability=None),
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "invalid_market_data"
+    assert rejection.get("field") == "model_probability"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_malformed_orderbook_rejected_invalid_market_data() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data=_build_market_data(
+            ts=time.time(),
+            orderbook={"bids": "broken", "asks": [{"price": 0.51, "size": 1000.0}]},
+        ),
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "invalid_market_data"
+    assert rejection.get("field") == "orderbook"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_missing_timestamp_rejected_invalid_market_data() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data={
+            "model_probability": 0.60,
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [{"price": 0.51, "size": 1000.0}],
+            },
+        },
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "invalid_market_data"
+    assert rejection.get("field") == "timestamp"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_stale_timestamp_rejected_stale_data() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_market_data_age_seconds=5.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data=_build_market_data(ts=time.time() - 120.0),
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "stale_data"
+    assert rejection.get("age_seconds", 0.0) > rejection.get("threshold_seconds", 0.0)
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_valid_fresh_market_data_allows_open() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data=_build_market_data(ts=time.time(), model_probability=0.65),
+    )
+
+    assert created is not None
+    rejection = engine.get_last_open_rejection()
+    assert rejection is None
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 1
+    assert snap.cash == 9_900.0
+
+
+def test_p17_4_direct_engine_entry_cannot_bypass_stale_market_data_guard() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_market_data_age_seconds=1.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        execution_market_data=_build_market_data(ts=time.time() - 10.0, model_probability=0.70),
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "stale_data"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_reference_price_derived_from_orderbook_not_injected_fallback() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        price=0.51,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.65,
+            "reference_price": 0.01,
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [{"price": 0.70, "size": 1000.0}],
+            },
+        },
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "price_deviation"
+    assert rejection.get("reference_price") == 0.70
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p17_4_existing_rejection_paths_still_enforced() -> None:
+    # price_deviation
+    deviation_engine = ExecutionEngine(starting_equity=10_000.0)
+    deviation_created = _open_with_boundary_data(
+        engine=deviation_engine,
+        price=0.60,
+        execution_market_data=_build_market_data(ts=time.time(), model_probability=0.70),
+    )
+    assert deviation_created is None
+    assert (deviation_engine.get_last_open_rejection() or {}).get("reason") == "price_deviation"
+
+    # ev_negative
+    ev_engine = ExecutionEngine(starting_equity=10_000.0)
+    ev_created = _open_with_boundary_data(
+        engine=ev_engine,
+        price=0.51,
+        execution_market_data=_build_market_data(ts=time.time(), model_probability=0.40),
+    )
+    assert ev_created is None
+    assert (ev_engine.get_last_open_rejection() or {}).get("reason") == "ev_negative"
+
+    # liquidity_insufficient
+    liquidity_engine = ExecutionEngine(starting_equity=10_000.0)
+    liquidity_created = _open_with_boundary_data(
+        engine=liquidity_engine,
+        price=0.51,
+        execution_market_data=_build_market_data(
+            ts=time.time(),
+            model_probability=0.65,
+            orderbook={"bids": [{"price": 0.49, "size": 1000.0}], "asks": []},
+        ),
+    )
+    assert liquidity_created is None
+    assert (liquidity_engine.get_last_open_rejection() or {}).get("reason") == "liquidity_insufficient"


### PR DESCRIPTION
### Motivation
- Execution-boundary drift checks previously trusted caller-supplied market inputs (`reference_price`, `model_probability`, `orderbook`) and permissive fallbacks, which allows stale/incomplete data to pass and creates unsafe execution decisions.  
- The P17.4 remediation must enforce fail-closed, authoritative market-data validation at the engine boundary so both StrategyTrigger and direct engine entry are blocked on weak inputs under MAJOR-tier safety rules.

### Description
- Added a strict market-data validation contract and helpers in `projects/polymarket/polyquantbot/execution/drift_guard.py` (`MarketDataValidationResult`, `validate_execution_market_data`, timestamp parsing, freshness max-age, normalized orderbook parsing, side-specific reference-price derivation).  
- Enforced the validation and drift/EV checks inside `ExecutionEngine.open_position(...)` in `projects/polymarket/polyquantbot/execution/engine.py`, running market-data validation before proof consumption and before any cash/state mutation, and rejecting with structured reasons (`invalid_market_data`, `stale_data`, `liquidity_insufficient`, `price_deviation`, `ev_negative`).  
- Removed permissive fallback behaviors (no `model_probability = 0.5` fallback and no trusting externally injected `reference_price`), and derived authoritative reference price deterministically from orderbook (YES/BUY/LONG → best ask, NO/SELL/SHORT → best bid).  
- Wired `StrategyTrigger` to pass the boundary payload (`timestamp`, `model_probability`, `orderbook`) while keeping final authority in the engine, and expanded/updated focused tests to cover missing/malformed/stale data, bypass attempts, authoritative price derivation, and existing rejection paths; also added the MAJOR-tier FORGE report and updated `PROJECT_STATE.md` for SENTINEL handoff.

### Testing
- Compiled modified modules with `python -m py_compile execution/drift_guard.py execution/engine.py execution/strategy_trigger.py tests/test_p17_4_execution_drift_guard_20260410.py` and received no compile errors.  
- Ran the focused test suite `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py` and observed `9 passed, 1 warning` (warning: unknown pytest `asyncio_mode` config option in environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d853e021f0832ebf03dc0ebf08f14d)