### PR TITLE
Align P18 drift validation with VWAP execution price basis

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 01:38
-🔄 Status       : P17.4 execution-boundary drift guard authority remediation implemented under MAJOR tier with fail-closed market-data validation.
+📅 Last Updated : 2026-04-10 03:08
+🔄 Status       : P18 execution-intelligence pricing-basis consistency fix implemented (VWAP-aligned drift/EV/entry basis) under STANDARD tier with P17.4 fail-closed authority preserved.
 
 ✅ COMPLETED
 - P17.4 boundary authority hardening completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
@@ -11,8 +11,14 @@
   - Removed permissive market-data fallback behavior (no silent `model_probability` defaults).
   - Preserved proof/drift separation: immutable proof snapshot verification remains separate from runtime drift validation.
   - Added focused P17.4 tests for invalid/stale data, direct engine-entry guard enforcement, and existing rejection-path continuity.
-- FORGE report added:
+- P18 execution-boundary consistency fix completed:
+  - Drift validation now uses VWAP-estimated execution price (no submitted-price authority for drift).
+  - EV validation, entry price, and implied probability now share the same VWAP execution basis.
+  - Requested/submitted price retained only for trace/debug context in rejection payloads.
+  - Fail-closed rejection preserved when VWAP estimation is unavailable/invalid.
+- FORGE reports added:
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_48_p18_drift_vwap_consistency_fix.md`
 
 🔧 IN PROGRESS
 - None.
@@ -21,7 +27,8 @@
 - SENTINEL MAJOR validation for P17.4 remediation.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required for p17-4-drift-guard-market-data-authority-remediation before merge. Source: reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md. Tier: MAJOR
+- Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_48_p18_drift_vwap_consistency_fix.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
+- Proof verification currently consumes requested size (not adjusted executable size) in open path; tracked as explicit out-of-scope follow-up.
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -149,10 +149,42 @@ class ExecutionEngine:
                     issue="reference_price_or_model_probability_missing_after_validation",
                 )
                 return None
+            requested_price = float(price)
+            requested_size = float(size)
+            estimated_execution = self._estimate_execution_vwap(
+                side=side,
+                requested_size=requested_size,
+                orderbook=(
+                    execution_market_data.get("orderbook")
+                    if isinstance(execution_market_data, dict)
+                    else None
+                ),
+            )
+            if estimated_execution is None:
+                self._record_open_rejection(
+                    reason="liquidity_insufficient",
+                    market=market,
+                    position_id=position_id,
+                    requested_size=requested_size,
+                    issue="vwap_estimation_unavailable",
+                )
+                return None
+            estimated_execution_price, adjusted_execution_size = estimated_execution
+            if estimated_execution_price <= 0.0 or adjusted_execution_size <= 0.0:
+                self._record_open_rejection(
+                    reason="liquidity_insufficient",
+                    market=market,
+                    position_id=position_id,
+                    requested_size=requested_size,
+                    estimated_execution_price=estimated_execution_price,
+                    adjusted_execution_size=adjusted_execution_size,
+                    issue="vwap_estimation_invalid",
+                )
+                return None
 
             drift_result = evaluate_execution_price_drift(
                 expected_price=market_data_validation.reference_price,
-                execution_price=float(price),
+                execution_price=estimated_execution_price,
                 max_drift_ratio=self._max_execution_price_drift_ratio,
             )
             if not drift_result.allowed:
@@ -161,7 +193,8 @@ class ExecutionEngine:
                     market=market,
                     position_id=position_id,
                     reference_price=market_data_validation.reference_price,
-                    execution_price=float(price),
+                    execution_price=estimated_execution_price,
+                    requested_price=requested_price,
                     drift_ratio=drift_result.drift_ratio,
                     max_drift_ratio=drift_result.max_drift_ratio,
                 )
@@ -169,9 +202,9 @@ class ExecutionEngine:
 
             normalized_side = str(side).strip().upper()
             if normalized_side in {"YES", "BUY", "LONG"}:
-                expected_value = float(market_data_validation.model_probability) - float(market_data_validation.reference_price)
+                expected_value = float(market_data_validation.model_probability) - estimated_execution_price
             elif normalized_side in {"NO", "SELL", "SHORT"}:
-                expected_value = (1.0 - float(market_data_validation.model_probability)) - float(market_data_validation.reference_price)
+                expected_value = (1.0 - float(market_data_validation.model_probability)) - estimated_execution_price
             else:
                 self._record_open_rejection(
                     reason="invalid_market_data",
@@ -188,7 +221,7 @@ class ExecutionEngine:
                     market=market,
                     position_id=position_id,
                     expected_value=expected_value,
-                    reference_price=market_data_validation.reference_price,
+                    execution_price=estimated_execution_price,
                     model_probability=market_data_validation.model_probability,
                 )
                 return None
@@ -204,7 +237,7 @@ class ExecutionEngine:
                 condition_id=str(market),
                 side=str(side),
                 price_snapshot=float(validation_proof.price_snapshot),
-                size=float(size),
+                size=requested_size,
             )
             if not proof_ok:
                 self._record_open_rejection(
@@ -214,13 +247,13 @@ class ExecutionEngine:
                     proof_id=validation_proof.proof_id,
                 )
                 return None
-            size = float(size)
-            if size <= 0:
+            size = adjusted_execution_size
+            if requested_size <= 0:
                 self._record_open_rejection(
                     reason="size_non_positive",
                     market=market,
                     position_id=position_id,
-                    requested_size=size,
+                    requested_size=requested_size,
                 )
                 return None
             if not position_id:
@@ -268,8 +301,8 @@ class ExecutionEngine:
                 market_id=market,
                 market_title=market_title,
                 side=side.upper(),
-                entry_price=float(price),
-                current_price=float(price),
+                entry_price=estimated_execution_price,
+                current_price=estimated_execution_price,
                 size=size,
                 pnl=0.0,
                 position_id=position_id
@@ -277,7 +310,7 @@ class ExecutionEngine:
             self._positions[market] = position
             self._position_context[position.position_id] = dict(position_context or {})
             self._cash -= size
-            self._implied_prob = max(0.01, min(0.99, float(price)))
+            self._implied_prob = max(0.01, min(0.99, estimated_execution_price))
             self._recalculate_unrealized()
             self._refresh_equity()
             log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
@@ -292,6 +325,58 @@ class ExecutionEngine:
         rejection_payload = {"reason": reason, **details}
         self._last_open_rejection = rejection_payload
         log.warning("execution_engine_open_rejected", **rejection_payload)
+
+    @staticmethod
+    def _estimate_execution_vwap(
+        *,
+        side: str,
+        requested_size: float,
+        orderbook: dict[str, Any] | None,
+    ) -> tuple[float, float] | None:
+        if requested_size <= 0.0 or not isinstance(orderbook, dict):
+            return None
+
+        normalized_side = str(side).strip().upper()
+        if normalized_side in {"YES", "BUY", "LONG"}:
+            raw_levels = orderbook.get("asks")
+            descending = False
+        elif normalized_side in {"NO", "SELL", "SHORT"}:
+            raw_levels = orderbook.get("bids")
+            descending = True
+        else:
+            return None
+        if not isinstance(raw_levels, list):
+            return None
+
+        levels: list[tuple[float, float]] = []
+        for raw_level in raw_levels:
+            if not isinstance(raw_level, dict):
+                continue
+            try:
+                level_price = float(raw_level.get("price"))
+                level_size = float(raw_level.get("size"))
+            except (TypeError, ValueError):
+                continue
+            if not (0.0 < level_price <= 1.0 and level_size > 0.0):
+                continue
+            levels.append((level_price, level_size))
+        if not levels:
+            return None
+
+        levels.sort(key=lambda item: item[0], reverse=descending)
+        remaining = requested_size
+        filled = 0.0
+        notional = 0.0
+        for level_price, level_size in levels:
+            if remaining <= 0.0:
+                break
+            executed = min(level_size, remaining)
+            filled += executed
+            notional += level_price * executed
+            remaining -= executed
+        if filled <= 0.0:
+            return None
+        return (notional / filled, filled)
 
     async def close_position(
         self,

--- a/projects/polymarket/polyquantbot/reports/forge/24_48_p18_drift_vwap_consistency_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_48_p18_drift_vwap_consistency_fix.md
@@ -1,0 +1,77 @@
+# 24_48_p18_drift_vwap_consistency_fix
+
+## Validation metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Drift validation in `ExecutionEngine.open_position(...)` now uses VWAP-estimated execution price.
+  2. Drift, EV, and final entry price all use a single execution-price basis in the P18 boundary path.
+  3. Fail-closed behavior is preserved for invalid/stale market data, EV-negative paths, liquidity/VWAP failures, and no-mutation-on-reject behavior.
+  4. P17.4 boundary authority remains the runtime gate.
+- Not in Scope:
+  - Proof-size contract redesign (proof verification still uses requested size).
+  - Risk policy changes.
+  - Slippage model redesign.
+  - Volatility/drift model expansion beyond existing threshold usage.
+  - Strategy/UI/reporting scope outside execution boundary consistency fix.
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_48_p18_drift_vwap_consistency_fix.md. Tier: STANDARD.
+
+## 1. What was built
+- Updated execution-boundary pricing consistency in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`.
+- Added deterministic VWAP estimation from side-specific executable orderbook levels and requested size.
+- Switched drift validation execution price basis from submitted/requested `price` to VWAP-estimated execution price.
+- Switched EV validation basis to the same VWAP-estimated execution price to align with drift and final entry.
+- Preserved requested price only for trace/debug context (`requested_price` retained in rejection details for price deviation).
+- Preserved fail-closed behavior: if VWAP cannot be estimated or is invalid, execution is rejected before drift/EV/proof/state mutation.
+
+## 2. Runtime sequence after fix
+1. Validate execution boundary market data (`validate_execution_market_data`).
+2. Compute slippage-aware executable size and VWAP-estimated execution price from orderbook levels.
+3. Reject fail-closed if VWAP estimation is unavailable/invalid (`liquidity_insufficient`).
+4. Run drift validation using:
+   - `expected_price = market_data_validation.reference_price`
+   - `execution_price = estimated_execution_price`
+5. Run EV validation using `estimated_execution_price`.
+6. Verify/consume validation proof (still uses requested size — known out-of-scope mismatch).
+7. Execute with adjusted executable size and VWAP-estimated execution price.
+
+## 3. Files modified
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_48_p18_drift_vwap_consistency_fix.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Drift rejection now triggers on VWAP execution deviation, even when submitted price alone would have passed.
+- Allowed execution path now uses consistent price basis across:
+  - drift check,
+  - EV check,
+  - stored `entry_price` / `current_price`,
+  - implied probability update.
+- Rejection-path continuity preserved for:
+  - invalid market data,
+  - stale data,
+  - EV-negative,
+  - liquidity/VWAP estimation failures,
+  - no-mutation-on-reject behavior.
+
+## 5. Test evidence
+Run location:
+`/workspace/walker-ai-team/projects/polymarket/polyquantbot`
+
+1) Compile check
+- Command: `python -m py_compile execution/engine.py tests/test_p17_4_execution_drift_guard_20260410.py`
+- Result: ✅ success
+
+2) Targeted execution-boundary tests
+- Command: `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py`
+- Result: ✅ `11 passed, 1 warning`
+- Warning: environment-level pytest config warning (`asyncio_mode`) remains non-blocking.
+
+## 6. Known limitations
+- Proof verification still consumes requested size, not adjusted executable size. This remains intentionally out of scope for this task.
+- Dynamic drift thresholding behavior is unchanged in this fix scope; this task only aligns execution-price basis consistency.
+
+## 7. What is next
+- COMMANDER re-review of PR #369 consistency blocker using this report and updated tests.
+- If review is satisfactory, proceed with STANDARD-tier merge gate: auto PR review + COMMANDER review.

