### PR TITLE
chore/infra: deploy live dashboard to GitHub Pages docs/

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-11 12:00
-- Status        : SENTINEL APPROVED — Resolver purity surgical fix (PR #394) validated APPROVED (score 96/100, 0 critical issues). PR is merge-eligible from SENTINEL perspective. COMMANDER merge decision pending.
+- Last Updated  : 2026-04-11 14:00
+- Status        : FORGE-X MINOR — Live Dashboard deployed to docs/ for GitHub Pages. docs/index.html + docs/LIVE_DASHBOARD.html committed to branch claude/deploy-dashboard-github-pages-nx06q. COMMANDER repository settings action required to enable GitHub Pages.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Live Dashboard GitHub Pages deployment (2026-04-11): created `docs/index.html` redirect entry point, confirmed `docs/LIVE_DASHBOARD.html` present; both files committed to branch `claude/deploy-dashboard-github-pages-nx06q`; report `projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md`; Validation Tier: MINOR.
 - SENTINEL validation complete for resolver purity surgical fix PR #394 (2026-04-11): verdict **APPROVED**, score **96/100**, 0 critical issues; compile gate passed on all 9 files, 5/5 import chains pass, resolver read-only purity AST-verified, ensure_* isolation confirmed, bridge constructor aligned, activation monitor task-exception containment verified, 11/11 tests pass; report `projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_revalidation_pr394.md`.
 - Resolver purity surgical fix / PR392 unblock (2026-04-11): eliminated resolver.py `=> None:` syntax error, fixed test_platform_phase2 `From __future__` + malformed env string, removed all `upsert` calls from `resolve_*` methods (AccountService / WalletAuthService / PermissionService), added `ensure_*` write-path counterparts, aligned LegacyContextBridge ContextResolver constructor (removed unsupported `execution_context_repository` / `audit_event_repository` params), hardened SystemActivationMonitor with `_safe_task` done-callback and non-fatal `_assert_loop` warning path, created import-chain test and forge report; 11 tests pass; report `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`.
 - P17 execution proof lifecycle (2026-04-09): implemented immutable validation proofs with dynamic TTL policy, DB-backed proof registry (`validation_proofs`), authoritative execution-boundary proof verification (existence/status/TTL/context/atomic consume), StrategyTrigger integration, and focused replay/expiry/context/restart/race/no-bypass tests; report `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`.
@@ -277,7 +278,13 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-COMMANDER merge decision required for PR #394 (resolver purity surgical fix).
+Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required for Live Dashboard GitHub Pages deployment.
+Source: projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md
+Branch: claude/deploy-dashboard-github-pages-nx06q
+Tier: MINOR
+Action: COMMANDER to enable GitHub Pages in repository settings (Source: docs/ folder on target branch) after merge.
+
+COMMANDER merge decision also required for PR #394 (resolver purity surgical fix).
 SENTINEL verdict: APPROVED (score 96/100, 0 critical issues).
 Report: projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_revalidation_pr394.md
 Branch: claude/fix-resolver-purity-pr392-Ujo1o

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="0; url=LIVE_DASHBOARD.html">
+<title>Walker AI — Redirecting...</title>
+</head>
+<body>
+<p>Redirecting to <a href="LIVE_DASHBOARD.html">Live Dashboard</a>...</p>
+</body>
+</html>

--- a/projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md
@@ -1,0 +1,80 @@
+# FORGE-X Report — 25_7 — Deploy Live Dashboard to GitHub Pages
+
+**Date:** 2026-04-11
+**Role:** FORGE-X
+**Task:** Deploy LIVE_DASHBOARD.html to docs/ folder for GitHub Pages access
+**Branch:** claude/deploy-dashboard-github-pages-nx06q
+
+---
+
+## Validation Tier: MINOR
+## Claim Level: FOUNDATION
+## Validation Target: Static HTML file deployment to docs/ for GitHub Pages
+## Not in Scope: Trading logic, runtime behavior, execution pipeline, risk layer, API integrations
+
+---
+
+## 1. What Was Built
+
+Deployed the Walker AI Live Dashboard static HTML file to the `docs/` folder to enable GitHub Pages access.
+
+Two files are now present in `docs/` for GitHub Pages:
+- `docs/LIVE_DASHBOARD.html` — the full live dashboard (was already present in repo)
+- `docs/index.html` — new redirect entry point using `<meta http-equiv="refresh">` to forward visitors to `LIVE_DASHBOARD.html`
+
+With GitHub Pages configured to serve from the `docs/` folder on the target branch, the dashboard will be accessible at the repository's GitHub Pages URL.
+
+---
+
+## 2. Current System Architecture
+
+```
+GitHub Pages (docs/ folder)
+├── docs/index.html          ← entry point — auto-redirects to LIVE_DASHBOARD.html
+└── docs/LIVE_DASHBOARD.html ← full Walker AI live dashboard HTML file
+```
+
+No changes to trading runtime, execution pipeline, risk layer, or any backend logic.
+This is a purely static file deployment concern.
+
+---
+
+## 3. Files Created / Modified (Full Paths)
+
+**Created:**
+- `docs/index.html` — redirect entry point for GitHub Pages root URL
+
+**Pre-existing (confirmed present, no modifications):**
+- `docs/LIVE_DASHBOARD.html` — Walker AI Live Dashboard HTML file
+
+---
+
+## 4. What Is Working
+
+- `docs/LIVE_DASHBOARD.html` confirmed present with correct Walker AI dashboard HTML content
+- `docs/index.html` created with `<meta http-equiv="refresh" content="0; url=LIVE_DASHBOARD.html">` redirect
+- Both files committed to branch `claude/deploy-dashboard-github-pages-nx06q`
+- GitHub Pages will serve `docs/index.html` as root, immediately redirecting to `LIVE_DASHBOARD.html`
+
+---
+
+## 5. Known Issues
+
+- None. Static file deployment only — no runtime implications.
+- GitHub Pages must be configured in repository settings to serve from `docs/` folder on the target branch. This is a repository settings action for COMMANDER.
+
+---
+
+## 6. What Is Next
+
+- COMMANDER: Configure GitHub Pages in repository settings → Source: `docs/` folder on the relevant branch
+- COMMANDER: Verify dashboard is accessible at the GitHub Pages URL after Pages build completes
+- No SENTINEL validation required (MINOR tier)
+
+---
+
+## Suggested Next Step
+
+COMMANDER to enable GitHub Pages in repository settings with source set to `docs/` folder. Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required.
+Source: `projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md`
+Tier: MINOR


### PR DESCRIPTION
## Summary

- `docs/LIVE_DASHBOARD.html` — confirmed present (Walker AI Live Dashboard)
- `docs/index.html` — created; `<meta http-equiv="refresh">` redirects root GitHub Pages URL to `LIVE_DASHBOARD.html`
- Forge report `25_7_deploy_live_dashboard_github_pages.md` written (MINOR tier)
- `PROJECT_STATE.md` updated (7 sections only)

## Done Criteria

- [x] `docs/LIVE_DASHBOARD.html` exists
- [x] `docs/index.html` exists with redirect
- [x] PR on `claude/deploy-dashboard-github-pages-nx06q`

## Validation Tier

MINOR — static file deployment only, no runtime behavior changes.

## COMMANDER Action Required

After merge: enable GitHub Pages in repository Settings → Pages → Source: `docs/` folder on `main` branch.

## Report

`projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md`

https://claude.ai/code/session_01FQ968GDbbXSTu17hFtAdcv