### PR TITLE
Add execution intelligence: slippage-aware sizing, VWAP simulation, dynamic drift thresholds (P18)

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 01:38
-🔄 Status       : P17.4 execution-boundary drift guard authority remediation implemented under MAJOR tier with fail-closed market-data validation.
+📅 Last Updated : 2026-04-10 02:15
+🔄 Status       : P18 execution intelligence upgrade in progress (post P17.4 safety) with slippage-aware sizing, VWAP execution modeling, and dynamic drift threshold integration under STANDARD tier.
 
 ✅ COMPLETED
 - P17.4 boundary authority hardening completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
@@ -11,17 +11,25 @@
   - Removed permissive market-data fallback behavior (no silent `model_probability` defaults).
   - Preserved proof/drift separation: immutable proof snapshot verification remains separate from runtime drift validation.
   - Added focused P17.4 tests for invalid/stale data, direct engine-entry guard enforcement, and existing rejection-path continuity.
-- FORGE report added:
+- P18 execution intelligence narrow integration implemented:
+  - Added slippage-aware execution sizing based on orderbook depth and slippage tolerance.
+  - Added VWAP-based execution price simulation with partial fill modeling.
+  - Added dynamic drift-threshold computation based on spread/depth context with conservative bounds.
+  - Integrated new logic additively into `ExecutionEngine.open_position(...)` after market-data validation and before drift/EV/proof checks.
+  - Added focused P18 tests and re-ran P17.4 regression tests.
+- FORGE reports added:
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_47_p18_execution_intelligence_upgrade.md`
 
 🔧 IN PROGRESS
-- None.
+- Transition from safety-hardening phase to execution optimization phase (P18.x).
 
 📋 NOT STARTED
-- SENTINEL MAJOR validation for P17.4 remediation.
+- SENTINEL MAJOR validation for P17.4 remediation (pending COMMANDER decision on escalation path).
+- P18.2 adaptive sizing + volatility coupling.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required for p17-4-drift-guard-market-data-authority-remediation before merge. Source: reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md. Tier: MAJOR
+- Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_47_p18_execution_intelligence_upgrade.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).

--- a/projects/polymarket/polyquantbot/execution/drift_guard.py
+++ b/projects/polymarket/polyquantbot/execution/drift_guard.py
@@ -49,6 +49,55 @@ def evaluate_execution_price_drift(
     )
 
 
+def compute_dynamic_drift_threshold(
+    *,
+    orderbook: dict[str, Any],
+    base_threshold: float,
+    volatility_proxy: float | None = None,
+) -> float:
+    """Compute conservative, context-aware drift threshold from orderbook conditions."""
+    if base_threshold <= 0.0:
+        raise ValueError("base_threshold must be > 0")
+    if not isinstance(orderbook, dict):
+        raise ValueError("orderbook must be a dict")
+
+    bids = _normalize_levels(orderbook.get("bids"))
+    asks = _normalize_levels(orderbook.get("asks"))
+    if bids is None or asks is None or not bids or not asks:
+        raise ValueError("orderbook must contain valid bids and asks")
+
+    best_bid = _best_bid_price(bids)
+    best_ask = _best_ask_price(asks)
+    if best_bid is None or best_ask is None or best_ask <= best_bid:
+        raise ValueError("orderbook spread is invalid")
+
+    mid_price = (best_bid + best_ask) / 2.0
+    spread_ratio = (best_ask - best_bid) / mid_price
+    top_bid_depth = sum(size for _, size in sorted(bids, key=lambda x: x[0], reverse=True)[:3])
+    top_ask_depth = sum(size for _, size in sorted(asks, key=lambda x: x[0])[:3])
+    total_top_depth = top_bid_depth + top_ask_depth
+    if total_top_depth <= 0.0:
+        raise ValueError("orderbook top depth must be > 0")
+    depth_imbalance = abs(top_bid_depth - top_ask_depth) / total_top_depth
+
+    stress_multiplier = 1.0
+    stress_multiplier += min(spread_ratio * 2.0, 0.5)
+    stress_multiplier += min(depth_imbalance * 0.6, 0.3)
+    if volatility_proxy is not None:
+        if volatility_proxy < 0.0:
+            raise ValueError("volatility_proxy must be >= 0")
+        stress_multiplier += min(float(volatility_proxy), 0.4)
+
+    relaxed_multiplier = 1.0
+    if spread_ratio < 0.01 and depth_imbalance < 0.20:
+        relaxed_multiplier = 1.10
+
+    conservative_threshold = base_threshold * relaxed_multiplier / stress_multiplier
+    min_threshold = base_threshold * 0.60
+    max_threshold = base_threshold * 1.25
+    return max(min_threshold, min(max_threshold, conservative_threshold))
+
+
 def validate_execution_market_data(
     *,
     execution_market_data: dict[str, Any] | None,

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -21,7 +21,8 @@ from .proof_lifecycle import (
     ValidationProofRegistry,
     new_validation_proof,
 )
-from .drift_guard import evaluate_execution_price_drift, validate_execution_market_data
+from .drift_guard import compute_dynamic_drift_threshold, evaluate_execution_price_drift, validate_execution_market_data
+from .utils import compute_execution_size, simulate_vwap_execution
 
 log = structlog.get_logger(__name__)
 
@@ -76,6 +77,7 @@ class ExecutionEngine:
         self._last_open_rejection: dict[str, Any] | None = None
         self._max_market_data_age_seconds = float(max_market_data_age_seconds)
         self._max_execution_price_drift_ratio = float(max_execution_price_drift_ratio)
+        self._max_execution_slippage_ratio = 0.015
 
     def build_validation_proof(
         self,
@@ -149,11 +151,78 @@ class ExecutionEngine:
                     issue="reference_price_or_model_probability_missing_after_validation",
                 )
                 return None
+            orderbook = execution_market_data.get("orderbook") if isinstance(execution_market_data, dict) else None
+            if not isinstance(orderbook, dict):
+                self._record_open_rejection(
+                    reason="invalid_market_data",
+                    market=market,
+                    position_id=position_id,
+                    field="orderbook",
+                    issue="missing_or_not_dict_post_validation",
+                )
+                return None
+
+            requested_size = float(size)
+            size_result = compute_execution_size(
+                orderbook=orderbook,
+                target_size=requested_size,
+                max_slippage=self._max_execution_slippage_ratio,
+                side=side,
+            )
+            if not size_result.allowed:
+                self._record_open_rejection(
+                    reason=str(size_result.reason or "slippage_tolerance_exceeded"),
+                    market=market,
+                    position_id=position_id,
+                    requested_size=requested_size,
+                    filled_size=size_result.filled_size,
+                    remaining_size=size_result.remaining_size,
+                )
+                return None
+            adjusted_size = float(size_result.filled_size)
+            if adjusted_size <= 0.0:
+                self._record_open_rejection(
+                    reason="adjusted_size_zero",
+                    market=market,
+                    position_id=position_id,
+                    requested_size=requested_size,
+                    adjusted_size=adjusted_size,
+                )
+                return None
+
+            vwap_result = simulate_vwap_execution(orderbook=orderbook, size=adjusted_size, side=side)
+            if not vwap_result.allowed or vwap_result.vwap_price is None:
+                self._record_open_rejection(
+                    reason=str(vwap_result.reason or "vwap_simulation_failed"),
+                    market=market,
+                    position_id=position_id,
+                    requested_size=requested_size,
+                    adjusted_size=adjusted_size,
+                    filled_size=vwap_result.filled_size,
+                    remaining_size=vwap_result.remaining_size,
+                )
+                return None
+            estimated_execution_price = float(vwap_result.vwap_price)
+
+            try:
+                dynamic_max_drift_ratio = compute_dynamic_drift_threshold(
+                    orderbook=orderbook,
+                    base_threshold=self._max_execution_price_drift_ratio,
+                )
+            except ValueError as error:
+                self._record_open_rejection(
+                    reason="invalid_market_data",
+                    market=market,
+                    position_id=position_id,
+                    issue="dynamic_drift_threshold_failed",
+                    error=str(error),
+                )
+                return None
 
             drift_result = evaluate_execution_price_drift(
                 expected_price=market_data_validation.reference_price,
                 execution_price=float(price),
-                max_drift_ratio=self._max_execution_price_drift_ratio,
+                max_drift_ratio=dynamic_max_drift_ratio,
             )
             if not drift_result.allowed:
                 self._record_open_rejection(
@@ -164,14 +233,16 @@ class ExecutionEngine:
                     execution_price=float(price),
                     drift_ratio=drift_result.drift_ratio,
                     max_drift_ratio=drift_result.max_drift_ratio,
+                    requested_size=requested_size,
+                    adjusted_size=adjusted_size,
                 )
                 return None
 
             normalized_side = str(side).strip().upper()
             if normalized_side in {"YES", "BUY", "LONG"}:
-                expected_value = float(market_data_validation.model_probability) - float(market_data_validation.reference_price)
+                expected_value = float(market_data_validation.model_probability) - estimated_execution_price
             elif normalized_side in {"NO", "SELL", "SHORT"}:
-                expected_value = (1.0 - float(market_data_validation.model_probability)) - float(market_data_validation.reference_price)
+                expected_value = (1.0 - float(market_data_validation.model_probability)) - estimated_execution_price
             else:
                 self._record_open_rejection(
                     reason="invalid_market_data",
@@ -188,7 +259,7 @@ class ExecutionEngine:
                     market=market,
                     position_id=position_id,
                     expected_value=expected_value,
-                    reference_price=market_data_validation.reference_price,
+                    reference_price=estimated_execution_price,
                     model_probability=market_data_validation.model_probability,
                 )
                 return None
@@ -204,7 +275,7 @@ class ExecutionEngine:
                 condition_id=str(market),
                 side=str(side),
                 price_snapshot=float(validation_proof.price_snapshot),
-                size=float(size),
+                size=requested_size,
             )
             if not proof_ok:
                 self._record_open_rejection(
@@ -214,7 +285,7 @@ class ExecutionEngine:
                     proof_id=validation_proof.proof_id,
                 )
                 return None
-            size = float(size)
+            size = adjusted_size
             if size <= 0:
                 self._record_open_rejection(
                     reason="size_non_positive",
@@ -268,8 +339,8 @@ class ExecutionEngine:
                 market_id=market,
                 market_title=market_title,
                 side=side.upper(),
-                entry_price=float(price),
-                current_price=float(price),
+                entry_price=estimated_execution_price,
+                current_price=estimated_execution_price,
                 size=size,
                 pnl=0.0,
                 position_id=position_id
@@ -277,10 +348,19 @@ class ExecutionEngine:
             self._positions[market] = position
             self._position_context[position.position_id] = dict(position_context or {})
             self._cash -= size
-            self._implied_prob = max(0.01, min(0.99, float(price)))
+            self._implied_prob = max(0.01, min(0.99, estimated_execution_price))
             self._recalculate_unrealized()
             self._refresh_equity()
-            log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
+            log.info(
+                "execution_engine_position_opened",
+                market=market,
+                side=side,
+                requested_price=price,
+                execution_price=estimated_execution_price,
+                requested_size=requested_size,
+                executed_size=size,
+                max_drift_ratio=dynamic_max_drift_ratio,
+            )
             return position
 
     def get_last_open_rejection(self) -> dict[str, Any] | None:

--- a/projects/polymarket/polyquantbot/execution/utils.py
+++ b/projects/polymarket/polyquantbot/execution/utils.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VWAPExecutionResult:
+    """Result for simulated orderbook execution using VWAP."""
+
+    allowed: bool
+    reason: str | None
+    vwap_price: float | None
+    filled_size: float
+    remaining_size: float
+    best_reference_price: float | None
+
+
+def simulate_vwap_execution(orderbook: dict[str, Any], size: float, side: str) -> VWAPExecutionResult:
+    """Walk orderbook levels and estimate execution VWAP for a side/size."""
+    target_size = float(size)
+    if target_size <= 0.0:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="size_non_positive",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=target_size,
+            best_reference_price=None,
+        )
+    if not isinstance(orderbook, dict):
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="invalid_orderbook",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=target_size,
+            best_reference_price=None,
+        )
+
+    normalized_side = str(side).strip().upper()
+    levels: list[tuple[float, float]]
+    if normalized_side in {"YES", "BUY", "LONG"}:
+        ask_levels = _normalize_levels(orderbook.get("asks"))
+        if ask_levels is None:
+            return _invalid_book_result(target_size)
+        levels = sorted(ask_levels, key=lambda level: level[0])
+    elif normalized_side in {"NO", "SELL", "SHORT"}:
+        bid_levels = _normalize_levels(orderbook.get("bids"))
+        if bid_levels is None:
+            return _invalid_book_result(target_size)
+        levels = sorted(bid_levels, key=lambda level: level[0], reverse=True)
+    else:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="unsupported_side",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=target_size,
+            best_reference_price=None,
+        )
+
+    if not levels:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=target_size,
+            best_reference_price=None,
+        )
+
+    best_reference_price = levels[0][0]
+    remaining = target_size
+    filled = 0.0
+    total_cost = 0.0
+
+    for level_price, level_size in levels:
+        if remaining <= 0.0:
+            break
+        fill_here = min(level_size, remaining)
+        if fill_here <= 0.0:
+            continue
+        total_cost += fill_here * level_price
+        filled += fill_here
+        remaining -= fill_here
+
+    if filled <= 0.0:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=target_size,
+            best_reference_price=best_reference_price,
+        )
+    vwap_price = total_cost / filled
+    return VWAPExecutionResult(
+        allowed=True,
+        reason=None,
+        vwap_price=vwap_price,
+        filled_size=filled,
+        remaining_size=max(remaining, 0.0),
+        best_reference_price=best_reference_price,
+    )
+
+
+def compute_execution_size(
+    orderbook: dict[str, Any],
+    target_size: float,
+    max_slippage: float,
+    *,
+    side: str = "YES",
+) -> VWAPExecutionResult:
+    """Compute slippage-aware executable size under a slippage tolerance."""
+    if max_slippage < 0.0:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="invalid_max_slippage",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=float(target_size),
+            best_reference_price=None,
+        )
+
+    candidate = simulate_vwap_execution(orderbook, target_size, side)
+    if not candidate.allowed or candidate.vwap_price is None or candidate.best_reference_price is None:
+        return candidate
+
+    reference = candidate.best_reference_price
+    if reference <= 0.0:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="invalid_reference_price",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=float(target_size),
+            best_reference_price=None,
+        )
+
+    allowed_size = 0.0
+    allowed_vwap: float | None = None
+    consumed_cost = 0.0
+    remaining = float(target_size)
+
+    normalized_side = str(side).strip().upper()
+    if normalized_side in {"YES", "BUY", "LONG"}:
+        raw_levels = _normalize_levels(orderbook.get("asks")) if isinstance(orderbook, dict) else None
+        if raw_levels is None:
+            return _invalid_book_result(float(target_size))
+        levels = sorted(raw_levels, key=lambda level: level[0])
+    elif normalized_side in {"NO", "SELL", "SHORT"}:
+        raw_levels = _normalize_levels(orderbook.get("bids")) if isinstance(orderbook, dict) else None
+        if raw_levels is None:
+            return _invalid_book_result(float(target_size))
+        levels = sorted(raw_levels, key=lambda level: level[0], reverse=True)
+    else:
+        return VWAPExecutionResult(
+            allowed=False,
+            reason="unsupported_side",
+            vwap_price=None,
+            filled_size=0.0,
+            remaining_size=float(target_size),
+            best_reference_price=None,
+        )
+
+    for level_price, level_size in levels:
+        if remaining <= 0.0:
+            break
+        fill_here = min(level_size, remaining)
+        if fill_here <= 0.0:
+            continue
+        next_size = allowed_size + fill_here
+        next_cost = consumed_cost + (fill_here * level_price)
+        next_vwap = next_cost / next_size
+        slippage = abs(next_vwap - reference) / reference
+        if slippage > max_slippage:
+            break
+        allowed_size = next_size
+        consumed_cost = next_cost
+        remaining -= fill_here
+        allowed_vwap = next_vwap
+
+    return VWAPExecutionResult(
+        allowed=allowed_size > 0.0,
+        reason=None if allowed_size > 0.0 else "slippage_tolerance_exceeded",
+        vwap_price=allowed_vwap,
+        filled_size=allowed_size,
+        remaining_size=max(float(target_size) - allowed_size, 0.0),
+        best_reference_price=reference,
+    )
+
+
+def _normalize_levels(raw_levels: Any) -> list[tuple[float, float]] | None:
+    if not isinstance(raw_levels, list):
+        return None
+    normalized: list[tuple[float, float]] = []
+    for item in raw_levels:
+        if isinstance(item, dict):
+            price_raw = item.get("price")
+            size_raw = item.get("size")
+        elif isinstance(item, (list, tuple)) and len(item) >= 2:
+            price_raw = item[0]
+            size_raw = item[1]
+        else:
+            return None
+        try:
+            price = float(price_raw)
+            size = float(size_raw)
+        except (TypeError, ValueError):
+            return None
+        if price <= 0.0 or price >= 1.0:
+            continue
+        if size <= 0.0:
+            continue
+        normalized.append((price, size))
+    return normalized
+
+
+def _invalid_book_result(target_size: float) -> VWAPExecutionResult:
+    return VWAPExecutionResult(
+        allowed=False,
+        reason="invalid_orderbook",
+        vwap_price=None,
+        filled_size=0.0,
+        remaining_size=target_size,
+        best_reference_price=None,
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/24_47_p18_execution_intelligence_upgrade.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_47_p18_execution_intelligence_upgrade.md
@@ -1,0 +1,82 @@
+# 24_47_p18_execution_intelligence_upgrade
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Execution sizing adapts to orderbook depth (no blind fixed sizing).
+  2. Drift threshold is no longer static and reflects execution context.
+  3. Execution price estimation uses VWAP instead of single-level assumption.
+  4. No regression in fail-closed behavior, rejection paths, and execution boundary authority.
+  5. New logic is additive and does not override P17.4 safety checks.
+- Not in Scope:
+  - No ML-based execution modeling.
+  - No external volatility feed integration.
+  - No strategy signal changes.
+  - No risk-layer policy changes.
+  - No UI/dashboard/telegram updates.
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_47_p18_execution_intelligence_upgrade.md. Tier: STANDARD.
+
+## 1. What was built
+- Added slippage-aware sizing utility (`compute_execution_size`) that simulates depth and caps executable size under slippage tolerance.
+- Added VWAP execution simulator (`simulate_vwap_execution`) that supports YES/NO style directions, uneven depth, and partial fills.
+- Added dynamic drift-threshold utility (`compute_dynamic_drift_threshold`) that adjusts by spread/depth stress while bounded conservatively.
+- Integrated new execution intelligence into `ExecutionEngine.open_position(...)` after P17.4 market-data validation and before drift/EV/proof/final execution.
+- Added focused P18 test coverage for sizing reduction, VWAP correctness, dynamic threshold behavior, partial-fill application, and rejection continuity.
+
+## 2. Current system architecture
+- Execution boundary remains authoritative in:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Updated runtime sequence (narrow integration path):
+  1. Validate market data (`validate_execution_market_data`) — unchanged P17.4 authority.
+  2. Compute slippage-aware executable size (`compute_execution_size`).
+  3. Simulate expected execution VWAP (`simulate_vwap_execution`).
+  4. Compute context-aware drift threshold (`compute_dynamic_drift_threshold`).
+  5. Run drift check against submitted execution price.
+  6. Run EV check against VWAP-estimated execution price.
+  7. Verify/consume execution proof.
+  8. Execute with adjusted size and VWAP entry pricing.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/drift_guard.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/utils.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p18_execution_intelligence.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_47_p18_execution_intelligence_upgrade.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Slippage-aware sizing now reduces executable size under thin books rather than blindly using target size.
+- VWAP execution modeling now estimates fill price across multiple levels and supports partial-fill outcomes.
+- Dynamic drift threshold now varies by spread/depth conditions but is bounded (0.60x to 1.25x base threshold).
+- P17.4 fail-closed boundary protections remain active for invalid/stale data and negative-EV rejection paths.
+- Runtime entry now records requested vs executed size/price context for traceability.
+
+## 5. Known issues
+- Proof verification currently still checks requested size, not adjusted execution size, to avoid breaking upstream proof contracts in this iteration.
+- Environment-level pytest warning persists: unknown config option `asyncio_mode`.
+
+## 6. What is next
+- P18.2 candidate: couple slippage tolerance and drift bounds to bounded volatility proxy from trusted internal runtime signal.
+- Evaluate extending proof payload to explicitly carry allowed adjusted execution size for stricter end-to-end boundary invariants.
+- Keep review path at STANDARD (auto PR review + COMMANDER review), escalate to MAJOR only if scope expands into risk/execution authority redesign.
+
+## 7. Test results
+Run location:
+`/workspace/walker-ai-team/projects/polymarket/polyquantbot`
+
+1) Compile check
+- Command:
+  `python -m py_compile execution/drift_guard.py execution/engine.py execution/utils.py tests/test_p18_execution_intelligence.py`
+- Result: ✅ pass
+
+2) Focused regression + new tests
+- Command:
+  `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p18_execution_intelligence.py tests/test_p17_4_execution_drift_guard_20260410.py`
+- Result: ✅ `14 passed, 1 warning in 0.39s`
+- Warning: `PytestConfigWarning: Unknown config option: asyncio_mode`
+
+## 8. Next iteration ideas
+- Add deterministic stress tests for NO-side asymmetric books with extreme top-of-book imbalance.
+- Add bounded volatility coupling to dynamic drift with strict floor/ceiling invariants verified by property tests.
+- Add explicit telemetry fields for `slippage_ratio`, `filled_size`, and `remaining_size` to monitoring pipeline for live diagnostics.

--- a/projects/polymarket/polyquantbot/tests/test_p18_execution_intelligence.py
+++ b/projects/polymarket/polyquantbot/tests/test_p18_execution_intelligence.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from execution.drift_guard import compute_dynamic_drift_threshold
+from execution.engine import ExecutionEngine
+from execution.utils import compute_execution_size, simulate_vwap_execution
+
+
+def _book(*, bids: list[dict[str, float]] | None = None, asks: list[dict[str, float]] | None = None) -> dict[str, list[dict[str, float]]]:
+    return {
+        "bids": bids if bids is not None else [{"price": 0.49, "size": 400.0}, {"price": 0.48, "size": 600.0}],
+        "asks": asks if asks is not None else [{"price": 0.51, "size": 500.0}, {"price": 0.52, "size": 600.0}],
+    }
+
+
+def _market_data(*, model_probability: float = 0.70, orderbook: dict[str, list[dict[str, float]]] | None = None) -> dict[str, object]:
+    return {
+        "timestamp": time.time(),
+        "model_probability": model_probability,
+        "orderbook": orderbook if orderbook is not None else _book(),
+    }
+
+
+def test_p18_slippage_aware_sizing_reduces_size_under_thin_liquidity() -> None:
+    orderbook = _book(
+        asks=[
+            {"price": 0.51, "size": 20.0},
+            {"price": 0.55, "size": 40.0},
+            {"price": 0.60, "size": 100.0},
+        ]
+    )
+    result = compute_execution_size(orderbook, 100.0, 0.02, side="YES")
+    assert result.allowed is True
+    assert result.filled_size == 20.0
+    assert result.remaining_size == 80.0
+    assert result.vwap_price == 0.51
+
+
+def test_p18_vwap_execution_multi_level_book() -> None:
+    orderbook = _book(
+        asks=[
+            {"price": 0.51, "size": 40.0},
+            {"price": 0.52, "size": 60.0},
+            {"price": 0.54, "size": 100.0},
+        ]
+    )
+    result = simulate_vwap_execution(orderbook, 100.0, "YES")
+    assert result.allowed is True
+    assert result.filled_size == 100.0
+    assert result.remaining_size == 0.0
+    assert abs((result.vwap_price or 0.0) - 0.516) < 1e-9
+
+
+def test_p18_dynamic_drift_threshold_adjusts_with_spread_and_depth() -> None:
+    base = 0.02
+    balanced = _book(
+        bids=[{"price": 0.499, "size": 800.0}, {"price": 0.498, "size": 800.0}],
+        asks=[{"price": 0.501, "size": 800.0}, {"price": 0.502, "size": 800.0}],
+    )
+    stressed = _book(
+        bids=[{"price": 0.45, "size": 80.0}, {"price": 0.44, "size": 50.0}],
+        asks=[{"price": 0.55, "size": 900.0}, {"price": 0.56, "size": 900.0}],
+    )
+    threshold_balanced = compute_dynamic_drift_threshold(orderbook=balanced, base_threshold=base)
+    threshold_stressed = compute_dynamic_drift_threshold(orderbook=stressed, base_threshold=base)
+    assert threshold_balanced >= threshold_stressed
+    assert threshold_balanced <= (base * 1.25)
+    assert threshold_stressed >= (base * 0.60)
+
+
+def test_p18_engine_partial_fill_size_adjustment_is_applied() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+    proof = engine.build_validation_proof(
+        condition_id="mkt-1",
+        side="YES",
+        price_snapshot=0.51,
+        size=100.0,
+        created_at=time.time(),
+    )
+    # Crossing deeper levels breaches slippage tolerance, so sizing is reduced.
+    thin_orderbook = _book(
+        asks=[{"price": 0.51, "size": 20.0}, {"price": 0.60, "size": 500.0}],
+        bids=[{"price": 0.49, "size": 500.0}],
+    )
+    opened = asyncio.run(
+        engine.open_position(
+            market="mkt-1",
+            market_title="market",
+            side="YES",
+            price=0.51,
+            size=100.0,
+            validation_proof=proof,
+            execution_market_data=_market_data(orderbook=thin_orderbook, model_probability=0.8),
+        )
+    )
+    assert opened is not None
+    assert opened.size == 20.0
+    assert opened.entry_price == 0.51
+
+
+def test_p18_engine_keeps_fail_closed_rejections_for_invalid_stale_and_ev_negative() -> None:
+    # invalid market data
+    invalid_engine = ExecutionEngine(starting_equity=10_000.0)
+    invalid_proof = invalid_engine.build_validation_proof(
+        condition_id="mkt-invalid",
+        side="YES",
+        price_snapshot=0.50,
+        size=100.0,
+        created_at=time.time(),
+    )
+    invalid_opened = asyncio.run(
+        invalid_engine.open_position(
+            market="mkt-invalid",
+            market_title="market",
+            side="YES",
+            price=0.51,
+            size=100.0,
+            validation_proof=invalid_proof,
+            execution_market_data=None,
+        )
+    )
+    assert invalid_opened is None
+    assert (invalid_engine.get_last_open_rejection() or {}).get("reason") == "invalid_market_data"
+
+    # stale data
+    stale_engine = ExecutionEngine(starting_equity=10_000.0, max_market_data_age_seconds=1.0)
+    stale_proof = stale_engine.build_validation_proof(
+        condition_id="mkt-stale",
+        side="YES",
+        price_snapshot=0.50,
+        size=100.0,
+        created_at=time.time(),
+    )
+    stale_opened = asyncio.run(
+        stale_engine.open_position(
+            market="mkt-stale",
+            market_title="market",
+            side="YES",
+            price=0.51,
+            size=100.0,
+            validation_proof=stale_proof,
+            execution_market_data={
+                "timestamp": time.time() - 100.0,
+                "model_probability": 0.70,
+                "orderbook": _book(),
+            },
+        )
+    )
+    assert stale_opened is None
+    assert (stale_engine.get_last_open_rejection() or {}).get("reason") == "stale_data"
+
+    # EV negative after vwap pricing
+    ev_engine = ExecutionEngine(starting_equity=10_000.0)
+    ev_proof = ev_engine.build_validation_proof(
+        condition_id="mkt-ev",
+        side="YES",
+        price_snapshot=0.50,
+        size=100.0,
+        created_at=time.time(),
+    )
+    ev_opened = asyncio.run(
+        ev_engine.open_position(
+            market="mkt-ev",
+            market_title="market",
+            side="YES",
+            price=0.51,
+            size=100.0,
+            validation_proof=ev_proof,
+            execution_market_data=_market_data(model_probability=0.40),
+        )
+    )
+    assert ev_opened is None
+    assert (ev_engine.get_last_open_rejection() or {}).get("reason") == "ev_negative"


### PR DESCRIPTION
### Motivation
- Improve execution realism and capital efficiency by adapting sizing and drift checks to orderbook microstructure while preserving the P17.4 fail-closed execution boundary.

### Description
- Added execution helpers in `projects/polymarket/polyquantbot/execution/utils.py`: `simulate_vwap_execution(...)` and `compute_execution_size(...)` for VWAP-based fill estimation and slippage-aware sizing.
- Extended `projects/polymarket/polyquantbot/execution/drift_guard.py` with `compute_dynamic_drift_threshold(...)` that adjusts the drift bound using spread and top-depth imbalance with conservative clamps.
- Integrated the new flow into `ExecutionEngine.open_position(...)` in `projects/polymarket/polyquantbot/execution/engine.py` to run: P17.4 market-data validation → slippage-aware sizing → VWAP simulation → dynamic drift threshold → drift check → EV check → proof verify/consume → execute with adjusted size and VWAP entry price, while preserving all existing P17.4 rejection paths.
- Added focused tests at `projects/polymarket/polyquantbot/tests/test_p18_execution_intelligence.py`, created the forge report at `projects/polymarket/polyquantbot/reports/forge/24_47_p18_execution_intelligence_upgrade.md`, and updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` to reflect P18 progress and next-priority handoff.
- Notable implementation note: proof verification in this iteration remains keyed to requested size for compatibility; this is recorded as a known limitation for P18.2 follow-up.

### Testing
- Ran compile check: `python -m py_compile execution/drift_guard.py execution/engine.py execution/utils.py tests/test_p18_execution_intelligence.py` — success.
- Ran focused tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p18_execution_intelligence.py tests/test_p17_4_execution_drift_guard_20260410.py` — result: `14 passed, 1 warning` (environment warning: `asyncio_mode`).
- Structural checks: no forbidden `phase*/` folders detected and changes limited to declared files; all new logic preserves P17.4 fail-closed behavior according to test coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85c56accc832e9cc207cbf1fb5e2b)