--- a/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
@@ -194,8 +194,8 @@ def test_p17_4_reference_price_derived_from_orderbook_not_injected_fallback() ->
 
     assert created is None
     rejection = engine.get_last_open_rejection() or {}
-    assert rejection.get("reason") == "price_deviation"
-    assert rejection.get("reference_price") == 0.70
+    assert rejection.get("reason") == "ev_negative"
+    assert rejection.get("execution_price") == 0.70
     snap = _snapshot(engine)
     assert len(snap.positions) == 0
     assert snap.cash == 10_000.0
@@ -206,8 +206,15 @@ def test_p17_4_existing_rejection_paths_still_enforced() -> None:
     deviation_engine = ExecutionEngine(starting_equity=10_000.0)
     deviation_created = _open_with_boundary_data(
         engine=deviation_engine,
-        price=0.60,
-        execution_market_data=_build_market_data(ts=time.time(), model_probability=0.70),
+        price=0.51,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.80,
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [{"price": 0.51, "size": 1.0}, {"price": 0.55, "size": 99.0}],
+            },
+        },
     )
     assert deviation_created is None
     assert (deviation_engine.get_last_open_rejection() or {}).get("reason") == "price_deviation"
@@ -235,3 +242,62 @@ def test_p17_4_existing_rejection_paths_still_enforced() -> None:
     )
     assert liquidity_created is None
     assert (liquidity_engine.get_last_open_rejection() or {}).get("reason") == "liquidity_insufficient"
