### PR TITLE
fix: PR396 execution attribution + rejection schema sync

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,17 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-10 12:43
-🔄 Status       : Phase 2 foundation for multi-user persistence and wallet/auth skeleton is implemented with legacy read-only bridge compatibility preserved.
+📅 Last Updated : 2026-04-11 07:18
+🔄 Status       : Phase 2 execution-isolation follow-up fix chain updated for PR #396 with MAJOR execution classification and attribution/rejection schema sync.
 
 ✅ COMPLETED
-- Phase 2 persistence foundation added for account, wallet binding, permission profile, strategy subscription, execution context, and audit event repositories under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/storage/`.
-- Phase 1 services upgraded to repository-aware behavior with fallback-safe defaults for empty/disabled persistence.
-- Wallet/auth integration skeleton contracts added under `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/auth/` with non-live provider behavior.
-- Context resolver extended to persist execution-context diagnostics and write minimal secret-safe audit events.
-- Legacy read-only bridge updated to use repository-backed resolver wiring when enabled while preserving fallback behavior.
-- Focused Phase 2 tests added for repository CRUD, resolver persistence, bridge compatibility, and regression safety.
-- FORGE report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md`
+- PR #396 follow-up fix applied to preserve distinct open-source attribution for command-driven `/trade` opens versus autonomous trigger opens.
+- Blocked-open terminal trace payload compatibility preserved at `outcome_data.execution_rejection.reason` flat path for existing consumers.
+- Focused execution-isolation tests added and passed in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
+- FORGE report added: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`.
 
 🔧 IN PROGRESS
 - None.
@@ -22,7 +18,7 @@
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- Auto PR review + COMMANDER review required before merge. Source: reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md. Tier: STANDARD
+- SENTINEL validation required for pr396-execution-isolation-review-fix-sync before merge. Source: reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
 - Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).

--- a/projects/polymarket/polyquantbot/execution/strategy_trigger.py
+++ b/projects/polymarket/polyquantbot/execution/strategy_trigger.py
@@ -419,6 +419,18 @@ class StrategyTrigger:
             "risk_state": self._risk_engine.as_dict(),
         }
 
+    @staticmethod
+    def _normalize_execution_rejection_payload(
+        rejection_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload = dict(rejection_payload)
+        nested_payload = payload.get("execution_rejection")
+        if isinstance(nested_payload, dict):
+            payload = dict(nested_payload)
+        if "reason" not in payload:
+            payload["reason"] = "execution_open_position_rejected"
+        return payload
+
     def _regime_strategy_modifiers(self, regime: MarketRegimeClassification) -> dict[str, float]:
         modifiers: dict[str, float] = {
             "S1": self._clamp(float(regime.strategy_weight_modifiers.get("S1", 1.0)), 0.85, 1.20),
@@ -2108,6 +2120,7 @@ class StrategyTrigger:
         market_price: float,
         aggregation_decision: StrategyAggregationDecision | None = None,
         market_context: dict[str, float] | None = None,
+        open_source: str = "execution.strategy_trigger.autonomous",
     ) -> str:
         if not self._risk_restore_ready:
             log.warning("risk_state_not_restored_fail_closed", reason=self._risk_restore_reason)
@@ -2375,6 +2388,7 @@ class StrategyTrigger:
                         if selected_candidate is not None
                         else "UNKNOWN"
                     ),
+                    "open_source": open_source,
                     "regime_at_entry": (
                         aggregation_decision.current_regime
                         if aggregation_decision is not None
@@ -2438,7 +2452,9 @@ class StrategyTrigger:
                     action="OPEN",
                 )
             if created is None:
-                rejection_payload = self._engine.get_last_open_rejection() or {}
+                rejection_payload = self._normalize_execution_rejection_payload(
+                    self._engine.get_last_open_rejection() or {},
+                )
                 rejection_reason = str(rejection_payload.get("reason", "execution_open_position_rejected"))
                 self._record_blocked_terminal_trace(
                     trade_id=trade_id,

--- a/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md
@@ -1,0 +1,71 @@
+# FORGE-X Report — 24_55_pr396_attribution_and_rejection_schema_fix
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:**
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+
+**Not in Scope:**
+- Renaming existing PR or branch
+- Broad execution-engine contract refactor
+- Wallet/auth or multi-user platform work
+- Websocket / worker / UI changes
+- Changes outside touched execution-entry surfaces
+- Merging or closing any PR
+
+**Suggested Next Step:** SENTINEL validation required for PR #396 follow-up fix chain before merge.
+
+---
+
+## 1. What Was Built
+
+Applied a narrow follow-up fix pass for PR #396 execution-isolation review findings:
+
+- Added explicit open-source attribution parameter to `StrategyTrigger.evaluate(...)` so command-driven opens can be labeled separately from autonomous opens.
+- Wired `/trade test` command flow to pass a manual source path (`execution.command_handler.trade_open.manual`) into the open path.
+- Preserved autonomous path behavior by keeping the default source as `execution.strategy_trigger.autonomous` when no explicit manual source is passed.
+- Added rejection payload normalization at blocked-open trace recording so `outcome_data.execution_rejection.reason` remains directly readable at a flat consumer-facing path.
+- Added focused Phase 3 execution-isolation tests for manual source attribution, autonomous source attribution, and flat blocked-open rejection schema.
+
+This change is explicitly a **follow-up fix** on the PR #396 execution-isolation chain.
+
+## 2. Current System Architecture
+
+Execution entry-point attribution now separates source intent without broad contract changes:
+
+- `telegram.command_handler` command-driven `/trade test` flow calls `StrategyTrigger.evaluate(..., open_source="execution.command_handler.trade_open.manual")`.
+- `execution.strategy_trigger` retains autonomous default source (`execution.strategy_trigger.autonomous`) for non-command-triggered opens.
+- `execution.strategy_trigger` writes `open_source` into `position_context` at open-time.
+- Blocked-open terminal traces keep `outcome_data.execution_rejection` flat for compatibility with existing trace consumers/tests.
+
+## 3. Files Created / Modified (full paths)
+
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+
+## 4. What Is Working
+
+- Manual `/trade` open path now passes explicit manual source attribution into the execution open context.
+- Autonomous open path still defaults to autonomous source attribution.
+- Blocked-open rejection payload remains assertion-friendly and flat at:
+  - `outcome_data.execution_rejection.reason`
+
+**Focused tests executed:**
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` → `3 passed`
+- `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` → pass
+
+## 5. Known Issues
+
+- Environment warning remains in pytest output: unknown config option `asyncio_mode`.
+- No additional execution-path scope was expanded in this fix pass by design.
+
+## 6. What Is Next
+
+SENTINEL validation required for `pr396-execution-isolation-review-fix-sync` before merge.  
+Source: `reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`  
+Tier: MAJOR

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -459,7 +459,10 @@ class CommandHandler:
                 target_pnl=20.0,
             ),
         )
