### PR TITLE
fix: resolver purity unblock — service split, bridge & monitor hardening, tests

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,29 +1,33 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 12:43
-🔄 Status       : Phase 2 foundation for multi-user persistence and wallet/auth skeleton is implemented with legacy read-only bridge compatibility preserved.
+📅 Last Updated : 2026-04-11 00:21
+🔄 Status       : FORGE-X completed MAJOR-tier resolver-purity unblock remediation for PR390 target path and prepared branch for SENTINEL validation.
 
 ✅ COMPLETED
-- Phase 2 persistence foundation added for account, wallet binding, permission profile, strategy subscription, execution context, and audit event repositories under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/storage/`.
-- Phase 1 services upgraded to repository-aware behavior with fallback-safe defaults for empty/disabled persistence.
-- Wallet/auth integration skeleton contracts added under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/auth/` with non-live provider behavior.
-- Context resolver extended to persist execution-context diagnostics and write minimal secret-safe audit events.
-- Legacy read-only bridge updated to use repository-backed resolver wiring when enabled while preserving fallback behavior.
-- Focused Phase 2 tests added for repository CRUD, resolver persistence, bridge compatibility, and regression safety.
+- Fixed resolver syntax blocker in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py` (`) ->`), removing py_compile hard stop.
+- Corrected Phase 2 test corruption in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py` (`from __future__` + `PLATFORM_AUTH_PROVIDER="polymarket"`).
+- Enforced read/write split in targeted services:
+  - `resolve_user_account` / `ensure_user_account`
+  - `resolve_wallet_binding` / `ensure_wallet_binding`
+  - `resolve_permission_profile` / `ensure_permission_profile`
+- Verified resolver path purity with write-spy assertions (`write_calls == 0`) and explicit service split tests.
+- Removed invalid resolver constructor args from `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py` to match signature exactly.
+- Hardened `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py` task runners with guarded try/except logging for async failures.
+- Added explicit import-chain proof test (`main -> command_handler -> strategy_trigger -> context_bridge -> resolver`).
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
-- Live Polymarket wallet/auth execution integration.
-- Multi-user execution queue workers and websocket subscriptions.
-- Public API and UI clients for multi-user platform controls.
+- SENTINEL MAJOR validation pass for resolver-purity final unblock scope.
+- Any post-SENTINEL remediation follow-up (if findings are raised).
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md. Tier: STANDARD
+- SENTINEL validation required for execute-final-fix-pr390-unblock before merge.
+  Source: reports/forge/24_52_resolver_purity_final_unblock_pr390.md
+  Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
-- `PLATFORM_STORAGE_BACKEND=sqlite` is scaffold-mapped to local JSON backend in this foundation phase.
+- Pytest warning persists in environment: unknown config option `asyncio_mode`.

--- a/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
+++ b/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
@@ -41,8 +41,6 @@ class LegacyContextBridge:
             wallet_auth_service=WalletAuthService(repository=bundle.wallet_bindings),
             permission_service=PermissionService(repository=bundle.permissions),
             strategy_subscription_service=StrategySubscriptionService(repository=bundle.strategy_subscriptions),
-            execution_context_repository=bundle.execution_contexts,
-            audit_event_repository=bundle.audit_events,
         )
 
     @staticmethod

--- a/projects/polymarket/polyquantbot/monitoring/system_activation.py
+++ b/projects/polymarket/polyquantbot/monitoring/system_activation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Optional
+from typing import Awaitable, Optional
 
 import structlog
 
@@ -50,42 +50,34 @@ class SystemActivationMonitor:
         self._assert_task: Optional[asyncio.Task] = None
         self._start_ts: float = 0.0
 
-    # ── Counters ──────────────────────────────────────────────────────────────
-
     def record_event(self) -> None:
-        """Increment the event counter (call on each WS event received)."""
         self.event_count += 1
 
     def record_signal(self) -> None:
-        """Increment the signal counter (call on each signal generated)."""
         self.signal_count += 1
 
     def record_trade(self) -> None:
-        """Increment the trade counter (call on each trade executed)."""
         self.trade_count += 1
 
     def record_ws_state(self, connected: bool) -> None:
-        """Update the current WebSocket connection state."""
         self.ws_connected = connected
 
-    # ── Lifecycle ─────────────────────────────────────────────────────────────
-
     async def start(self) -> None:
-        """Start background logging and assertion tasks."""
         if self._running:
             return
         self._running = True
         self._start_ts = time.time()
         self._log_task = asyncio.create_task(
-            self._log_loop(), name="activation_monitor_log"
+            self._run_guarded(self._log_loop(), runner_name="activation_monitor_log"),
+            name="activation_monitor_log",
         )
         self._assert_task = asyncio.create_task(
-            self._assert_loop(), name="activation_monitor_assert"
+            self._run_guarded(self._assert_loop(), runner_name="activation_monitor_assert"),
+            name="activation_monitor_assert",
         )
         log.info("system_activation_monitor_started")
 
     async def stop(self) -> None:
-        """Stop background tasks."""
         self._running = False
         for task in (self._log_task, self._assert_task):
             if task and not task.done():
@@ -96,10 +88,19 @@ class SystemActivationMonitor:
                     pass
         log.info("system_activation_monitor_stopped")
 
-    # ── Internal loops ────────────────────────────────────────────────────────
+    async def _run_guarded(self, runner: Awaitable[None], *, runner_name: str) -> None:
+        try:
+            await runner
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.exception(
+                "system_activation_monitor_runner_failed",
+                runner=runner_name,
+                error=str(exc),
+            )
 
     async def _log_loop(self) -> None:
-        """Log event/signal counts every log_interval_s seconds."""
         while self._running:
             await asyncio.sleep(self._log_interval)
             log.info(
@@ -110,7 +111,6 @@ class SystemActivationMonitor:
             )
 
     async def _assert_loop(self) -> None:
-        """After assert_interval_s, validate liveness — raises if no events received."""
         await asyncio.sleep(self._assert_interval)
         elapsed = time.time() - self._start_ts
 

--- a/projects/polymarket/polyquantbot/platform/accounts/service.py
+++ b/projects/polymarket/polyquantbot/platform/accounts/service.py
@@ -17,6 +17,17 @@ class AccountService:
             existing = self._repository.get_by_user_id(user_id=normalized_user_id)
             if existing is not None:
                 return UserAccount(**existing.__dict__)
+        return self._build_default_account(legacy_user_id=legacy_user_id, source_type=source_type)
+
+    def ensure_user_account(self, *, legacy_user_id: str, source_type: str = "legacy") -> UserAccount:
+        account = self.resolve_user_account(legacy_user_id=legacy_user_id, source_type=source_type)
+        if self._repository is not None:
+            self._repository.upsert(UserAccountRecord(**account.__dict__))
+        return account
+
+    @staticmethod
+    def _build_default_account(*, legacy_user_id: str, source_type: str) -> UserAccount:
+        normalized_user_id = legacy_user_id.strip() or "legacy-default"
         now = utc_now()
         record = UserAccountRecord(
             user_id=normalized_user_id,
@@ -26,6 +37,4 @@ class AccountService:
             created_at=now,
             updated_at=now,
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
         return UserAccount(**record.__dict__)

--- a/projects/polymarket/polyquantbot/platform/context/resolver.py
+++ b/projects/polymarket/polyquantbot/platform/context/resolver.py
@@ -35,7 +35,7 @@ class ContextResolver:
         wallet_auth_service: WalletAuthService | None = None,
         permission_service: PermissionService | None = None,
         strategy_subscription_service: StrategySubscriptionService | None = None,
-    ) => None:
+    ) -> None:
         self._account_service = account_service or AccountService()
         self._wallet_auth_service = wallet_auth_service or WalletAuthService()
         self._permission_service = permission_service or PermissionService()

--- a/projects/polymarket/polyquantbot/platform/permissions/service.py
+++ b/projects/polymarket/polyquantbot/platform/permissions/service.py
@@ -22,7 +22,35 @@ class PermissionService:
             existing = self._repository.get_by_user_id(user_id=user_id)
             if existing is not None:
                 return PermissionProfile(**existing.__dict__)
+        return self._build_default_permission_profile(
+            user_id=user_id,
+            allowed_markets=allowed_markets,
+            mode=mode,
+        )
 