+
+
+def test_p18_drift_validation_uses_vwap_not_requested_price() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_execution_price_drift_ratio=0.02)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        price=0.51,
+        size=100.0,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.80,
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [
+                    {"price": 0.51, "size": 1.0},
+                    {"price": 0.55, "size": 99.0},
+                ],
+            },
+        },
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "price_deviation"
+    assert rejection.get("requested_price") == 0.51
+    assert rejection.get("execution_price", 0.0) > 0.54
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0
+
+
+def test_p18_vwap_pricing_basis_consistent_across_drift_ev_and_entry() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_execution_price_drift_ratio=0.03)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        price=0.51,
+        size=100.0,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.64,
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [
+                    {"price": 0.51, "size": 30.0},
+                    {"price": 0.512, "size": 70.0},
+                ],
+            },
+        },
+    )
+
+    assert created is not None
+    expected_vwap = ((30.0 * 0.51) + (70.0 * 0.512)) / 100.0
+    assert created.entry_price == expected_vwap
+    assert created.current_price == expected_vwap
+    assert created.size == 100.0
+    snap = _snapshot(engine)
+    assert snap.implied_prob == expected_vwap


### PR DESCRIPTION
### Motivation
- Fix a consistency bug where drift validation compared the submitted/requested `price` while EV and actual execution used a VWAP-estimated execution price, allowing mismatches that could pass drift checks but execute materially worse. 
- Preserve existing P17.4 fail-closed market-data authority and rejection semantics while making the pricing basis deterministic and explainable.

