### PR TITLE
execution: Phase 3 — Add ExecutionIsolationGateway and route execution through isolation boundary

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,31 +1,32 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-11 09:24
-🔄 Status       : Phase 2 execution-isolation chain (PR #396 canonical path) now includes attribution/rejection schema fixes from prior parallel path, with flat rejection compatibility and explicit manual open source attribution.
+📅 Last Updated : 2026-04-11 09:38
+🔄 Status       : Phase 2 execution-isolation chain on canonical PR #396 head revalidated by SENTINEL rerun; attribution split and flat rejection compatibility confirmed on current checked-out head.
 
 ✅ COMPLETED
-- Artifact continuity established on canonical branch across:
+- Artifact continuity confirmed across:
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
-- `StrategyTrigger` now resolves explicit open source with autonomous default `execution.strategy_trigger.autonomous`.
-- Blocked-open rejection payload is normalized/flattened to keep compatibility at `execution_rejection.reason` while retaining sibling metadata.
-- Command-driven open path in `telegram.command_handler` now sends manual source attribution `execution.command_handler.trade_open.manual`.
-- Focused Phase 3 and p16 regression tests updated and passing for attribution/rejection schema compatibility.
+- MAJOR SENTINEL rerun executed and approved on current validated head commit `8831c25e67eee82da52d7f2516e0fd2221d52970`.
+- Execution isolation gateway routing verified for autonomous open/close and command/manual close entry points.
+- Command-driven open source attribution confirmed as `execution.command_handler.trade_open.manual`, distinct from autonomous default.
+- Blocked-open rejection compatibility confirmed at flat `execution_rejection.reason` with sibling metadata preservation.
+- Focused compile + execution-isolation + p16 sizing-block regression checks passed (warning-only pytest config environment note remains).
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
-- MAJOR SENTINEL rerun for canonical PR #396 branch.
 - Live Polymarket wallet/auth execution integration.
 - Multi-user execution queue workers and websocket subscriptions.
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md. Tier: MAJOR
+- COMMANDER review required on SENTINEL verdict before merge decision. Source: reports/sentinel/24_56_pr396_execution_isolation_rerun.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Long-term fix pending: refactor `ExecutionEngine.open_position` to return result + rejection payload directly and remove dependency on post-call rejection fetch.
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
+- Naming continuity drift: roadmap/system truth labels this execution-isolation chain under Phase 2 while branch/report naming still references Phase 3.
 - `PLATFORM_STORAGE_BACKEND=sqlite` is scaffold-mapped to local JSON backend in this foundation phase.

--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,27 +1,29 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-11 02:29
-🔄 Status       : PR #396 review fix pass applied for execution isolation boundary with atomic open rejection handling, public gateway engine property, and traceability lookup optimization.
+📅 Last Updated : 2026-04-11 09:24
+🔄 Status       : Phase 2 execution-isolation chain (PR #396 canonical path) now includes attribution/rejection schema fixes from prior parallel path, with flat rejection compatibility and explicit manual open source attribution.
 
 ✅ COMPLETED
-- Added `self._open_lock` to `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py` and wrapped open attempt + rejection lookup atomically.
-- Added public `engine` property to execution isolation gateway and switched singleton guard check to property access.
-- Cached close-rejection trace lookup in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`.
-- Added focused concurrent lock behavior test in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
-- FORGE review-fix report added:
+- Artifact continuity established on canonical branch across:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+- `StrategyTrigger` now resolves explicit open source with autonomous default `execution.strategy_trigger.autonomous`.
+- Blocked-open rejection payload is normalized/flattened to keep compatibility at `execution_rejection.reason` while retaining sibling metadata.
+- Command-driven open path in `telegram.command_handler` now sends manual source attribution `execution.command_handler.trade_open.manual`.
+- Focused Phase 3 and p16 regression tests updated and passing for attribution/rejection schema compatibility.
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
-- SENTINEL validation pass for original MAJOR Phase 3 isolation foundation.
+- MAJOR SENTINEL rerun for canonical PR #396 branch.
 - Live Polymarket wallet/auth execution integration.
 - Multi-user execution queue workers and websocket subscriptions.
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_54_pr396_review_fix_pass.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Long-term fix pending: refactor `ExecutionEngine.open_position` to return result + rejection payload directly and remove dependency on post-call rejection fetch.

--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,28 +1,28 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 12:43
-🔄 Status       : Phase 2 foundation for multi-user persistence and wallet/auth skeleton is implemented with legacy read-only bridge compatibility preserved.
+📅 Last Updated : 2026-04-11 02:01
+🔄 Status       : Phase 3 execution isolation foundation is implemented: autonomous and command/manual execution mutations now route through one authoritative gateway, while resolver/bridge/startup paths remain side-effect free in touched scope.
 
 ✅ COMPLETED
-- Phase 2 persistence foundation added for account, wallet binding, permission profile, strategy subscription, execution context, and audit event repositories under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/storage/`.
-- Phase 1 services upgraded to repository-aware behavior with fallback-safe defaults for empty/disabled persistence.
-- Wallet/auth integration skeleton contracts added under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/auth/` with non-live provider behavior.
-- Context resolver extended to persist execution-context diagnostics and write minimal secret-safe audit events.
-- Legacy read-only bridge updated to use repository-backed resolver wiring when enabled while preserving fallback behavior.
-- Focused Phase 2 tests added for repository CRUD, resolver persistence, bridge compatibility, and regression safety.
+- Introduced authoritative execution mutation gateway at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py` and enforced source-attributed allow/block decisions.
+- Routed `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py` open/close mutations through execution isolation boundary.
+- Routed `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py` manual close mutation through the same execution isolation boundary.
+- Suppressed legacy bridge audit persistence writes in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py` to keep resolve/attach flow side-effect free.
+- Added focused Phase 3 tests at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
 - FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md`
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
+- SENTINEL validation pass for Phase 3 execution isolation foundation (MAJOR tier).
 - Live Polymarket wallet/auth execution integration.
 - Multi-user execution queue workers and websocket subscriptions.
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md. Tier: STANDARD
+- SENTINEL validation required before merge. Source: reports/forge/24_53_phase3_execution_isolation_foundation.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).

--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,29 +1,29 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-11 02:01
-🔄 Status       : Phase 3 execution isolation foundation is implemented: autonomous and command/manual execution mutations now route through one authoritative gateway, while resolver/bridge/startup paths remain side-effect free in touched scope.
+📅 Last Updated : 2026-04-11 02:29
+🔄 Status       : PR #396 review fix pass applied for execution isolation boundary with atomic open rejection handling, public gateway engine property, and traceability lookup optimization.
 
 ✅ COMPLETED
-- Introduced authoritative execution mutation gateway at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py` and enforced source-attributed allow/block decisions.
-- Routed `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py` open/close mutations through execution isolation boundary.
-- Routed `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py` manual close mutation through the same execution isolation boundary.
-- Suppressed legacy bridge audit persistence writes in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py` to keep resolve/attach flow side-effect free.
-- Added focused Phase 3 tests at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
-- FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
+- Added `self._open_lock` to `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py` and wrapped open attempt + rejection lookup atomically.
+- Added public `engine` property to execution isolation gateway and switched singleton guard check to property access.
+- Cached close-rejection trace lookup in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`.
+- Added focused concurrent lock behavior test in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
+- FORGE review-fix report added:
+  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
 
 🔧 IN PROGRESS
 - None.
 
 📋 NOT STARTED
-- SENTINEL validation pass for Phase 3 execution isolation foundation (MAJOR tier).
+- SENTINEL validation pass for original MAJOR Phase 3 isolation foundation.
 - Live Polymarket wallet/auth execution integration.
 - Multi-user execution queue workers and websocket subscriptions.
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: reports/forge/24_53_phase3_execution_isolation_foundation.md. Tier: MAJOR
+- Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_54_pr396_review_fix_pass.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
+- Long-term fix pending: refactor `ExecutionEngine.open_position` to return result + rejection payload directly and remove dependency on post-call rejection fetch.
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
 - `PLATFORM_STORAGE_BACKEND=sqlite` is scaffold-mapped to local JSON backend in this foundation phase.

--- a/projects/polymarket/polyquantbot/execution/execution_isolation.py
+++ b/projects/polymarket/polyquantbot/execution/execution_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,11 @@ class ExecutionIsolationGateway:
 
     def __init__(self, engine: ExecutionEngine) -> None:
         self._engine = engine
+        self._open_lock = asyncio.Lock()
+
+    @property
+    def engine(self) -> ExecutionEngine:
+        return self._engine
 
     async def open_position(
         self,
@@ -55,24 +61,25 @@ class ExecutionIsolationGateway:
                 details={"risk_decision": risk_decision},
             )
 
-        opened = await self._engine.open_position(
-            market=market,
-            market_title=market_title,
-            side=side,
-            price=price,
-            size=size,
-            position_id=position_id,
-            position_context=position_context,
-            validation_proof=validation_proof,
-            execution_market_data=execution_market_data,
-        )
-        if opened is None:
-            rejection = self._engine.get_last_open_rejection() or {}
-            return self._block(
-                source_path=source_path,
-                reason=str(rejection.get("reason", "execution_open_rejected")),
-                details={"engine_rejection": rejection},
+        async with self._open_lock:
+            opened = await self._engine.open_position(
+                market=market,
+                market_title=market_title,
+                side=side,
+                price=price,
+                size=size,
+                position_id=position_id,
+                position_context=position_context,
+                validation_proof=validation_proof,
+                execution_market_data=execution_market_data,
             )
+            rejection = self._engine.get_last_open_rejection() or {}
+            if opened is None:
+                return self._block(
+                    source_path=source_path,
+                    reason=str(rejection.get("reason", "execution_open_rejected")),
+                    details={"engine_rejection": rejection},
+                )
 
         log.info(
             "execution_isolation_decision",
@@ -156,6 +163,6 @@ _gateway_singleton: ExecutionIsolationGateway | None = None
 def get_execution_isolation_gateway(engine: ExecutionEngine | None = None) -> ExecutionIsolationGateway:
     global _gateway_singleton  # noqa: PLW0603
     resolved_engine = engine or get_execution_engine()
-    if _gateway_singleton is None or _gateway_singleton._engine is not resolved_engine:
+    if _gateway_singleton is None or _gateway_singleton.engine is not resolved_engine:
         _gateway_singleton = ExecutionIsolationGateway(engine=resolved_engine)
     return _gateway_singleton

--- a/projects/polymarket/polyquantbot/execution/execution_isolation.py
+++ b/projects/polymarket/polyquantbot/execution/execution_isolation.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from .engine import ExecutionEngine, Position, ValidationProof, get_execution_engine
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ExecutionIsolationOutcome:
+    allowed: bool
+    reason: str
+    source_path: str
+    position: Position | None = None
+    realized_pnl: float | None = None
+    details: dict[str, Any] | None = None
+
+
+class ExecutionIsolationGateway:
+    """Single authoritative mutation boundary for execution runtime state."""
+
+    def __init__(self, engine: ExecutionEngine) -> None:
+        self._engine = engine
+
+    async def open_position(
+        self,
+        *,
+        source_path: str,
+        market: str,
+        market_title: str,
+        side: str,
+        price: float,
+        size: float,
+        position_id: str | None,
+        position_context: dict[str, Any],
+        execution_market_data: dict[str, Any],
+        validation_proof: ValidationProof | None,
+        risk_decision: str,
+        risk_reason: str,
+    ) -> ExecutionIsolationOutcome:
+        if risk_decision != "ALLOW":
+            return self._block(
+                source_path=source_path,
+                reason="risk_decision_not_allow",
+                details={"risk_decision": risk_decision, "risk_reason": risk_reason},
+            )
+        if not isinstance(validation_proof, ValidationProof):
+            return self._block(
+                source_path=source_path,
+                reason="validation_proof_required",
+                details={"risk_decision": risk_decision},
+            )
+
+        opened = await self._engine.open_position(
+            market=market,
+            market_title=market_title,
+            side=side,
+            price=price,
+            size=size,
+            position_id=position_id,
+            position_context=position_context,
+            validation_proof=validation_proof,
+            execution_market_data=execution_market_data,
+        )
+        if opened is None:
+            rejection = self._engine.get_last_open_rejection() or {}
+            return self._block(
+                source_path=source_path,
+                reason=str(rejection.get("reason", "execution_open_rejected")),
+                details={"engine_rejection": rejection},
+            )
+
+        log.info(
+            "execution_isolation_decision",
+            source_path=source_path,
+            action="open",
+            outcome="allow",
+            reason="opened",
+            market=market,
+            position_id=opened.position_id,
+        )
+        return ExecutionIsolationOutcome(
+            allowed=True,
+            reason="opened",
+            source_path=source_path,
+            position=opened,
+            details={"market": market, "position_id": opened.position_id},
+        )
+
+    async def close_position(
+        self,
+        *,
+        source_path: str,
+        position: Position,
+        close_price: float,
+        close_context: dict[str, Any],
+        terminal_reason: str,
+    ) -> ExecutionIsolationOutcome:
+        resolved_terminal_reason = terminal_reason.strip()
+        if not resolved_terminal_reason:
+            return self._block(
+                source_path=source_path,
+                reason="terminal_reason_required",
+                details={"action": "close"},
+            )
+
+        enriched_close_context = dict(close_context)
+        enriched_close_context.setdefault("terminal_reason", resolved_terminal_reason)
+        realized = await self._engine.close_position(
+            position,
+            close_price,
+            close_context=enriched_close_context,
+        )
+        log.info(
+            "execution_isolation_decision",
+            source_path=source_path,
+            action="close",
+            outcome="allow",
+            reason=resolved_terminal_reason,
+            market=position.market_id,
+            position_id=position.position_id,
+            realized_pnl=realized,
+        )
+        return ExecutionIsolationOutcome(
+            allowed=True,
+            reason=resolved_terminal_reason,
+            source_path=source_path,
+            realized_pnl=realized,
+            details={"market": position.market_id, "position_id": position.position_id},
+        )
+
+    def _block(self, *, source_path: str, reason: str, details: dict[str, Any]) -> ExecutionIsolationOutcome:
+        log.warning(
+            "execution_isolation_decision",
+            source_path=source_path,
+            action="mutate",
+            outcome="block",
+            reason=reason,
+            details=details,
+        )
+        return ExecutionIsolationOutcome(
+            allowed=False,
+            reason=reason,
+            source_path=source_path,
+            details=details,
+        )
+
+
+_gateway_singleton: ExecutionIsolationGateway | None = None
+
+
+def get_execution_isolation_gateway(engine: ExecutionEngine | None = None) -> ExecutionIsolationGateway:
+    global _gateway_singleton  # noqa: PLW0603
+    resolved_engine = engine or get_execution_engine()
+    if _gateway_singleton is None or _gateway_singleton._engine is not resolved_engine:
+        _gateway_singleton = ExecutionIsolationGateway(engine=resolved_engine)
+    return _gateway_singleton

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -426,6 +426,39 @@ class StrategyTrigger:
             "risk_state": self._risk_engine.as_dict(),
         }
 
+    @staticmethod
+    def _resolve_open_source(market_context: dict[str, Any] | None) -> str:
+        context = market_context or {}
+        source = str(context.get("open_source", "execution.strategy_trigger.autonomous")).strip()
+        return source or "execution.strategy_trigger.autonomous"
+
+    @staticmethod
+    def _normalize_open_rejection_payload(
+        payload: dict[str, Any] | None,
+        *,
+        fallback_reason: str,
+    ) -> dict[str, Any]:
+        source_payload = dict(payload or {})
+        nested_execution = source_payload.get("execution_rejection")
+        nested_engine = source_payload.get("engine_rejection")
+        flat: dict[str, Any] = {}
+
+        if isinstance(nested_execution, dict):
+            flat.update(nested_execution)
+        if isinstance(nested_engine, dict):
+            for key, value in nested_engine.items():
+                flat.setdefault(str(key), value)
+        for key, value in source_payload.items():
+            if key in {"execution_rejection", "engine_rejection"}:
+                continue
+            flat.setdefault(str(key), value)
+
+        flat_reason = flat.get("reason")
+        if isinstance(flat_reason, str) and flat_reason.strip():
+            return flat
+        flat["reason"] = fallback_reason
+        return flat
+
     def _regime_strategy_modifiers(self, regime: MarketRegimeClassification) -> dict[str, float]:
         modifiers: dict[str, float] = {
             "S1": self._clamp(float(regime.strategy_weight_modifiers.get("S1", 1.0)), 0.85, 1.20),
@@ -2364,8 +2397,9 @@ class StrategyTrigger:
                 signal_data=signal_data,
                 decision_data=decision_data,
             )
+            open_source = self._resolve_open_source(market_context)
             open_outcome = await self._execution_gateway.open_position(
-                source_path="execution.strategy_trigger.autonomous",
+                source_path=open_source,
                 market=target_market_id,
                 market_title=str(candidate_title),
                 side=self._config.side,
@@ -2450,6 +2484,10 @@ class StrategyTrigger:
                 )
             if created is None:
                 rejection_reason = open_outcome.reason
+                normalized_rejection = self._normalize_open_rejection_payload(
+                    open_outcome.details,
+                    fallback_reason=rejection_reason,
+                )
                 self._record_blocked_terminal_trace(
                     trade_id=trade_id,
                     signal_data=signal_data,
@@ -2461,7 +2499,7 @@ class StrategyTrigger:
                     },
                     terminal_stage="execution_engine_rejected_open",
                     reason=rejection_reason,
-                    extra_details={"execution_rejection": open_outcome.details or {}},
+                    extra_details={"execution_rejection": normalized_rejection},
                     terminal_outcome="BLOCKED",
                 )
                 return "BLOCKED"

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from .engine import ExecutionEngine
+from .execution_isolation import ExecutionIsolationGateway, get_execution_isolation_gateway
 from .intelligence import ExecutionIntelligence, MarketSnapshot
 from .trade_trace import TradeTraceEngine
 from ..legacy.adapters.context_bridge import LegacyContextBridge
@@ -293,8 +294,14 @@ class StrategyTrigger:
     IF pnl > target -> close position
     """
 
-    def __init__(self, engine: ExecutionEngine, config: StrategyConfig) -> None:
+    def __init__(
+        self,
+        engine: ExecutionEngine,
+        config: StrategyConfig,
+        execution_gateway: ExecutionIsolationGateway | None = None,
+    ) -> None:
         self._engine = engine
+        self._execution_gateway = execution_gateway or get_execution_isolation_gateway(engine)
         self._config = config
         self._intelligence = ExecutionIntelligence()
         self._last_trigger_time: float | None = None
@@ -2357,7 +2364,8 @@ class StrategyTrigger:
                 signal_data=signal_data,
                 decision_data=decision_data,
             )
-            created = await self._engine.open_position(
+            open_outcome = await self._execution_gateway.open_position(
+                source_path="execution.strategy_trigger.autonomous",
                 market=target_market_id,
                 market_title=str(candidate_title),
                 side=self._config.side,
@@ -2388,7 +2396,10 @@ class StrategyTrigger:
                     "trade_id": trade_id,
                 },
                 validation_proof=validation_proof,
+                risk_decision=validation_result.decision,
+                risk_reason=validation_result.reason,
             )
+            created = open_outcome.position
             if created:
                 execution_data = self._execution_tracker.record_fill(
                     trade_id=trade_id,
@@ -2438,8 +2449,7 @@ class StrategyTrigger:
                     action="OPEN",
                 )
             if created is None:
-                rejection_payload = self._engine.get_last_open_rejection() or {}
-                rejection_reason = str(rejection_payload.get("reason", "execution_open_position_rejected"))
+                rejection_reason = open_outcome.reason
                 self._record_blocked_terminal_trace(
                     trade_id=trade_id,
                     signal_data=signal_data,
@@ -2451,7 +2461,7 @@ class StrategyTrigger:
                     },
                     terminal_stage="execution_engine_rejected_open",
                     reason=rejection_reason,
-                    extra_details={"execution_rejection": rejection_payload},
+                    extra_details={"execution_rejection": open_outcome.details or {}},
                     terminal_outcome="BLOCKED",
                 )
                 return "BLOCKED"
@@ -2476,15 +2486,29 @@ class StrategyTrigger:
                     exit_efficiency = 1.0
                 elif exit_decision.exit_reason in {"stop_loss_threshold_breached", "signal_invalidation"}:
                     exit_efficiency = 0.3
-                await self._engine.close_position(
-                    tracked,
-                    market_price,
+                close_outcome = await self._execution_gateway.close_position(
+                    source_path="execution.strategy_trigger.autonomous",
+                    position=tracked,
+                    close_price=market_price,
                     close_context={
                         **entry_context,
                         "exit_reason": exit_decision.exit_reason,
                         "exit_efficiency": exit_efficiency,
                     },
+                    terminal_reason=exit_decision.exit_reason,
                 )
+                if not close_outcome.allowed:
+                    self._record_blocked_terminal_trace(
+                        trade_id=trade_id,
+                        signal_data=self._trade_traceability.get(trade_id, {}).get("signal_data", {}),
+                        decision_data=self._trade_traceability.get(trade_id, {}).get("decision_data", {}),
+                        validation_result=self._trade_traceability.get(trade_id, {}).get("validation_result", {}),
+                        terminal_stage="execution_isolation_rejected_close",
+                        reason=close_outcome.reason,
+                        extra_details={"execution_rejection": close_outcome.details or {}},
+                        terminal_outcome="BLOCKED",
+                    )
+                    return "BLOCKED"
                 validation_data = self._trade_validator.validate_closed_trade(
                     trade_id=trade_id,
                     expected_edge=float(entry_context.get("theoretical_edge", 0.0)),

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -2498,11 +2498,12 @@ class StrategyTrigger:
                     terminal_reason=exit_decision.exit_reason,
                 )
                 if not close_outcome.allowed:
+                    trace = self._trade_traceability.get(trade_id, {})
                     self._record_blocked_terminal_trace(
                         trade_id=trade_id,
-                        signal_data=self._trade_traceability.get(trade_id, {}).get("signal_data", {}),
-                        decision_data=self._trade_traceability.get(trade_id, {}).get("decision_data", {}),
-                        validation_result=self._trade_traceability.get(trade_id, {}).get("validation_result", {}),
+                        signal_data=trace.get("signal_data", {}),
+                        decision_data=trace.get("decision_data", {}),
+                        validation_result=trace.get("validation_result", {}),
                         terminal_stage="execution_isolation_rejected_close",
                         reason=close_outcome.reason,
                         extra_details={"execution_rejection": close_outcome.details or {}},

--- a/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
+++ b/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import uuid
 from dataclasses import dataclass
 
 import structlog
@@ -13,7 +12,6 @@ from ...platform.permissions.service import PermissionService
 from ...platform.storage import build_repository_bundle_from_env
 from ...platform.strategy_subscriptions.service import StrategySubscriptionService
 from ...platform.wallet_auth.service import WalletAuthService
-from ...platform.storage.models import AuditEventRecord, utc_now
 
 log = structlog.get_logger(__name__)
 
@@ -32,10 +30,8 @@ class LegacyContextBridge:
     def __init__(self, resolver: ContextResolver | None = None) -> None:
         if resolver is not None:
             self._resolver = resolver
-            self._audit_events = None
             return
         bundle = build_repository_bundle_from_env()
-        self._audit_events = bundle.audit_events
         self._resolver = ContextResolver(
             account_service=AccountService(repository=bundle.accounts),
             wallet_auth_service=WalletAuthService(repository=bundle.wallet_bindings),
@@ -104,17 +100,10 @@ class LegacyContextBridge:
             )
 
     def _write_bridge_audit(self, *, seed: LegacySessionSeed, action: str, status: str) -> None:
-        if self._audit_events is None:
-            return
-        self._audit_events.append(
-            AuditEventRecord(
-                event_id=f"evt-{uuid.uuid4().hex[:10]}",
-                user_id=seed.user_id,
-                category="bridge",
-                action=action,
-                status=status,
-                trace_id=seed.trace_id,
-                payload_json={"mode": seed.mode},
-                created_at=utc_now(),
-            )
+        log.info(
+            "platform_context_bridge_audit_suppressed",
+            user_id=seed.user_id,
+            action=action,
+            status=status,
+            trace_id=seed.trace_id,
         )

--- a/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md
@@ -1,0 +1,75 @@
+# FORGE-X Report — 24_53_phase3_execution_isolation_foundation
+
+**Validation Tier:** MAJOR  
+**Claim Level:** FULL RUNTIME INTEGRATION  
+**Validation Target:** projects/polymarket/polyquantbot/execution/ ; projects/polymarket/polyquantbot/telegram/ ; projects/polymarket/polyquantbot/main.py ; projects/polymarket/polyquantbot/platform/context/ ; projects/polymarket/polyquantbot/legacy/adapters/ ; projects/polymarket/polyquantbot/monitoring/ ; projects/polymarket/polyquantbot/tests/ ; projects/polymarket/polyquantbot/PROJECT_STATE.md ; projects/polymarket/polyquantbot/reports/forge/  
+**Not in Scope:** strategy alpha logic changes; new trading models; wallet live execution integration; websocket architecture rewrite; UI redesign; broad refactor outside touched execution-entry surfaces; changing Kelly/risk policy values unless required to preserve existing enforcement  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: reports/forge/24_53_phase3_execution_isolation_foundation.md. Tier: MAJOR
+
+---
+
+## 1. What was built
+
+Phase 3 execution isolation foundation was implemented by introducing one authoritative mutation boundary: `ExecutionIsolationGateway`.
+
+Implemented outcomes:
+- Added `projects/polymarket/polyquantbot/execution/execution_isolation.py` as the single mutation gateway for open/close execution state transitions in touched runtime scope.
+- Routed autonomous mutation path (`StrategyTrigger`) through this boundary for both open and close actions.
+- Routed command/manual mutation path (`telegram.command_handler`) through the same boundary for manual close actions and explicit gateway injection into the strategy-trigger trade-test path.
+- Enforced proof/risk/terminal-reason guardrails at gateway entry before execution mutations.
+- Added structured attribution logs (`execution_isolation_decision`) with source path, action, allow/block outcome, and explicit reason.
+- Preserved resolver/startup purity by keeping resolver read-only and suppressing bridge audit persistence writes in attach/fallback flow.
+
+## 2. Current system architecture
+
+### Short architecture note — mutation surfaces and isolated boundary
+
+Current mutation-capable surfaces in touched runtime path before this phase:
+- Autonomous trigger path: `StrategyTrigger.evaluate()` could directly call `ExecutionEngine.open_position()` and `ExecutionEngine.close_position()`.
+- Command/manual path: `telegram.command_handler` could directly call close mutation on execution engine.
+- Resolver/bridge/startup path: context resolve/attach/bootstrap flows were expected to be read-only, but bridge fallback path still had audit persistence side effects.
+
+Intended and delivered boundary rule:
+- **Read paths compose state** (`ContextResolver`, `LegacyContextBridge.attach_context`, startup wiring, import-chain paths).
+- **Execution paths mutate state only through one gateway** (`ExecutionIsolationGateway`).
+- **No silent write authority** for resolver/bridge/startup/read-only attach flows.
+
+Boundary flow now:
+- `StrategyTrigger` → `ExecutionIsolationGateway.open_position/close_position` → `ExecutionEngine`.
+- `CommandHandler` manual close → `ExecutionIsolationGateway.close_position` → `ExecutionEngine`.
+
+## 3. Files created / modified (full paths)
+
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
+
+## 4. What is working
+
+- Exactly one authoritative execution-isolation gateway is present in touched runtime scope and used by both autonomous and command/manual execution entries.
+- Gateway blocks mutation attempts when risk decision is not ALLOW or proof is missing/invalid.
+- Gateway blocks close attempts without explicit terminal reason.
+- Blocked mutation attempts emit explicit structured block outcomes with source path attribution.
+- Allowed mutation attempts emit structured allow outcomes and preserve execution truth fields (position id, exit reason, realized pnl in engine closed-trade record).
+- Resolver remains read-only (`resolve_*` only); no write-through wiring was reintroduced.
+- Bridge attach fallback no longer persists audit events in this touched scope.
+- Import chain remains compile-clean for:
+  - `projects.polymarket.polyquantbot.main`
+  - `projects.polymarket.polyquantbot.telegram.command_handler`
+  - `projects.polymarket.polyquantbot.execution.strategy_trigger`
+  - `projects.polymarket.polyquantbot.legacy.adapters.context_bridge`
+  - `projects.polymarket.polyquantbot.platform.context.resolver`
+
+## 5. Known issues
+
+- Environment warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- This phase does not refactor all non-targeted execution-capable modules outside touched scope (e.g., independent paper-engine internals); scope remains focused on declared entry surfaces.
+
+## 6. What is next
+
+SENTINEL validation required for `phase3 execution isolation foundation` before merge.  
+Source: `reports/forge/24_53_phase3_execution_isolation_foundation.md`  
+Tier: MAJOR

--- a/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md
@@ -1,0 +1,48 @@
+# FORGE-X Report — 24_54_pr396_review_fix_pass
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** projects/polymarket/polyquantbot/execution/execution_isolation.py ; projects/polymarket/polyquantbot/execution/strategy_trigger.py ; projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py ; projects/polymarket/polyquantbot/PROJECT_STATE.md ; projects/polymarket/polyquantbot/reports/forge/  
+**Not in Scope:** execution engine return-contract refactor; broader runtime architecture updates; strategy alpha changes; telemetry redesign  
+**Suggested Next Step:** Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_54_pr396_review_fix_pass.md. Tier: STANDARD
+
+---
+
+## 1. What was built
+
+Applied PR #396 review fix pass on the previously introduced execution isolation layer:
+- Added atomic lock (`self._open_lock`) to `ExecutionIsolationGateway` and wrapped `open_position` + `get_last_open_rejection` sequence in one lock-protected section.
+- Added public property `engine` and switched singleton engine identity check to `gateway.engine`.
+- Optimized close rejection traceability lookup in `StrategyTrigger` by caching trace map once.
+- Added focused concurrency test to verify lock behavior prevents rejection-reason overwrite under concurrent open attempts.
+
+## 2. Current system architecture
+
+- Runtime mutation entry remains narrow and unchanged in scope: `StrategyTrigger` and command-driven flows still call the same `ExecutionIsolationGateway`.
+- The gateway now serializes open-attempt result/rejection readout using an internal asyncio lock to keep per-call rejection attribution stable.
+- This pass does not alter `ExecutionEngine` public contract; lock-based containment is applied only at the gateway layer.
+
+## 3. Files created / modified (full paths)
+
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
+
+## 4. What is working
+
+- Concurrent gateway open attempts now read rejection state atomically per call.
+- Singleton gateway check no longer accesses private field (`_engine`) from outside class.
+- Close rejection branch in `StrategyTrigger` uses one cached trace lookup.
+- Focused pytest file passes including new lock behavior test.
+
+## 5. Known issues
+
+- Long-term hardening remains: `ExecutionEngine.open_position` should eventually return tuple/result including rejection payload directly, to remove external post-call rejection lookup dependence.
+- Pytest warning remains in environment: `Unknown config option: asyncio_mode`.
+
+## 6. What is next
+
+Codex auto PR review + COMMANDER review required before merge.  
+Source: `reports/forge/24_54_pr396_review_fix_pass.md`  
+Tier: STANDARD

--- a/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md
@@ -1,0 +1,56 @@
+# FORGE-X Report — 24_55_pr396_attribution_and_rejection_schema_fix
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** projects/polymarket/polyquantbot/execution/strategy_trigger.py ; projects/polymarket/polyquantbot/telegram/command_handler.py ; projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py ; projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py ; projects/polymarket/polyquantbot/PROJECT_STATE.md ; projects/polymarket/polyquantbot/reports/forge/  
+**Not in Scope:** execution-engine contract refactor; execution-isolation architecture redesign; wallet/auth and multi-user roadmap work; websocket/worker/UI changes; new PR creation  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md. Tier: MAJOR
+
+---
+
+## 1. What was built
+
+Canonical PR #396 follow-up fixes from closed #399 path were ported onto this branch:
+- Added explicit open-source resolution in `StrategyTrigger` with autonomous default `execution.strategy_trigger.autonomous`.
+- Added blocked-open rejection payload normalization/flattening so trace remains compatible at `execution_rejection.reason`.
+- Flattened nested rejection shapes while preserving useful sibling metadata from outer payload.
+- Updated command-driven open flow in `telegram.command_handler` to pass explicit manual attribution source: `execution.command_handler.trade_open.manual`.
+- Added focused tests for source attribution distinction/defaults and flat rejection payload compatibility/metadata preservation.
+- Extended p16 sizing-block regression to enforce flat rejection path compatibility.
+
+## 2. Current system architecture
+
+- Open mutation source is now explicit and context-resolved in strategy path:
+  - default autonomous source remains `execution.strategy_trigger.autonomous`.
+  - manual command-driven source can be injected via market context and is now passed from command handler.
+- Blocked-open rejection schema is normalized before trace write, so downstream consumers read consistent flat path:
+  - `outcome_data.execution_rejection.reason`
+- Existing execution-isolation gateway architecture remains unchanged (narrow integration only).
+
+## 3. Files created / modified (full paths)
+
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+
+## 4. What is working
+
+- Command-driven open attribution is distinct from autonomous attribution and explicitly set by command path.
+- Autonomous open attribution default remains intact.
+- Blocked-open rejection payload is flat and assertion-friendly at `execution_rejection.reason`.
+- Flattened payload keeps sibling metadata (example fields like `source_path`, `attempt_id`) when present.
+- Focused execution-isolation test suite passes.
+- Focused p16 regression for rejection reason path passes.
+
+## 5. Known issues
+
+- Long-term improvement still deferred: `ExecutionEngine.open_position` should eventually return structured `(result, rejection)` directly to remove post-call rejection dependency.
+- Environment warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode`.
+
+## 6. What is next
+
+SENTINEL validation required before merge on canonical PR #396 branch.  
+Source: `reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`  
+Tier: MAJOR

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md
@@ -1,0 +1,126 @@
+# SENTINEL Report — 24_56_pr396_execution_isolation_rerun
+
+**Task:** pr396-major-rerun-on-canonical-head  
+**Validation Tier:** MAJOR  
+**Claim Level Evaluated:** FULL RUNTIME INTEGRATION (touched execution-entry surfaces only)  
+**Verdict:** APPROVED  
+**Stability / Validation Score:** 92/100
+
+## 1) Branch / Head Context Used (actual validated state)
+
+- Repository path validated: `/workspace/walker-ai-team`
+- Command: `git rev-parse --abbrev-ref HEAD` → `work`
+- Command: `git rev-parse HEAD` → `8831c25e67eee82da52d7f2516e0fd2221d52970`
+
+Codex worktree note:
+- HEAD/branch label is `work` in this environment; no remote-tracking branch metadata is configured locally.
+- Per repository Codex worktree rule, this is not a blocker by itself.
+- Validation was executed on the actual current checked-out head commit above (not on an older cached report snapshot).
+
+## 2) Traceability Gate (24_53 → 24_54 → 24_55 continuity)
+
+Confirmed present and internally continuous on validated head:
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+
+PROJECT_STATE continuity check:
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md` currently points NEXT PRIORITY to MAJOR SENTINEL validation sourced from `reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`.
+
+Roadmap/drift note:
+- Current project truth text and architecture notes place this execution-isolation chain under **Phase 2** continuity.
+- Branch/report naming still uses “Phase 3” wording.
+- This is documented as naming continuity drift only (non-blocking).
+
+## 3) Code-Presence Gate
+
+### 3.1 ExecutionIsolationGateway existence
+- `ExecutionIsolationGateway` exists in `projects/polymarket/polyquantbot/execution/execution_isolation.py`.
+
+### 3.2 Autonomous open/close route through gateway
+- `StrategyTrigger` open path calls `self._execution_gateway.open_position(...)`.
+- `StrategyTrigger` autonomous close path calls `self._execution_gateway.close_position(...)` with source path `execution.strategy_trigger.autonomous`.
+
+### 3.3 Command/manual close route through gateway
+- `telegram.command_handler` close flow (`_handle_trade_close`) calls `execution_gateway.close_position(...)`.
+
+### 3.4 Command/manual open attribution split
+- `telegram.command_handler` test-open flow injects `market_context={"open_source": "execution.command_handler.trade_open.manual"}`.
+- `StrategyTrigger` resolves open source via `_resolve_open_source(...)`.
+
+## 4) Runtime-Behavior Gate
+
+### 4.1 Autonomous default open source
+- `_resolve_open_source` default remains `execution.strategy_trigger.autonomous` when no explicit source is supplied.
+
+### 4.2 Command-driven open source distinct from autonomous
+- Command path provides explicit manual source `execution.command_handler.trade_open.manual`.
+- This avoids autonomous mislabeling in command-driven open flow.
+
+### 4.3 Flat rejection compatibility (`execution_rejection.reason`)
+- `_normalize_open_rejection_payload(...)` flattens nested payloads and ensures `reason` is always available.
+- Blocked-open trace writes use `extra_details={"execution_rejection": normalized_rejection}` preserving flat path compatibility.
+
+### 4.4 Sibling metadata preservation in flattened payload
+- Normalizer merges nested `execution_rejection`/`engine_rejection` plus non-nested sibling keys using `setdefault`, preserving extra metadata when present.
+
+### 4.5 Resolver/bridge/startup purity in touched scope
+- `LegacyContextBridge._write_bridge_audit(...)` is audit-suppressed to logging only; no persistence write introduced.
+- No contradictory write-path behavior detected in touched bridge scope.
+
+## 5) Focused Evidence Gate (exact commands and exact results)
+
+1. `git rev-parse --abbrev-ref HEAD`
+   - Result: `work`
+
+2. `git rev-parse HEAD`
+   - Result: `8831c25e67eee82da52d7f2516e0fd2221d52970`
+
+3. `python -m py_compile projects/polymarket/polyquantbot/execution/execution_isolation.py projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py`
+   - Result: PASS (exit code 0)
+
+4. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+   - Result: PASS — `7 passed, 1 warning in 0.29s`
+   - Warning: `PytestConfigWarning: Unknown config option: asyncio_mode` (non-blocking env/config warning)
+
+5. `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py -k execution_rejection_reason_for_sizing_block`
+   - Result: PASS — `1 passed, 12 deselected, 1 warning in 0.21s`
+   - Warning: `PytestConfigWarning: Unknown config option: asyncio_mode` (non-blocking env/config warning)
+
+## 6) Claim/Safety Gate Assessment
+
+Assessment scope: only declared touched execution-entry surfaces and direct dependency evidence.
+
+- Evidence supports that the execution-isolation chain is actively wired for:
+  - autonomous open path,
+  - autonomous close path,
+  - manual command close path,
+  - command-driven open attribution routing.
+- Rejection schema compatibility (flat reason path + sibling metadata preservation) is verified in code and focused regression tests.
+- No critical safety contradiction detected in touched scope.
+
+Claim judgment:
+- Declared task-level claim (`FULL RUNTIME INTEGRATION` for touched execution-entry surfaces) is **supported within validated scope**.
+- Global system-wide FULL integration outside touched scope is **not claimed here**.
+
+## 7) Blockers / Drift Notes
+
+### Blockers
+- None (for this scoped MAJOR rerun target).
+
+### Non-blocking drift notes
+1. Naming continuity drift:
+   - roadmap/project truth references Phase 2 continuity,
+   - branch/report names still include “Phase 3”.
+2. Environment/config warning persists:
+   - `Unknown config option: asyncio_mode` during pytest.
+3. Long-term technical debt (already acknowledged in forge/project state):
+   - `ExecutionEngine.open_position` return-contract refactor remains pending.
+
+## 8) Supersession Note
+
+This rerun supersedes stale/parallel earlier SENTINEL conclusions when they contradict the validated current head state listed in Section 1.
+
+---
+
+**Final SENTINEL Decision:** **APPROVED** for canonical PR #396 execution-isolation rerun scope on validated current head `8831c25e67eee82da52d7f2516e0fd2221d52970`.

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -462,7 +462,10 @@ class CommandHandler:
             ),
             execution_gateway=execution_gateway,
         )
-        result = await trigger.evaluate(0.42)
+        result = await trigger.evaluate(
+            0.42,
+            market_context={"open_source": "execution.command_handler.trade_open.manual"},
+        )
         await engine.update_mark_to_market({market: 0.46})
         payload = await export_execution_payload()
         get_portfolio_service().merge_execution_state(

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -11,6 +11,7 @@ from ..config.runtime_config import ConfigManager
 from ..core.system_state import SystemState, SystemStateManager
 from ..interface.telegram.view_handler import render_view, safe_count, safe_number
 from ..execution.engine import export_execution_payload, get_execution_engine
+from ..execution.execution_isolation import get_execution_isolation_gateway
 from ..execution.observability import (
     EVENT_OUTCOME,
     EVENT_STAGE,
@@ -450,6 +451,7 @@ class CommandHandler:
             )
         self._trade_intents[intent] = now
         engine = get_execution_engine()
+        execution_gateway = get_execution_isolation_gateway(engine)
         trigger = StrategyTrigger(
             engine=engine,
             config=StrategyConfig(
@@ -458,6 +460,7 @@ class CommandHandler:
                 threshold=0.45,
                 target_pnl=20.0,
             ),
+            execution_gateway=execution_gateway,
         )
         result = await trigger.evaluate(0.42)
         await engine.update_mark_to_market({market: 0.46})
@@ -505,6 +508,7 @@ class CommandHandler:
             )
         market = args.strip()
         engine = get_execution_engine()
+        execution_gateway = get_execution_isolation_gateway(engine)
         snapshot = await engine.snapshot()
         position = next((p for p in snapshot.positions if p.market_id == market), None)
         if position is None:
@@ -512,7 +516,19 @@ class CommandHandler:
                 success=False,
                 message=f"No open position for {market}.",
             )
-        realized_pnl = await engine.close_position(position, 0.50)
+        close_outcome = await execution_gateway.close_position(
+            source_path="telegram.command_handler.manual",
+            position=position,
+            close_price=0.50,
+            close_context={"exit_reason": "manual_command_close"},
+            terminal_reason="manual_command_close",
+        )
+        if not close_outcome.allowed:
+            return CommandResult(
+                success=False,
+                message=f"manual_close_blocked: {close_outcome.reason}",
+            )
+        realized_pnl = float(close_outcome.realized_pnl or 0.0)
         payload = await export_execution_payload()
         get_portfolio_service().merge_execution_state(
             positions=payload.get("positions", []),

--- a/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
+++ b/projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+import time
 from pathlib import Path
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine, ExecutionValidationProof
@@ -326,6 +327,12 @@ def test_p16_successful_trade_records_execution_trace() -> None:
                 "spread": 0.01,
                 "best_bid": 0.445,
                 "best_ask": 0.455,
+                "timestamp": time.time(),
+                "model_probability": 0.62,
+                "orderbook": {
+                    "asks": [[0.45, 500.0], [0.46, 500.0]],
+                    "bids": [[0.44, 500.0]],
+                },
             },
         )
         assert decision == "OPENED"
@@ -512,6 +519,12 @@ def test_p16_strategy_trigger_records_execution_rejection_reason_for_sizing_bloc
                 "spread": 0.01,
                 "best_bid": 0.445,
                 "best_ask": 0.455,
+                "timestamp": time.time(),
+                "model_probability": 0.62,
+                "orderbook": {
+                    "asks": [[0.45, 500.0], [0.46, 500.0]],
+                    "bids": [[0.44, 500.0]],
+                },
             },
         )
         assert decision == "BLOCKED"
@@ -526,5 +539,7 @@ def test_p16_strategy_trigger_records_execution_rejection_reason_for_sizing_bloc
         assert trace is not None
         assert trace["outcome_data"]["reason"] == "max_position_size_exceeded"
         assert trace["outcome_data"]["execution_rejection"]["reason"] == "max_position_size_exceeded"
+        assert "engine_rejection" not in trace["outcome_data"]["execution_rejection"]
+        assert trace["outcome_data"]["execution_rejection"]["market"] == "MARKET-1"
 
     asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
@@ -15,6 +15,7 @@ from projects.polymarket.polyquantbot.execution.execution_isolation import (
     get_execution_isolation_gateway,
 )
 from projects.polymarket.polyquantbot.execution.proof_lifecycle import new_validation_proof
+from projects.polymarket.polyquantbot.execution.strategy_trigger import StrategyConfig, StrategyTrigger
 
 
 def _valid_market_data(reference_price: float = 0.41) -> dict[str, object]:
@@ -51,6 +52,39 @@ def test_phase3_autonomous_and_manual_paths_route_through_isolation_gateway() ->
     assert "self._engine.close_position(" not in trigger_source
     assert "execution_gateway.close_position(" in command_source
     assert "execution_gateway=execution_gateway" in command_source
+    assert "execution.command_handler.trade_open.manual" in command_source
+    assert "execution.strategy_trigger.autonomous" in trigger_source
+
+
+def test_phase3_open_source_default_and_manual_are_distinct() -> None:
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=10_000.0),
+        config=StrategyConfig(market_id="m-source"),
+    )
+    assert trigger._resolve_open_source(None) == "execution.strategy_trigger.autonomous"  # noqa: SLF001
+    assert (
+        trigger._resolve_open_source({"open_source": "execution.command_handler.trade_open.manual"})  # noqa: SLF001
+        == "execution.command_handler.trade_open.manual"
+    )
+
+
+def test_phase3_open_rejection_payload_is_flat_and_keeps_sibling_metadata() -> None:
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=10_000.0),
+        config=StrategyConfig(market_id="m-rejection"),
+    )
+    normalized = trigger._normalize_open_rejection_payload(  # noqa: SLF001
+        {
+            "engine_rejection": {"reason": "max_position_size_exceeded", "limit": 100.0},
+            "source_path": "execution.command_handler.trade_open.manual",
+            "attempt_id": "attempt-1",
+        },
+        fallback_reason="execution_open_position_rejected",
+    )
+    assert normalized["reason"] == "max_position_size_exceeded"
+    assert normalized["limit"] == 100.0
+    assert normalized["source_path"] == "execution.command_handler.trade_open.manual"
+    assert normalized["attempt_id"] == "attempt-1"
 
 
 def test_phase3_isolation_boundary_rejects_bypass_without_risk_or_proof() -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.execution_isolation import get_execution_isolation_gateway
+
+
+def _valid_market_data(reference_price: float = 0.41) -> dict[str, object]:
+    return {
+        "timestamp": time.time(),
+        "model_probability": 0.62,
+        "orderbook": {
+            "asks": [[reference_price, 500.0], [reference_price + 0.01, 500.0]],
+            "bids": [[reference_price - 0.01, 500.0]],
+        },
+        "volatility": 0.1,
+    }
+
+
+def test_phase3_resolver_bridge_startup_paths_remain_read_only() -> None:
+    resolver_source = Path("projects/polymarket/polyquantbot/platform/context/resolver.py").read_text(encoding="utf-8")
+    bridge_source = Path("projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py").read_text(encoding="utf-8")
+    main_source = Path("projects/polymarket/polyquantbot/main.py").read_text(encoding="utf-8")
+
+    assert "resolve_user_account(" in resolver_source
+    assert "ensure_user_account(" not in resolver_source
+    assert "AuditEventRecord" not in bridge_source
+    assert "platform_context_bridge_audit_suppressed" in bridge_source
+    assert "engine_container.restore_from_db" in main_source
+
+
+def test_phase3_autonomous_and_manual_paths_route_through_isolation_gateway() -> None:
+    trigger_source = Path("projects/polymarket/polyquantbot/execution/strategy_trigger.py").read_text(encoding="utf-8")
+    command_source = Path("projects/polymarket/polyquantbot/telegram/command_handler.py").read_text(encoding="utf-8")
+
+    assert "self._execution_gateway.open_position(" in trigger_source
+    assert "self._execution_gateway.close_position(" in trigger_source
+    assert "self._engine.open_position(" not in trigger_source
+    assert "self._engine.close_position(" not in trigger_source
+    assert "execution_gateway.close_position(" in command_source
+    assert "execution_gateway=execution_gateway" in command_source
+
+
+def test_phase3_isolation_boundary_rejects_bypass_without_risk_or_proof() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        gateway = get_execution_isolation_gateway(engine)
+
+        blocked = await gateway.open_position(
+            source_path="tests.direct_bypass",
+            market="m-bypass",
+            market_title="Bypass",
+            side="YES",
+            price=0.41,
+            size=100.0,
+            position_id="bypass-1",
+            position_context={"strategy_source": "TEST"},
+            execution_market_data=_valid_market_data(),
+            validation_proof=None,
+            risk_decision="ALLOW",
+            risk_reason="ok",
+        )
+        assert blocked.allowed is False
+        assert blocked.reason == "validation_proof_required"
+
+        snapshot = await engine.snapshot()
+        assert len(snapshot.positions) == 0
+
+    asyncio.run(_run())
+
+
+def test_phase3_isolation_boundary_enforces_risk_then_preserves_execution_truth() -> None:
+    async def _run() -> None:
+        engine = ExecutionEngine(starting_equity=10_000.0)
+        gateway = get_execution_isolation_gateway(engine)
+
+        blocked_risk = await gateway.open_position(
+            source_path="tests.risk_block",
+            market="m-risk",
+            market_title="Risk Block",
+            side="YES",
+            price=0.41,
+            size=100.0,
+            position_id="risk-1",
+            position_context={"strategy_source": "TEST"},
+            execution_market_data=_valid_market_data(),
+            validation_proof=None,
+            risk_decision="BLOCK",
+            risk_reason="pre_trade_validator_block",
+        )
+        assert blocked_risk.allowed is False
+        assert blocked_risk.reason == "risk_decision_not_allow"
+
+        proof = engine.build_validation_proof(
+            condition_id="m-success",
+            side="YES",
+            price_snapshot=0.41,
+            size=100.0,
+            market_type="normal",
+            volatility_proxy=0.1,
+        )
+        opened = await gateway.open_position(
+            source_path="tests.allow",
+            market="m-success",
+            market_title="Success",
+            side="YES",
+            price=0.41,
+            size=100.0,
+            position_id="allow-1",
+            position_context={"strategy_source": "TEST", "trade_id": "allow-1"},
+            execution_market_data=_valid_market_data(),
+            validation_proof=proof,
+            risk_decision="ALLOW",
+            risk_reason="ok",
+        )
+        assert opened.allowed is True
+        assert opened.position is not None
+
+        close_blocked = await gateway.close_position(
+            source_path="tests.close_block",
+            position=opened.position,
+            close_price=0.5,
+            close_context={},
+            terminal_reason="",
+        )
+        assert close_blocked.allowed is False
+        assert close_blocked.reason == "terminal_reason_required"
+
+        closed = await gateway.close_position(
+            source_path="tests.close_allow",
+            position=opened.position,
+            close_price=0.5,
+            close_context={"exit_reason": "take_profit"},
+            terminal_reason="take_profit",
+        )
+        assert closed.allowed is True
+        assert isinstance(closed.realized_pnl, float)
+
+        assert len(engine._closed_trades) == 1  # noqa: SLF001
+        assert engine._closed_trades[0]["position_id"] == "allow-1"  # noqa: SLF001
+        assert engine._closed_trades[0]["exit_reason"] == "take_profit"  # noqa: SLF001
+
+    asyncio.run(_run())

--- a/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
@@ -10,7 +10,11 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
-from projects.polymarket.polyquantbot.execution.execution_isolation import get_execution_isolation_gateway
+from projects.polymarket.polyquantbot.execution.execution_isolation import (
+    ExecutionIsolationGateway,
+    get_execution_isolation_gateway,
+)
+from projects.polymarket.polyquantbot.execution.proof_lifecycle import new_validation_proof
 
 
 def _valid_market_data(reference_price: float = 0.41) -> dict[str, object]:
@@ -147,5 +151,75 @@ def test_phase3_isolation_boundary_enforces_risk_then_preserves_execution_truth(
         assert len(engine._closed_trades) == 1  # noqa: SLF001
         assert engine._closed_trades[0]["position_id"] == "allow-1"  # noqa: SLF001
         assert engine._closed_trades[0]["exit_reason"] == "take_profit"  # noqa: SLF001
+
+    asyncio.run(_run())
+
+
+def test_phase3_isolation_open_lock_keeps_rejection_reason_per_call() -> None:
+    class _RaceEngine:
+        def __init__(self) -> None:
+            self._last_open_rejection: dict[str, object] | None = None
+
+        async def open_position(self, **kwargs: object) -> None:
+            position_id = str(kwargs.get("position_id", "unknown"))
+            self._last_open_rejection = {"reason": f"reject_{position_id}"}
+            await asyncio.sleep(0.01)
+            return None
+
+        def get_last_open_rejection(self) -> dict[str, object] | None:
+            return dict(self._last_open_rejection or {})
+
+    async def _run() -> None:
+        gateway = ExecutionIsolationGateway(engine=_RaceEngine())  # type: ignore[arg-type]
+        proof_a = new_validation_proof(
+            condition_id="m-lock-a",
+            side="YES",
+            price_snapshot=0.41,
+            size=10.0,
+            ttl_seconds=30,
+        )
+        proof_b = new_validation_proof(
+            condition_id="m-lock-b",
+            side="YES",
+            price_snapshot=0.41,
+            size=10.0,
+            ttl_seconds=30,
+        )
+
+        outcome_a, outcome_b = await asyncio.gather(
+            gateway.open_position(
+                source_path="tests.lock.a",
+                market="m-lock-a",
+                market_title="Lock A",
+                side="YES",
+                price=0.41,
+                size=10.0,
+                position_id="A",
+                position_context={},
+                execution_market_data=_valid_market_data(),
+                validation_proof=proof_a,
+                risk_decision="ALLOW",
+                risk_reason="ok",
+            ),
+            gateway.open_position(
+                source_path="tests.lock.b",
+                market="m-lock-b",
+                market_title="Lock B",
+                side="YES",
+                price=0.41,
+                size=10.0,
+                position_id="B",
+                position_context={},
+                execution_market_data=_valid_market_data(),
+                validation_proof=proof_b,
+                risk_decision="ALLOW",
+                risk_reason="ok",
+            ),
+        )
+
+        assert outcome_a.allowed is False
+        assert outcome_b.allowed is False
+        assert outcome_a.reason == "reject_A"
+        assert outcome_b.reason == "reject_B"
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Isolate all runtime mutations behind one authoritative gateway so resolver/bridge/startup remain side-effect free and every execution mutation passes proof and risk enforcement.
- Ensure autonomous (`StrategyTrigger`) and manual/command-driven mutation paths share the same enforced mutation boundary with explicit source attribution and structured allow/block outcomes.

### Description
- Added a single authoritative gateway `ExecutionIsolationGateway` at `projects/polymarket/polyquantbot/execution/execution_isolation.py` that enforces risk decision, validation proof presence, and terminal-reason rules and emits structured `execution_isolation_decision` logs.
- Routed autonomous open/close flows in `projects/polymarket/polyquantbot/execution/strategy_trigger.py` through the gateway (injectable via `execution_gateway`) and adapted open/close handling to use gateway outcomes and explicit rejection handling.
- Routed manual/command-driven close and injected the gateway into the trade-test path in `projects/polymarket/polyquantbot/telegram/command_handler.py` so command flows also use the same gateway.
- Preserved resolver/bridge purity by suppressing legacy bridge audit persistence writes in `projects/polymarket/polyquantbot/legacy/adapters/context_bridge.py` so attach/resolve remains read-only in the touched scope.
- Added focused tests at `projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` and a FORGE report at `projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`, and updated `PROJECT_STATE.md` to reflect Phase 3 state and next priority.

### Testing
- Compiled touched files with `python3 -m py_compile` (files: `execution/execution_isolation.py`, `execution/strategy_trigger.py`, `telegram/command_handler.py`, `legacy/adapters/context_bridge.py`, test file) and the compile step passed.
- Ran focused pytest with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py projects/polymarket/polyquantbot/tests/test_platform_resolver_import_chain_20260411.py` and all tests passed (`9 passed, 1 warning`).
- Performed import-chain validation by importing modules `projects.polymarket.polyquantbot.main`, `projects.polymarket.polyquantbot.telegram.command_handler`, `projects.polymarket.polyquantbot.execution.strategy_trigger`, `projects.polymarket.polyquantbot.legacy.adapters.context_bridge`, and `projects.polymarket.polyquantbot.platform.context.resolver` and the imports succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9aa64e1b8832e8b0307d216f17a47)