### PR TITLE
fix: add minimal account envelope risk binding in StrategyTrigger

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,26 +1,24 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 04:12
-🔄 Status       : P18 final execution consistency remediation completed with dynamic drift threshold restoration on VWAP execution basis.
+📅 Last Updated : 2026-04-10 05:53
+🔄 Status       : MAJOR narrow-integration runtime account envelope risk-binding fix implemented in StrategyTrigger with structural binding presence enforcement.
 
 ✅ COMPLETED
-- P18 final remediation completed in active root `/workspace/walker-ai-team/projects/polymarket/polyquantbot`:
-  - Restored dynamic drift threshold computation and runtime enforcement in `ExecutionEngine.open_position(...)`.
-  - Preserved VWAP execution-price consistency across drift validation, EV validation, entry/current pricing, and implied probability.
-  - Kept requested/submitted price as trace/debug only; no reintroduction of requested-price drift authority.
-  - Preserved fail-closed behavior for invalid/stale market data, liquidity insufficiency, EV-negative rejection, and no-mutation-on-reject paths.
-  - Added focused tests for dynamic threshold restoration, VWAP consistency continuity, and combined VWAP+dynamic-threshold decision behavior.
-- FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_49_p18_final_dynamic_drift_restore.md`
+- Implemented minimal runtime `AccountEnvelope` binding surface in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`.
+- Added structural binding resolution (`risk profile row exists => bound`) independent from JSON config content.
+- Enforced fail-closed StrategyTrigger block reason `risk_profile_binding_missing` when binding is absent.
+- Added focused MAJOR tests for bound empty config pass, bound populated config pass, missing-binding fail-close, and persistence-gate regression continuity.
+- Added FORGE report: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md`.
 
 🔧 IN PROGRESS
-- None.
+- Awaiting SENTINEL MAJOR validation for persistence gate continuity, risk binding correctness, and execution boundary preservation.
 
 📋 NOT STARTED
 - None.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_49_p18_final_dynamic_drift_restore.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/25_3_account_envelope_risk_binding_minimal.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this remediation task).
+- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
+- Account envelope integration is intentionally narrow to StrategyTrigger runtime path only; broader account-system orchestration remains out of scope.

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -283,6 +283,34 @@ class MarketRegimeClassification:
     strategy_weight_modifiers: dict[str, float]
 
 
+@dataclass(frozen=True)
+class AccountEnvelope:
+    account_id: str
+    risk_profile_present: bool
+    risk_profile_config: dict[str, Any]
+
+    @classmethod
+    def from_risk_profile_row(
+        cls,
+        *,
+        account_id: str,
+        risk_profile_row: dict[str, Any] | None,
+    ) -> "AccountEnvelope":
+        if risk_profile_row is None:
+            return cls(
+                account_id=account_id,
+                risk_profile_present=False,
+                risk_profile_config={},
+            )
+        config_payload = risk_profile_row.get("config")
+        config = config_payload if isinstance(config_payload, dict) else {}
+        return cls(
+            account_id=account_id,
+            risk_profile_present=True,
+            risk_profile_config=config,
+        )
+
+
 class StrategyTrigger:
     """Strategy trigger with execution intelligence.
     
@@ -2078,6 +2106,7 @@ class StrategyTrigger:
         market_price: float,
         aggregation_decision: StrategyAggregationDecision | None = None,
         market_context: dict[str, float] | None = None,
+        account_envelope: AccountEnvelope | None = None,
     ) -> str:
         if not self._risk_restore_ready:
             log.warning("risk_state_not_restored_fail_closed", reason=self._risk_restore_reason)
@@ -2116,6 +2145,41 @@ class StrategyTrigger:
         if open_pos is None and market_price < self._config.threshold and entry_score >= 0.5:
             current_total_exposure = sum(position.exposure() for position in snapshot.positions)
             trade_id = str(uuid.uuid4())
+            resolved_account_envelope = account_envelope
+            if resolved_account_envelope is None:
+                context_account_id = str((market_context or {}).get("account_id", "default"))
+                context_risk_profile_row_raw = (market_context or {}).get("risk_profile_row")
+                context_risk_profile_row = (
+                    context_risk_profile_row_raw
+                    if isinstance(context_risk_profile_row_raw, dict)
+                    else None
+                )
+                resolved_account_envelope = AccountEnvelope.from_risk_profile_row(
+                    account_id=context_account_id,
+                    risk_profile_row=context_risk_profile_row,
+                )
+            if not resolved_account_envelope.risk_profile_present:
+                self._record_blocked_terminal_trace(
+                    trade_id=trade_id,
+                    signal_data={
+                        "expected_value": float((market_context or {}).get("expected_value", 0.0)),
+                        "edge": 0.0,
+                        "liquidity_usd": float((market_context or {}).get("liquidity_usd", 0.0)),
+                        "spread": float((market_context or {}).get("spread", 0.0)),
+                    },
+                    decision_data={
+                        "account_id": resolved_account_envelope.account_id,
+                    },
+                    validation_result={
+                        "decision": "NOT_EVALUATED",
+                        "reason": "risk_profile_binding_missing",
+                        "checks": {},
+                    },
+                    terminal_stage="risk_profile_binding_block",
+                    reason="risk_profile_binding_missing",
+                    terminal_outcome="BLOCKED",
+                )
+                return "BLOCKED"
             selected_candidate = None
             if aggregation_decision is not None and aggregation_decision.selected_trade:
                 selected_candidate = next(

--- a/projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md
@@ -1,0 +1,70 @@
+# 25_3_account_envelope_risk_binding_minimal
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. Runtime distinguishes bound risk profile vs missing risk profile using structural binding presence.
+  2. `config = {}` on a bound profile is treated as valid (not unbound).
+  3. `StrategyTrigger.evaluate(...)` does not block on empty profile config when binding exists.
+  4. Missing binding remains fail-closed with explicit reason `risk_profile_binding_missing`.
+- Not in Scope:
+  - Multi-user account system.
+  - DB schema changes.
+  - Wallet auth / session auth.
+  - Execution engine logic redesign.
+  - Order/fill/position lifecycle changes.
+  - UI/dashboard surfaces.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md`. Tier: MAJOR.
+
+## 1. What was built
+- Added minimal runtime `AccountEnvelope` structure in `execution/strategy_trigger.py` with:
+  - `account_id`
+  - `risk_profile_present`
+  - `risk_profile_config`
+- Added structural risk-binding resolver `AccountEnvelope.from_risk_profile_row(...)`:
+  - row present => `risk_profile_present=True`
+  - row missing => `risk_profile_present=False`
+  - no config-content-based binding check.
+- Integrated account envelope gating in `StrategyTrigger.evaluate(...)` pre-execution path:
+  - missing binding blocks fail-closed with `risk_profile_binding_missing`.
+  - bound profile allows execution path regardless of empty vs populated config.
+- Added focused MAJOR tests for bound-empty-config pass, bound-populated-config pass, missing-binding block reason, and persistence-gate regression continuity.
+
+## 2. Current system architecture
+- Strategy path entry now includes minimal account envelope layer before execution-prep:
+  1. Existing persistence restore gate check (`_risk_restore_ready`) remains first and unchanged.
+  2. When entry conditions are met, trigger resolves account envelope from explicit input (or context row fallback).
+  3. Structural binding check:
+     - `risk_profile_present=False` => terminal block (`risk_profile_binding_missing`).
+     - `risk_profile_present=True` => continue normal strategy validation/execution flow.
+  4. Existing pre-trade validator, execution quality gate, validation-proof flow, and execution handoff remain unchanged.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p25_account_envelope_risk_binding_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Bound risk profile with `config = {}` is accepted as bound and does not block execution.
+- Bound risk profile with populated config is accepted.
+- Missing risk profile binding blocks fail-closed with reason `risk_profile_binding_missing`.
+- Existing persistence restore fail-closed gate still blocks before binding path when risk state is unavailable.
+
+### Test evidence (project root: `/workspace/walker-ai-team/projects/polymarket/polyquantbot`)
+1. `python -m py_compile execution/strategy_trigger.py tests/test_p25_account_envelope_risk_binding_20260410.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p25_account_envelope_risk_binding_20260410.py`
+   - ✅ `4 passed, 1 warning`
+
+## 5. Known issues
+- Existing project pytest warning remains in this environment: unknown config option `asyncio_mode` (non-blocking for this scope).
+- This patch intentionally introduces only minimal binding surface in strategy trigger path; broader account lifecycle orchestration remains out of scope.
+
+## 6. What is next
+- MAJOR-tier handoff to SENTINEL for runtime validation of:
+  - persistence gate continuity,
+  - structural risk-binding correctness,
+  - execution-boundary preservation.
+- COMMANDER merge decision should wait for SENTINEL verdict per MAJOR policy.

