### PR TITLE
Unblock PR #408: Reconcile PROJECT_STATE.md & ROADMAP.md (docs-only)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,13 +1,14 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-11 14:00
-- Status        : FORGE-X MINOR — Live Dashboard deployed to docs/ for GitHub Pages. docs/index.html + docs/LIVE_DASHBOARD.html committed to branch claude/deploy-dashboard-github-pages-nx06q. COMMANDER repository settings action required to enable GitHub Pages.
+- Last Updated  : 2026-04-11 15:05
+- Status        : FORGE-X MINOR — PR #408 mergeability reconcile pass completed on branch feature/sync-repository-truth-after-phase-2-merge-2026-04-11 with docs-only repo-truth sync preserved; awaiting COMMANDER merge re-check.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
 - Live Dashboard GitHub Pages deployment (2026-04-11): created `docs/index.html` redirect entry point, confirmed `docs/LIVE_DASHBOARD.html` present; both files committed to branch `claude/deploy-dashboard-github-pages-nx06q`; report `projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md`; Validation Tier: MINOR.
+- PR #408 mergeability unblock + repo-truth reconcile (2026-04-11): reconciled root `PROJECT_STATE.md` + `ROADMAP.md` against current repo truth, corrected Phase 2.6 status continuity, and documented non-mergeable root cause/remediation in `projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md`; docs/report scope only; Validation Tier: MINOR.
 - SENTINEL validation complete for resolver purity surgical fix PR #394 (2026-04-11): verdict **APPROVED**, score **96/100**, 0 critical issues; compile gate passed on all 9 files, 5/5 import chains pass, resolver read-only purity AST-verified, ensure_* isolation confirmed, bridge constructor aligned, activation monitor task-exception containment verified, 11/11 tests pass; report `projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_revalidation_pr394.md`.
 - Resolver purity surgical fix / PR392 unblock (2026-04-11): eliminated resolver.py `=> None:` syntax error, fixed test_platform_phase2 `From __future__` + malformed env string, removed all `upsert` calls from `resolve_*` methods (AccountService / WalletAuthService / PermissionService), added `ensure_*` write-path counterparts, aligned LegacyContextBridge ContextResolver constructor (removed unsupported `execution_context_repository` / `audit_event_repository` params), hardened SystemActivationMonitor with `_safe_task` done-callback and non-fatal `_assert_loop` warning path, created import-chain test and forge report; 11 tests pass; report `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`.
 - P17 execution proof lifecycle (2026-04-09): implemented immutable validation proofs with dynamic TTL policy, DB-backed proof registry (`validation_proofs`), authoritative execution-boundary proof verification (existence/status/TTL/context/atomic consume), StrategyTrigger integration, and focused replay/expiry/context/restart/race/no-bypass tests; report `projects/polymarket/polyquantbot/reports/forge/24_40_execution_proof_lifecycle_ttl_replay_safety.md`.
@@ -278,16 +279,10 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
-Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required for Live Dashboard GitHub Pages deployment.
-Source: projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md
-Branch: claude/deploy-dashboard-github-pages-nx06q
+Auto PR review + COMMANDER review required before merge.
+Source: projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md
 Tier: MINOR
-Action: COMMANDER to enable GitHub Pages in repository settings (Source: docs/ folder on target branch) after merge.
-
-COMMANDER merge decision also required for PR #394 (resolver purity surgical fix).
-SENTINEL verdict: APPROVED (score 96/100, 0 critical issues).
-Report: projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_revalidation_pr394.md
-Branch: claude/fix-resolver-purity-pr392-Ujo1o
+Action: COMMANDER to re-check PR #408 mergeability on GitHub after this branch update is pushed.
 
 ## ⚠️ KNOWN ISSUES
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,11 +113,13 @@
 ### Platform Shell
 | # | Task | Status | Notes |
 |---|---|---|---|
-| 2.6 | Create platform folder structure (platform/gateway, accounts, wallet_auth) | ❌ | |
+| 2.6 | Create platform folder structure (platform/gateway, accounts, wallet_auth) | ✅ | Merged via PR #408 chain (Phase 2 foundation shell) |
 | 2.7 | Build public API/app gateway skeleton | ❌ | |
 | 2.8 | Add legacy-core facade adapter | ❌ | |
 | 2.9 | Add dual-mode routing (legacy + platform path) | ❌ | |
 | 2.10 | Staging deploy on Fly.io | ❌ | Migration from Railway pending |
