### PR TITLE
fix: enforce fail-closed trade-intent persistence gating in StrategyTrigger

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,26 +1,31 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 04:12
-🔄 Status       : P18 final execution consistency remediation completed with dynamic drift threshold restoration on VWAP execution basis.
+📅 Last Updated : 2026-04-10 06:18
+🔄 Status       : MAJOR follow-up patch applied for fail-closed trade-intent persistence gating in `StrategyTrigger` with regression coverage in touched scope.
 
 ✅ COMPLETED
-- P18 final remediation completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
-  - Restored dynamic drift threshold computation and runtime enforcement in `ExecutionEngine.open_position(...)`.
-  - Preserved VWAP execution-price consistency across drift validation, EV validation, entry/current pricing, and implied probability.
-  - Kept requested/submitted price as trace/debug only; no reintroduction of requested-price drift authority.
-  - Preserved fail-closed behavior for invalid/stale market data, liquidity insufficiency, EV-negative rejection, and no-mutation-on-reject paths.
-  - Added focused tests for dynamic threshold restoration, VWAP consistency continuity, and combined VWAP+dynamic-threshold decision behavior.
+- Added fail-closed trade-intent persistence gate in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`:
+  - persistence returning `False` now blocks immediately before proof creation/execution
+  - persistence exceptions now block immediately before proof creation/execution
+  - blocked path emits explicit reason `trade_intent_persistence_failed`
+- Added focused regression tests in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` for:
+  - persistence `False` block/no-proof/no-open
+  - persistence exception block/no-proof/no-open
+  - success-path non-regression for decision -> persistence -> proof -> open
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md`
 
 🔧 IN PROGRESS
-- None.
+- Runtime account envelope risk-profile default-binding fix (`config = {}` with bound profile) could not be patched in this repository snapshot because no corresponding implementation surface (`risk_profiles` / account-envelope binding subsystem) is present in code.
 
 📋 NOT STARTED
 - None.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_49_p18_final_dynamic_drift_restore.md. Tier: STANDARD
+- SENTINEL validation required for public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding before merge.
+- Source: reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md
+- Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).
+- Requested runtime account-envelope/default-risk-binding subsystem is not present in current repository snapshot, so that part remains pending until source surface is available.
+- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this patch scope).

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import inspect
 import time
 import structlog
 import uuid
@@ -316,6 +317,7 @@ class StrategyTrigger:
         self._position_entry_context: dict[str, dict[str, object]] = {}
         self._pre_trade_validator = PreTradeValidator()
         self._execution_tracker = ExecutionTracker()
+        self._trade_intent_writer: Any | None = None
         self._trade_validator = TradeValidator()
         self._risk_engine = RiskEngine(persistence_path=self._config.risk_state_persistence_path)
         self._risk_restore_ready = False
@@ -388,6 +390,65 @@ class StrategyTrigger:
             },
             "risk_state": self._risk_engine.as_dict(),
         }
+
+    async def _persist_trade_intent(
+        self,
+        *,
+        trade_id: str,
+        expected_price: float,
+        signal_data: dict[str, Any],
+        decision_data: dict[str, Any],
+    ) -> bool:
+        writer = self._trade_intent_writer
+        if writer is None:
+            self._execution_tracker.record_order_submission(
+                trade_id=trade_id,
+                expected_price=expected_price,
+                signal_data=signal_data,
+                decision_data=decision_data,
+            )
+            return True
+        write_callable = getattr(writer, "write", None)
+        if write_callable is None:
+            log.error(
+                "trade_intent_persistence_failed",
+                reason="trade_intent_persistence_failed",
+                trade_id=trade_id,
+                error="trade_intent_writer_missing_write",
+            )
+            return False
+        try:
+            result = write_callable(
+                trade_id=trade_id,
+                expected_price=expected_price,
+                signal_data=signal_data,
+                decision_data=decision_data,
+            )
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:
+            log.error(
+                "trade_intent_persistence_failed",
+                reason="trade_intent_persistence_failed",
+                trade_id=trade_id,
+                error=str(exc),
+            )
+            return False
+        if result is False:
+            log.error(
+                "trade_intent_persistence_failed",
+                reason="trade_intent_persistence_failed",
+                trade_id=trade_id,
+                error="trade_intent_writer_returned_false",
+            )
+            return False
+        self._execution_tracker.record_order_submission(
+            trade_id=trade_id,
+            expected_price=expected_price,
+            signal_data=signal_data,
+            decision_data=decision_data,
+        )
+        return True
 
     def _regime_strategy_modifiers(self, regime: MarketRegimeClassification) -> dict[str, float]:
         modifiers: dict[str, float] = {
@@ -2303,6 +2364,27 @@ class StrategyTrigger:
             if market_type not in {"fast", "normal"}:
                 market_type = "fast" if float((market_context or {}).get("spread", 0.0)) >= 0.03 else "normal"
             volatility_proxy = (market_context or {}).get("volatility")
+            persisted = await self._persist_trade_intent(
+                trade_id=trade_id,
+                expected_price=readiness.expected_fill_price,
+                signal_data=signal_data,
+                decision_data=decision_data,
+            )
+            if not persisted:
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data=signal_data,
+                    decision_data=decision_data,
+                    validation_result={
+                        "decision": validation_result.decision,
+                        "reason": validation_result.reason,
+                        "checks": validation_result.checks,
+                    },
+                    terminal_stage="trade_intent_persistence_block",
+                    reason="trade_intent_persistence_failed",
+                    terminal_outcome="BLOCKED",
+                )
+                return "BLOCKED"
             validation_proof = self._engine.build_validation_proof(
                 condition_id=target_market_id,
                 side=self._config.side,
@@ -2310,12 +2392,6 @@ class StrategyTrigger:
                 size=size,
                 market_type=market_type,
                 volatility_proxy=float(volatility_proxy) if volatility_proxy is not None else None,
-            )
-            self._execution_tracker.record_order_submission(
-                trade_id=trade_id,
-                expected_price=readiness.expected_fill_price,
-                signal_data=signal_data,
-                decision_data=decision_data,
             )
             created = await self._engine.open_position(
                 market=target_market_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md
@@ -1,0 +1,60 @@
+# 24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. `StrategyTrigger.evaluate()` blocks before proof creation/execution when trade-intent persistence returns `False`.
+  2. `StrategyTrigger.evaluate()` blocks fail-closed before proof creation/execution when trade-intent persistence raises.
+  3. Existing execution-boundary fail-closed behavior remains intact in the touched `StrategyTrigger -> ExecutionEngine` path.
+  4. Existing successful path still proceeds decision -> persistence -> proof -> execution in touched scope.
+- Not in Scope:
+  - Schema changes.
+  - Orders/fills/positions persistence redesign.
+  - Websocket/user reconciliation.
+  - Auth vault hardening.
+  - Live order submission changes.
+  - Public dashboard/UI changes.
+  - Runtime account envelope risk-binding subsystem changes (no corresponding implementation surface located in this repository snapshot).
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md`. Tier: MAJOR.
+
+## 1. What was built
+- Added an explicit trade-intent persistence gate in `StrategyTrigger` via `_persist_trade_intent(...)`.
+- Enforced fail-closed behavior: when persistence returns `False` or raises, the flow records a blocked terminal trace and returns `BLOCKED` immediately.
+- Reordered entry flow so proof creation (`build_validation_proof`) occurs only after persistence succeeds.
+
+## 2. Current system architecture
+- In the touched entry path, runtime sequence is now:
+  1. Pre-trade validator ALLOW.
+  2. Persist trade intent via configured writer (or default tracker-backed persistence).
+  3. If persistence fails (`False` or exception): block with reason `trade_intent_persistence_failed` and stop.
+  4. Only on persistence success: build validation proof.
+  5. Only then call `ExecutionEngine.open_position(...)`.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- `trade_intent_writer.write(...) -> False` now blocks execution before proof creation and before `open_position`.
+- `trade_intent_writer.write(...)` raising an exception now blocks execution before proof creation and before `open_position`.
+- Success path remains functional: on persistence success, proof creation and open-position execution still occur in the touched path.
+
+### Test evidence
+From `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
+1. `python -m py_compile execution/strategy_trigger.py tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p16_execution_validation_risk_enforcement_20260409.py -k "trade_intent_persistence_false_blocks_before_proof_and_open or trade_intent_persistence_exception_blocks_before_proof_and_open or trade_intent_persistence_success_keeps_normal_path"`
+   - ✅ pass (`3 passed, 13 deselected`)
+
+## 5. Known issues
+- The requested runtime account-envelope/default risk-binding subsystem (including `risk_profiles.config = {}` binding behavior) is not present in this repository snapshot, so that portion is not patched in this changeset.
+- Pytest emits environment warning: unknown config option `asyncio_mode`.
+
+## 6. What is next
+- Run SENTINEL MAJOR re-validation on this patch scope:
+  - `StrategyTrigger` fail-closed persistence gate
+  - proof/execution call ordering
+  - non-regression of touched successful path

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+import time
 from pathlib import Path
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, ExecutionValidationProof
@@ -310,6 +311,148 @@ def test_p16_blocked_terminal_traceability_has_single_terminal_trace_per_path() 
             if trace.get("outcome_data", {}).get("terminal_stage") == "execution_engine_rejected_open"
         ]
         assert len(engine_traces) == 1
+
+    asyncio.run(_run())
+
+
+def test_p16_trade_intent_persistence_false_blocks_before_proof_and_open() -> None:
+    class _FailFalseWriter:
+        async def write(self, **_: object) -> bool:
+            return False
+
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._trade_intent_writer = _FailFalseWriter()  # noqa: SLF001
+        proof_calls = 0
+        open_calls = 0
+        original_build = trigger._engine.build_validation_proof  # noqa: SLF001
+        original_open = trigger._engine.open_position  # noqa: SLF001
+
+        def _counted_build(*args: object, **kwargs: object):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original_build(*args, **kwargs)
+
+        async def _counted_open(*args: object, **kwargs: object):
+            nonlocal open_calls
+            open_calls += 1
+            return await original_open(*args, **kwargs)
+
+        trigger._engine.build_validation_proof = _counted_build  # type: ignore[assignment] # noqa: SLF001
+        trigger._engine.open_position = _counted_open  # type: ignore[assignment] # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "timestamp": time.time(),
+                "model_probability": 0.62,
+                "orderbook": {"bids": [[0.44, 10_000.0]], "asks": [[0.46, 10_000.0]]},
+            },
+        )
+        assert decision == "BLOCKED"
+        assert proof_calls == 0
+        assert open_calls == 0
+        trace = next(iter(trigger._trade_traceability.values()))  # noqa: SLF001
+        assert trace["outcome_data"]["reason"] == "trade_intent_persistence_failed"
+
+    asyncio.run(_run())
+
+
+def test_p16_trade_intent_persistence_exception_blocks_before_proof_and_open() -> None:
+    class _RaiseWriter:
+        async def write(self, **_: object) -> bool:
+            raise RuntimeError("db down")
+
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._trade_intent_writer = _RaiseWriter()  # noqa: SLF001
+        proof_calls = 0
+        open_calls = 0
+        original_build = trigger._engine.build_validation_proof  # noqa: SLF001
+        original_open = trigger._engine.open_position  # noqa: SLF001
+
+        def _counted_build(*args: object, **kwargs: object):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original_build(*args, **kwargs)
+
+        async def _counted_open(*args: object, **kwargs: object):
+            nonlocal open_calls
+            open_calls += 1
+            return await original_open(*args, **kwargs)
+
+        trigger._engine.build_validation_proof = _counted_build  # type: ignore[assignment] # noqa: SLF001
+        trigger._engine.open_position = _counted_open  # type: ignore[assignment] # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "timestamp": time.time(),
+                "model_probability": 0.62,
+                "orderbook": {"bids": [[0.44, 10_000.0]], "asks": [[0.46, 10_000.0]]},
+            },
+        )
+        assert decision == "BLOCKED"
+        assert proof_calls == 0
+        assert open_calls == 0
+        trace = next(iter(trigger._trade_traceability.values()))  # noqa: SLF001
+        assert trace["outcome_data"]["reason"] == "trade_intent_persistence_failed"
+
+    asyncio.run(_run())
+
+
+def test_p16_trade_intent_persistence_success_keeps_normal_path() -> None:
+    class _SuccessWriter:
+        async def write(self, **_: object) -> bool:
+            return True
+
+    async def _run() -> None:
+        trigger = _build_trigger()
+        trigger._trade_intent_writer = _SuccessWriter()  # noqa: SLF001
+        proof_calls = 0
+        open_calls = 0
+        original_build = trigger._engine.build_validation_proof  # noqa: SLF001
+        original_open = trigger._engine.open_position  # noqa: SLF001
+
+        def _counted_build(*args: object, **kwargs: object):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original_build(*args, **kwargs)
+
+        async def _counted_open(*args: object, **kwargs: object):
+            nonlocal open_calls
+            open_calls += 1
+            return await original_open(*args, **kwargs)
+
+        trigger._engine.build_validation_proof = _counted_build  # type: ignore[assignment] # noqa: SLF001
+        trigger._engine.open_position = _counted_open  # type: ignore[assignment] # noqa: SLF001
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context={
+                "expected_value": 0.12,
+                "liquidity_usd": 50_000.0,
+                "spread": 0.01,
+                "best_bid": 0.445,
+                "best_ask": 0.455,
+                "timestamp": time.time(),
+                "model_probability": 0.62,
+                "orderbook": {"bids": [[0.44, 10_000.0]], "asks": [[0.46, 10_000.0]]},
+            },
+        )
+        assert decision == "OPENED"
+        assert proof_calls == 1
+        assert open_calls == 1
 
     asyncio.run(_run())
 


### PR DESCRIPTION
### Motivation
- Ensure `trade_intent` persistence acts as an authoritative fail-closed gate so a failed or raising persistence writer blocks before any proof creation or execution. 
- Also intended to accept an actually bound/default risk profile even when its JSON `config = {}`, but the runtime account-envelope/risk-binding surface was not present in this repo snapshot so that part could not be patched here.

### Description
- Added a `_persist_trade_intent(...)` helper and a `_trade_intent_writer` field to `projects/polymarket/polyquantbot/execution/strategy_trigger.py` to centralize persistence and error handling. 
- Reordered `StrategyTrigger.evaluate()` so persistence is performed and must succeed before calling `build_validation_proof(...)` or `ExecutionEngine.open_position(...)`. 
- Enforced fail-closed behavior: when persistence returns `False`, raises, or the writer is misconfigured, evaluation records a blocked terminal trace and returns `BLOCKED` with a clear reason `trade_intent_persistence_failed`. 
- Moved `ExecutionTracker.record_order_submission(...)` to occur only on successful persistence. 
- Added focused regression tests in `projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py` covering persistence `False`, persistence exception, and persistence-success non-regression. 
- Added FORGE report `projects/polymarket/polyquantbot/reports/forge/24_50_public_account_wallet_foundation_fix_fail_closed_persistence_and_default_risk_binding.md` and updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` with MAJOR-tier handoff notes and the caveat about the missing risk-binding surface.

### Testing
- Type-compile check: `python -m py_compile execution/strategy_trigger.py tests/test_p16_execution_validation_risk_enforcement_20260409.py` — passed. 
- Focused pytest run: `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p16_execution_validation_risk_enforcement_20260409.py -k "trade_intent_persistence_false_blocks_before_proof_and_open or trade_intent_persistence_exception_blocks_before_proof_and_open or trade_intent_persistence_success_keeps_normal_path"` — passed (`3 passed, 13 deselected`). 
- Note: broader test failures observed during intermediate iteration were fixed; current patch leaves the requested runtime account-envelope/default-risk-binding fix outstanding because the relevant implementation surface (`risk_profiles` / account-envelope binding) was not present in this repository snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d884782350832eb41fa4ef08c9d01f)