### PR TITLE
fix: restore P18 dynamic drift threshold on VWAP execution basis

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,27 +1,26 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 01:38
-🔄 Status       : P17.4 execution-boundary drift guard authority remediation implemented under MAJOR tier with fail-closed market-data validation.
+📅 Last Updated : 2026-04-10 04:12
+🔄 Status       : P18 final execution consistency remediation completed with dynamic drift threshold restoration on VWAP execution basis.
 
 ✅ COMPLETED
-- P17.4 boundary authority hardening completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
-  - Added strict execution boundary market-data validation (missing/malformed/incomplete data now rejected).
-  - Added snapshot timestamp age enforcement with deterministic `stale_data` rejection.
-  - Enforced authoritative reference price derivation from orderbook executable levels (no caller `reference_price` trust).
-  - Removed permissive market-data fallback behavior (no silent `model_probability` defaults).
-  - Preserved proof/drift separation: immutable proof snapshot verification remains separate from runtime drift validation.
-  - Added focused P17.4 tests for invalid/stale data, direct engine-entry guard enforcement, and existing rejection-path continuity.
+- P18 final remediation completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
+  - Restored dynamic drift threshold computation and runtime enforcement in `ExecutionEngine.open_position(...)`.
+  - Preserved VWAP execution-price consistency across drift validation, EV validation, entry/current pricing, and implied probability.
+  - Kept requested/submitted price as trace/debug only; no reintroduction of requested-price drift authority.
+  - Preserved fail-closed behavior for invalid/stale market data, liquidity insufficiency, EV-negative rejection, and no-mutation-on-reject paths.
+  - Added focused tests for dynamic threshold restoration, VWAP consistency continuity, and combined VWAP+dynamic-threshold decision behavior.
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
-- SENTINEL MAJOR validation for P17.4 remediation.
+- None.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required for p17-4-drift-guard-market-data-authority-remediation before merge. Source: reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md. Tier: MAJOR
+- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_49_p18_final_dynamic_drift_restore.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).

--- a/projects/polymarket/polyquantbot/execution/drift_guard.py
+++ b/projects/polymarket/polyquantbot/execution/drift_guard.py
@@ -25,6 +25,27 @@ class MarketDataValidationResult:
     model_probability: float | None
 
 
