### PR TITLE
chore: SENTINEL rerun for PR #396 execution-isolation chain

### DIFF
--- a/projects/polymarket/polyquantbot/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/PROJECT_STATE.md
@@ -1,29 +1,27 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-📅 Last Updated : 2026-04-11 02:29
-🔄 Status       : PR #396 review fix pass applied for execution isolation boundary with atomic open rejection handling, public gateway engine property, and traceability lookup optimization.
+📅 Last Updated : 2026-04-11 08:30
+🔄 Status       : SENTINEL MAJOR rerun for PR #396 execution-isolation chain completed on current branch state with BLOCKED verdict due missing forge artifact continuity and attribution/rejection-schema validation gaps.
 
 ✅ COMPLETED
-- Added `self._open_lock` to `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py` and wrapped open attempt + rejection lookup atomically.
-- Added public `engine` property to execution isolation gateway and switched singleton guard check to property access.
-- Cached close-rejection trace lookup in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`.
-- Added focused concurrent lock behavior test in `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`.
-- FORGE review-fix report added:
-  - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
+- Ran SENTINEL MAJOR rerun for PR #396 execution-isolation scope on current branch state snapshot.
+- Produced rerun report at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md`.
+- Revalidated gateway presence and autonomous/manual close routing through execution isolation boundary.
+- Executed focused compile gate and focused pytest evidence collection for execution-isolation scope.
 
 🔧 IN PROGRESS
-- None.
+- FORGE-X remediation for missing `24_55` artifact continuity and runtime behavior gaps (manual open attribution split and flat rejection payload compatibility).
 
 📋 NOT STARTED
-- SENTINEL validation pass for original MAJOR Phase 3 isolation foundation.
 - Live Polymarket wallet/auth execution integration.
 - Multi-user execution queue workers and websocket subscriptions.
 - Public API and UI clients for multi-user platform controls.
 
 🎯 NEXT PRIORITY
-- Codex auto PR review + COMMANDER review required before merge. Source: reports/forge/24_54_pr396_review_fix_pass.md. Tier: STANDARD
+- FORGE-X remediation required before revalidation. Source: reports/sentinel/24_56_pr396_execution_isolation_rerun.md. Tier: MAJOR
 
 ⚠️ KNOWN ISSUES