+    def ensure_permission_profile(
+        self,
+        *,
+        user_id: str,
+        allowed_markets: tuple[str, ...],
+        mode: str,
+    ) -> PermissionProfile:
+        profile = self.resolve_permission_profile(
+            user_id=user_id,
+            allowed_markets=allowed_markets,
+            mode=mode,
+        )
+        if self._repository is not None:
+            self._repository.upsert(PermissionProfileRecord(**profile.__dict__))
+        return profile
+
+    @staticmethod
+    def _build_default_permission_profile(
+        *,
+        user_id: str,
+        allowed_markets: tuple[str, ...],
+        mode: str,
+    ) -> PermissionProfile:
         normalized_mode = mode.strip().upper()
         record = PermissionProfileRecord(
             user_id=user_id,
@@ -34,6 +62,4 @@ class PermissionService:
             version="phase2-foundation",
             updated_at=utc_now(),
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
         return PermissionProfile(**record.__dict__)

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/service.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/service.py
@@ -28,6 +28,63 @@ class WalletAuthService:
             existing = self._repository.get_by_id(wallet_binding_id=wallet_binding_id)
             if existing is not None:
                 return WalletBinding(**existing.__dict__)
+        return self._build_default_wallet_binding(
+            user_id=user_id,
+            wallet_binding_id=wallet_binding_id,
+            wallet_type=wallet_type,
+            signature_type=signature_type,
+            funder_address=funder_address,
+            auth_state=auth_state,
+            mode=mode,
+        )
+
+    def ensure_wallet_binding(
+        self,
+        *,
+        user_id: str,
+        wallet_binding_id: str,
+        wallet_type: str,
+        signature_type: str,
+        funder_address: str,
+        auth_state: str,
+        mode: str,
+    ) -> WalletBinding:
+        binding = self.resolve_wallet_binding(
+            user_id=user_id,
+            wallet_binding_id=wallet_binding_id,
+            wallet_type=wallet_type,
+            signature_type=signature_type,
+            funder_address=funder_address,
+            auth_state=auth_state,
+            mode=mode,
+        )
+        if self._repository is not None:
+            self._repository.upsert(WalletBindingRecord(**binding.__dict__))
+        return binding
+
+    def to_wallet_context(self, binding: WalletBinding) -> WalletContext:
+        return WalletContext(
+            user_id=binding.user_id,
+            wallet_binding_id=binding.wallet_binding_id,
+            wallet_type=binding.wallet_type,
+            signature_type=binding.signature_type,
+            auth_state=binding.auth_state,
+            funder_address=binding.funder_address,
+            mode=binding.mode,
+            auth_provider=binding.auth_provider,
+        )
+
+    def _build_default_wallet_binding(
+        self,
+        *,
+        user_id: str,
+        wallet_binding_id: str,
+        wallet_type: str,
+        signature_type: str,
+        funder_address: str,
+        auth_state: str,
+        mode: str,
+    ) -> WalletBinding:
         l1_context = self._auth_provider.bootstrap_l1_context(user_id=user_id, wallet_hint=funder_address)
         validated_state = self._auth_provider.validate_auth_state(auth_context=l1_context)
         now = utc_now()
@@ -43,18 +100,4 @@ class WalletAuthService:
             created_at=now,
             updated_at=now,
         )
-        if self._repository is not None:
-            self._repository.upsert(record)
         return WalletBinding(**record.__dict__)
-
-    def to_wallet_context(self, binding: WalletBinding) -> WalletContext:
-        return WalletContext(
-            user_id=binding.user_id,
-            wallet_binding_id=binding.wallet_binding_id,
-            wallet_type=binding.wallet_type,
-            signature_type=binding.signature_type,
-            auth_state=binding.auth_state,
-            funder_address=binding.funder_address,
-            mode=binding.mode,
-            auth_provider=binding.auth_provider,
-        )