+@dataclass(frozen=True)
+class ExecutionPriceEstimateResult:
+    """Execution-price estimation outcome from orderbook levels."""
+
+    allowed: bool
+    reason: str | None
+    details: dict[str, Any]
+    estimated_execution_price: float | None
+    executable_size: float
+
+
+@dataclass(frozen=True)
+class DynamicDriftThresholdResult:
+    """Dynamic drift-threshold computation outcome."""
+
+    allowed: bool
+    reason: str | None
+    details: dict[str, Any]
+    max_drift_ratio: float | None
+
+
 def evaluate_execution_price_drift(
     *,
     expected_price: float,
@@ -172,6 +193,208 @@ def validate_execution_market_data(
         },
         reference_price=reference_price,
         model_probability=model_probability,
+    )
+
+
+def estimate_execution_price_from_orderbook(
+    *,
+    orderbook: dict[str, Any],
+    side: str,
+    requested_size: float,
+) -> ExecutionPriceEstimateResult:
+    """Estimate executable VWAP from orderbook depth for the requested side."""
+    if requested_size <= 0.0:
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "size", "issue": "non_positive", "value": requested_size},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+    if not isinstance(orderbook, dict):
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "missing_or_not_dict"},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+    bids = _normalize_levels(orderbook.get("bids"))
+    asks = _normalize_levels(orderbook.get("asks"))
+    if bids is None or asks is None:
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "malformed_levels"},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+
+    normalized_side = str(side).strip().upper()
+    if normalized_side in {"YES", "BUY", "LONG"}:
+        book_levels = sorted(asks, key=lambda level: level[0])
+    elif normalized_side in {"NO", "SELL", "SHORT"}:
+        book_levels = sorted(bids, key=lambda level: level[0], reverse=True)
+    else:
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "side", "issue": "unsupported_value", "value": side},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+    if not book_levels:
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            details={"field": "orderbook", "issue": "no_executable_levels", "side": normalized_side},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+
+    remaining = float(requested_size)
+    filled_size = 0.0
+    total_notional = 0.0
+    for level_price, level_size in book_levels:
+        if remaining <= 0.0:
+            break
+        take_size = min(level_size, remaining)
+        if take_size <= 0.0:
+            continue
+        total_notional += float(level_price) * take_size
+        filled_size += take_size
+        remaining -= take_size
+    if filled_size <= 0.0:
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            details={"field": "orderbook", "issue": "no_fillable_size", "side": normalized_side},
+            estimated_execution_price=None,
+            executable_size=0.0,
+        )
+    if filled_size + 1e-9 < float(requested_size):
+        return ExecutionPriceEstimateResult(
+            allowed=False,
+            reason="liquidity_insufficient",
+            details={
+                "field": "orderbook",
+                "issue": "insufficient_depth",
+                "side": normalized_side,
+                "requested_size": float(requested_size),
+                "fillable_size": filled_size,
+            },
+            estimated_execution_price=None,
+            executable_size=filled_size,
+        )
+
+    return ExecutionPriceEstimateResult(
+        allowed=True,
+        reason=None,
+        details={"side": normalized_side, "requested_size": float(requested_size)},
+        estimated_execution_price=(total_notional / filled_size),
+        executable_size=filled_size,
+    )
+
+
+def compute_dynamic_drift_threshold(
+    *,
+    orderbook: dict[str, Any],
+    side: str,
+    base_max_drift_ratio: float,
+    volatility: float | None = None,
+) -> DynamicDriftThresholdResult:
+    """Compute dynamic drift threshold from spread/depth stress and volatility."""
+    if base_max_drift_ratio <= 0.0:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "base_max_drift_ratio", "issue": "non_positive", "value": base_max_drift_ratio},
+            max_drift_ratio=None,
+        )
+    if volatility is not None and (volatility < 0.0 or volatility > 1.0):
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "volatility", "issue": "out_of_range", "value": volatility},
+            max_drift_ratio=None,
+        )
+    if not isinstance(orderbook, dict):
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "missing_or_not_dict"},
+            max_drift_ratio=None,
+        )
+    bids = _normalize_levels(orderbook.get("bids"))
+    asks = _normalize_levels(orderbook.get("asks"))
+    if bids is None or asks is None or not bids or not asks:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "orderbook", "issue": "invalid_depth_levels"},
+            max_drift_ratio=None,
+        )
+
+    best_bid = _best_bid_price(bids)
+    best_ask = _best_ask_price(asks)
+    if best_bid is None or best_ask is None or best_ask <= 0.0 or best_bid <= 0.0 or best_ask <= best_bid:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "spread", "issue": "invalid_or_non_positive"},
+            max_drift_ratio=None,
+        )
+
+    normalized_side = str(side).strip().upper()
+    if normalized_side in {"YES", "BUY", "LONG"}:
+        same_side_depth = sum(size for _, size in asks)
+        opposite_side_depth = sum(size for _, size in bids)
+    elif normalized_side in {"NO", "SELL", "SHORT"}:
+        same_side_depth = sum(size for _, size in bids)
+        opposite_side_depth = sum(size for _, size in asks)
+    else:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "side", "issue": "unsupported_value", "value": side},
+            max_drift_ratio=None,
+        )
+    if same_side_depth <= 0.0 or opposite_side_depth <= 0.0:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "depth", "issue": "non_positive"},
+            max_drift_ratio=None,
+        )
+
+    midpoint = (best_bid + best_ask) / 2.0
+    if midpoint <= 0.0:
+        return DynamicDriftThresholdResult(
+            allowed=False,
+            reason="invalid_market_data",
+            details={"field": "spread", "issue": "invalid_midpoint"},
+            max_drift_ratio=None,
+        )
+    spread_ratio = (best_ask - best_bid) / midpoint
+    depth_imbalance = abs(same_side_depth - opposite_side_depth) / (same_side_depth + opposite_side_depth)
+    volatility_factor = float(volatility) if volatility is not None else 0.0
+    stress_score = min(1.0, (spread_ratio * 8.0) + (depth_imbalance * 0.7) + (volatility_factor * 0.8))
+
+    floor_ratio = float(base_max_drift_ratio) * 0.15
+    dynamic_ratio = max(floor_ratio, float(base_max_drift_ratio) * (1.0 - (0.90 * stress_score)))
+    dynamic_ratio = min(float(base_max_drift_ratio), dynamic_ratio)
+
+    return DynamicDriftThresholdResult(
+        allowed=True,
+        reason=None,
+        details={
+            "spread_ratio": spread_ratio,
+            "depth_imbalance": depth_imbalance,
+            "volatility": volatility_factor,
+            "stress_score": stress_score,
+            "floor_ratio": floor_ratio,
+        },
+        max_drift_ratio=dynamic_ratio,
     )
 
 

