### PR TITLE
SENTINEL: resolver purity regression validation — BLOCKED

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-09 23:28
-- Status        : FORGE-X completed MAJOR-tier execution proof lifecycle (dynamic TTL + replay-safe single-use + persistent DB registry + fail-closed execution-boundary verification) in StrategyTrigger→ExecutionEngine path.
+- Last Updated  : 2026-04-10 01:10
+- Status        : SENTINEL re-ran MAJOR validation for resolver purity regression scope and confirmed BLOCKED due resolver parse failure, bridge constructor mismatch, and startup-path instability.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- SENTINEL revalidation `resolver-purity-regression-validation-2026-04-10` (2026-04-10): verdict **BLOCKED** (score **32/100**); resolver remains unparsable, bridge constructor wiring mismatched, resolver path not purity-safe under injected repositories, activation monitor degraded-startup exception risk remains; report `projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md`.
 - P17 execution proof lifecycle (2026-04-09): implemented immutable validation proofs with dynamic TTL policy, DB-backed proof registry (`validation_proofs`), authoritative execution-boundary proof verification (existence/status/TTL/context/atomic consume), StrategyTrigger integration, and focused replay/expiry/context/restart/race/no-bypass tests; report `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`.
 - P16 execution-boundary position-sizing enforcement (2026-04-10): enforced authoritative boundary sizing checks in `ExecutionEngine.open_position(...)` for non-positive/per-trade-cap/capital-risk-allowed size violations before mutation, preserved signed validation-proof enforcement, propagated structured rejection reason into StrategyTrigger blocked terminal trace, and added focused tests; report `projects/polymarket/polyquantbot/reports/forge/24_39_execution_position_sizing_boundary_enforcement.md`.
 - P16 execution-boundary validation-proof enforcement (2026-04-09): replaced trust-only execution entry assumption with signed `ExecutionValidationProof` contract at engine boundary, wired StrategyTrigger ALLOW path to pass proof payload, and added focused no-proof/fake-proof/pass-proof runtime tests; report `projects/polymarket/polyquantbot/reports/forge/24_38_execution_validation_proof_boundary_enforcement.md`.

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md
@@ -1,0 +1,128 @@
+# SENTINEL Validation Report — resolver-purity-regression-validation-2026-04-10
+
+- Date: 2026-04-10
+- Validation Tier: MAJOR
+- Claim Level under validation: NARROW INTEGRATION
+- Scope:
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/
+  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_regression_fix.md
+
+## Required Upstream Artifact Check
+
+- Expected forge report path `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_regression_fix.md` is missing.
+- Drift recorded: upstream implementation evidence for PR #385 is not present at declared path.
+
+## Validation Evidence (runtime + static)
+
+Commands executed:
+
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/main.py`
+   - Result: **FAIL**
+   - Evidence: `resolver.py` syntax error at line 38 (`)=> None:`).
+
+2. Import-chain smoke:
+   - `importlib.import_module("projects.polymarket.polyquantbot.platform.context.resolver")`
+   - `importlib.import_module("projects.polymarket.polyquantbot.legacy.adapters.context_bridge")`
+   - `importlib.import_module("projects.polymarket.polyquantbot.execution.strategy_trigger")`
+   - `importlib.import_module("projects.polymarket.polyquantbot.telegram.command_handler")`
+   - Result: **FAIL** for resolver, bridge, strategy_trigger, command_handler due to same resolver syntax error.
+
+3. Targeted tests:
+   - `pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
+   - Result: **FAIL** during collection.
+   - Evidence:
+     - test file syntax error (unterminated string literal) in `test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+     - missing module import path setup (`ModuleNotFoundError: No module named 'projects'`) in the second test in this execution context.
+
+## Findings by Requested Validation Step
+
+### 1) Resolver Purity Enforcement — **FAILED (CRITICAL)**
+
+- `ContextResolver.__init__` currently contains invalid syntax and cannot load.
+- Purity cannot be validated at runtime while module is unparsable.
+- Static inspection confirms resolver currently composes from services only, but runtime validation is blocked by syntax failure.
+
+### 2) Hidden Side-Effect Scan — **FAILED (CRITICAL)**
+
+- `ContextResolver.resolve()` calls:
+  - `AccountService.resolve_user_account(...)`
+  - `WalletAuthService.resolve_wallet_binding(...)`
+  - `PermissionService.resolve_permission_profile(...)`
+  - `StrategySubscriptionService.list_user_subscriptions(...)`
+- Service implementations include repository `upsert(...)` writes when repository is injected.
+- In current bridge wiring, repositories are injected for account/wallet/permission/subscription services, enabling write-through side effects from resolver path.
+
+### 3) Constructor Integrity Check — **FAILED (CRITICAL)**
+
+- `ContextResolver` constructor does not declare `ExecutionContextRepository` or `AuditEventRepository` parameters directly.
+- However, `LegacyContextBridge` currently attempts to instantiate `ContextResolver(..., execution_context_repository=..., audit_event_repository=...)`, which is a constructor mismatch and violates clean instantiation requirement.
+- Bridge also injects persistence-backed services, which contaminates resolver purity path with potential writes.
+
+### 4) Startup Path Integrity — **FAILED (CRITICAL)**
+
+- Import chain validation fails at resolver parse stage.
+- `main.py` itself imports, but downstream startup path to command handler / strategy trigger is broken due to resolver syntax error.
+
+### 5) Railway Crash Regression Validation — **FAILED (CRITICAL)**
+
+- Syntax error in resolver is unresolved.
+- This is sufficient to re-trigger startup failure once path is imported in runtime flow.
+
+### 6) Activation Monitor Safety — **FAILED (CRITICAL)**
+
+- `SystemActivationMonitor._assert_loop()` raises `RuntimeError` when no events are seen after interval.
+- Task created via `asyncio.create_task(...)` in `start()` has no internal exception guard.
+- This can surface as unhandled task exception/noisy startup behavior under degraded startup/no-feed states.
+
+### 7) Logging Behavior Validation — **CONDITIONAL/NOT VERIFIED**
+
+- Full runtime logging behavior could not be validated because startup chain fails before stable run.
+- No conclusive evidence that duplication/spam regressions are fully resolved in this task scope.
+
+### 8) Test Suite Validation — **FAILED (CRITICAL)**
+
+- Resolver-related target tests do not pass in current state due to syntax/import issues.
+
+### 9) Execution Path Safety Check — **CONDITIONAL**
+
+- No direct modifications to strategy/risk/execution logic were validated in this run.
+- However, resolver/bridge startup instability blocks confidence in clean execution entry conditions for this path.
+
+### 10) Claim Level Validation (NARROW INTEGRATION) — **FAILED**
+
+- Declared narrow fix objective (“resolver purity restored”) is not met because resolver module fails parse and bridge wiring still introduces side-effect-prone service dependencies + constructor mismatch.
+
+## Critical Issues
+
+1. Resolver syntax error blocks import/runtime validation.
+2. Bridge constructs resolver with unsupported constructor args.
+3. Resolver call path can still perform persistence writes through injected service repositories.
+4. Startup import chain is broken for command handler / strategy trigger path.
+5. Activation monitor can raise unhandled background task exception.
+6. Declared forge report artifact for this PR is missing at provided path.
+
+## Non-Critical Issues
+
+1. Targeted pytest run includes environment/import-path warning (`No module named 'projects'`) for one test execution context.
+2. `asyncio_mode` pytest config warning present; non-blocking unless async correctness is impacted.
+
+## Verdict
+
+- Verdict: **BLOCKED**
+- Resolver is PURE: **NO**
+- Execution path is clean: **NO**
+
+## Recommendation
+
+- **Fix required before merge**.
+- Required remediation order:
+  1. Fix resolver syntax (`)=>` to `)->`) and rerun compile/import chain checks.
+  2. Remove constructor mismatch in `LegacyContextBridge` and ensure resolver receives only purity-safe dependencies.
+  3. Ensure resolver path is read-only (no repository write-through from called services in this path).
+  4. Harden `SystemActivationMonitor` assert task to avoid unhandled exceptions during degraded startup.
+  5. Restore missing forge report at declared path or correct the declared path in task metadata.
+  6. Re-run targeted resolver/startup tests and provide passing evidence.

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md
@@ -1,128 +1,187 @@
-# SENTINEL Validation Report — resolver-purity-regression-validation-2026-04-10
+# 24_53_resolver_purity_regression_validation_20260410
 
-- Date: 2026-04-10
+## Validation Metadata
 - Validation Tier: MAJOR
-- Claim Level under validation: NARROW INTEGRATION
-- Scope:
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/
-  - /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_regression_fix.md
+- Claim Level Under Test: NARROW INTEGRATION
+- Validation Target:
+  1. Verify ContextResolver purity and side-effect-free behavior.
+  2. Verify startup import chain integrity to StrategyTrigger/CommandHandler path.
+  3. Verify Railway crash regression status for resolver/bridge path.
+  4. Verify activation monitor startup safety behavior in degraded/no-event conditions.
+- Not in Scope:
+  - Phase 3 execution isolation logic.
+  - Strategy logic correctness.
+  - Risk model correctness.
+  - WebSocket architecture redesign beyond startup safety.
+  - Performance benchmarking beyond obvious blocking/failure behavior.
 
-## Required Upstream Artifact Check
+## Upstream Artifact Check
+- Expected forge report `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_regression_fix.md` is **missing** in repository at validation time.
+- Drift recorded: validation target references a non-existent forge artifact.
 
-- Expected forge report path `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_regression_fix.md` is missing.
-- Drift recorded: upstream implementation evidence for PR #385 is not present at declared path.
+## Evidence Commands + Runtime Proof
 
-## Validation Evidence (runtime + static)
-
-Commands executed:
-
-1. `python -m py_compile projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/main.py`
+1. `PYTHONPATH=/workspace/walker-ai-team python -m py_compile projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/main.py`
    - Result: **FAIL**
-   - Evidence: `resolver.py` syntax error at line 38 (`)=> None:`).
+   - Runtime proof:
+     - `SyntaxError: expected ':'`
+     - File: `projects/polymarket/polyquantbot/platform/context/resolver.py:38`
+     - Snippet: `) => None:`
 
-2. Import-chain smoke:
-   - `importlib.import_module("projects.polymarket.polyquantbot.platform.context.resolver")`
-   - `importlib.import_module("projects.polymarket.polyquantbot.legacy.adapters.context_bridge")`
-   - `importlib.import_module("projects.polymarket.polyquantbot.execution.strategy_trigger")`
-   - `importlib.import_module("projects.polymarket.polyquantbot.telegram.command_handler")`
-   - Result: **FAIL** for resolver, bridge, strategy_trigger, command_handler due to same resolver syntax error.
+2. Import-chain smoke check:
+   - `PYTHONPATH=/workspace/walker-ai-team python - <<'PY' ... importlib.import_module(...) ... PY`
+   - Result:
+     - `OK projects.polymarket.polyquantbot.main`
+     - `FAIL ...telegram.command_handler SyntaxError expected ':' (resolver.py, line 38)`
+     - `FAIL ...execution.strategy_trigger SyntaxError expected ':' (resolver.py, line 38)`
+     - `FAIL ...legacy.adapters.context_bridge SyntaxError expected ':' (resolver.py, line 38)`
+     - `FAIL ...platform.context.resolver SyntaxError expected ':' (resolver.py, line 38)`
 
-3. Targeted tests:
-   - `pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
-   - Result: **FAIL** during collection.
-   - Evidence:
-     - test file syntax error (unterminated string literal) in `test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
-     - missing module import path setup (`ModuleNotFoundError: No module named 'projects'`) in the second test in this execution context.
+3. Resolver-focused tests:
+   - `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+   - Result: **FAIL** during collection
+   - Runtime proof:
+     - `SyntaxError: unterminated string literal`
+     - File: `projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py:38`
+     - Snippet: `os.environ["PLATFORM_AUTH_PROVIDER � = "polymarket"`
 
