### PR TITLE
fix: phase 2.7 public/app gateway skeleton blockers for PR #413

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-11 14:00
-- Status        : FORGE-X MINOR — Live Dashboard deployed to docs/ for GitHub Pages. docs/index.html + docs/LIVE_DASHBOARD.html committed to branch claude/deploy-dashboard-github-pages-nx06q. COMMANDER repository settings action required to enable GitHub Pages.
+- Last Updated  : 2026-04-11 20:45
+- Status        : FORGE-X MAJOR — PR #413 Phase 2.7 FOUNDATION blocker-fix pass applied on branch feature/build-public/app-gateway-skeleton-2026-04-11; public/app gateway seam now composes safely and canonical tests execute; pending fresh SENTINEL rerun.
 
 ---
 
@@ -131,6 +131,10 @@ Status:
 ---
 
 ## 🚧 IN PROGRESS
+
+### PR #413 phase 2.7 gateway skeleton blocker-fix handoff
+- MAJOR-tier FOUNDATION blocker-fix is complete for public/app gateway skeleton seam: factory composition now uses `build_legacy_core_facade(...)`, invalid/absent mode fails closed to disabled, and non-activation semantics are test-enforced in canonical Phase 2.7 test artifact.
+- Awaiting fresh SENTINEL rerun against updated PR #413 branch head before merge.
 
 ### P17 execution proof lifecycle handoff
 - MAJOR-tier FULL RUNTIME INTEGRATION implementation is complete for StrategyTrigger→ExecutionEngine proof lifecycle enforcement (dynamic TTL, replay safety, persistence, fail-closed verifier, atomic consume).
@@ -278,6 +282,11 @@ Status:
 
 ## 🎯 NEXT PRIORITY
 
+SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md. Tier: MAJOR
+PR: #413
+Branch: feature/build-public/app-gateway-skeleton-2026-04-11
+Action: Run fresh SENTINEL rerun on updated blocker-fix head for Phase 2.7 FOUNDATION scope.
+
 Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required for Live Dashboard GitHub Pages deployment.
 Source: projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md
 Branch: claude/deploy-dashboard-github-pages-nx06q
@@ -291,6 +300,7 @@ Branch: claude/fix-resolver-purity-pr392-Ujo1o
 
 ## ⚠️ KNOWN ISSUES
 
+- PR #413 remains FOUNDATION-only for Phase 2.7: public/app gateway seam is intentionally non-activating, and production/public routing activation remains out of scope pending later phases.
 - Resolver purity fix (2026-04-11): `ensure_*` methods are not yet wired into `ContextResolver.resolve()` — resolver remains read-only by design; callers requiring persistence must invoke `ensure_*` directly.
 - Resolver purity fix (2026-04-11): `execution_context_repository` and `audit_event_repository` bundle fields are unused by the bridge after the constructor fix; their persistence is deferred to a future scope if needed.
 - P17 proof lifecycle currently uses lazy expiration enforcement at execution boundary; background cleanup of expired rows is deferred.

--- a/projects/polymarket/polyquantbot/api/app_gateway.py
+++ b/projects/polymarket/polyquantbot/api/app_gateway.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.gateway.gateway_factory import (
+    build_public_app_gateway,
+    resolve_public_app_gateway_mode,
+)
+from projects.polymarket.polyquantbot.platform.gateway.public_app_gateway import PublicAppGateway
+
+
+def create_public_app_gateway(*, mode: str | None = None) -> PublicAppGateway:
+    """Create the Phase 2.7 public/app gateway skeleton with safe defaults."""
+
+    selected_mode = resolve_public_app_gateway_mode(mode)
+    return build_public_app_gateway(mode=selected_mode)