### Description
- Added a deterministic VWAP estimator (`_estimate_execution_vwap`) in `projects/polymarket/polyquantbot/execution/engine.py` that computes VWAP and executable filled size from side-specific orderbook levels and requested size. 
- Switched drift validation in `ExecutionEngine.open_position(...)` to use the VWAP-estimated execution price instead of the submitted `price`, and included the original requested price only in rejection payloads (`requested_price`) for traceability. 
- Aligned EV calculation, stored `entry_price`/`current_price`, and implied probability updates to use the same VWAP-estimated execution price; preserved proof verification behavior (proof still consumes requested size) as an explicit out-of-scope limitation. 
- Preserved fail-closed behavior by rejecting when VWAP estimation is unavailable or invalid (`liquidity_insufficient`) and added/updated unit tests to prove the corrected behavior; added the FORGE report and updated `PROJECT_STATE.md` accordingly.

### Testing
- Compiled targeted modules with `python -m py_compile execution/engine.py tests/test_p17_4_execution_drift_guard_20260410.py` and saw no compile errors. 
- Ran the targeted test suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py` and received `11 passed, 1 warning` (warning: environment pytest config `asyncio_mode`, non-blocking). 
- Tests added/updated verify that drift validation uses VWAP (rejects when VWAP would fail even if requested price would pass), that EV/drift/entry share the same VWAP basis on allowed paths, and that existing P17.4 rejection paths and no-mutation-on-reject behavior remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d868d03e60832ebe5bf541a1f7ee85)