### PR TITLE
feature: public account wallet foundation v1 (MAJOR/FOUNDATION)

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,17 +1,16 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 04:12
-🔄 Status       : P18 final execution consistency remediation completed with dynamic drift threshold restoration on VWAP execution basis.
+📅 Last Updated : 2026-04-10 06:10
+🔄 Status       : Public account wallet foundation v1 (MAJOR/FOUNDATION) implemented with durable account/runtime schema, fail-closed account envelope resolver, and trade-intent persistence boundary integration.
 
 ✅ COMPLETED
-- P18 final remediation completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
-  - Restored dynamic drift threshold computation and runtime enforcement in `ExecutionEngine.open_position(...)`.
-  - Preserved VWAP execution-price consistency across drift validation, EV validation, entry/current pricing, and implied probability.
-  - Kept requested/submitted price as trace/debug only; no reintroduction of requested-price drift authority.
-  - Preserved fail-closed behavior for invalid/stale market data, liquidity insufficiency, EV-negative rejection, and no-mutation-on-reject paths.
-  - Added focused tests for dynamic threshold restoration, VWAP consistency continuity, and combined VWAP+dynamic-threshold decision behavior.
+- Public account wallet foundation v1 completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
+  - Added durable persistence schema for `users`, `trading_accounts`, `api_credentials`, `risk_profiles`, and `trade_intents`.
+  - Added fail-closed `AccountRuntimeResolver` + `TradeIntentWriter` foundation services.
+  - Integrated StrategyTrigger with optional account envelope resolution and trade-intent persistence while preserving existing execution-proof submission path.
+  - Added focused tests for account resolution, mode gating, trade-intent persistence, and fail-closed missing-live-auth behavior.
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md`
 
 🔧 IN PROGRESS
 - None.
@@ -20,7 +19,7 @@
 - None.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_49_p18_final_dynamic_drift_restore.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/24_50_public_account_wallet_foundation_v1.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).
+- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this foundation task).

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -10,6 +10,7 @@ from typing import Any
 from .engine import ExecutionEngine
 from .intelligence import ExecutionIntelligence, MarketSnapshot
 from .trade_trace import TradeTraceEngine
+from ..infra.account_runtime import AccountRuntimeResolver, AccountRuntimeResolutionError, TradeIntentWriter
 from ..strategy.falcon_alpha_strategy import FalconSignal
 from ..core.analytics.trade_validator import TradeValidator
 from ..core.execution.execution_tracker import ExecutionTracker
@@ -290,7 +291,16 @@ class StrategyTrigger:
     IF pnl > target -> close position
     """
 
-    def __init__(self, engine: ExecutionEngine, config: StrategyConfig) -> None:
+    def __init__(
+        self,
+        engine: ExecutionEngine,
+        config: StrategyConfig,
+        *,
+        account_runtime_resolver: AccountRuntimeResolver | None = None,
+        trade_intent_writer: TradeIntentWriter | None = None,
+        account_user_id: str | None = None,
+        trading_account_id: str | None = None,
+    ) -> None:
         self._engine = engine
         self._config = config
         self._intelligence = ExecutionIntelligence()
@@ -343,6 +353,10 @@ class StrategyTrigger:
             "fallback_to_neutral": True,
         }
         self._last_dynamic_strategy_weights: dict[str, float] = self._default_dynamic_strategy_weights()
+        self._account_runtime_resolver = account_runtime_resolver
+        self._trade_intent_writer = trade_intent_writer
+        self._account_user_id = account_user_id
+        self._trading_account_id = trading_account_id
 
     @staticmethod
     def _clamp(value: float, lower: float, upper: float) -> float:
@@ -2303,6 +2317,64 @@ class StrategyTrigger:
             if market_type not in {"fast", "normal"}:
                 market_type = "fast" if float((market_context or {}).get("spread", 0.0)) >= 0.03 else "normal"
             volatility_proxy = (market_context or {}).get("volatility")
+
+            resolved_user_id = ""
+            resolved_account_id = ""
+            resolved_mode = "paper"
+            if self._account_runtime_resolver is not None:
+                if not self._account_user_id:
+                    self._record_blocked_terminal_trace(
+                        trade_id=trade_id,
+                        signal_data=signal_data,
+                        decision_data=decision_data,
+                        validation_result={"decision": "NOT_EVALUATED", "reason": "account_user_missing", "checks": {}},
+                        terminal_stage="account_runtime_resolver_block",
+                        reason="account_user_missing",
+                        terminal_outcome="BLOCKED",
+                    )
+                    return "BLOCKED"
+                try:
+                    account_envelope = await self._account_runtime_resolver.resolve_active_envelope(
+                        user_id=self._account_user_id,
+                        trading_account_id=self._trading_account_id,
+                    )
+                except AccountRuntimeResolutionError as exc:
+                    self._record_blocked_terminal_trace(
+                        trade_id=trade_id,
+                        signal_data=signal_data,
+                        decision_data=decision_data,
+                        validation_result={"decision": "NOT_EVALUATED", "reason": "account_runtime_resolution_failed", "checks": {}},
+                        terminal_stage="account_runtime_resolver_block",
+                        reason=str(exc),
+                        terminal_outcome="BLOCKED",
+                    )
+                    return "BLOCKED"
+                resolved_user_id = account_envelope.user_id
+                resolved_account_id = account_envelope.trading_account_id
+                resolved_mode = account_envelope.mode
+
+            if self._trade_intent_writer is not None:
+                await self._trade_intent_writer.write(
+                    payload={
+                        "trade_intent_id": trade_id,
+                        "user_id": resolved_user_id,
+                        "trading_account_id": resolved_account_id,
+                        "mode": resolved_mode,
+                        "market_id": target_market_id,
+                        "side": self._config.side,
+                        "size": size,
+                        "expected_price": readiness.expected_fill_price,
+                        "expected_value": signal_data["expected_value"],
+                        "strategy_source": decision_data["strategy_source"],
+                        "status": "recorded",
+                        "metadata": {
+                            "entry_quality": readiness.execution_quality_reason,
+                            "entry_timing": readiness.timing_reason,
+                            "risk_state": self._risk_engine.as_dict(),
+                        },
+                    }
+                )
+
             validation_proof = self._engine.build_validation_proof(
                 condition_id=target_market_id,
                 side=self._config.side,

--- a/projects/polymarket/polyquantbot/infra/account_runtime.py
+++ b/projects/polymarket/polyquantbot/infra/account_runtime.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+ALLOWED_ACCOUNT_MODES: set[str] = {"paper", "live_shadow", "live"}
+
+
+class AccountRuntimeResolutionError(RuntimeError):
+    """Raised when account runtime context is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class WalletAuthMetadata:
+    wallet_type: str | None
+    wallet_address: str | None
+    proxy_wallet_address: str | None
+    funder_address: str | None
+    credential_reference: str | None
+
+
+@dataclass(frozen=True)
+class AccountRuntimeEnvelope:
+    user_id: str
+    trading_account_id: str
+    mode: str
+    risk_profile: dict[str, Any]
+    wallet_auth: WalletAuthMetadata
+
+
+class AccountRuntimeRepository(Protocol):
+    async def resolve_account_runtime_row(
+        self,
+        *,
+        user_id: str,
+        trading_account_id: str | None,
+    ) -> dict[str, Any] | None:
+        ...
+
+    async def insert_trade_intent(self, payload: dict[str, Any]) -> bool:
+        ...
+
+
+class AccountRuntimeResolver:
+    """Resolve active account + mode envelope and fail closed on invalid state."""
+
+    def __init__(self, repository: AccountRuntimeRepository) -> None:
+        self._repository = repository
+
+    async def resolve_active_envelope(
+        self,
+        *,
+        user_id: str,
+        trading_account_id: str | None = None,
+    ) -> AccountRuntimeEnvelope:
+        row = await self._repository.resolve_account_runtime_row(
+            user_id=user_id,
+            trading_account_id=trading_account_id,
+        )
+        if row is None:
+            raise AccountRuntimeResolutionError("account_not_found")
+
+        mode = str(row.get("mode", "")).strip().lower()
+        if mode not in ALLOWED_ACCOUNT_MODES:
+            raise AccountRuntimeResolutionError("invalid_account_mode")
+
+        wallet_auth = WalletAuthMetadata(
+            wallet_type=_normalize_optional_text(row.get("wallet_type")),
+            wallet_address=_normalize_optional_text(row.get("wallet_address")),
+            proxy_wallet_address=_normalize_optional_text(row.get("proxy_wallet_address")),
+            funder_address=_normalize_optional_text(row.get("funder_address")),
+            credential_reference=_normalize_optional_text(row.get("credential_reference")),
+        )
+        if mode == "live" and not wallet_auth.credential_reference:
+            raise AccountRuntimeResolutionError("missing_live_auth_metadata")
+
+        raw_profile = row.get("risk_profile")
+        risk_profile = raw_profile if isinstance(raw_profile, dict) else {}
+        if not risk_profile:
+            raise AccountRuntimeResolutionError("risk_profile_not_bound")
+
+        return AccountRuntimeEnvelope(
+            user_id=str(row.get("user_id", user_id)),
+            trading_account_id=str(row.get("trading_account_id", "")),
+            mode=mode,
+            risk_profile=risk_profile,
+            wallet_auth=wallet_auth,
+        )
+
+
+class TradeIntentWriter:
+    """Persistence boundary for strategy decisions (not execution truth)."""
+
+    def __init__(self, repository: AccountRuntimeRepository) -> None:
+        self._repository = repository
+
+    async def write(self, *, payload: dict[str, Any]) -> bool:
+        return await self._repository.insert_trade_intent(payload)
+
+
+def _normalize_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -175,6 +175,79 @@ CREATE TABLE IF NOT EXISTS trade_ledger (
 );
 """
 
+_DDL_USERS = """
+CREATE TABLE IF NOT EXISTS users (
+    user_id          TEXT        PRIMARY KEY,
+    external_ref     TEXT        NOT NULL DEFAULT '',
+    display_name     TEXT        NOT NULL DEFAULT '',
+    created_at       DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at       DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+"""
+
+_DDL_RISK_PROFILES = """
+CREATE TABLE IF NOT EXISTS risk_profiles (
+    risk_profile_id      TEXT        PRIMARY KEY,
+    max_position_ratio   DOUBLE PRECISION NOT NULL DEFAULT 0.10,
+    max_concurrent_trades INTEGER    NOT NULL DEFAULT 5,
+    daily_loss_limit_usd DOUBLE PRECISION NOT NULL DEFAULT -2000.0,
+    max_drawdown_ratio   DOUBLE PRECISION NOT NULL DEFAULT 0.08,
+    config               JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at           DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at           DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+"""
+
+_DDL_TRADING_ACCOUNTS = """
+CREATE TABLE IF NOT EXISTS trading_accounts (
+    trading_account_id    TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    mode                  TEXT        NOT NULL DEFAULT 'paper',
+    wallet_type           TEXT        NOT NULL DEFAULT '',
+    wallet_address        TEXT        NOT NULL DEFAULT '',
+    proxy_wallet_address  TEXT        NOT NULL DEFAULT '',
+    funder_address        TEXT        NOT NULL DEFAULT '',
+    credential_reference  TEXT        NOT NULL DEFAULT '',
+    risk_profile_id       TEXT        NOT NULL REFERENCES risk_profiles(risk_profile_id),
+    is_active             BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+"""
+
+_DDL_API_CREDENTIALS = """
+CREATE TABLE IF NOT EXISTS api_credentials (
+    credential_id         TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    credential_reference  TEXT        NOT NULL UNIQUE,
+    provider              TEXT        NOT NULL DEFAULT 'polymarket',
+    auth_type             TEXT        NOT NULL DEFAULT 'placeholder',
+    secret_ref            TEXT        NOT NULL DEFAULT '',
+    is_active             BOOLEAN     NOT NULL DEFAULT TRUE,
+    metadata              JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+"""
+
+_DDL_TRADE_INTENTS = """
+CREATE TABLE IF NOT EXISTS trade_intents (
+    trade_intent_id       TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    trading_account_id    TEXT        NOT NULL REFERENCES trading_accounts(trading_account_id) ON DELETE CASCADE,
+    mode                  TEXT        NOT NULL,
+    market_id             TEXT        NOT NULL,
+    side                  TEXT        NOT NULL,
+    size                  DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    expected_price        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    expected_value        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    strategy_source       TEXT        NOT NULL DEFAULT '',
+    status                TEXT        NOT NULL DEFAULT 'recorded',
+    metadata              JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+"""
+
 
 # ── DatabaseClient ─────────────────────────────────────────────────────────────
 
@@ -322,6 +395,11 @@ class DatabaseClient:
             await conn.execute(_DDL_WALLET_STATE)
             await conn.execute(_DDL_PAPER_POSITIONS)
             await conn.execute(_DDL_TRADE_LEDGER)
+            await conn.execute(_DDL_USERS)
+            await conn.execute(_DDL_RISK_PROFILES)
+            await conn.execute(_DDL_TRADING_ACCOUNTS)
+            await conn.execute(_DDL_API_CREDENTIALS)
+            await conn.execute(_DDL_TRADE_INTENTS)
         log.info("db_schema_applied")
 
     # ── Trades ────────────────────────────────────────────────────────────────
@@ -429,6 +507,229 @@ class DatabaseClient:
             )
         sql = "UPDATE trades SET status = $2 WHERE trade_id = $1"
         return await self._execute(sql, trade_id, status, op_label="update_trade_status")
+
+    async def upsert_user(self, *, user_id: str, external_ref: str, display_name: str) -> bool:
+        sql = """
+            INSERT INTO users (user_id, external_ref, display_name, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (user_id) DO UPDATE
+            SET external_ref = EXCLUDED.external_ref,
+                display_name = EXCLUDED.display_name,
+                updated_at = EXCLUDED.updated_at
+        """
+        now = time.time()
+        return await self._execute(
+            sql,
+            user_id,
+            external_ref,
+            display_name,
+            now,
+            now,
+            op_label="upsert_user_identity",
+        )
+
+    async def upsert_risk_profile(
+        self,
+        *,
+        risk_profile_id: str,
+        config: dict[str, Any],
+        max_position_ratio: float = 0.10,
+        max_concurrent_trades: int = 5,
+        daily_loss_limit_usd: float = -2000.0,
+        max_drawdown_ratio: float = 0.08,
+    ) -> bool:
+        sql = """
+            INSERT INTO risk_profiles (
+                risk_profile_id, max_position_ratio, max_concurrent_trades,
+                daily_loss_limit_usd, max_drawdown_ratio, config, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (risk_profile_id) DO UPDATE
+            SET max_position_ratio = EXCLUDED.max_position_ratio,
+                max_concurrent_trades = EXCLUDED.max_concurrent_trades,
+                daily_loss_limit_usd = EXCLUDED.daily_loss_limit_usd,
+                max_drawdown_ratio = EXCLUDED.max_drawdown_ratio,
+                config = EXCLUDED.config,
+                updated_at = EXCLUDED.updated_at
+        """
+        now = time.time()
+        return await self._execute(
+            sql,
+            risk_profile_id,
+            max_position_ratio,
+            max_concurrent_trades,
+            daily_loss_limit_usd,
+            max_drawdown_ratio,
+            json.dumps(config or {}),
+            now,
+            now,
+            op_label="upsert_risk_profile",
+        )
+
+    async def upsert_trading_account(
+        self,
+        *,
+        trading_account_id: str,
+        user_id: str,
+        mode: str,
+        risk_profile_id: str,
+        wallet_type: str = "",
+        wallet_address: str = "",
+        proxy_wallet_address: str = "",
+        funder_address: str = "",
+        credential_reference: str = "",
+        is_active: bool = True,
+    ) -> bool:
+        sql = """
+            INSERT INTO trading_accounts (
+                trading_account_id, user_id, mode, wallet_type, wallet_address,
+                proxy_wallet_address, funder_address, credential_reference, risk_profile_id,
+                is_active, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            ON CONFLICT (trading_account_id) DO UPDATE
+            SET user_id = EXCLUDED.user_id,
+                mode = EXCLUDED.mode,
+                wallet_type = EXCLUDED.wallet_type,
+                wallet_address = EXCLUDED.wallet_address,
+                proxy_wallet_address = EXCLUDED.proxy_wallet_address,
+                funder_address = EXCLUDED.funder_address,
+                credential_reference = EXCLUDED.credential_reference,
+                risk_profile_id = EXCLUDED.risk_profile_id,
+                is_active = EXCLUDED.is_active,
+                updated_at = EXCLUDED.updated_at
+        """
+        now = time.time()
+        return await self._execute(
+            sql,
+            trading_account_id,
+            user_id,
+            mode,
+            wallet_type,
+            wallet_address,
+            proxy_wallet_address,
+            funder_address,
+            credential_reference,
+            risk_profile_id,
+            is_active,
+            now,
+            now,
+            op_label="upsert_trading_account",
+        )
+
+    async def upsert_api_credential(
+        self,
+        *,
+        credential_id: str,
+        user_id: str,
+        credential_reference: str,
+        provider: str = "polymarket",
+        auth_type: str = "placeholder",
+        secret_ref: str = "",
+        metadata: dict[str, Any] | None = None,
+        is_active: bool = True,
+    ) -> bool:
+        sql = """
+            INSERT INTO api_credentials (
+                credential_id, user_id, credential_reference, provider, auth_type,
+                secret_ref, is_active, metadata, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (credential_id) DO UPDATE
+            SET user_id = EXCLUDED.user_id,
+                credential_reference = EXCLUDED.credential_reference,
+                provider = EXCLUDED.provider,
+                auth_type = EXCLUDED.auth_type,
+                secret_ref = EXCLUDED.secret_ref,
+                is_active = EXCLUDED.is_active,
+                metadata = EXCLUDED.metadata,
+                updated_at = EXCLUDED.updated_at
+        """
+        now = time.time()
+        return await self._execute(
+            sql,
+            credential_id,
+            user_id,
+            credential_reference,
+            provider,
+            auth_type,
+            secret_ref,
+            is_active,
+            json.dumps(metadata or {}),
+            now,
+            now,
+            op_label="upsert_api_credential",
+        )
+
+    async def resolve_account_runtime_row(
+        self,
+        *,
+        user_id: str,
+        trading_account_id: str | None,
+    ) -> dict[str, Any] | None:
+        if trading_account_id:
+            sql = """
+                SELECT
+                    u.user_id AS user_id,
+                    ta.trading_account_id AS trading_account_id,
+                    ta.mode AS mode,
+                    ta.wallet_type AS wallet_type,
+                    ta.wallet_address AS wallet_address,
+                    ta.proxy_wallet_address AS proxy_wallet_address,
+                    ta.funder_address AS funder_address,
+                    ta.credential_reference AS credential_reference,
+                    rp.config AS risk_profile
+                FROM trading_accounts ta
+                JOIN users u ON u.user_id = ta.user_id
+                JOIN risk_profiles rp ON rp.risk_profile_id = ta.risk_profile_id
+                WHERE ta.user_id = $1 AND ta.trading_account_id = $2 AND ta.is_active = TRUE
+                LIMIT 1
+            """
+            rows = await self._fetch(sql, user_id, trading_account_id, op_label="resolve_account_runtime_row")
+        else:
+            sql = """
+                SELECT
+                    u.user_id AS user_id,
+                    ta.trading_account_id AS trading_account_id,
+                    ta.mode AS mode,
+                    ta.wallet_type AS wallet_type,
+                    ta.wallet_address AS wallet_address,
+                    ta.proxy_wallet_address AS proxy_wallet_address,
+                    ta.funder_address AS funder_address,
+                    ta.credential_reference AS credential_reference,
+                    rp.config AS risk_profile
+                FROM trading_accounts ta
+                JOIN users u ON u.user_id = ta.user_id
+                JOIN risk_profiles rp ON rp.risk_profile_id = ta.risk_profile_id
+                WHERE ta.user_id = $1 AND ta.is_active = TRUE
+                ORDER BY ta.updated_at DESC
+                LIMIT 1
+            """
+            rows = await self._fetch(sql, user_id, op_label="resolve_account_runtime_row")
+        return rows[0] if rows else None
+
+    async def insert_trade_intent(self, payload: dict[str, Any]) -> bool:
+        sql = """
+            INSERT INTO trade_intents (
+                trade_intent_id, user_id, trading_account_id, mode, market_id, side,
+                size, expected_price, expected_value, strategy_source, status, metadata, created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ON CONFLICT (trade_intent_id) DO NOTHING
+        """
+        return await self._execute(
+            sql,
+            str(payload.get("trade_intent_id", "")),
+            str(payload.get("user_id", "")),
+            str(payload.get("trading_account_id", "")),
+            str(payload.get("mode", "paper")),
+            str(payload.get("market_id", "")),
+            str(payload.get("side", "")),
+            float(payload.get("size", 0.0)),
+            float(payload.get("expected_price", 0.0)),
+            float(payload.get("expected_value", 0.0)),
+            str(payload.get("strategy_source", "")),
+            str(payload.get("status", "recorded")),
+            json.dumps(payload.get("metadata", {})),
+            float(payload.get("created_at", time.time())),
+            op_label="insert_trade_intent",
+        )
 
     # ── Positions ─────────────────────────────────────────────────────────────
 

--- a/projects/polymarket/polyquantbot/infra/db/migrations/20260410_public_account_wallet_foundation_v1.sql
+++ b/projects/polymarket/polyquantbot/infra/db/migrations/20260410_public_account_wallet_foundation_v1.sql
@@ -1,0 +1,65 @@
+-- public account wallet foundation v1
+-- durable entities: users, risk_profiles, trading_accounts, api_credentials, trade_intents
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id          TEXT        PRIMARY KEY,
+    external_ref     TEXT        NOT NULL DEFAULT '',
+    display_name     TEXT        NOT NULL DEFAULT '',
+    created_at       DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at       DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+
+CREATE TABLE IF NOT EXISTS risk_profiles (
+    risk_profile_id       TEXT        PRIMARY KEY,
+    max_position_ratio    DOUBLE PRECISION NOT NULL DEFAULT 0.10,
+    max_concurrent_trades INTEGER     NOT NULL DEFAULT 5,
+    daily_loss_limit_usd  DOUBLE PRECISION NOT NULL DEFAULT -2000.0,
+    max_drawdown_ratio    DOUBLE PRECISION NOT NULL DEFAULT 0.08,
+    config                JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+
+CREATE TABLE IF NOT EXISTS trading_accounts (
+    trading_account_id    TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    mode                  TEXT        NOT NULL DEFAULT 'paper',
+    wallet_type           TEXT        NOT NULL DEFAULT '',
+    wallet_address        TEXT        NOT NULL DEFAULT '',
+    proxy_wallet_address  TEXT        NOT NULL DEFAULT '',
+    funder_address        TEXT        NOT NULL DEFAULT '',
+    credential_reference  TEXT        NOT NULL DEFAULT '',
+    risk_profile_id       TEXT        NOT NULL REFERENCES risk_profiles(risk_profile_id),
+    is_active             BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+
+CREATE TABLE IF NOT EXISTS api_credentials (
+    credential_id         TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    credential_reference  TEXT        NOT NULL UNIQUE,
+    provider              TEXT        NOT NULL DEFAULT 'polymarket',
+    auth_type             TEXT        NOT NULL DEFAULT 'placeholder',
+    secret_ref            TEXT        NOT NULL DEFAULT '',
+    is_active             BOOLEAN     NOT NULL DEFAULT TRUE,
+    metadata              JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+    updated_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);
+
+CREATE TABLE IF NOT EXISTS trade_intents (
+    trade_intent_id       TEXT        PRIMARY KEY,
+    user_id               TEXT        NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    trading_account_id    TEXT        NOT NULL REFERENCES trading_accounts(trading_account_id) ON DELETE CASCADE,
+    mode                  TEXT        NOT NULL,
+    market_id             TEXT        NOT NULL,
+    side                  TEXT        NOT NULL,
+    size                  DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    expected_price        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    expected_value        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    strategy_source       TEXT        NOT NULL DEFAULT '',
+    status                TEXT        NOT NULL DEFAULT 'recorded',
+    metadata              JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())
+);

--- a/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md
@@ -1,0 +1,77 @@
+# 24_50_public_account_wallet_foundation_v1
+
+## Validation metadata
+- Validation Tier: MAJOR
+- Claim Level: FOUNDATION
+- Validation Target:
+  1. Durable persistence schema coverage for `users`, `trading_accounts`, `api_credentials`, `risk_profiles`, and `trade_intents`.
+  2. Runtime-safe account envelope resolution for active account, mode (`paper`, `live_shadow`, `live`), wallet/auth metadata, and bound risk profile.
+  3. Existing StrategyTrigger → ExecutionEngine proof-verified path unchanged for current runtime behavior.
+  4. Narrow integration to persist strategy decisions as `trade_intents` without replacing execution truth semantics.
+  5. Fail-closed behavior for invalid mode / missing live auth metadata.
+- Not in Scope:
+  - Deposit/withdraw/bridge UX and wallet product flows.
+  - Full per-user live order submission routing.
+  - Orders/fills/positions public persistence surface.
+  - Credential vault hardening beyond placeholder credential reference slot.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md`. Tier: MAJOR.
+
+## 1. What was built
+- Added public-account foundation schema contracts in DB layer for:
+  - `users`
+  - `risk_profiles`
+  - `trading_accounts`
+  - `api_credentials`
+  - `trade_intents`
+- Added migration artifact at:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/migrations/20260410_public_account_wallet_foundation_v1.sql`
+- Added runtime account envelope module:
+  - `AccountRuntimeResolver` for fail-closed mode/account/auth/risk-profile resolution
+  - `TradeIntentWriter` for strategy-decision persistence boundary
+- Added narrow StrategyTrigger integration:
+  - Optional account resolver check before execution submission
+  - Optional trade-intent write on validated decision path
+  - Preserved existing execution proof generation and engine-boundary verification flow
+
+## 2. Current system architecture
+1. StrategyTrigger computes decision and pre-trade validation exactly as before.
+2. If account resolver is configured:
+   - resolve active envelope for user/account
+   - fail closed on invalid mode / missing account / missing live auth metadata / missing risk profile
+3. If trade-intent writer is configured:
+   - persist decision intent (`trade_intents`) as auditability boundary record
+4. Build execution validation proof and submit `open_position(...)` through existing authoritative path.
+5. Execution truth remains owned by ExecutionEngine + downstream trade lifecycle, while `trade_intents` stays decision-level persistence.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/database.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/account_runtime.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/migrations/20260410_public_account_wallet_foundation_v1.sql`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- DB schema includes durable foundation entities for public account runtime.
+- Account runtime envelope resolves and validates allowed mode set (`paper`, `live_shadow`, `live`).
+- Resolver rejects invalid mode and missing live credential reference in `live` mode.
+- StrategyTrigger can record trade intents as decision persistence without replacing execution-proof boundary behavior.
+- Existing StrategyTrigger execution path still opens positions through proof-aware `ExecutionEngine.open_position(...)`.
+
+## 5. Validation commands
+- `python -m py_compile /workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/account_runtime.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/infra/db/database.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py`
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py`
+
+## 6. Known issues
+- Existing environment warning may still appear in pytest (`Unknown config option: asyncio_mode`) and is non-blocking for scoped task verification.
+- API credential secret hardening remains placeholder/reference only by design in this foundation phase.
+
+## 7. Suggested next step
+- Phase 2: `public execution account binding v1`
+  - add orders/fills/positions schema
+  - add paper/live_shadow execution adapters
+  - prepare live-capable per-account execution path
+
+## 8. What is next
+- SENTINEL MAJOR validation on declared target scope before merge.

--- a/projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+from projects.polymarket.polyquantbot.infra.account_runtime import (
+    AccountRuntimeResolutionError,
+    AccountRuntimeResolver,
+    TradeIntentWriter,
+)
+
+
+class _InMemoryAccountRuntimeRepository:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self._row = row
+        self.trade_intents: list[dict[str, Any]] = []
+
+    async def resolve_account_runtime_row(
+        self,
+        *,
+        user_id: str,
+        trading_account_id: str | None,
+    ) -> dict[str, Any] | None:
+        if self._row is None:
+            return None
+        if str(self._row.get("user_id")) != user_id:
+            return None
+        if trading_account_id and str(self._row.get("trading_account_id")) != trading_account_id:
+            return None
+        return dict(self._row)
+
+    async def insert_trade_intent(self, payload: dict[str, Any]) -> bool:
+        self.trade_intents.append(dict(payload))
+        return True
+
+
+def _seed_risk_state_file(path: Path) -> None:
+    path.write_text(
+        (
+            '{"correlated_exposure_ratio":0.0,'
+            '"daily_pnl_by_day":{},'
+            '"drawdown_ratio":0.0,'
+            '"equity":10000.0,'
+            '"global_trade_block":false,'
+            '"open_trades":0,'
+            '"peak_equity":10000.0,'
+            '"portfolio_pnl":0.0,'
+            '"version":1}'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_aggregation() -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S1",
+        decision="ENTER",
+        reason="test_signal",
+        edge=0.06,
+        confidence=0.9,
+        score=0.95,
+        market_metadata={"market_id": "MARKET-1", "title": "Test Market"},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S1",
+        ranked_candidates=[candidate],
+        selection_reason="highest_score",
+        top_score=0.95,
+        decision="ENTER",
+    )
+
+
+def _build_trigger(
+    *,
+    resolver: AccountRuntimeResolver | None = None,
+    writer: TradeIntentWriter | None = None,
+    account_user_id: str | None = None,
+    trading_account_id: str | None = None,
+) -> StrategyTrigger:
+    state_file = Path(tempfile.mkstemp(suffix="_public_account_risk_state.json")[1])
+    _seed_risk_state_file(state_file)
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=10_000.0),
+        config=StrategyConfig(
+            market_id="MARKET-1",
+            threshold=0.60,
+            target_pnl=2.0,
+            risk_state_persistence_path=str(state_file),
+        ),
+        account_runtime_resolver=resolver,
+        trade_intent_writer=writer,
+        account_user_id=account_user_id,
+        trading_account_id=trading_account_id,
+    )
+    trigger._cooldown_seconds = 0.0  # noqa: SLF001
+    trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+    return trigger
+
+
+def test_account_runtime_resolver_resolves_active_paper_envelope() -> None:
+    async def _run() -> None:
+        repository = _InMemoryAccountRuntimeRepository(
+            row={
+                "user_id": "user-1",
+                "trading_account_id": "acct-1",
+                "mode": "paper",
+                "wallet_type": "custodial",
+                "wallet_address": "0xabc",
+                "proxy_wallet_address": "",
+                "funder_address": "",
+                "credential_reference": "",
+                "risk_profile": {"profile": "default"},
+            }
+        )
+        resolver = AccountRuntimeResolver(repository)
+        envelope = await resolver.resolve_active_envelope(user_id="user-1", trading_account_id="acct-1")
+        assert envelope.mode == "paper"
+        assert envelope.trading_account_id == "acct-1"
+        assert envelope.risk_profile["profile"] == "default"
+
+    asyncio.run(_run())
+
+
+def test_account_runtime_resolver_fails_closed_on_invalid_mode() -> None:
+    async def _run() -> None:
+        repository = _InMemoryAccountRuntimeRepository(
+            row={
+                "user_id": "user-1",
+                "trading_account_id": "acct-1",
+                "mode": "sandbox",
+                "risk_profile": {"profile": "default"},
+            }
+        )
+        resolver = AccountRuntimeResolver(repository)
+        try:
+            await resolver.resolve_active_envelope(user_id="user-1", trading_account_id="acct-1")
+        except AccountRuntimeResolutionError as exc:
+            assert str(exc) == "invalid_account_mode"
+            return
+        raise AssertionError("expected AccountRuntimeResolutionError for invalid mode")
+
+    asyncio.run(_run())
+
+
+def test_account_runtime_resolver_fails_closed_on_live_without_auth_metadata() -> None:
+    async def _run() -> None:
+        repository = _InMemoryAccountRuntimeRepository(
+            row={
+                "user_id": "user-1",
+                "trading_account_id": "acct-1",
+                "mode": "live",
+                "wallet_type": "custodial",
+                "wallet_address": "0xabc",
+                "credential_reference": "",
+                "risk_profile": {"profile": "strict"},
+            }
+        )
+        resolver = AccountRuntimeResolver(repository)
+        try:
+            await resolver.resolve_active_envelope(user_id="user-1", trading_account_id="acct-1")
+        except AccountRuntimeResolutionError as exc:
+            assert str(exc) == "missing_live_auth_metadata"
+            return
+        raise AssertionError("expected AccountRuntimeResolutionError for missing live auth metadata")
+
+    asyncio.run(_run())
+
+
+def test_strategy_trigger_records_trade_intent_without_bypassing_execution_proof_path() -> None:
+    async def _run() -> None:
+        repository = _InMemoryAccountRuntimeRepository(
+            row={
+                "user_id": "user-1",
+                "trading_account_id": "acct-1",
+                "mode": "live_shadow",
+                "wallet_type": "custodial",
+                "wallet_address": "0xabc",
+                "credential_reference": "cred-ref-1",
+                "risk_profile": {"profile": "default"},
+            }
+        )
+        resolver = AccountRuntimeResolver(repository)
+        writer = TradeIntentWriter(repository)
+        trigger = _build_trigger(
+            resolver=resolver,
+            writer=writer,
+            account_user_id="user-1",
+            trading_account_id="acct-1",
+        )
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "model_probability": 0.62,
+                "orderbook": {"bids": [[0.45, 20000.0]], "asks": [[0.46, 20000.0]]},
+                "timestamp": time.time(),
+            },
+        )
+        assert decision == "OPENED"
+        assert len(repository.trade_intents) == 1
+        assert repository.trade_intents[0]["mode"] == "live_shadow"
+        assert repository.trade_intents[0]["status"] == "recorded"
+
+    asyncio.run(_run())
+
+
+def test_strategy_trigger_fails_closed_when_live_auth_metadata_missing() -> None:
+    async def _run() -> None:
+        repository = _InMemoryAccountRuntimeRepository(
+            row={
+                "user_id": "user-1",
+                "trading_account_id": "acct-1",
+                "mode": "live",
+                "wallet_type": "custodial",
+                "wallet_address": "0xabc",
+                "credential_reference": "",
+                "risk_profile": {"profile": "default"},
+            }
+        )
+        resolver = AccountRuntimeResolver(repository)
+        writer = TradeIntentWriter(repository)
+        trigger = _build_trigger(
+            resolver=resolver,
+            writer=writer,
+            account_user_id="user-1",
+            trading_account_id="acct-1",
+        )
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.10,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+            },
+        )
+        assert decision == "BLOCKED"
+        assert repository.trade_intents == []
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Introduce a foundation for multi-user public account/runtime support with durable persistence and a fail-closed runtime envelope while preserving the existing StrategyTrigger→ExecutionEngine proof-verified execution boundary. 
- Provide a decision-level persistence boundary (`trade_intents`) and mode separation (`paper`, `live_shadow`, `live`) to enable future per-account execution and auditability without enabling full live order routing. 

### Description
- Added a runtime account envelope module `projects/polymarket/polyquantbot/infra/account_runtime.py` implementing `AccountRuntimeResolver`, `AccountRuntimeResolutionError`, `WalletAuthMetadata`, `AccountRuntimeEnvelope`, and `TradeIntentWriter`. 
- Extended the DB layer in `projects/polymarket/polyquantbot/infra/db/database.py` with new DDL and runtime methods for `users`, `risk_profiles`, `trading_accounts`, `api_credentials`, and `trade_intents`, and added a migration SQL artifact at `projects/polymarket/polyquantbot/infra/db/migrations/20260410_public_account_wallet_foundation_v1.sql`. 
- Integrated a narrow, optional path into `StrategyTrigger` (`projects/polymarket/polyquantbot/execution/strategy_trigger.py`) to resolve the active account envelope (fail-closed on missing/invalid mode or missing live auth metadata) and to persist a `trade_intent` before building the existing execution validation proof and calling `open_position(...)`, preserving execution-proof semantics. 
- Added focused unit tests `projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_v1.md`, and updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` with MAJOR-tier / FOUNDATION claim and SENTINEL handoff. 

### Testing
- Ran static compile checks with `python -m py_compile projects/polymarket/polyquantbot/infra/account_runtime.py projects/polymarket/polyquantbot/infra/db/database.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py` which passed. 
- Executed the focused test suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_public_account_wallet_foundation_v1_20260410.py` and all tests passed (`5 passed`), with a non-blocking pytest environment warning about `Unknown config option: asyncio_mode`. 
- Validation commands used are recorded in the forge report and the added test file demonstrates account resolution, mode gating, trade-intent persistence, and fail-closed behavior for missing live auth metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87aadcec4832eafb1f9976e30b3e2)