--- a/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md
@@ -1,0 +1,80 @@
+# 24_52_resolver_purity_final_unblock_pr390
+
+## Validation Metadata
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/accounts/service.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/service.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/permissions/service.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py`
+- Not in Scope:
+  - No Phase 3 work.
+  - No execution logic changes.
+  - No strategy/risk logic changes.
+  - No websocket behavior changes.
+  - No infra expansion.
+- Suggested Next Step: SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`. Tier: MAJOR.
+
+## 1. What was built
+- Fixed resolver constructor syntax blocker by replacing invalid `) =>` with valid `) ->`.
+- Corrected Phase 2 test corruption (`From __future__` and malformed `PLATFORM_AUTH_PROVIDER` env assignment) so pytest collection no longer crashes.
+- Enforced resolver purity by splitting service behavior into read-only `resolve_*` and explicit write `ensure_*` methods for account, wallet-binding, and permission-profile services.
+- Removed invalid bridge constructor arguments (`execution_context_repository`, `audit_event_repository`) so bridge wiring matches resolver signature.
+- Hardened activation monitor background tasks with guarded async runners to prevent unhandled runtime task exceptions while preserving structured logs.
+- Added write-spy and service-split tests that prove resolver path write_calls remain zero and ensure-paths perform writes.
+- Added explicit import-chain test for `main -> command_handler -> strategy_trigger -> context_bridge -> resolver`.
+
+## 2. Current system architecture
+1. `ContextResolver.resolve(...)` now composes only read-path data through `resolve_*` service methods.
+2. `AccountService`, `WalletAuthService`, and `PermissionService` expose two paths:
+   - `resolve_*`: read-only + default materialization in memory, no repository upsert.
+   - `ensure_*`: explicit persistence via repository upsert.
+3. `LegacyContextBridge` initializes resolver with service-only dependencies; resolver signature mismatch is removed.
+4. `SystemActivationMonitor` wraps async loop tasks in guarded runners so task failures are logged and contained (no silent failure, no unhandled task exception propagation).
+5. Test layer now includes direct write-spy proof and import-chain proof to support SENTINEL revalidation.
+
+## 3. Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/context/resolver.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/accounts/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/permissions/service.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/monitoring/system_activation.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`
+
+## 4. What is working
+- Resolver module and touched tests compile without syntax error.
+- Pytest collection and execution succeed for touched resolver/bridge/import-chain tests.
+- Resolver purity proof passes: resolver invocation does not call repository writes.
+- Service split proof passes: `resolve_*` path performs no writes; `ensure_*` path performs writes.
+- Main-to-resolver import chain resolves successfully.
+- Activation monitor starts async runners with failure-logging guard.
+
+### Root cause + proof summary
+- Root cause: persistence-side effects were embedded in read-path methods (`resolve_*`) and resolver constructor wiring drift introduced signature mismatch + syntax/test corruption.
+- Applied fix: strict read/write separation in services, constructor alignment, syntax repair, and sentinel-proof tests with write spies.
+- Proof of resolver purity: `test_resolver_pure_path_does_not_write_to_repositories` asserts all write counters stay `0` after `resolver.resolve(...)`.
+
+### Test evidence
+Project root: `/workspace/walker-ai-team/projects/polymarket/polyquantbot`
+1. `python -m py_compile platform/context/resolver.py platform/accounts/service.py platform/wallet_auth/service.py platform/permissions/service.py platform/strategy_subscriptions/service.py legacy/adapters/context_bridge.py monitoring/system_activation.py tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py tests/test_platform_resolver_import_chain_20260411.py`
+   - ✅ pass
+2. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py`
+   - ✅ `9 passed, 1 warning`
+3. `python - <<'PY' ... import main/command_handler/strategy_trigger/context_bridge/resolver ... PY`
+   - ✅ pass (`import chain ok`)
+
+## 5. Known issues
+- Environment warning remains: pytest reports unknown config option `asyncio_mode`.
+- Activation monitor guard now logs task failure instead of bubbling runtime exceptions through task handles; this behavior shift should be included in SENTINEL verification scope.
+
+## 6. What is next
+- SENTINEL validation required before merge.
+- SENTINEL should verify resolver call chain purity (`resolver -> service.resolve_* -> repository.get`) and confirm no write bypass exists in touched path.

--- a/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
+++ b/projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py
@@ -1,18 +1,59 @@
-# Updated test to remove persistence-assumptions from resolver.
-
-From __future__ import annotations
+from __future__ import annotations
 
 import os
 import tempfile
 from pathlib import Path
 
-from projects.polymarket.polyquantbot.legacy.adapters.context_bridge import LegacyContextBridge
 from projects.polymarket.polyquantbot.platform.accounts.service import AccountService
 from projects.polymarket.polyquantbot.platform.context.resolver import ContextResolver, LegacySessionSeed
 from projects.polymarket.polyquantbot.platform.permissions.service import PermissionService
 from projects.polymarket.polyquantbot.platform.storage.factory import build_repository_bundle_from_env
+from projects.polymarket.polyquantbot.platform.storage.models import (
+    PermissionProfileRecord,
+    UserAccountRecord,
+    WalletBindingRecord,
+)
 from projects.polymarket.polyquantbot.platform.strategy_subscriptions.service import StrategySubscriptionService
 from projects.polymarket.polyquantbot.platform.wallet_auth.service import WalletAuthService
+
+
+class _SpyUserAccountRepository:
+    def __init__(self) -> None:
+        self.write_calls = 0
+        self._rows: dict[str, UserAccountRecord] = {}
+
+    def get_by_user_id(self, *, user_id: str) -> UserAccountRecord | None:
+        return self._rows.get(user_id)
+
+    def upsert(self, record: UserAccountRecord) -> None:
+        self.write_calls += 1
+        self._rows[record.user_id] = record
+
+
+class _SpyWalletBindingRepository:
+    def __init__(self) -> None:
+        self.write_calls = 0
+        self._rows: dict[str, WalletBindingRecord] = {}
+
+    def get_by_id(self, *, wallet_binding_id: str) -> WalletBindingRecord | None:
+        return self._rows.get(wallet_binding_id)
+
+    def upsert(self, record: WalletBindingRecord) -> None:
+        self.write_calls += 1
+        self._rows[record.wallet_binding_id] = record
+
+
+class _SpyPermissionProfileRepository:
+    def __init__(self) -> None:
+        self.write_calls = 0
+        self._rows: dict[str, PermissionProfileRecord] = {}
+
+    def get_by_user_id(self, *, user_id: str) -> PermissionProfileRecord | None:
+        return self._rows.get(user_id)
+
+    def upsert(self, record: PermissionProfileRecord) -> None:
+        self.write_calls += 1
+        self._rows[record.user_id] = record
 
 
 def _seed() -> LegacySessionSeed:
@@ -35,7 +76,7 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
         storage_file = Path(temp_dir) / "platform_storage.json"
         os.environ["PLATFORM_STORAGE_BACKEND"] = "json"
         os.environ["PLATFORM_STORAGE_PATH"] = str(storage_file)
-        os.environ["PLATFORM_AUTH_PROVIDER  = "polymarket"
+        os.environ["PLATFORM_AUTH_PROVIDER"] = "polymarket"
         try:
             bundle = build_repository_bundle_from_env()
             assert bundle.accounts is not None
@@ -48,8 +89,8 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
             permission_service = PermissionService(repository=bundle.permissions)
             subscription_service = StrategySubscriptionService(repository=bundle.strategy_subscriptions)
 
-            account = account_service.resolve_user_account(legacy_user_id="legacy-user-2", source_type="legacy-session")
-            wallet = wallet_service.resolve_wallet_binding(
+            account = account_service.ensure_user_account(legacy_user_id="legacy-user-2", source_type="legacy-session")
+            wallet = wallet_service.ensure_wallet_binding(
                 user_id=account.user_id,
                 wallet_binding_id="wb-2",
                 wallet_type="LEGACY_SESSION",
@@ -58,7 +99,7 @@ def test_phase2_repository_crud_and_service_wiring() -> None:
                 auth_state="UNVERIFIED",
                 mode="PAPER",
             )
-            permission = permission_service.resolve_permission_profile(
+            permission = permission_service.ensure_permission_profile(
                 user_id=account.user_id,
                 allowed_markets=("MKT-A",),
                 mode="PAPER",
@@ -84,3 +125,72 @@ def test_phase2_context_resolver_is_pure() -> None:
     resolver = ContextResolver()
     envelope = resolver.resolve(_seed())
     assert envelope.execution_context.trace_id == "trace-2"
+
+
+def test_resolver_pure_path_does_not_write_to_repositories() -> None:
+    account_repo = _SpyUserAccountRepository()
+    wallet_repo = _SpyWalletBindingRepository()
+    permission_repo = _SpyPermissionProfileRepository()
+    resolver = ContextResolver(
+        account_service=AccountService(repository=account_repo),
+        wallet_auth_service=WalletAuthService(repository=wallet_repo),
+        permission_service=PermissionService(repository=permission_repo),
+    )
+
+    resolver.resolve(_seed())
+
+    assert account_repo.write_calls == 0
+    assert wallet_repo.write_calls == 0
+    assert permission_repo.write_calls == 0
+
+
+def test_service_split_resolve_no_write_ensure_write() -> None:
+    account_repo = _SpyUserAccountRepository()
+    wallet_repo = _SpyWalletBindingRepository()
+    permission_repo = _SpyPermissionProfileRepository()
+
+    account_service = AccountService(repository=account_repo)
+    wallet_service = WalletAuthService(repository=wallet_repo)
+    permission_service = PermissionService(repository=permission_repo)
+
+    account = account_service.resolve_user_account(legacy_user_id="legacy-user-3", source_type="legacy-session")
+    wallet = wallet_service.resolve_wallet_binding(
+        user_id=account.user_id,
+        wallet_binding_id="wb-3",
+        wallet_type="LEGACY_SESSION",
+        signature_type="SESSION",
+        funder_address="abc888",
+        auth_state="UNVERIFIED",
+        mode="PAPER",
+    )
+    permission = permission_service.resolve_permission_profile(
+        user_id=account.user_id,
+        allowed_markets=("MKT-B",),
+        mode="PAPER",
+    )
+
+    assert wallet.wallet_binding_id == "wb-3"
+    assert permission.user_id == "legacy-user-3"
+    assert account_repo.write_calls == 0
+    assert wallet_repo.write_calls == 0
+    assert permission_repo.write_calls == 0
+
+    account_service.ensure_user_account(legacy_user_id="legacy-user-3", source_type="legacy-session")
+    wallet_service.ensure_wallet_binding(
+        user_id=account.user_id,
+        wallet_binding_id="wb-3",
+        wallet_type="LEGACY_SESSION",
+        signature_type="SESSION",
+        funder_address="abc888",
+        auth_state="UNVERIFIED",
+        mode="PAPER",
+    )
+    permission_service.ensure_permission_profile(
+        user_id=account.user_id,
+        allowed_markets=("MKT-B",),
+        mode="PAPER",
+    )
+
+    assert account_repo.write_calls == 1
+    assert wallet_repo.write_calls == 1
+    assert permission_repo.write_calls == 1

--- a/projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+
+def test_import_chain_main_to_resolver() -> None:
+    import projects.polymarket.polyquantbot.main as main_module
+    from projects.polymarket.polyquantbot.execution import strategy_trigger
+    from projects.polymarket.polyquantbot.legacy.adapters import context_bridge
+    from projects.polymarket.polyquantbot.platform.context import resolver
+    from projects.polymarket.polyquantbot.telegram import command_handler
+
+    assert main_module is not None
+    assert command_handler is not None
+    assert strategy_trigger is not None
+    assert context_bridge is not None
+    assert resolver is not None


### PR DESCRIPTION
### Motivation
- Remove syntax and test corruption blockers that prevented `resolver` and related tests from compiling and running. 
- Enforce strict read-only semantics for the resolver path so resolution never performs repository writes. 
- Align bridge wiring and harden activation monitor to avoid unhandled background task failures. 
- Provide provable, automated evidence (write-spy + import-chain tests) so SENTINEL can validate the MAJOR-tier fix. 

### Description
- Fixed constructor annotation syntax in `projects/polymarket/polyquantbot/platform/context/resolver.py` and removed invalid constructor args from `projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`. 
- Split service behavior into read-only `resolve_*` and explicit write `ensure_*` methods in `projects/polymarket/polyquantbot/platform/accounts/service.py`, `projects/polymarket/polyquantbot/platform/wallet_auth/service.py`, and `projects/polymarket/polyquantbot/platform/permissions/service.py` so `resolve_*` no longer calls `repository.upsert()`. 
- Hardened `projects/polymarket/polyquantbot/monitoring/system_activation.py` by wrapping background loops in a guarded runner that logs exceptions instead of letting unhandled task exceptions bubble. 
- Added tests proving resolver purity and service split (`tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py`) plus an import-chain smoke test (`tests/test_platform_resolver_import_chain_20260411.py`), and created the FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md` and updated `PROJECT_STATE.md`. 

### Testing
- Ran `python -m py_compile platform/context/resolver.py platform/accounts/service.py platform/wallet_auth/service.py platform/permissions/service.py platform/strategy_subscriptions/service.py legacy/adapters/context_bridge.py monitoring/system_activation.py tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py tests/test_platform_resolver_import_chain_20260411.py`, which passed with no syntax errors. 
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_platform_phase2_persistence_wallet_auth_foundation_20260410.py projects/polymarket/polyquantbot/tests/test_platform_foundation_phase1_legacy_readonly_bridge_20260410.py projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py` which produced `9 passed, 1 warning` (the warning is a pytest `asyncio_mode` config warning). 
- Performed an import-chain smoke test via a small Python snippet importing `main`, `command_handler`, `strategy_trigger`, `context_bridge`, and `resolver`, which printed `import chain ok` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d993186804832ea6e6ab8f60a69d11)