-## Findings by Requested Validation Step
+4. Bridge/startup path tests:
+   - `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
+   - Result: **FAIL** during collection
+   - Runtime proof:
+     - Import trace reaches `execution.strategy_trigger` → `legacy.adapters.context_bridge` → `platform.context.resolver`
+     - Fails with `SyntaxError` at `resolver.py:38`.
 
-### 1) Resolver Purity Enforcement — **FAILED (CRITICAL)**
+## Step-by-Step Findings (Requested Scope)
 
-- `ContextResolver.__init__` currently contains invalid syntax and cannot load.
-- Purity cannot be validated at runtime while module is unparsable.
-- Static inspection confirms resolver currently composes from services only, but runtime validation is blocked by syntax failure.
+### 1) Resolver Purity Enforcement — CRITICAL FAIL
 
-### 2) Hidden Side-Effect Scan — **FAILED (CRITICAL)**
+Evidence:
+- `ContextResolver` is currently unparsable because constructor annotation uses `)=>` instead of `)->`.
+  - File: `projects/polymarket/polyquantbot/platform/context/resolver.py:32-39`
+  - Snippet:
+  ```python
+  def __init__(
+      ...
+  ) => None:
+  ```
 
-- `ContextResolver.resolve()` calls:
-  - `AccountService.resolve_user_account(...)`
-  - `WalletAuthService.resolve_wallet_binding(...)`
-  - `PermissionService.resolve_permission_profile(...)`
-  - `StrategySubscriptionService.list_user_subscriptions(...)`
-- Service implementations include repository `upsert(...)` writes when repository is injected.
-- In current bridge wiring, repositories are injected for account/wallet/permission/subscription services, enabling write-through side effects from resolver path.
+Impact:
+- Resolver cannot be imported; deterministic purity cannot be established in runtime.
 
-### 3) Constructor Integrity Check — **FAILED (CRITICAL)**
+### 2) Hidden Side-Effect Scan — CRITICAL FAIL
 
-- `ContextResolver` constructor does not declare `ExecutionContextRepository` or `AuditEventRepository` parameters directly.
-- However, `LegacyContextBridge` currently attempts to instantiate `ContextResolver(..., execution_context_repository=..., audit_event_repository=...)`, which is a constructor mismatch and violates clean instantiation requirement.
-- Bridge also injects persistence-backed services, which contaminates resolver purity path with potential writes.
+Evidence (write-through path exists when repositories are injected):
+- `AccountService.resolve_user_account(...)` can call `_repository.upsert(record)`.
+  - `projects/polymarket/polyquantbot/platform/accounts/service.py:29-30`
+- `WalletAuthService.resolve_wallet_binding(...)` can call `_repository.upsert(record)`.
+  - `projects/polymarket/polyquantbot/platform/wallet_auth/service.py:46-47`
+- `PermissionService.resolve_permission_profile(...)` can call `_repository.upsert(record)`.
+  - `projects/polymarket/polyquantbot/platform/permissions/service.py:37-38`
 
-### 4) Startup Path Integrity — **FAILED (CRITICAL)**
+Bridge wiring injects persistence-backed services into resolver path:
+- `projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py:40-43`
 
-- Import chain validation fails at resolver parse stage.
-- `main.py` itself imports, but downstream startup path to command handler / strategy trigger is broken due to resolver syntax error.
+Impact:
+- Resolver path is not guaranteed read-only under current bridge wiring.
 
-### 5) Railway Crash Regression Validation — **FAILED (CRITICAL)**
+### 3) Constructor Integrity Check — CRITICAL FAIL
 
-- Syntax error in resolver is unresolved.
-- This is sufficient to re-trigger startup failure once path is imported in runtime flow.
+Evidence:
+- `ContextResolver.__init__` accepts only service dependencies.
+  - `projects/polymarket/polyquantbot/platform/context/resolver.py:32-37`
+- `LegacyContextBridge` instantiation passes unsupported kwargs:
+  - `execution_context_repository=...`
+  - `audit_event_repository=...`
+  - `projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py:44-45`
 
-### 6) Activation Monitor Safety — **FAILED (CRITICAL)**
+Impact:
+- Constructor mismatch remains; startup path unsafe even if syntax typo is corrected.
 
-- `SystemActivationMonitor._assert_loop()` raises `RuntimeError` when no events are seen after interval.
-- Task created via `asyncio.create_task(...)` in `start()` has no internal exception guard.
-- This can surface as unhandled task exception/noisy startup behavior under degraded startup/no-feed states.
+### 4) Startup Path Integrity — CRITICAL FAIL
 
-### 7) Logging Behavior Validation — **CONDITIONAL/NOT VERIFIED**
+Evidence:
+- Import chain fails exactly on required runtime path:
+  - `main.py` imports OK (module parse only).
+  - `command_handler`, `strategy_trigger`, `context_bridge`, `resolver` all fail due to `resolver.py:38` syntax error.
 
-- Full runtime logging behavior could not be validated because startup chain fails before stable run.
-- No conclusive evidence that duplication/spam regressions are fully resolved in this task scope.
+Impact:
+- Startup path integrity is not restored for operational flow.
 
-### 8) Test Suite Validation — **FAILED (CRITICAL)**
+### 5) Railway Crash Regression Validation — CRITICAL FAIL
 
-- Resolver-related target tests do not pass in current state due to syntax/import issues.
+Evidence:
+- Syntax error remains in resolver.
+- Any startup path invoking bridge/resolver chain re-enters parse failure.
 
-### 9) Execution Path Safety Check — **CONDITIONAL**
+Impact:
+- Crash regression is not resolved.
 
-- No direct modifications to strategy/risk/execution logic were validated in this run.
-- However, resolver/bridge startup instability blocks confidence in clean execution entry conditions for this path.
+### 6) Activation Monitor Safety — CRITICAL FAIL
 
-### 10) Claim Level Validation (NARROW INTEGRATION) — **FAILED**
+Evidence:
+- `SystemActivationMonitor.start()` creates `_assert_loop()` as background task with `asyncio.create_task(...)`.
+  - `projects/polymarket/polyquantbot/monitoring/system_activation.py:82-84`
+- `_assert_loop()` raises `RuntimeError` on zero events after interval.
+  - `projects/polymarket/polyquantbot/monitoring/system_activation.py:117-122`
 
-- Declared narrow fix objective (“resolver purity restored”) is not met because resolver module fails parse and bridge wiring still introduces side-effect-prone service dependencies + constructor mismatch.
+Impact:
+- Degraded startup/no-feed state can produce unhandled background task exception behavior.
+
+### 7) Logging Behavior Validation — CONDITIONAL
+
+Evidence:
+- Full startup run cannot be completed because resolver chain fails parse.
+- No stable runtime window to prove duplication/spam remediation.
+
+### 8) Test Suite Validation — CRITICAL FAIL
+
+Evidence:
+- Target resolver-purity test file contains syntax corruption (`From __future__`, broken env string line).
+- Bridge test collection blocked by resolver syntax error in import path.
+
+Impact:
+- Required tests are not passing and do not currently provide purity assurance.
+
+### 9) Execution Path Safety Check — CONDITIONAL
+
+Evidence:
+- No direct strategy/risk/execution algorithm edits were observed in this validation.
+- But startup resolver/bridge chain instability contaminates pre-execution entry reliability.
+
+### 10) Claim-Level Validation (NARROW INTEGRATION) — FAIL
+
+Evidence:
+- Claimed target (“resolver purity regression fix”) is not delivered in runnable code state.
+- Resolver not importable; bridge wiring still side-effect/mismatch prone.
 
 ## Critical Issues
-
-1. Resolver syntax error blocks import/runtime validation.
-2. Bridge constructs resolver with unsupported constructor args.
-3. Resolver call path can still perform persistence writes through injected service repositories.
-4. Startup import chain is broken for command handler / strategy trigger path.
-5. Activation monitor can raise unhandled background task exception.
-6. Declared forge report artifact for this PR is missing at provided path.
+1. Resolver parse failure at `resolver.py:38`.
+2. Bridge passes unsupported constructor kwargs into `ContextResolver`.
+3. Resolver path can still trigger persistence writes via injected services.
+4. Startup import chain fails in command/strategy/bridge path.
+5. Activation monitor can raise unhandled background exception in degraded startup.
+6. Referenced forge report artifact (`24_52...`) missing.
+7. Resolver-focused test file is syntactically broken and cannot validate purity.
 
 ## Non-Critical Issues
+1. Pytest warning: unknown config option `asyncio_mode` (advisory unless async correctness issue is shown).
 
-1. Targeted pytest run includes environment/import-path warning (`No module named 'projects'`) for one test execution context.
-2. `asyncio_mode` pytest config warning present; non-blocking unless async correctness is impacted.
-
-## Verdict
-
+## Score + Verdict
+- Score: **32 / 100**
 - Verdict: **BLOCKED**
+
+Explicit confirmations:
 - Resolver is PURE: **NO**
 - Execution path is clean: **NO**
 
 ## Recommendation
-
-- **Fix required before merge**.
-- Required remediation order:
-  1. Fix resolver syntax (`)=>` to `)->`) and rerun compile/import chain checks.
-  2. Remove constructor mismatch in `LegacyContextBridge` and ensure resolver receives only purity-safe dependencies.
-  3. Ensure resolver path is read-only (no repository write-through from called services in this path).
-  4. Harden `SystemActivationMonitor` assert task to avoid unhandled exceptions during degraded startup.
-  5. Restore missing forge report at declared path or correct the declared path in task metadata.
-  6. Re-run targeted resolver/startup tests and provide passing evidence.
+- **Fix required before merge.**
+- Required order:
+  1. Fix resolver syntax in `platform/context/resolver.py`.
+  2. Remove unsupported kwargs from bridge resolver construction.
+  3. Enforce read-only resolver path (no write-through service wiring on resolve path).
+  4. Harden activation monitor assert task handling for degraded startup.
+  5. Repair broken resolver-purity test file syntax.
+  6. Restore/correct missing forge report reference for traceability.
+  7. Re-run compile/import/pytest evidence and resubmit for SENTINEL MAJOR revalidation.


### PR DESCRIPTION
### Motivation
- Produce an authoritative SENTINEL validation for the resolver-purity regression (PR #385) to verify `ContextResolver` purity, Railway startup stability, and absence of hidden side effects before merge.

### Description
- Add SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_regression_validation_20260410.md` documenting critical findings: `ContextResolver` syntax error, `LegacyContextBridge` constructor mismatch and persistence-backed service injection, potential write-through side effects from service calls, activation-monitor unhandled assert behavior, and a missing upstream forge report; verdict: **BLOCKED**.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/context/resolver.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/main.py`, which failed with a syntax error in `resolver.py` at line 38.
- Executed an import-chain smoke test (`importlib.import_module` for resolver, bridge, strategy_trigger, command_handler), which failed to import resolver/bridge/strategy_trigger/command_handler due to the resolver parse error (only `main` imported OK).
- Ran targeted pytest for resolver/bridge tests (`pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`), which failed during collection due to a test file syntax issue and environment import-path (`ModuleNotFoundError: No module named 'projects'`) in this context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d922175bec832e9c60ee06c95a65d1)