--- a/projects/polymarket/polyquantbot/tests/test_p25_account_envelope_risk_binding_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_p25_account_envelope_risk_binding_20260410.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    AccountEnvelope,
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+def _seed_risk_state_file(path: Path) -> None:
+    path.write_text(
+        (
+            '{"correlated_exposure_ratio":0.0,'
+            '"daily_pnl_by_day":{},'
+            '"drawdown_ratio":0.0,'
+            '"equity":10000.0,'
+            '"global_trade_block":false,'
+            '"open_trades":0,'
+            '"peak_equity":10000.0,'
+            '"portfolio_pnl":0.0,'
+            '"version":1}'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_trigger(*, risk_state_path: str | None = None) -> StrategyTrigger:
+    state_file = Path(risk_state_path) if risk_state_path else Path(tempfile.mkstemp(suffix="_p25_risk_state.json")[1])
+    if not state_file.exists() or state_file.stat().st_size == 0:
+        _seed_risk_state_file(state_file)
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=10_000.0),
+        config=StrategyConfig(
+            market_id="MARKET-1",
+            threshold=0.60,
+            target_pnl=2.0,
+            risk_state_persistence_path=str(state_file),
+        ),
+    )
+    trigger._cooldown_seconds = 0.0  # noqa: SLF001
+    trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+    return trigger
+
+
+def _aggregation() -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S1",
+        decision="ENTER",
+        reason="test_signal",
+        edge=0.05,
+        confidence=0.9,
+        score=0.95,
+        market_metadata={"market_id": "MARKET-1", "title": "Test Market"},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S1",
+        ranked_candidates=[candidate],
+        selection_reason="highest_score",
+        top_score=0.95,
+        decision="ENTER",
+    )
+
+
+def _market_context() -> dict[str, float]:
+    return {
+        "expected_value": 0.15,
+        "liquidity_usd": 50_000.0,
+        "spread": 0.01,
+        "best_bid": 0.445,
+        "best_ask": 0.455,
+        "timestamp": float(time.time()),
+        "model_probability": 0.60,
+        "orderbook": {
+            "bids": [[0.44, 15_000.0]],
+            "asks": [[0.46, 15_000.0]],
+        },
+    }
+
+
+def test_bound_risk_profile_empty_config_is_valid() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_aggregation(),
+            market_context=_market_context(),
+            account_envelope=AccountEnvelope(
+                account_id="acct-1",
+                risk_profile_present=True,
+                risk_profile_config={},
+            ),
+        )
+        assert decision == "OPENED"
+
+    asyncio.run(_run())
+
+
+def test_bound_risk_profile_populated_config_is_valid() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_aggregation(),
+            market_context=_market_context(),
+            account_envelope=AccountEnvelope(
+                account_id="acct-1",
+                risk_profile_present=True,
+                risk_profile_config={"level": "balanced", "max_position_ratio": 0.1},
+            ),
+        )
+        assert decision == "OPENED"
+
+    asyncio.run(_run())
+
+
+def test_missing_risk_profile_binding_blocks_fail_closed() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        decision = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_aggregation(),
+            market_context=_market_context(),
+            account_envelope=AccountEnvelope(
+                account_id="acct-1",
+                risk_profile_present=False,
+                risk_profile_config={},
+            ),
+        )
+        assert decision == "BLOCKED"
+        traces = [
+            trace
+            for trace in trigger._trade_traceability.values()  # noqa: SLF001
+            if trace.get("outcome_data", {}).get("terminal_stage") == "risk_profile_binding_block"
+        ]
+        assert len(traces) == 1
+        assert traces[0]["outcome_data"]["reason"] == "risk_profile_binding_missing"
+
+    asyncio.run(_run())
+
+
+def test_regression_persistence_gate_still_blocks_before_binding() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        missing_state_path = Path(temp_dir) / "missing.json"
+        trigger = StrategyTrigger(
+            engine=ExecutionEngine(starting_equity=10_000.0),
+            config=StrategyConfig(
+                market_id="MARKET-1",
+                threshold=0.60,
+                target_pnl=2.0,
+                risk_state_persistence_path=str(missing_state_path),
+            ),
+        )
+        trigger._cooldown_seconds = 0.0  # noqa: SLF001
+        trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+        decision = asyncio.run(
+            trigger.evaluate(
+                market_price=0.45,
+                aggregation_decision=_aggregation(),
+                market_context=_market_context(),
+                account_envelope=AccountEnvelope(
+                    account_id="acct-1",
+                    risk_profile_present=True,
+                    risk_profile_config={},
+                ),
+            )
+        )
+        assert trigger.get_risk_restore_status()["ready"] is False
+        assert decision == "BLOCKED"