--- a/projects/polymarket/polyquantbot/execution/engine.py
+++ b/projects/polymarket/polyquantbot/execution/engine.py
@@ -21,7 +21,12 @@ from .proof_lifecycle import (
     ValidationProofRegistry,
     new_validation_proof,
 )
-from .drift_guard import evaluate_execution_price_drift, validate_execution_market_data
+from .drift_guard import (
+    compute_dynamic_drift_threshold,
+    estimate_execution_price_from_orderbook,
+    evaluate_execution_price_drift,
+    validate_execution_market_data,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -150,10 +155,59 @@ class ExecutionEngine:
                 )
                 return None
 
+            orderbook_payload = execution_market_data.get("orderbook") if isinstance(execution_market_data, dict) else None
+            execution_price_estimation = estimate_execution_price_from_orderbook(
+                orderbook=orderbook_payload if isinstance(orderbook_payload, dict) else {},
+                side=side,
+                requested_size=float(size),
+            )
+            if not execution_price_estimation.allowed or execution_price_estimation.estimated_execution_price is None:
+                self._record_open_rejection(
+                    reason=str(execution_price_estimation.reason or "liquidity_insufficient"),
+                    market=market,
+                    position_id=position_id,
+                    **execution_price_estimation.details,
+                )
+                return None
+            estimated_execution_price = float(execution_price_estimation.estimated_execution_price)
+
+            volatility_raw = execution_market_data.get("volatility") if isinstance(execution_market_data, dict) else None
+            volatility_input: float | None
+            if volatility_raw is None:
+                volatility_input = None
+            else:
+                try:
+                    volatility_input = float(volatility_raw)
+                except (TypeError, ValueError):
+                    self._record_open_rejection(
+                        reason="invalid_market_data",
+                        market=market,
+                        position_id=position_id,
+                        field="volatility",
+                        issue="invalid_or_non_numeric",
+                        value=volatility_raw,
+                    )
+                    return None
+
+            dynamic_drift_threshold = compute_dynamic_drift_threshold(
+                orderbook=orderbook_payload if isinstance(orderbook_payload, dict) else {},
+                side=side,
+                base_max_drift_ratio=self._max_execution_price_drift_ratio,
+                volatility=volatility_input,
+            )
+            if not dynamic_drift_threshold.allowed or dynamic_drift_threshold.max_drift_ratio is None:
+                self._record_open_rejection(
+                    reason=str(dynamic_drift_threshold.reason or "invalid_market_data"),
+                    market=market,
+                    position_id=position_id,
+                    **dynamic_drift_threshold.details,
+                )
+                return None
+
             drift_result = evaluate_execution_price_drift(
                 expected_price=market_data_validation.reference_price,
-                execution_price=float(price),
-                max_drift_ratio=self._max_execution_price_drift_ratio,
+                execution_price=estimated_execution_price,
+                max_drift_ratio=float(dynamic_drift_threshold.max_drift_ratio),
             )
             if not drift_result.allowed:
                 self._record_open_rejection(
@@ -161,7 +215,8 @@ class ExecutionEngine:
                     market=market,
                     position_id=position_id,
                     reference_price=market_data_validation.reference_price,
-                    execution_price=float(price),
+                    execution_price=estimated_execution_price,
+                    requested_price=float(price),
                     drift_ratio=drift_result.drift_ratio,
                     max_drift_ratio=drift_result.max_drift_ratio,
                 )
@@ -169,9 +224,9 @@ class ExecutionEngine:
 
             normalized_side = str(side).strip().upper()
             if normalized_side in {"YES", "BUY", "LONG"}:
-                expected_value = float(market_data_validation.model_probability) - float(market_data_validation.reference_price)
+                expected_value = float(market_data_validation.model_probability) - estimated_execution_price
             elif normalized_side in {"NO", "SELL", "SHORT"}:
-                expected_value = (1.0 - float(market_data_validation.model_probability)) - float(market_data_validation.reference_price)
+                expected_value = (1.0 - float(market_data_validation.model_probability)) - estimated_execution_price
             else:
                 self._record_open_rejection(
                     reason="invalid_market_data",
@@ -189,6 +244,7 @@ class ExecutionEngine:
                     position_id=position_id,
                     expected_value=expected_value,
                     reference_price=market_data_validation.reference_price,
+                    estimated_execution_price=estimated_execution_price,
                     model_probability=market_data_validation.model_probability,
                 )
                 return None
@@ -268,8 +324,8 @@ class ExecutionEngine:
                 market_id=market,
                 market_title=market_title,
                 side=side.upper(),
-                entry_price=float(price),
-                current_price=float(price),
+                entry_price=estimated_execution_price,
+                current_price=estimated_execution_price,
                 size=size,
                 pnl=0.0,
                 position_id=position_id
@@ -277,10 +333,17 @@ class ExecutionEngine:
             self._positions[market] = position
             self._position_context[position.position_id] = dict(position_context or {})
             self._cash -= size
-            self._implied_prob = max(0.01, min(0.99, float(price)))
+            self._implied_prob = max(0.01, min(0.99, estimated_execution_price))
             self._recalculate_unrealized()
             self._refresh_equity()
-            log.info("execution_engine_position_opened", market=market, side=side, price=price, size=size)
+            log.info(
+                "execution_engine_position_opened",
+                market=market,
+                side=side,
+                requested_price=float(price),
+                execution_price=estimated_execution_price,
+                size=size,
+            )
             return position
 
     def get_last_open_rejection(self) -> dict[str, Any] | None:

--- a/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md
@@ -1,0 +1,79 @@
+# 24_49_p18_final_dynamic_drift_restore
+
+## Validation Metadata
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Drift validation continues to use VWAP-estimated execution price.
+  2. Dynamic drift thresholding is restored and actively used in `ExecutionEngine.open_position(...)`.
+  3. Drift, EV, entry price, and implied probability remain aligned on VWAP execution basis.
+  4. Existing fail-closed rejection paths remain enforced with no mutation on reject.
+  5. P18 execution intelligence path restores dynamic drift thresholding without reverting to requested-price drift checks.
+- Not in Scope:
+  - Proof-size contract redesign.
+  - New volatility feed integrations.
+  - New slippage model redesign.
+  - Broad execution architecture refactor.
+- Suggested Next Step: Codex auto PR review + COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`. Tier: STANDARD.
+
+## 1. What was built
+- Restored dynamic drift threshold usage in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py` by wiring `compute_dynamic_drift_threshold(...)` into the open-position decision path.
+- Restored VWAP execution basis consistency by estimating executable price from orderbook depth and using that same VWAP price for:
+  - drift validation
+  - EV validation
+  - position entry price
+  - position current price at open
+  - implied probability at open
+- Preserved requested/submitted `price` as trace/debug context only (logged and included in rejection details), not as execution-basis authority.
+- Added fail-closed handling for dynamic-threshold input failures (invalid orderbook/spread/depth/volatility).
+
+## 2. Current system architecture
+Runtime sequence after this final fix:
+1. Validate execution-boundary market data (`validate_execution_market_data`).
+2. Estimate executable VWAP from orderbook depth (`estimate_execution_price_from_orderbook`).
+3. Compute dynamic drift threshold from spread/depth/volatility stress (`compute_dynamic_drift_threshold`).
+4. Fail-closed reject on threshold computation invalidity.
+5. Run drift validation against `(expected=reference_price, execution=estimated_vwap, max=dynamic_max_drift_ratio)`.
+6. Run EV validation using the same estimated VWAP execution price.
+7. Verify/consume validation proof.
+8. Open position using VWAP-estimated execution price.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/drift_guard.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/engine.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Dynamic drift thresholding is actively computed and used in `open_position` drift checks.
+- Drift and EV checks share VWAP-estimated execution price basis.
+- Entry/current/implied values at open are aligned to VWAP-estimated execution price.
+- Existing fail-closed behavior remains for invalid market data, stale data, EV-negative, and liquidity-insufficient paths.
+- Rejection path remains no-mutation (no cash/position mutation when rejected).
+
+### Test evidence (project root: `/workspace/walker-ai-team/projects/polymarket/polyquantbot`)
+1. `python -m py_compile execution/drift_guard.py execution/engine.py tests/test_p17_4_execution_drift_guard_20260410.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py`
+   - ✅ `12 passed, 1 warning`
+   - Includes coverage for:
+     - dynamic threshold restored and decision-path active
+     - balanced vs stressed orderbook threshold behavior
+     - VWAP basis consistency and requested-price non-authority
+     - fail-closed volatility-input rejection
+     - existing p17.4 rejection-path continuity
+
+## 5. Known issues
+- Environment warning remains: pytest unknown config option `asyncio_mode` (non-blocking in this scope).
+- Proof-size mismatch redesign remains intentionally out of scope for this task.
+
+## 6. What is next
+- STANDARD-tier handoff to Codex auto PR review + COMMANDER review for merge decision.
+- COMMANDER can re-check PR #369 follow-up alignment against restored adaptive drift behavior.
+
+## 7. Validation handoff summary
+- Dynamic drift threshold restored: ✅
+- VWAP pricing consistency preserved: ✅
+- Requested price is trace/debug only (not drift/EV authority): ✅
+- Proof-size mismatch redesign out of scope: ✅