-- Long-term fix pending: refactor `ExecutionEngine.open_position` to return result + rejection payload directly and remove dependency on post-call rejection fetch.
-- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking for this task).
-- `PLATFORM_STORAGE_BACKEND=sqlite` is scaffold-mapped to local JSON backend in this foundation phase.
+- Missing forge artifact: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`.
+- Command-driven `/trade` open attribution is not yet verified as distinct from autonomous open source path.
+- Blocked-open rejection payload compatibility at `execution_rejection.reason` failed focused regression check.
+- Pytest warning: unknown config option `asyncio_mode` in current environment (non-blocking).

--- a/projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md
@@ -1,0 +1,141 @@
+# SENTINEL Report — 24_56_pr396_execution_isolation_rerun
+
+**Validation Tier:** MAJOR  
+**Claim Level:** FULL RUNTIME INTEGRATION  
+**Validation Target:**
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/execution_isolation.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/execution/strategy_trigger.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/telegram/command_handler.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_53_phase3_execution_isolation_foundation.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_54_pr396_review_fix_pass.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+- `/workspace/walker-ai-team/projects/polymarket/polyquantbot/PROJECT_STATE.md`
+**Not in Scope:** untouched subsystems outside declared execution-entry surfaces unless required by direct dependency evidence
+
+---
+
+## 🧪 TEST PLAN
+
+| Phase | Gate | Result |
+|---|---|---|
+| 0 | Actual-head + artifact + state traceability | ❌ FAIL |
+| 1 | Code-presence gate (gateway + entry surfaces) | ✅ PASS |
+| 2 | Runtime behavior gate (autonomous/manual paths, attribution, rejection schema) | ❌ FAIL |
+| 3 | Focused compile/import/test evidence | ❌ FAIL (mixed results) |
+| 4 | Claim/safety gate vs FULL RUNTIME INTEGRATION | ❌ FAIL |
+
+---
+
+## 🔍 FINDINGS
+
+### Phase 0 — Actual-head and traceability gate
+
+- Local git branch context in Codex worktree is `work` and no remote is configured, so branch `feature/implement-execution-isolation-for-phase-3-2026-04-11` could not be fetched/checked out directly in this environment.
+- Required forge artifacts:
+  - `24_53_phase3_execution_isolation_foundation.md` ✅ present
+  - `24_54_pr396_review_fix_pass.md` ✅ present
+  - `24_55_pr396_attribution_and_rejection_schema_fix.md` ❌ missing
+- `PROJECT_STATE.md` still points to STANDARD next-step (`24_54`) and does not yet reflect a completed MAJOR sentinel rerun chain.
+
+**Result:** Traceability gate failed due missing `24_55` artifact and stale state chain.
+
+### Phase 1 — Code-presence gate
+
+- `ExecutionIsolationGateway` exists and is wired as singleton gateway (`get_execution_isolation_gateway`).
+- Autonomous trigger route uses gateway for open and close:
+  - `self._execution_gateway.open_position(...)`
+  - `self._execution_gateway.close_position(...)`
+- Manual close route uses gateway:
+  - `execution_gateway.close_position(source_path="telegram.command_handler.manual", ...)`
+
+**Result:** Code-presence gate passed for declared touched entry surfaces.
+
+### Phase 2 — Runtime behavior gate
+
+#### 2.1 Autonomous trigger open/close via gateway
+PASS — both autonomous open and close route through gateway.
+
+#### 2.2 Manual close path via gateway
+PASS — `/trade close` manual close path routes through gateway.
+
+#### 2.3 Command-driven open attribution separation (manual vs autonomous)
+FAIL — `/trade test` creates `StrategyTrigger` and executes `trigger.evaluate(...)` without a distinct manual-open source marker, while gateway open source path remains `execution.strategy_trigger.autonomous`.
+
+#### 2.4 Blocked-open rejection payload compatibility
+FAIL — blocked open trace payload shape is nested via `{"execution_rejection": {"engine_rejection": {...}}}` from gateway details, not flat at `execution_rejection.reason` as required.
+
+### Phase 3 — Focused validation evidence
+
+#### Compile gate
+- `python -m py_compile` passed for all declared modules/tests in target scope.
+
+#### Focused pytest gate
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+  - ✅ 5 passed
+  - ⚠️ env warning: unknown config option `asyncio_mode`
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py -k execution_rejection_reason_for_sizing_block`
+  - ❌ failed
+  - observed outcome reason `invalid_market_data` and nested rejection payload, contradicting required flat `execution_rejection.reason` compatibility target
+
+### Phase 4 — Claim/safety gate (MAJOR, FULL RUNTIME INTEGRATION)
+
+Given missing required forge artifact `24_55`, lack of verified manual-open attribution separation, and rejection-payload compatibility failure under focused regression evidence, the declared FULL RUNTIME INTEGRATION claim is not validated on this branch state.
+
+---
+
+## ⚠️ CRITICAL ISSUES
+
+1. Missing required forge artifact for claimed fix chain:
+   - `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md`
+2. Manual `/trade` open attribution not proven distinct from autonomous open route.
+3. Blocked-open rejection payload compatibility at `execution_rejection.reason` not preserved in focused regression evidence.
+
+---
+
+## 📊 STABILITY SCORE
+
+| Category | Weight | Score |
+|---|---:|---:|
+| Traceability and artifact chain | 20 | 6 |
+| Code-presence gating | 20 | 18 |
+| Runtime behavior coverage | 30 | 12 |
+| Focused test evidence | 20 | 10 |
+| Claim-level alignment | 10 | 2 |
+| **Total** | **100** | **48 / 100** |
+
+Verdict threshold policy:
+- APPROVED: ≥85 and zero critical
+- CONDITIONAL: 60–84
+- BLOCKED: <60 or any critical
+
+**Result: BLOCKED (48/100, critical issues present).**
+
+---
+
+## 🚫 GO-LIVE STATUS
+
+**BLOCKED** — this rerun supersedes stale conclusions from PR #397 for this scope and records current branch evidence as non-approvable until attribution/rejection-schema chain is fully consistent and traceable.
+
+---
+
+## 🛠 RECOMMENDED FORGE-X FOLLOW-UP
+
+1. Restore/commit missing forge report `24_55_pr396_attribution_and_rejection_schema_fix.md` with traceable evidence and metadata.
+2. Ensure `/trade` command-driven opens carry explicit manual source attribution distinct from autonomous open path.
+3. Normalize blocked-open rejection payload so downstream traceability remains compatible at `execution_rejection.reason`.
+4. Re-run focused regression:
+   - `test_phase3_execution_isolation_foundation_20260411.py`
+   - `test_p16_execution_validation_risk_enforcement_20260409.py -k execution_rejection_reason_for_sizing_block`
+5. Request SENTINEL rerun after forge chain is complete.
+
+---
+
+## Evidence Commands
+
+- `git rev-parse --abbrev-ref HEAD`
+- `git remote -v`
+- `for f in ...24_53...24_54...24_55...; do [ -f "$f" ] ...; done`
+- `python -m py_compile ...`
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py -k execution_rejection_reason_for_sizing_block`


### PR DESCRIPTION
### Motivation

- Re-run a MAJOR SENTINEL validation on the actual PR #396 head to replace stale conclusions and verify the execution-isolation fixes and attribution/rejection-schema behavior.
- Ensure traceability of forge artifacts and confirm the gateway-based execution-entry surfaces behave per the FULL RUNTIME INTEGRATION claim.

### Description

- Added a new SENTINEL report at `projects/polymarket/polyquantbot/reports/sentinel/24_56_pr396_execution_isolation_rerun.md` that documents phase gates, findings, score, and a final verdict of `BLOCKED` for the current branch state.
- Updated `projects/polymarket/polyquantbot/PROJECT_STATE.md` to record the rerun (report-first, state-second) with timestamp, updated status, `NEXT PRIORITY` pointing to FORGE-X remediation, and `⚠️ KNOWN ISSUES` listing missing artifact and runtime gaps.
- Key files referenced/verified: `projects/polymarket/polyquantbot/execution/execution_isolation.py`, `projects/polymarket/polyquantbot/execution/strategy_trigger.py`, `projects/polymarket/polyquantbot/telegram/command_handler.py`, `projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py`, and forge reports `24_53` & `24_54` (note: `24_55` is missing).

### Testing

- Syntax/compile gate: ran `python -m py_compile` on the target modules and it passed for the declared files (compile: PASS).
- Focused pytest: ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase3_execution_isolation_foundation_20260411.py` and it passed (`5 passed`, 1 warning).
- Regression/assertion evidence: ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_p16_execution_validation_risk_enforcement_20260409.py -k execution_rejection_reason_for_sizing_block` and observed a failing assertion where the rejection reason was `invalid_market_data` and the rejection payload was nested, contradicting the required flat `execution_rejection.reason` shape (test: FAIL); running the same test without `PYTHONPATH` produced a collection error initially (`ModuleNotFoundError: No module named 'projects'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da06537c70832e93bbe1ce7eafdfd7)