--- a/projects/polymarket/polyquantbot/platform/gateway/gateway_factory.py
+++ b/projects/polymarket/polyquantbot/platform/gateway/gateway_factory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+from .facade_factory import (
+    LEGACY_CORE_FACADE_CONTEXT_RESOLVER,
+    LEGACY_CORE_FACADE_DISABLED,
+    LEGACY_CORE_FACADE_MODE_ENV,
+    build_legacy_core_facade,
+)
+from .public_app_gateway import PublicAppGateway
+
+PUBLIC_APP_GATEWAY_MODE_ENV = "PLATFORM_PUBLIC_APP_GATEWAY_MODE"
+PUBLIC_APP_GATEWAY_MODE_DISABLED = LEGACY_CORE_FACADE_DISABLED
+PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE = "legacy-facade"
+
+
+def resolve_public_app_gateway_mode(mode: str | None = None) -> str:
+    """Normalize public/app gateway mode with safe fallback semantics."""
+
+    raw_mode = mode if mode is not None else os.getenv(PUBLIC_APP_GATEWAY_MODE_ENV, PUBLIC_APP_GATEWAY_MODE_DISABLED)
+    normalized = raw_mode.strip().lower()
+    if normalized in {PUBLIC_APP_GATEWAY_MODE_DISABLED, PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE}:
+        return normalized
+    return PUBLIC_APP_GATEWAY_MODE_DISABLED
+
+
+def build_public_app_gateway(*, mode: str | None = None) -> PublicAppGateway:
+    """Build Phase 2.7 public/app gateway skeleton without runtime activation."""
+
+    selected_mode = resolve_public_app_gateway_mode(mode)
+    facade_mode = (
+        LEGACY_CORE_FACADE_CONTEXT_RESOLVER
+        if selected_mode == PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE
+        else LEGACY_CORE_FACADE_DISABLED
+    )
+    facade = build_legacy_core_facade(mode=facade_mode)
+    return PublicAppGateway(
+        mode=selected_mode,
+        legacy_core_facade=facade,
+        runtime_routing_active=False,
+    )

--- a/projects/polymarket/polyquantbot/platform/gateway/public_app_gateway.py
+++ b/projects/polymarket/polyquantbot/platform/gateway/public_app_gateway.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .legacy_core_facade import LegacyCoreFacade
+
+
+@dataclass(frozen=True)
+class PublicAppGateway:
+    """Foundation-only public/app gateway skeleton for Phase 2.7.
+
+    This seam is intentionally non-activating. It can compose legacy facade
+    dependencies for follow-up phases without enabling runtime routing.
+    """
+
+    mode: str
+    legacy_core_facade: LegacyCoreFacade
+    runtime_routing_active: bool = False
+
+    def is_active(self) -> bool:
+        """Return deterministic runtime activation state for this skeleton."""
+
+        return self.runtime_routing_active