-        result = await trigger.evaluate(0.42)
+        result = await trigger.evaluate(
+            0.42,
+            open_source="execution.command_handler.trade_open.manual",
+        )
         await engine.update_mark_to_market({market: 0.46})
         payload = await export_execution_payload()
         get_portfolio_service().merge_execution_state(

--- a/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from projects.polymarket.polyquantbot.execution.engine import ExecutionEngine
+from projects.polymarket.polyquantbot.execution.models import Position
+from projects.polymarket.polyquantbot.execution.strategy_trigger import (
+    StrategyAggregationDecision,
+    StrategyCandidateScore,
+    StrategyConfig,
+    StrategyTrigger,
+)
+
+
+def _build_aggregation() -> StrategyAggregationDecision:
+    candidate = StrategyCandidateScore(
+        strategy_name="S1",
+        decision="ENTER",
+        reason="test_signal",
+        edge=0.06,
+        confidence=0.9,
+        score=0.95,
+        market_metadata={"market_id": "MARKET-1", "title": "Test Market"},
+    )
+    return StrategyAggregationDecision(
+        selected_trade="S1",
+        ranked_candidates=[candidate],
+        selection_reason="highest_score",
+        top_score=0.95,
+        decision="ENTER",
+    )
+
+
+def _seed_risk_state_file(path: Path) -> None:
+    path.write_text(
+        (
+            '{"correlated_exposure_ratio":0.0,'
+            '"daily_pnl_by_day":{},'
+            '"drawdown_ratio":0.0,'
+            '"equity":10000.0,'
+            '"global_trade_block":false,'
+            '"open_trades":0,'
+            '"peak_equity":10000.0,'
+            '"portfolio_pnl":0.0,'
+            '"version":1}'
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_trigger() -> StrategyTrigger:
+    state_file = Path(tempfile.mkstemp(suffix="_phase3_execution_isolation_risk_state.json")[1])
+    _seed_risk_state_file(state_file)
+    trigger = StrategyTrigger(
+        engine=ExecutionEngine(starting_equity=10_000.0),
+        config=StrategyConfig(
+            market_id="MARKET-1",
+            threshold=0.60,
+            target_pnl=2.0,
+            risk_state_persistence_path=str(state_file),
+        ),
+    )
+    trigger._cooldown_seconds = 0.0  # noqa: SLF001
+    trigger._intelligence.evaluate_entry = lambda _snapshot: {"score": 1.0, "reasons": ["test"]}  # type: ignore[assignment] # noqa: SLF001
+    return trigger
+
+
+def _market_context() -> dict[str, Any]:
+    return {
+        "expected_value": 0.10,
+        "liquidity_usd": 50_000.0,
+        "spread": 0.01,
+        "best_bid": 0.445,
+        "best_ask": 0.455,
+    }
+
+
+def test_manual_trade_open_source_is_distinct_from_autonomous_source() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        captured_contexts: list[dict[str, Any]] = []
+
+        async def _open_position_spy(**kwargs: Any) -> Position:
+            captured_contexts.append(dict(kwargs.get("position_context") or {}))
+            return Position(
+                market_id="MARKET-1",
+                market_title="Test Market",
+                side="YES",
+                entry_price=0.45,
+                current_price=0.45,
+                size=100.0,
+                position_id=str(kwargs.get("position_id", "manual-id")),
+            )
+
+        trigger._engine.open_position = _open_position_spy  # type: ignore[assignment] # noqa: SLF001
+
+        manual_result = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context=_market_context(),
+            open_source="execution.command_handler.trade_open.manual",
+        )
+
+        assert manual_result == "OPENED"
+        assert captured_contexts[0]["open_source"] == "execution.command_handler.trade_open.manual"
+
+    asyncio.run(_run())
+
+
+def test_autonomous_open_source_remains_strategy_trigger_default() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+        captured_contexts: list[dict[str, Any]] = []
+
+        async def _open_position_spy(**kwargs: Any) -> Position:
+            captured_contexts.append(dict(kwargs.get("position_context") or {}))
+            return Position(
+                market_id="MARKET-1",
+                market_title="Test Market",
+                side="YES",
+                entry_price=0.45,
+                current_price=0.45,
+                size=100.0,
+                position_id=str(kwargs.get("position_id", "auto-id")),
+            )
+
+        trigger._engine.open_position = _open_position_spy  # type: ignore[assignment] # noqa: SLF001
+
+        autonomous_result = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context=_market_context(),
+        )
+
+        assert autonomous_result == "OPENED"
+        assert captured_contexts[0]["open_source"] == "execution.strategy_trigger.autonomous"
+
+    asyncio.run(_run())
+
+
+def test_blocked_open_rejection_payload_schema_stays_flat() -> None:
+    async def _run() -> None:
+        trigger = _build_trigger()
+
+        async def _reject_open(**_kwargs: Any) -> None:
+            return None
+
+        trigger._engine.open_position = _reject_open  # type: ignore[assignment] # noqa: SLF001
+        trigger._engine.get_last_open_rejection = lambda: {  # type: ignore[assignment] # noqa: SLF001
+            "execution_rejection": {
+                "reason": "max_position_size_exceeded",
+                "position_size": 1500.0,
+            },
+        }
+
+        result = await trigger.evaluate(
+            market_price=0.45,
+            aggregation_decision=_build_aggregation(),
+            market_context=_market_context(),
+        )
+
+        assert result == "BLOCKED"
+        trace = next(iter(trigger._trade_traceability.values()))  # noqa: SLF001
+        rejection_payload = trace["outcome_data"]["execution_rejection"]
+        assert rejection_payload["reason"] == "max_position_size_exceeded"
+        assert "execution_rejection" not in rejection_payload
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Preserve distinct source attribution between command-driven `/trade` opens and autonomous trigger opens so user-initiated opens are not mislabeled as autonomous. 
- Maintain backward-compatible, flat blocked-open rejection payload shape so existing trace consumers/tests can read `execution_rejection.reason` directly. 
- Sync branch-local reporting and `PROJECT_STATE.md` to classify this follow-up as MAJOR execution work and preserve Phase 2 roadmap truth.

### Description
- Added an `open_source` parameter to `StrategyTrigger.evaluate(...)` with default `execution.strategy_trigger.autonomous` and wrote `open_source` into `position_context` at open time in `projects/polymarket/polyquantbot/execution/strategy_trigger.py`.
- Normalized engine rejection payloads via `StrategyTrigger._normalize_execution_rejection_payload(...)` and used it before recording blocked-open terminal traces so the rejection is flattened for consumers.
- Wired command-driven `/trade test` flow in `projects/polymarket/polyquantbot/telegram/command_handler.py` to call `trigger.evaluate(..., open_source="execution.command_handler.trade_open.manual")` so manual opens are attributed separately.
- Added focused tests `projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` validating manual vs autonomous attribution and flat blocked-open rejection schema.
- Created forge report `projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md` documenting the change (Validation Tier: MAJOR, Claim Level: NARROW INTEGRATION) and updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` to reflect the MAJOR classification and NEXT PRIORITY to SENTINEL re-run.

### Testing
- Ran byte-compile check: `python -m py_compile projects/polymarket/polyquantbot/execution/strategy_trigger.py projects/polymarket/polyquantbot/telegram/command_handler.py projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` — passed.
- Executed focused pytest: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` — `3 passed` (one non-fatal pytest config warning about `asyncio_mode` observed).
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f502cea8832e80e58ab036b94a00)