### PR TITLE
Restore ContextResolver purity and preserve Railway startup hotfix

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,29 +1,26 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 12:43
-🔄 Status       : Phase 2 foundation for multi-user persistence and wallet/auth skeleton is implemented with legacy read-only bridge compatibility preserved.
+📅 Last Updated : 2026-04-10 14:46
+🔄 Status       : Railway hotfix integrity restored for context resolver purity; architecture is back to pure composition while startup stability gating remains active.
 
 ✅ COMPLETED
-- Phase 2 persistence foundation added for account, wallet binding, permission profile, strategy subscription, execution context, and audit event repositories under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/storage/`.
-- Phase 1 services upgraded to repository-aware behavior with fallback-safe defaults for empty/disabled persistence.
-- Wallet/auth integration skeleton contracts added under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/auth/` with non-live provider behavior.
-- Context resolver extended to persist execution-context diagnostics and write minimal secret-safe audit events.
-- Legacy read-only bridge updated to use repository-backed resolver wiring when enabled while preserving fallback behavior.
-- Focused Phase 2 tests added for repository CRUD, resolver persistence, bridge compatibility, and regression safety.
+- ContextResolver purity regression from PR #383 removed: resolver is composition-only with zero persistence/audit side effects.
+- Legacy bridge resolver wiring decoupled from resolver repository side-effect dependencies while preserving fallback-safe strict/non-strict semantics.
+- Activation monitor unhealthy-boot behavior converted to controlled boot-health state/logging (no unhandled task exception noise).
+- Focused regression tests added/updated for resolver purity, bridge smoke path, startup import chain, and startup log marker dedup regression.
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md`
 
 🔧 IN PROGRESS
-- None.
+- Railway hotfix branch remains open pending MAJOR-tier SENTINEL validation before merge.
 
 📋 NOT STARTED
-- Live Polymarket wallet/auth execution integration.
-- Multi-user execution queue workers and websocket subscriptions.
-- Public API and UI clients for multi-user platform controls.
+- Phase 3 execution isolation runtime refactor.
+- Websocket architecture rewrite.
+- Live wallet/auth integration and execution queue workers.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
-- `PLATFORM_STORAGE_BACKEND=sqlite` is scaffold-mapped to local JSON backend in this foundation phase.

--- a/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
+++ b/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
@@ -41,8 +41,6 @@ class LegacyContextBridge:
             wallet_auth_service=WalletAuthService(repository=bundle.wallet_bindings),
             permission_service=PermissionService(repository=bundle.permissions),
             strategy_subscription_service=StrategySubscriptionService(repository=bundle.strategy_subscriptions),
-            execution_context_repository=bundle.execution_contexts,
-            audit_event_repository=bundle.audit_events,
         )
 
     @staticmethod

--- a/projects/polymarket/polyquantbot/monitoring/system_activation.py
+++ b/projects/polymarket/polyquantbot/monitoring/system_activation.py
@@ -9,7 +9,7 @@ Periodic logging (every 10s):
     "events=X signals=Y"
 
 Assertions (every 60s):
-    - If event_count == 0 after 60s → raises RuntimeError
+    - If event_count == 0 after 60s → marks boot health as unhealthy
     - If event_count > 0 and signal_count == 0 after 60s → logs WARNING "NO SIGNAL GENERATED"
 """
 from __future__ import annotations
@@ -49,6 +49,16 @@ class SystemActivationMonitor:
         self._log_task: Optional[asyncio.Task] = None
         self._assert_task: Optional[asyncio.Task] = None
         self._start_ts: float = 0.0
+        self._boot_healthy: bool = True
+        self._boot_health_reason: str = "pending"
+
+    def is_boot_healthy(self) -> bool:
+        """Return latest startup health state from assert loop."""
+        return self._boot_healthy
+
+    def boot_health_reason(self) -> str:
+        """Return latest startup health reason code."""
+        return self._boot_health_reason
 
     # ── Counters ──────────────────────────────────────────────────────────────
 
@@ -76,6 +86,8 @@ class SystemActivationMonitor:
             return
         self._running = True
         self._start_ts = time.time()
+        self._boot_healthy = True
+        self._boot_health_reason = "pending"
         self._log_task = asyncio.create_task(
             self._log_loop(), name="activation_monitor_log"
         )
@@ -110,18 +122,26 @@ class SystemActivationMonitor:
             )
 
     async def _assert_loop(self) -> None:
-        """After assert_interval_s, validate liveness — raises if no events received."""
+        """After assert_interval_s, validate liveness with controlled startup noise."""
         await asyncio.sleep(self._assert_interval)
         elapsed = time.time() - self._start_ts
 
         if self.event_count == 0:
-            raise RuntimeError(
-                f"No events received after {round(elapsed, 1)}s — "
-                "WebSocket feed may be disconnected or market IDs may be invalid. "
-                "Check WebSocket connection status and verify MARKET_IDS are correct condition IDs."
+            self._boot_healthy = False
+            self._boot_health_reason = "no_events_received"
+            log.error(
+                "activation_boot_health_unhealthy",
+                elapsed_s=round(elapsed, 1),
+                event_count=self.event_count,
+                signal_count=self.signal_count,
+                hint="WebSocket feed may be disconnected or MARKET_IDS may be invalid",
             )
+            return
 
-        if self.event_count > 0 and self.signal_count == 0:
+        self._boot_healthy = True
+        self._boot_health_reason = "healthy"
+
+        if self.signal_count == 0:
             log.warning(
                 "NO SIGNAL GENERATED",
                 event_count=self.event_count,

--- a/projects/polymarket/polyquantbot/platform/context/resolver.py
+++ b/projects/polymarket/polyquantbot/platform/context/resolver.py
@@ -25,8 +25,13 @@ class LegacySessionSeed:
 
 
 class ContextResolver:
-    """Composes platform context contracts from legacy identifiers.
-    PURE: no side-effects.
+    """Pure composition layer for platform context contracts.
+
+    Contract:
+    - input: LegacySessionSeed
+    - output: PlatformContextEnvelope
+    - no persistence/audit side effects
+    - no hidden mutations
     """
 
     def __init__(
@@ -35,7 +40,7 @@ class ContextResolver:
         wallet_auth_service: WalletAuthService | None = None,
         permission_service: PermissionService | None = None,
         strategy_subscription_service: StrategySubscriptionService | None = None,
-    ) => None:
+    ) -> None:
         self._account_service = account_service or AccountService()
         self._wallet_auth_service = wallet_auth_service or WalletAuthService()
         self._permission_service = permission_service or PermissionService()

--- a/projects/polymarket/polyquantbot/reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md
@@ -1,0 +1,70 @@
+# 24_52_fix_core_resolver_purity_regression_20260410
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/`
+  2. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/`
+  3. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/`
+  4. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py`
+  5. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/`
+- Not in Scope:
+  - Phase 3 execution isolation runtime refactor.
+  - Websocket architecture rewrite.
+  - Strategy logic, risk rule, or order placement logic changes.
+  - Wallet/auth live integration changes.
+  - Telegram menu/API/queue worker surface changes.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md`. Tier: MAJOR.
+
+## 1. What was built
+- Restored `ContextResolver` as a pure composition layer by removing all resolver-side repository wiring and side-effect pathways.
+- Removed repository coupling from `LegacyContextBridge` resolver construction so bridge still resolves context safely without injecting persistence/audit dependencies into resolver.
+- Preserved Railway hotfix runtime stability scope by fixing resolver syntax/import breakage and keeping startup import path valid.
+- Kept activation monitor boot-health gating while converting unhealthy boot behavior into controlled logging (no unhandled background-task exception noise).
+- Repaired and aligned focused tests for resolver purity, bridge smoke path, startup import-chain/log-marker regressions, and activation monitor boot-health behavior.
+
+## 2. Current system architecture
+- `ContextResolver.resolve()` is now a pure composer:
+  - Input: `LegacySessionSeed`
+  - Output: `PlatformContextEnvelope`
+  - No persistence writes
+  - No audit writes
+  - No hidden mutation side effects
+- `LegacyContextBridge` remains fallback-safe and strict/non-strict semantics are preserved; bridge-level audit behavior remains bridge-local and is no longer coupled via resolver constructor dependencies.
+- `SystemActivationMonitor` enforces boot health via explicit internal state (`healthy` / `no_events_received`) with controlled error logging for unhealthy startup conditions.
+- Architecture integrity rule reinforced: persistence/audit writes are forbidden inside resolver and belong to execution/orchestration/dedicated persistence services.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_system_activation_final.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_fix_core_resolver_purity_regression_20260410.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Resolver constructor no longer accepts execution-context/audit repositories and resolver contract is pure.
+- No residual resolver path persistence/audit helper methods remain.
+- Legacy bridge still resolves and fallback behavior remains intact in non-strict mode; strict behavior path remains available.
+- Activation monitor unhealthy startup no longer surfaces unhandled task exceptions; state is exposed via boot-health flags.
+- Startup import-chain regression coverage passes and startup log marker dedup assertions pass.
+
+### Test evidence
+Project root: `/workspace/walker-ai-team`
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/monitoring/system_activation.py projects/polymarket/polyquantbot/main.py projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_system_activation_final.py projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py`
+   - ✅ `12 passed, 1 warning`
+3. `rg -n "execution_context_repository|audit_event_repository|_persist_execution_context|_write_resolve_audit" projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+   - ✅ no resolver-side persistence/audit dependency remnants
+
+## 5. Known issues
+- Existing environment-level pytest warning remains: unknown config option `asyncio_mode`.
+- Full repository-wide historical `phase*` textual references still exist in legacy report/test naming, outside this scoped fix.
+
+## 6. What is next
+- SENTINEL validation required before merge.
+- SENTINEL should validate this task against declared NARROW INTEGRATION target only, with architecture check that resolver remains side-effect free and Railway startup hotfix behavior stays intact.

--- a/projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from projects.polymarket.polyquantbot.monitoring.system_activation import SystemActivationMonitor
+from projects.polymarket.polyquantbot.platform.context.resolver import ContextResolver, LegacySessionSeed
+
+
+def test_regression_activation_monitor_unhealthy_boot_is_controlled() -> None:
+    async def _run() -> None:
+        monitor = SystemActivationMonitor(log_interval_s=9999, assert_interval_s=0.01)
+        await monitor.start()
+        await asyncio.sleep(0.05)
+
+        assert monitor._assert_task is not None
+        assert monitor._assert_task.done()
+        assert monitor._assert_task.exception() is None
+        assert monitor.is_boot_healthy() is False
+        assert monitor.boot_health_reason() == "no_events_received"
+
+        await monitor.stop()
+
+    asyncio.run(_run())
+
+
+def test_regression_activation_monitor_healthy_boot_no_event_attribution_noise() -> None:
+    async def _run() -> None:
+        monitor = SystemActivationMonitor(log_interval_s=9999, assert_interval_s=0.01)
+        monitor.record_event()
+        monitor.record_signal()
+        await monitor.start()
+        await asyncio.sleep(0.05)
+
+        assert monitor._assert_task is not None
+        assert monitor._assert_task.done()
+        assert monitor._assert_task.exception() is None
+        assert monitor.is_boot_healthy() is True
+        assert monitor.boot_health_reason() == "healthy"
+
+        await monitor.stop()
+
+    asyncio.run(_run())
+
+
+def test_regression_context_resolver_constructor_has_no_repository_side_effect_dependencies() -> None:
+    signature = inspect.signature(ContextResolver.__init__)
+    assert "execution_context_repository" not in signature.parameters
+    assert "audit_event_repository" not in signature.parameters
+
+
+def test_regression_context_resolver_composes_envelope_without_side_effect_contract() -> None:
+    resolver = ContextResolver()
+    seed = LegacySessionSeed(
+        user_id="legacy-user-r1",
+        external_user_id="session-r1",
+        mode="PAPER",
+        wallet_binding_id="wb-r1",
+        wallet_type="LEGACY_SESSION",
+        signature_type="SESSION",
+        funder_address="abc123",
+        auth_state="UNVERIFIED",
+        allowed_markets=("MKT-1", "MKT-2"),
+        trace_id="trace-r1",
+    )
+
+    envelope = resolver.resolve(seed)
+
+    assert envelope.user_account.user_id == "legacy-user-r1"
+    assert envelope.execution_context.trace_id == "trace-r1"
+    assert envelope.execution_context.allowed_markets == ("MKT-1", "MKT-2")
+
+
+def test_regression_startup_import_chain_and_log_dedup_markers_present_once() -> None:
+    from projects.polymarket.polyquantbot import main as main_module
+
+    source = inspect.getsource(main_module)
+    assert source.count("🚀 PolyQuantBot starting (Railway)") == 1
+    assert source.count("🚀 NEW TELEGRAM SYSTEM ACTIVE") == 1
+    assert source.count("ENTRYPOINT: main.py") == 1

--- a/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
@@ -1,6 +1,4 @@
-# Updated test to remove persistence-assumptions from resolver.
-
-From __future__ import annotations
+from __future__ import annotations
 
 import os
 import tempfile
@@ -35,7 +33,7 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
         storage_file = Path(temp_dir) / "platform_storage.json"
         os.environ["PLATFORM_STORAGE_BACKEND"] = "json"
         os.environ["PLATFORM_STORAGE_PATH"] = str(storage_file)
-        os.environ["PLATFORM_AUTH_PROVIDER  = "polymarket"
+        os.environ["PLATFORM_AUTH_PROVIDER"] = "polymarket"
         try:
             bundle = build_repository_bundle_from_env()
             assert bundle.accounts is not None
@@ -84,3 +82,16 @@ def test_phase2_context_resolver_is_pure() -> None:
     resolver = ContextResolver()
     envelope = resolver.resolve(_seed())
     assert envelope.execution_context.trace_id == "trace-2"
+
+
+def test_phase2_legacy_context_bridge_smoke_import_and_resolve() -> None:
+    os.environ["ENABLE_PLATFORM_CONTEXT_BRIDGE"] = "true"
+    os.environ["PLATFORM_CONTEXT_STRICT_MODE"] = "false"
+    try:
+        bridge = LegacyContextBridge()
+        result = bridge.attach_context(seed=_seed())
+    finally:
+        os.environ.pop("ENABLE_PLATFORM_CONTEXT_BRIDGE", None)
+        os.environ.pop("PLATFORM_CONTEXT_STRICT_MODE", None)
+
+    assert result.strict_mode_blocked is False

--- a/projects/polymarket/polyquantbot/tests/test_system_activation_final.py
+++ b/projects/polymarket/polyquantbot/tests/test_system_activation_final.py
@@ -239,18 +239,17 @@ async def test_sa25_log_loop_fires_at_interval():
     await monitor.stop()
 
 
-async def test_sa26_assert_loop_raises_on_no_events():
-    """SA-26: Assert loop raises RuntimeError if event_count==0 after interval."""
+async def test_sa26_assert_loop_marks_unhealthy_on_no_events() -> None:
+    """SA-26: Assert loop marks unhealthy state if event_count==0 after interval."""
     from projects.polymarket.polyquantbot.monitoring.system_activation import SystemActivationMonitor
     monitor = SystemActivationMonitor(log_interval_s=9999, assert_interval_s=0.05)
     await monitor.start()
     await asyncio.sleep(0.3)
-    # The assert_task should have completed; check it has an exception
     assert monitor._assert_task is not None
     assert monitor._assert_task.done()
-    exc = monitor._assert_task.exception()
-    assert isinstance(exc, RuntimeError)
-    assert "No events received" in str(exc)
+    assert monitor._assert_task.exception() is None
+    assert monitor.is_boot_healthy() is False
+    assert monitor.boot_health_reason() == "no_events_received"
     await monitor.stop()
 
 


### PR DESCRIPTION
### Motivation
- A regression (introduced by prior persistence wiring) caused `ContextResolver.resolve()` to perform persistence/audit side effects, violating the intended pure composition contract and increasing blast radius. 
- The Railway hotfix (resolver syntax/startup-noise/activation monitor gating) must remain intact while removing resolver-side IO and audit coupling. 

### Description
- Restored `ContextResolver` to a pure composition layer with no persistence or audit side effects and removed repository-side parameters from its constructor (modified `projects/polymarket/polyquantbot/platform/context/resolver.py`).
- Decoupled repository/audit wiring from the resolver in `LegacyContextBridge` so the bridge still emits audits locally while the resolver remains side-effect free (modified `projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`).
- Converted `SystemActivationMonitor` startup behavior from raising an unhandled background exception to a controlled boot-health state with explicit getters and logged error state to reduce startup noise (modified `projects/polymarket/polyquantbot/monitoring/system_activation.py`).
- Updated and added focused regression tests that assert resolver purity, legacy bridge smoke import/resolve, startup import-chain/log-marker dedup, and activation monitor healthy/unhealthy startup behavior, and added the required forge report and `PROJECT_STATE.md` update (files under `projects/polymarket/polyquantbot/tests/` and `projects/polymarket/polyquantbot/reports/forge/`).
- Declared Validation Tier: `MAJOR` and Claim Level: `NARROW INTEGRATION` and left next step as `SENTINEL validation required before merge` in the forge report and `PROJECT_STATE.md`.

### Testing
- Ran syntax checks with `python -m py_compile` over the touched modules including `platform/context/resolver.py`, `legacy/adapters/context_bridge.py`, `monitoring/system_activation.py`, `main.py` and the modified tests, and the compile step passed.
- Executed targeted tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_core_resolver_purity_regression_20260410.py` which returned `12 passed, 1 warning`.
- Note: an initial full pytest run surfaced missing async test-plugin errors (environment lacked the async pytest plugin), the async tests were exercised via synchronous wrappers for CI-friendly execution and the targeted regression suite passed; the remaining environment warning is non-blocking (`Unknown config option: asyncio_mode`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90c804c80832eaf4b9ce9e54ad69e)