--- a/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py
@@ -194,7 +194,7 @@ def test_p17_4_reference_price_derived_from_orderbook_not_injected_fallback() ->
 
     assert created is None
     rejection = engine.get_last_open_rejection() or {}
-    assert rejection.get("reason") == "price_deviation"
+    assert rejection.get("reason") == "ev_negative"
     assert rejection.get("reference_price") == 0.70
     snap = _snapshot(engine)
     assert len(snap.positions) == 0
@@ -207,7 +207,15 @@ def test_p17_4_existing_rejection_paths_still_enforced() -> None:
     deviation_created = _open_with_boundary_data(
         engine=deviation_engine,
         price=0.60,
-        execution_market_data=_build_market_data(ts=time.time(), model_probability=0.70),
+        size=100.0,
+        execution_market_data=_build_market_data(
+            ts=time.time(),
+            model_probability=0.95,
+            orderbook={
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [{"price": 0.51, "size": 1.0}, {"price": 0.80, "size": 200.0}],
+            },
+        ),
     )
     assert deviation_created is None
     assert (deviation_engine.get_last_open_rejection() or {}).get("reason") == "price_deviation"
@@ -235,3 +243,99 @@ def test_p17_4_existing_rejection_paths_still_enforced() -> None:
     )
     assert liquidity_created is None
     assert (liquidity_engine.get_last_open_rejection() or {}).get("reason") == "liquidity_insufficient"