+
+> Sequencing note: continue implementation order `2.8 -> 2.7 -> 2.9` for Phase 2 shell continuity, only while it remains consistent with current repo truth.
 
 ### Multi-User DB Schema
 | # | Task | Status | Notes |

--- a/projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md
@@ -1,0 +1,51 @@
+# FORGE-X Report — 24_59_phase2_repo_truth_sync_after_24_58_merge
+
+**Validation Tier:** MINOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** /workspace/walker-ai-team/PROJECT_STATE.md ; /workspace/walker-ai-team/ROADMAP.md ; /workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md  
+**Not in Scope:** runtime/code changes under /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/; execution/risk/strategy behavior changes; PR #409 branch changes; reintroducing project-local PROJECT_STATE.md; SENTINEL/BRIEFER work; broad historical drift cleanup beyond PR #408 mergeability unblock  
+**Suggested Next Step:** Auto PR review + COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md. Tier: MINOR
+
+---
+
+## 1. What was built
+
+- Performed a docs-only reconciliation pass to unblock PR #408 mergeability while preserving the original repository-truth-sync objective.
+- Reconciled root `PROJECT_STATE.md` and `ROADMAP.md` with current repository truth in the touched scope (Phase 2 continuity + current handoff state).
+- Added this follow-up forge report documenting root cause, exact files reconciled, and scope boundaries.
+
+## 2. Current system architecture
+
+- Runtime architecture is unchanged.
+- No execution, risk, strategy, platform runtime, or API behavior was modified.
+- This is a documentation/state consistency reconciliation only.
+
+## 3. Files created / modified (full paths)
+
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md`
+
+## 4. What is working
+
+- Root cause for PR non-mergeability was reconciled as branch drift in docs/state files against newer repository truth on mainline continuity (`PROJECT_STATE.md` and `ROADMAP.md`).
+- `PROJECT_STATE.md` now reflects the PR #408 reconcile outcome and a MINOR-tier review handoff line for COMMANDER re-check.
+- `ROADMAP.md` Phase 2.6 status is aligned as completed/merged for the platform shell foundation chain, with sequencing note retained conditionally to avoid contradicting current truth.
+- Diff scope remains docs/report only; no runtime module files changed.
+
+## 5. Known issues
+
+- Direct GitHub UI mergeability status could not be verified from this container environment after local reconcile; COMMANDER re-check is still required after push.
+- PR #409 remains downstream follow-up work and was intentionally not modified in this task.
+
+## 6. What is next
+
+- Push this branch update to the existing PR #408 branch and re-check mergeability on GitHub.
+- Complete Codex auto PR review + COMMANDER review for this MINOR-tier docs/state reconcile before merge.
+
+## Validation commands run
+
+- `git status --short --branch`
+- `git log --oneline -- PROJECT_STATE.md ROADMAP.md`
+- `git diff -- PROJECT_STATE.md ROADMAP.md projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md`
+- `git diff --name-only`


### PR DESCRIPTION
### Motivation
- Resolve GitHub "Pull Request is not mergeable" caused by branch drift in repository state/docs while preserving the original docs-only repo-truth-sync intent for PR #408.

### Description
- Reconciled root `PROJECT_STATE.md` (timestamp, status, NEXT PRIORITY) and `ROADMAP.md` (mark Phase 2.6 completed + conditional sequencing note), added follow-up FORGE-X report at `projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md`, and committed all changes on branch `feature/sync-repository-truth-after-phase-2-merge-2026-04-11` with no runtime code modifications.

### Testing
- Ran validation commands `git status --short --branch`, `git diff --name-only`, `git log --oneline -- PROJECT_STATE.md ROADMAP.md`, `git diff -- PROJECT_STATE.md ROADMAP.md projects/polymarket/polyquantbot/reports/forge/24_59_phase2_repo_truth_sync_after_24_58_merge.md`, and a `find` check for `phase*` folders; all checks passed locally; GitHub UI mergeability could not be verified from this container and requires COMMANDER re-check on PR #408.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da83457fbc832e969c902b2218a4b7)