--- a/projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md
@@ -1,0 +1,58 @@
+# FORGE-X Report — 24_61_phase2_7_public_app_gateway_blocker_fix_pr413
+
+**Validation Tier:** MAJOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway/gateway_factory.py ; /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway/public_app_gateway.py ; /workspace/walker-ai-team/projects/polymarket/polyquantbot/api/app_gateway.py ; /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py ; /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_legacy_core_facade_adapter_foundation_20260411.py  
+**Not in Scope:** Phase 2.9 dual-mode routing; production/public route activation; execution/risk/strategy/capital/settlement logic changes; resolver purity rewrites outside touched gateway seam; roadmap phase completion flips; new facade contracts beyond existing Phase 2.8 seam; broad refactor outside blocker-fix files  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md. Tier: MAJOR
+
+---
+
+## 1. What was built
+
+- Added Phase 2.7 gateway skeleton composition files for the public/app seam (`gateway_factory.py`, `public_app_gateway.py`, `api/app_gateway.py`) with deterministic non-activation semantics.
+- Implemented mode normalization with safe fallback (`disabled`) for absent/invalid public-app gateway mode values.
+- Enforced that legacy-facade composition in the gateway factory only goes through `build_legacy_core_facade(...)`.
+- Replaced hardcoded resolver mode usage in the new gateway composition path by consuming `LEGACY_CORE_FACADE_CONTEXT_RESOLVER`.
+- Added canonical Phase 2.7 seam test artifact at `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py` with deterministic assertions for non-activation behavior.
+
+## 2. Current system architecture
+
+- `platform/gateway/gateway_factory.py` is now the single mode-normalization + composition point for the public/app gateway skeleton.
+- `platform/gateway/public_app_gateway.py` holds a foundation-only immutable seam object with explicit non-activation runtime state.
+- `api/app_gateway.py` provides the API-facing constructor wrapper that normalizes mode and returns the non-activating skeleton.
+- `legacy-facade` mode can construct a legacy facade seam, but runtime routing remains inactive by contract (`runtime_routing_active=False`).
+- Invalid/unknown gateway mode inputs fail closed to `disabled`.
+
+## 3. Files created / modified (full paths)
+
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway/public_app_gateway.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway/gateway_factory.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/api/app_gateway.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md`
+
+## 4. What is working
+
+- Gateway factory no longer requires any direct `LegacyCoreFacade` instantiation path; facade composition is delegated through `build_legacy_core_facade(...)`.
+- Legacy-facade mode selection in gateway factory uses exported `LEGACY_CORE_FACADE_CONTEXT_RESOLVER` constant.
+- Disabled mode remains deterministic and inactive.
+- Legacy-facade mode constructs facade seam successfully while preserving non-activation runtime semantics.
+- Invalid public-app gateway mode values safely fall back to disabled mode.
+- Canonical Phase 2.7 test file executes from repo package root with `PYTHONPATH=/workspace/walker-ai-team`.
+
+## 5. Known issues
+
+- FOUNDATION claim only: no production route activation and no dual-mode runtime routing is introduced in this blocker-fix pass.
+- Pytest environment continues to emit existing warning for unknown `asyncio_mode` config option; focused tests pass.
+
+## 6. What is next
+
+- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md. Tier: MAJOR
+- If SENTINEL approves this blocker-fix head, proceed to COMMANDER merge decision for PR #413 Phase 2.7 FOUNDATION scope.
+
+## Validation commands run
+
+- `find /workspace/walker-ai-team -type d -name 'phase*'`
+- `python -m compileall /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway /workspace/walker-ai-team/projects/polymarket/polyquantbot/api /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py`
+- `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_legacy_core_facade_adapter_foundation_20260411.py`

--- a/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+
+from projects.polymarket.polyquantbot.api.app_gateway import create_public_app_gateway
+from projects.polymarket.polyquantbot.platform.gateway.facade_factory import (
+    LEGACY_CORE_FACADE_CONTEXT_RESOLVER,
+    LEGACY_CORE_FACADE_DISABLED,
+)
+from projects.polymarket.polyquantbot.platform.gateway.gateway_factory import (
+    PUBLIC_APP_GATEWAY_MODE_DISABLED,
+    PUBLIC_APP_GATEWAY_MODE_ENV,
+    PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE,
+    resolve_public_app_gateway_mode,
+)
+
+
+def test_phase2_7_gateway_disabled_mode_stays_non_activating() -> None:
+    os.environ.pop(PUBLIC_APP_GATEWAY_MODE_ENV, None)
+    gateway = create_public_app_gateway(mode=PUBLIC_APP_GATEWAY_MODE_DISABLED)
+
+    assert gateway.mode == PUBLIC_APP_GATEWAY_MODE_DISABLED
+    assert gateway.is_active() is False
+
+    resolution = gateway.legacy_core_facade.resolve_context(seed=_seed())
+    assert resolution.activated is False
+    assert resolution.source == LEGACY_CORE_FACADE_DISABLED
+    assert resolution.context_envelope is None
+
+
+def test_phase2_7_gateway_legacy_facade_mode_builds_seam_without_runtime_activation() -> None:
+    gateway = create_public_app_gateway(mode=PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE)
+
+    assert gateway.mode == PUBLIC_APP_GATEWAY_MODE_LEGACY_FACADE
+    assert gateway.is_active() is False
+
+    resolution = gateway.legacy_core_facade.resolve_context(seed=_seed())
+    assert resolution.activated is True
+    assert resolution.source == LEGACY_CORE_FACADE_CONTEXT_RESOLVER
+    assert resolution.context_envelope is not None
+
+
+def test_phase2_7_gateway_invalid_mode_falls_back_to_disabled() -> None:
+    assert resolve_public_app_gateway_mode("INVALID") == PUBLIC_APP_GATEWAY_MODE_DISABLED
+
+    os.environ[PUBLIC_APP_GATEWAY_MODE_ENV] = "BAD-MODE"
+    try:
+        gateway = create_public_app_gateway()
+    finally:
+        os.environ.pop(PUBLIC_APP_GATEWAY_MODE_ENV, None)
+
+    assert gateway.mode == PUBLIC_APP_GATEWAY_MODE_DISABLED
+    assert gateway.is_active() is False
+    resolution = gateway.legacy_core_facade.resolve_context(seed=_seed())
+    assert resolution.source == LEGACY_CORE_FACADE_DISABLED
+    assert resolution.activated is False
+
+
+def _seed() -> "LegacySessionSeed":
+    from projects.polymarket.polyquantbot.platform.context.resolver import LegacySessionSeed
+
+    return LegacySessionSeed(
+        user_id="gateway-user",
+        external_user_id="gateway-external-user",
+        mode="PAPER",
+        wallet_binding_id="gateway-wallet",
+        wallet_type="LEGACY_SESSION",
+        signature_type="SESSION",
+        funder_address="gateway-funder",
+        auth_state="UNVERIFIED",
+        allowed_markets=("MKT-GATEWAY",),
+        trace_id="trace-gateway",
+    )


### PR DESCRIPTION
### Motivation
- Remove unsafe direct instantiation paths and close a gateway composition drift that caused SENTINEL blockers on PR #413.  
- Provide a deterministic, non-activating Phase 2.7 public/app gateway seam so follow-up wiring can safely compose a legacy facade without enabling runtime routing.  
- Align tests and FORGE-X metadata so the branch is ready for a fresh SENTINEL rerun (FOUNDATION claim, MAJOR tier).

### Description
- Replaced the hardcoded legacy-context string and removed any direct `LegacyCoreFacade` construction by routing facade composition through `build_legacy_core_facade(...)` and consuming the exported `LEGACY_CORE_FACADE_CONTEXT_RESOLVER` constant.  
- Added a non-activating foundation seam `PublicAppGateway` and a gateway factory `build_public_app_gateway` + `resolve_public_app_gateway_mode` that normalizes mode with safe fallback to `disabled`.  
- Added an API wrapper `create_public_app_gateway` for canonical repo-root imports used by tests, and created the canonical Phase 2.7 test `tests/test_phase2_7_public_app_gateway_skeleton_20260411.py`.  
- Added FORGE-X report `projects/polymarket/polyquantbot/reports/forge/24_61_phase2_7_public_app_gateway_blocker_fix_pr413.md` and updated `PROJECT_STATE.md` to record the blocker-fix handoff and next step (SENTINEL rerun); Validation Tier: `MAJOR`; Claim Level: `FOUNDATION`.

### Testing
- Ran repository phase-folder check with `find /workspace/walker-ai-team -type d -name 'phase*'` which returned no forbidden `phase*` folders.  
- Verified Python compile sanity with `python -m compileall /workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/gateway /workspace/walker-ai-team/projects/polymarket/polyquantbot/api /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py` which completed successfully.  
- Executed tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_7_public_app_gateway_skeleton_20260411.py /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase2_legacy_core_facade_adapter_foundation_20260411.py` which passed (`7 passed`) with a single non-blocking pytest config warning about `asyncio_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab2520fb8832e88eb92a520a514a9)