+
+
+def test_p18_vwap_execution_basis_used_for_drift_ev_and_entry_price() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_execution_price_drift_ratio=0.05)
+    execution_market_data = {
+        "timestamp": time.time(),
+        "model_probability": 0.63,
+        "orderbook": {
+            "bids": [{"price": 0.49, "size": 200.0}, {"price": 0.48, "size": 200.0}],
+            "asks": [{"price": 0.51, "size": 60.0}, {"price": 0.52, "size": 40.0}],
+        },
+    }
+    created = _open_with_boundary_data(
+        engine=engine,
+        side="YES",
+        price=0.20,  # requested price is trace/debug only
+        size=100.0,
+        execution_market_data=execution_market_data,
+    )
+
+    expected_vwap = (0.51 * 60.0 + 0.52 * 40.0) / 100.0
+    assert created is not None
+    assert created.entry_price == expected_vwap
+    assert created.current_price == expected_vwap
+    snap = _snapshot(engine)
+    assert snap.implied_prob == expected_vwap
+    assert (engine.get_last_open_rejection() or {}).get("reason") is None
+
+
+def test_p18_dynamic_drift_threshold_balanced_vs_stressed_books() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0, max_execution_price_drift_ratio=0.02)
+
+    balanced = _open_with_boundary_data(
+        engine=engine,
+        side="YES",
+        price=0.95,  # requested price intentionally misleading
+        size=300.0,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.62,
+            "orderbook": {
+                "bids": [{"price": 0.50, "size": 1200.0}],
+                "asks": [{"price": 0.51, "size": 100.0}, {"price": 0.515, "size": 400.0}],
+            },
+        },
+    )
+    assert balanced is not None
+
+    stressed_engine = ExecutionEngine(starting_equity=10_000.0, max_execution_price_drift_ratio=0.02)
+    stressed = _open_with_boundary_data(
+        engine=stressed_engine,
+        side="YES",
+        price=0.95,
+        size=300.0,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.62,
+            "orderbook": {
+                "bids": [{"price": 0.30, "size": 1500.0}],
+                "asks": [{"price": 0.51, "size": 100.0}, {"price": 0.515, "size": 400.0}],
+            },
+        },
+    )
+    assert stressed is None
+    rejection = stressed_engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "price_deviation"
+    assert rejection.get("execution_price") == (0.51 * 100.0 + 0.515 * 200.0) / 300.0
+    assert rejection.get("max_drift_ratio", 0.0) < 0.02
+
+
+def test_p18_dynamic_drift_threshold_fail_closed_on_invalid_volatility_input() -> None:
+    engine = ExecutionEngine(starting_equity=10_000.0)
+
+    created = _open_with_boundary_data(
+        engine=engine,
+        side="YES",
+        price=0.51,
+        size=100.0,
+        execution_market_data={
+            "timestamp": time.time(),
+            "model_probability": 0.65,
+            "volatility": "bad-value",
+            "orderbook": {
+                "bids": [{"price": 0.49, "size": 1000.0}],
+                "asks": [{"price": 0.51, "size": 1000.0}],
+            },
+        },
+    )
+
+    assert created is None
+    rejection = engine.get_last_open_rejection() or {}
+    assert rejection.get("reason") == "invalid_market_data"
+    assert rejection.get("field") == "volatility"
+    snap = _snapshot(engine)
+    assert len(snap.positions) == 0
+    assert snap.cash == 10_000.0


### PR DESCRIPTION
### Motivation
- Restore the P18 dynamic drift-threshold behavior that was lost after the VWAP-pricing consistency fix while preserving the corrected VWAP execution-price basis and existing fail-closed market-data guards.
- Ensure drift, EV, stored entry/current price, and implied probability are computed from the same VWAP execution estimate and keep requested/submitted price as trace-only metadata.

### Description
- Reintroduced dynamic drift-threshold computation and orderbook VWAP estimation in `projects/polymarket/polyquantbot/execution/drift_guard.py` by adding `estimate_execution_price_from_orderbook(...)`, `compute_dynamic_drift_threshold(...)`, and result dataclasses (`ExecutionPriceEstimateResult`, `DynamicDriftThresholdResult`).
- Wired dynamic threshold and VWAP estimation into the runtime decision path in `projects/polymarket/polyquantbot/execution/engine.py` so `open_position(...)` now: validates market data → estimates VWAP execution price → computes dynamic max-drift → fail-closed on invalid inputs → runs drift validation (using `expected_price = reference_price` and `execution_price = estimated_execution_price`) → runs EV validation using the same VWAP → opens position with VWAP as entry/current price and implied probability.
- Added safe volatility parsing and explicit fail-closed rejection when volatility input is invalid, and preserved existing rejection semantics (no state mutation on reject, same rejection reasons).
- Added/updated unit tests in `projects/polymarket/polyquantbot/tests/test_p17_4_execution_drift_guard_20260410.py` to cover VWAP basis continuity, dynamic-threshold behavior (balanced vs stressed books), invalid volatility fail-closed path, and combined VWAP+dynamic-threshold decisions.
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md` and updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` with STANDARD-tier, NARROW_INTEGRATION handoff.

### Testing
- Ran static compile: `python -m py_compile execution/drift_guard.py execution/engine.py tests/test_p17_4_execution_drift_guard_20260410.py` which passed with no compile errors.
- Ran focused unit tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p17_4_execution_drift_guard_20260410.py` which returned `12 passed, 1 warning` (warning: unknown pytest config option `asyncio_mode`, non-blocking for this change).
- All modified tests passed and validate: dynamic drift threshold usage, VWAP pricing consistency across drift/EV/entry, and no regressions on existing fail-closed rejection paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d877b5d9a0832eb073ac0d7238fd89)