### PR DESCRIPTION
### Motivation
- Fix Issue B where a bound risk profile with `config = {}` was incorrectly treated as unbound, causing StrategyTrigger to block when a structural binding existed. 
- Provide a minimal runtime binding surface so the system distinguishes between a missing risk-profile binding (fail-closed) and a present binding with an empty config (valid). 
- Keep the patch minimal and scoped to the StrategyTrigger execution path without changing DB schemas or broader account systems.

### Description
- Added a lightweight `AccountEnvelope` dataclass and `AccountEnvelope.from_risk_profile_row(...)` to interpret binding based on the presence of a risk-profile row, not JSON content (`execution/strategy_trigger.py`).
- Extended `StrategyTrigger.evaluate(...)` with an optional `account_envelope` parameter and a fallback resolver that reads `market_context["risk_profile_row"]` when the envelope is not provided, and treats a present row as bound regardless of whether `config == {}`.
- Enforced fail-closed behavior: if `risk_profile_present` is `False`, the trigger records a blocked terminal trace and returns `BLOCKED` with reason `risk_profile_binding_missing` before proceeding to pre-trade validation and execution-proof flow.
- Files changed/added: `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `projects/polymarket/polyquantbot/tests/test_p25_account_envelope_risk_binding_20260410.py`, `projects/polymarket/polyquantbot/reports/forge/25_3_account_envelope_risk_binding_minimal.md`, and `projects/polymarket/polyquantbot/PROJECT_STATE.md`.

### Testing
- Compiled modified modules: `python -m py_compile execution/strategy_trigger.py tests/test_p25_account_envelope_risk_binding_20260410.py` — passed.
- Ran focused tests: `PYTHONPATH=/workspace/walker-ai-team pytest -q tests/test_p25_account_envelope_risk_binding_20260410.py` — `4 passed, 1 warning` (pytest config warning unrelated to this change).
- Created a MAJOR-tier forge report and updated `PROJECT_STATE.md` to document the change and request SENTINEL validation before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88f9e7484832eb2362dcb9b4d18dd)