### PR TITLE
fix: unblock resolver purity sentinel regression path

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,17 +1,17 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 12:43
-🔄 Status       : Phase 2 foundation for multi-user persistence and wallet/auth skeleton is implemented with legacy read-only bridge compatibility preserved.
+📅 Last Updated : 2026-04-10 16:27
+🔄 Status       : Resolver purity blocker fix applied for SENTINEL re-run readiness, with startup chain and bridge compatibility preserved.
 
 ✅ COMPLETED
-- Phase 2 persistence foundation added for account, wallet binding, permission profile, strategy subscription, execution context, and audit event repositories under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/storage/`.
-- Phase 1 services upgraded to repository-aware behavior with fallback-safe defaults for empty/disabled persistence.
-- Wallet/auth integration skeleton contracts added under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/auth/` with non-live provider behavior.
-- Context resolver extended to persist execution-context diagnostics and write minimal secret-safe audit events.
-- Legacy read-only bridge updated to use repository-backed resolver wiring when enabled while preserving fallback behavior.
-- Focused Phase 2 tests added for repository CRUD, resolver persistence, bridge compatibility, and regression safety.
+- Resolver fatal syntax regression fixed in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py` and startup import chain restored.
+- Resolver path purity restored: resolver call chain now uses read-only service methods with no repository write-through side effects.
+- Repository-backed writes split to explicit orchestration paths via `ensure_user_account`, `ensure_wallet_binding`, and `ensure_permission_profile`.
+- Legacy bridge constructor mismatch removed and strict/non-strict fallback behavior preserved.
+- Activation monitor background assertion path hardened to avoid unhandled task exception noise during degraded startup.
+- Focused regression tests updated for import-chain smoke, resolver determinism, no repository attrs, and write-spy purity proof.
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md`
 
 🔧 IN PROGRESS
 - None.
@@ -22,7 +22,7 @@
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).

--- a/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
+++ b/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
@@ -41,8 +41,6 @@ class LegacyContextBridge:
             wallet_auth_service=WalletAuthService(repository=bundle.wallet_bindings),
             permission_service=PermissionService(repository=bundle.permissions),
             strategy_subscription_service=StrategySubscriptionService(repository=bundle.strategy_subscriptions),
-            execution_context_repository=bundle.execution_contexts,
-            audit_event_repository=bundle.audit_events,
         )
 
     @staticmethod

--- a/projects/polymarket/polyquantbot/main.py
+++ b/projects/polymarket/polyquantbot/main.py
@@ -65,8 +65,6 @@ async def main() -> None:
     startup_state = StartupStateTracker()
 
     # ── Entrypoint assertion — confirms correct runtime path ───────────────────
-    print("🚀 NEW TELEGRAM SYSTEM ACTIVE")
-    print("ENTRYPOINT: main.py")
     log.info(
         "entrypoint_active",
         entrypoint="projects/polymarket/polyquantbot/main.py",

--- a/projects/polymarket/polyquantbot/monitoring/system_activation.py
+++ b/projects/polymarket/polyquantbot/monitoring/system_activation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 import structlog
 
@@ -77,10 +77,10 @@ class SystemActivationMonitor:
         self._running = True
         self._start_ts = time.time()
         self._log_task = asyncio.create_task(
-            self._log_loop(), name="activation_monitor_log"
+            self._run_guarded(self._log_loop, "activation_monitor_log"), name="activation_monitor_log"
         )
         self._assert_task = asyncio.create_task(
-            self._assert_loop(), name="activation_monitor_assert"
+            self._run_guarded(self._assert_loop, "activation_monitor_assert"), name="activation_monitor_assert"
         )
         log.info("system_activation_monitor_started")
 
@@ -107,6 +107,18 @@ class SystemActivationMonitor:
                 events=self.event_count,
                 signals=self.signal_count,
                 trades=self.trade_count,
+            )
+
+    async def _run_guarded(self, runner: Callable[[], Awaitable[None]], task_name: str) -> None:
+        try:
+            await runner()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.error(
+                "activation_monitor_task_failed",
+                task_name=task_name,
+                error=str(exc),
             )
 
     async def _assert_loop(self) -> None:

--- a/projects/polymarket/polyquantbot/platform/README.md
+++ b/projects/polymarket/polyquantbot/platform/README.md
@@ -14,13 +14,14 @@ This package extends the Phase 1 read-only bridge with **foundation-level persis
   - `ExecutionContextRecord`
   - `AuditEventRecord`
 - Service wiring upgrades:
-  - `AccountService` uses account repository when configured.
-  - `WalletAuthService` uses wallet binding repository and auth provider skeleton.
-  - `PermissionService` uses permission repository.
-  - `ContextResolver` persists execution context metadata + writes audit events.
+  - `AccountService` supports read-only `resolve_*` methods and explicit write `ensure_*` methods.
+  - `WalletAuthService` supports read-only `resolve_*` methods and explicit write `ensure_*` methods.
+  - `PermissionService` supports read-only `resolve_*` methods and explicit write `ensure_*` methods.
+  - `ContextResolver` is a pure composer: resolve-only, no persistence, no audit writes, no hidden mutation.
 - Strategy subscription foundation:
   - enable/disable strategy IDs per user via repository-backed service.
 - Legacy bridge remains read-only and feature-flagged, with fallback continuity.
+- Any persistence/audit writes must be performed by orchestration/execution layers or dedicated persistence services, not by `ContextResolver.resolve()`.
 
 ## Storage/backend configuration
 

--- a/projects/polymarket/polyquantbot/platform/accounts/service.py
+++ b/projects/polymarket/polyquantbot/platform/accounts/service.py
@@ -17,8 +17,27 @@ class AccountService:
             existing = self._repository.get_by_user_id(user_id=normalized_user_id)
             if existing is not None:
                 return UserAccount(**existing.__dict__)
+        return self._build_default_account(
+            legacy_user_id=legacy_user_id,
+            normalized_user_id=normalized_user_id,
+            source_type=source_type,
+        )
+
+    def ensure_user_account(self, *, legacy_user_id: str, source_type: str = "legacy") -> UserAccount:
+        account = self.resolve_user_account(legacy_user_id=legacy_user_id, source_type=source_type)
+        if self._repository is not None:
+            self._repository.upsert(UserAccountRecord(**account.__dict__))
+        return account
+
+    @staticmethod
+    def _build_default_account(
+        *,
+        legacy_user_id: str,
+        normalized_user_id: str,
+        source_type: str,
+    ) -> UserAccount:
         now = utc_now()
-        record = UserAccountRecord(
+        return UserAccount(
             user_id=normalized_user_id,
             external_user_id=legacy_user_id,
             source_type=source_type,
@@ -26,6 +45,3 @@ class AccountService:
             created_at=now,
             updated_at=now,
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
-        return UserAccount(**record.__dict__)

--- a/projects/polymarket/polyquantbot/platform/context/resolver.py
+++ b/projects/polymarket/polyquantbot/platform/context/resolver.py
@@ -35,7 +35,7 @@ class ContextResolver:
         wallet_auth_service: WalletAuthService | None = None,
         permission_service: PermissionService | None = None,
         strategy_subscription_service: StrategySubscriptionService | None = None,
-    ) => None:
+    ) -> None:
         self._account_service = account_service or AccountService()
         self._wallet_auth_service = wallet_auth_service or WalletAuthService()
         self._permission_service = permission_service or PermissionService()

--- a/projects/polymarket/polyquantbot/platform/permissions/service.py
+++ b/projects/polymarket/polyquantbot/platform/permissions/service.py
@@ -22,9 +22,37 @@ class PermissionService:
             existing = self._repository.get_by_user_id(user_id=user_id)
             if existing is not None:
                 return PermissionProfile(**existing.__dict__)
+        return self._build_default_permission_profile(
+            user_id=user_id,
+            allowed_markets=allowed_markets,
+            mode=mode,
+        )
 
+    def ensure_permission_profile(
+        self,
+        *,
+        user_id: str,
+        allowed_markets: tuple[str, ...],
+        mode: str,
+    ) -> PermissionProfile:
+        profile = self.resolve_permission_profile(
+            user_id=user_id,
+            allowed_markets=allowed_markets,
+            mode=mode,
+        )
+        if self._repository is not None:
+            self._repository.upsert(PermissionProfileRecord(**profile.__dict__))
+        return profile
+
+    @staticmethod
+    def _build_default_permission_profile(
+        *,
+        user_id: str,
+        allowed_markets: tuple[str, ...],
+        mode: str,
+    ) -> PermissionProfile:
         normalized_mode = mode.strip().upper()
-        record = PermissionProfileRecord(
+        return PermissionProfile(
             user_id=user_id,
             allowed_markets=allowed_markets,
             live_enabled=normalized_mode == "LIVE",
@@ -34,6 +62,3 @@ class PermissionService:
             version="phase2-foundation",
             updated_at=utc_now(),
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
-        return PermissionProfile(**record.__dict__)

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/service.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/service.py
@@ -28,10 +28,55 @@ class WalletAuthService:
             existing = self._repository.get_by_id(wallet_binding_id=wallet_binding_id)
             if existing is not None:
                 return WalletBinding(**existing.__dict__)
+        return self._build_default_binding(
+            user_id=user_id,
+            wallet_binding_id=wallet_binding_id,
+            wallet_type=wallet_type,
+            signature_type=signature_type,
+            funder_address=funder_address,
+            auth_state=auth_state,
+            mode=mode,
+        )
+
+    def ensure_wallet_binding(
+        self,
+        *,
+        user_id: str,
+        wallet_binding_id: str,
+        wallet_type: str,
+        signature_type: str,
+        funder_address: str,
+        auth_state: str,
+        mode: str,
+    ) -> WalletBinding:
+        binding = self.resolve_wallet_binding(
+            user_id=user_id,
+            wallet_binding_id=wallet_binding_id,
+            wallet_type=wallet_type,
+            signature_type=signature_type,
+            funder_address=funder_address,
+            auth_state=auth_state,
+            mode=mode,
+        )
+        if self._repository is not None:
+            self._repository.upsert(WalletBindingRecord(**binding.__dict__))
+        return binding
+
+    def _build_default_binding(
+        self,
+        *,
+        user_id: str,
+        wallet_binding_id: str,
+        wallet_type: str,
+        signature_type: str,
+        funder_address: str,
+        auth_state: str,
+        mode: str,
+    ) -> WalletBinding:
         l1_context = self._auth_provider.bootstrap_l1_context(user_id=user_id, wallet_hint=funder_address)
         validated_state = self._auth_provider.validate_auth_state(auth_context=l1_context)
         now = utc_now()
-        record = WalletBindingRecord(
+        return WalletBinding(
             wallet_binding_id=wallet_binding_id,
             user_id=user_id,
             wallet_type=wallet_type,
@@ -43,9 +88,6 @@ class WalletAuthService:
             created_at=now,
             updated_at=now,
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
-        return WalletBinding(**record.__dict__)
 
     def to_wallet_context(self, binding: WalletBinding) -> WalletContext:
         return WalletContext(

--- a/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md
@@ -1,0 +1,82 @@
+# 24_52_resolver_purity_sentinel_block_fix_20260410
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  1. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py`
+  2. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/accounts/service.py`
+  3. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/service.py`
+  4. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/permissions/service.py`
+  5. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/strategy_subscriptions/service.py`
+  6. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+  7. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py`
+  8. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py`
+  9. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/README.md`
+  10. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+  11. `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
+- Not in Scope:
+  - Phase 3 execution isolation runtime refactor.
+  - Websocket architecture rewrite.
+  - Strategy logic changes.
+  - Risk rule changes.
+  - Order placement logic changes.
+  - Wallet/auth live integration changes.
+  - UI/Telegram menu changes.
+  - Queue/worker additions.
+  - Broad storage redesign beyond read-only purity enforcement for resolver path.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md`. Tier: MAJOR.
+
+## 1. What was built
+- Fixed fatal resolver syntax error in `ContextResolver.__init__` so resolver imports cleanly through startup chain.
+- Restored resolver purity by keeping `ContextResolver.resolve()` as composition-only and removing write-through behavior from service methods used in resolver path.
+- Split service behavior into explicit read-only resolve methods and explicit write methods (`ensure_user_account`, `ensure_wallet_binding`, `ensure_permission_profile`) so persistence is opt-in outside resolver.
+- Removed invalid constructor args from `LegacyContextBridge` resolver instantiation to match the pure resolver contract.
+- Hardened activation monitor background task execution with guarded task wrapper to prevent unhandled task exception noise under degraded startup.
+- Kept Railway startup import safety and reduced startup banner noise by removing duplicate entrypoint `print` calls in `main.py` while preserving startup signal.
+- Repaired and expanded focused tests for resolver purity, bridge constructor path, startup import chain smoke, deterministic resolver output, and no-write regression proof.
+
+## 2. Current system architecture
+1. Resolver path (`ContextResolver.resolve`) is now read-only and deterministic for stable repository snapshots; it only composes `PlatformContextEnvelope`.
+2. Repository-backed writes are now explicit orchestration actions via `ensure_*` service methods, not hidden in read paths.
+3. Legacy bridge still supports enabled/disabled + strict/non-strict semantics, but now instantiates resolver with only supported purity-safe dependencies.
+4. Activation monitor runs assertion/log loops through guarded wrappers that log failures instead of leaking unhandled task exceptions.
+5. Startup import chain remains valid for `main.py`, telegram command handler path, strategy trigger path, bridge, and resolver.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/accounts/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/permissions/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/main.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/README.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What is working
+- Resolver imports and compiles successfully with corrected syntax.
+- Resolver call chain performs zero repository write operations in read path (verified with write-spy regression test).
+- Legacy bridge constructor successfully initializes with pure resolver dependency signature.
+- Startup import chain smoke passes for required modules.
+- Activation monitor unhealthy assertion path is logged and contained without unhandled background task exceptions.
+
+### Validation command evidence
+Project root: `/workspace/walker-ai-team/projects/polymarket/polyquantbot`
+1. `python -m py_compile platform/context/resolver.py platform/accounts/service.py platform/wallet_auth/service.py platform/permissions/service.py platform/strategy_subscriptions/service.py legacy/adapters/context_bridge.py monitoring/system_activation.py main.py tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team python - <<'PY' ... importlib.import_module(...) ... PY`
+   - ✅ pass (`ok`, startup banner printed once by module import)
+3. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+   - ✅ pass (`9 passed, 1 warning`)
+
+## 5. Known issues
+- Environment warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- Existing storage backend placeholder behavior (`sqlite` selector mapped to local JSON backend) remains unchanged and out of scope for this fix.
+
+## 6. What is next
+- SENTINEL validation required before merge for resolver purity regression unblock path.
+- SENTINEL should verify no read-path writes, strict/non-strict bridge continuity, and startup/activation behavior under degraded boot.

--- a/projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import os
 import tempfile
 from pathlib import Path
@@ -8,6 +9,7 @@ from pathlib import Path
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
 from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
 from projects.polymarket.polyquantbot.legacy.adapters.context_bridge import LegacyContextBridge
+from projects.polymarket.polyquantbot.monitoring.system_activation import SystemActivationMonitor
 from projects.polymarket.polyquantbot.platform.context.resolver import ContextResolver, LegacySessionSeed
 
 
@@ -150,5 +152,35 @@ def test_phase1_bridge_strict_mode_blocks_on_resolution_failure() -> None:
                 os.environ.pop("PLATFORM_CONTEXT_STRICT_MODE", None)
 
             assert decision == "BLOCKED"
+
+    asyncio.run(_run())
+
+
+def test_startup_import_chain_smoke() -> None:
+    importlib.import_module("projects.polymarket.polyquantbot.main")
+    importlib.import_module("projects.polymarket.polyquantbot.telegram.command_handler")
+    importlib.import_module("projects.polymarket.polyquantbot.execution.strategy_trigger")
+    importlib.import_module("projects.polymarket.polyquantbot.legacy.adapters.context_bridge")
+    importlib.import_module("projects.polymarket.polyquantbot.platform.context.resolver")
+
+
+def test_bridge_constructor_succeeds_without_resolver_constructor_mismatch() -> None:
+    os.environ["PLATFORM_STORAGE_BACKEND"] = "none"
+    try:
+        bridge = LegacyContextBridge()
+    finally:
+        os.environ.pop("PLATFORM_STORAGE_BACKEND", None)
+    assert bridge is not None
+
+
+def test_activation_monitor_handles_unhealthy_assertion_without_unhandled_task_exception() -> None:
+    async def _run() -> None:
+        monitor = SystemActivationMonitor(log_interval_s=0.01, assert_interval_s=0.02)
+        await monitor.start()
+        await asyncio.sleep(0.05)
+        assert monitor._assert_task is not None  # noqa: SLF001
+        assert monitor._assert_task.done() is True  # noqa: SLF001
+        assert monitor._assert_task.exception() is None  # noqa: SLF001
+        await monitor.stop()
 
     asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
@@ -1,18 +1,80 @@
-# Updated test to remove persistence-assumptions from resolver.
-
-From __future__ import annotations
+from __future__ import annotations
 
 import os
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
-from projects.polymarket.polyquantbot.legacy.adapters.context_bridge import LegacyContextBridge
 from projects.polymarket.polyquantbot.platform.accounts.service import AccountService
 from projects.polymarket.polyquantbot.platform.context.resolver import ContextResolver, LegacySessionSeed
 from projects.polymarket.polyquantbot.platform.permissions.service import PermissionService
+from projects.polymarket.polyquantbot.platform.storage.models import (
+    PermissionProfileRecord,
+    UserAccountRecord,
+    WalletBindingRecord,
+)
 from projects.polymarket.polyquantbot.platform.storage.factory import build_repository_bundle_from_env
 from projects.polymarket.polyquantbot.platform.strategy_subscriptions.service import StrategySubscriptionService
 from projects.polymarket.polyquantbot.platform.wallet_auth.service import WalletAuthService
+
+
+class _WriteSpy:
+    def __init__(self) -> None:
+        self.write_calls: list[str] = []
+
+    def record(self, method_name: str) -> None:
+        self.write_calls.append(method_name)
+
+
+class _ReadOnlyAccountRepo:
+    def __init__(self, spy: _WriteSpy, record: UserAccountRecord | None = None) -> None:
+        self._spy = spy
+        self._record = record
+
+    def get_by_user_id(self, *, user_id: str) -> UserAccountRecord | None:
+        return self._record
+
+    def upsert(self, record: UserAccountRecord) -> UserAccountRecord:
+        self._spy.record("accounts.upsert")
+        return record
+
+
+class _ReadOnlyWalletRepo:
+    def __init__(self, spy: _WriteSpy, record: WalletBindingRecord | None = None) -> None:
+        self._spy = spy
+        self._record = record
+
+    def get_by_id(self, *, wallet_binding_id: str) -> WalletBindingRecord | None:
+        return self._record
+
+    def upsert(self, record: WalletBindingRecord) -> WalletBindingRecord:
+        self._spy.record("wallet_bindings.upsert")
+        return record
+
+
+class _ReadOnlyPermissionRepo:
+    def __init__(self, spy: _WriteSpy, record: PermissionProfileRecord | None = None) -> None:
+        self._spy = spy
+        self._record = record
+
+    def get_by_user_id(self, *, user_id: str) -> PermissionProfileRecord | None:
+        return self._record
+
+    def upsert(self, record: PermissionProfileRecord) -> PermissionProfileRecord:
+        self._spy.record("permissions.upsert")
+        return record
+
+
+class _ReadOnlySubscriptionRepo:
+    def __init__(self, spy: _WriteSpy) -> None:
+        self._spy = spy
+
+    def list_by_user_id(self, *, user_id: str) -> tuple:
+        return ()
+
+    def upsert(self, record) -> object:
+        self._spy.record("subscriptions.upsert")
+        return record
 
 
 def _seed() -> LegacySessionSeed:
@@ -30,12 +92,12 @@ def _seed() -> LegacySessionSeed:
     )
 
 
-def test_phase2_repository_crud_and_service_wiring() -> None:
+def test_phase2_repository_write_paths_are_explicit() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         storage_file = Path(temp_dir) / "platform_storage.json"
         os.environ["PLATFORM_STORAGE_BACKEND"] = "json"
         os.environ["PLATFORM_STORAGE_PATH"] = str(storage_file)
-        os.environ["PLATFORM_AUTH_PROVIDER  = "polymarket"
+        os.environ["PLATFORM_AUTH_PROVIDER"] = "polymarket"
         try:
             bundle = build_repository_bundle_from_env()
             assert bundle.accounts is not None
@@ -48,8 +110,8 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
             permission_service = PermissionService(repository=bundle.permissions)
             subscription_service = StrategySubscriptionService(repository=bundle.strategy_subscriptions)
 
-            account = account_service.resolve_user_account(legacy_user_id="legacy-user-2", source_type="legacy-session")
-            wallet = wallet_service.resolve_wallet_binding(
+            account = account_service.ensure_user_account(legacy_user_id="legacy-user-2", source_type="legacy-session")
+            wallet = wallet_service.ensure_wallet_binding(
                 user_id=account.user_id,
                 wallet_binding_id="wb-2",
                 wallet_type="LEGACY_SESSION",
@@ -58,7 +120,7 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
                 auth_state="UNVERIFIED",
                 mode="PAPER",
             )
-            permission = permission_service.resolve_permission_profile(
+            permission = permission_service.ensure_permission_profile(
                 user_id=account.user_id,
                 allowed_markets=("MKT-A",),
                 mode="PAPER",
@@ -80,7 +142,63 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
             os.environ.pop("PLATFORM_AUTH_PROVIDER", None)
 
 
-def test_phase2_context_resolver_is_pure() -> None:
-    resolver = ContextResolver()
-    envelope = resolver.resolve(_seed())
-    assert envelope.execution_context.trace_id == "trace-2"
+def test_phase2_resolver_has_no_repository_attrs_and_no_write_through_side_effects() -> None:
+    fixed_ts = datetime(2026, 4, 10, 0, 0, tzinfo=timezone.utc)
+    spy = _WriteSpy()
+    resolver = ContextResolver(
+        account_service=AccountService(
+            repository=_ReadOnlyAccountRepo(
+                spy,
+                UserAccountRecord(
+                    user_id="legacy-user-2",
+                    external_user_id="session-2",
+                    source_type="legacy-session",
+                    status="active",
+                    created_at=fixed_ts,
+                    updated_at=fixed_ts,
+                ),
+            )
+        ),
+        wallet_auth_service=WalletAuthService(
+            repository=_ReadOnlyWalletRepo(
+                spy,
+                WalletBindingRecord(
+                    wallet_binding_id="wb-2",
+                    user_id="legacy-user-2",
+                    wallet_type="LEGACY_SESSION",
+                    signature_type="SESSION",
+                    funder_address="0xabc123",
+                    auth_state="UNVERIFIED",
+                    mode="PAPER",
+                    auth_provider="polymarket",
+                    created_at=fixed_ts,
+                    updated_at=fixed_ts,
+                ),
+            )
+        ),
+        permission_service=PermissionService(
+            repository=_ReadOnlyPermissionRepo(
+                spy,
+                PermissionProfileRecord(
+                    user_id="legacy-user-2",
+                    allowed_markets=("MKT-A",),
+                    live_enabled=False,
+                    paper_enabled=True,
+                    max_notional_cap=5_000.0,
+                    max_positions_cap=5,
+                    version="phase2-foundation",
+                    updated_at=fixed_ts,
+                ),
+            )
+        ),
+        strategy_subscription_service=StrategySubscriptionService(repository=_ReadOnlySubscriptionRepo(spy)),
+    )
+
+    assert not any("repository" in name for name in vars(resolver))
+
+    first = resolver.resolve(_seed())
+    second = resolver.resolve(_seed())
+
+    assert first == second
+    assert first.execution_context.trace_id == "trace-2"
+    assert spy.write_calls == []


### PR DESCRIPTION
### Motivation
- Fix a fatal syntax error in the resolver that prevented clean imports and blocked SENTINEL revalidation.  
- Restore true read-only purity for the resolver call chain so `ContextResolver.resolve()` has no persistence or hidden mutations.  
- Remove legacy bridge constructor mismatch and preserve Railway startup safety and activation-monitor stability.  
- Provide narrow-scope, testable evidence so SENTINEL can re-run validation on the resolver purity path.

### Description
- Fixed `ContextResolver.__init__` signature to a valid `) -> None:` and ensured resolver remains a pure composer that only calls read-only service methods and returns a `PlatformContextEnvelope` (`projects/polymarket/polyquantbot/platform/context/resolver.py`).  
- Split service read/write responsibilities by adding explicit write methods: `ensure_user_account`, `ensure_wallet_binding`, and `ensure_permission_profile`, while keeping `resolve_*` methods read-only (`projects/polymarket/polyquantbot/platform/accounts/service.py`, `projects/polymarket/polyquantbot/platform/wallet_auth/service.py`, `projects/polymarket/polyquantbot/platform/permissions/service.py`).  
- Removed unsupported resolver constructor args from `LegacyContextBridge` so bridge instantiates the pure resolver only with purity-safe dependencies (`projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`).  
- Hardened `SystemActivationMonitor` background tasks by wrapping loops with a guarded async runner that logs internal failures instead of letting unhandled task exceptions surface (`projects/polymarket/polyquantbot/monitoring/system_activation.py`).  
- Reduced duplicate startup banner noise and preserved structured startup signaling in `main.py`, updated platform docs to declare resolver purity, and added a focused FORGE report and PROJECT_STATE update documenting the MAJOR handoff (`projects/polymarket/polyquantbot/main.py`, `projects/polymarket/polyquantbot/platform/README.md`, `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md`, `projects/polymarket/polyquantbot/PROJECT_STATE.md`).  
- Repaired and extended targeted tests to prove: resolver imports succeed, startup import-chain smoke, bridge constructor success, resolver has no repository attributes, resolver determinism for same input, and read-path produces no repository writes via a write-spy regression (`projects/polymarket/polyquantbot/tests/...`).

### Testing
- Ran syntax checks with `python -m py_compile` on all touched modules: this passed for `platform/context/resolver.py`, `platform/accounts/service.py`, `platform/wallet_auth/service.py`, `platform/permissions/service.py`, `platform/strategy_subscriptions/service.py`, `legacy/adapters/context_bridge.py`, `monitoring/system_activation.py`, `main.py`, and the two focused tests.  
- Performed import-chain smoke using `PYTHONPATH=/workspace/walker-ai-team python - <<'PY' ... importlib.import_module(...) ... PY`, which returned `ok` and the startup banner once, confirming startup import stability.  
- Executed the focused pytest suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`, which completed successfully: `9 passed, 1 warning` (the warning is an existing `PytestConfigWarning: Unknown config option: asyncio_mode`).  
- The new write-spy regression test asserts no repository write calls occur during `ContextResolver.resolve()` and passed (no write calls recorded).  

Done ✅ — resolver-purity-sentinel-block-fix-2026-04-10 complete.  
Validation Tier: MAJOR  
Claim Level: NARROW INTEGRATION  
Report: `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_sentinel_block_fix_20260410.md`  
State: `projects/polymarket/polyquantbot/PROJECT_STATE.md` updated

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d923ed2f64832eaaa22c07da4cb595)