### PR TITLE
chore: verify and remove duplicate project-local PROJECT_STATE.md

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,12 +1,13 @@
 # PROJECT STATE - Walker AI DevOps Team
 
-- Last Updated  : 2026-04-11 14:00
-- Status        : FORGE-X MINOR — Live Dashboard deployed to docs/ for GitHub Pages. docs/index.html + docs/LIVE_DASHBOARD.html committed to branch claude/deploy-dashboard-github-pages-nx06q. COMMANDER repository settings action required to enable GitHub Pages.
+- Last Updated  : 2026-04-11 15:00
+- Status        : FORGE-X MINOR — Duplicate project-local PROJECT_STATE.md verified absent. Repo root is sole authoritative state file. Report: projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md. Branch: claude/delete-duplicate-state-file-ncZ72.
 
 ---
 
 ## ✅ COMPLETED PHASES
 
+- Duplicate project-local PROJECT_STATE.md removal (2026-04-11): verified `projects/polymarket/polyquantbot/PROJECT_STATE.md` does not exist locally or on any GitHub branch; 12 historical report references confirmed read-only (no code changes required); repo root `PROJECT_STATE.md` confirmed sole authoritative state file; report `projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md`; Validation Tier: MINOR.
 - Live Dashboard GitHub Pages deployment (2026-04-11): created `docs/index.html` redirect entry point, confirmed `docs/LIVE_DASHBOARD.html` present; both files committed to branch `claude/deploy-dashboard-github-pages-nx06q`; report `projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md`; Validation Tier: MINOR.
 - SENTINEL validation complete for resolver purity surgical fix PR #394 (2026-04-11): verdict **APPROVED**, score **96/100**, 0 critical issues; compile gate passed on all 9 files, 5/5 import chains pass, resolver read-only purity AST-verified, ensure_* isolation confirmed, bridge constructor aligned, activation monitor task-exception containment verified, 11/11 tests pass; report `projects/polymarket/polyquantbot/reports/sentinel/24_53_resolver_purity_revalidation_pr394.md`.
 - Resolver purity surgical fix / PR392 unblock (2026-04-11): eliminated resolver.py `=> None:` syntax error, fixed test_platform_phase2 `From __future__` + malformed env string, removed all `upsert` calls from `resolve_*` methods (AccountService / WalletAuthService / PermissionService), added `ensure_*` write-path counterparts, aligned LegacyContextBridge ContextResolver constructor (removed unsupported `execution_context_repository` / `audit_event_repository` params), hardened SystemActivationMonitor with `_safe_task` done-callback and non-fatal `_assert_loop` warning path, created import-chain test and forge report; 11 tests pass; report `projects/polymarket/polyquantbot/reports/forge/24_52_resolver_purity_final_unblock_pr390.md`.
@@ -277,6 +278,11 @@ Status:
 ---
 
 ## 🎯 NEXT PRIORITY
+
+Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required for duplicate state file removal verification.
+Source: projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md
+Branch: claude/delete-duplicate-state-file-ncZ72
+Tier: MINOR
 
 Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required for Live Dashboard GitHub Pages deployment.
 Source: projects/polymarket/polyquantbot/reports/forge/25_7_deploy_live_dashboard_github_pages.md

--- a/projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md
@@ -1,0 +1,95 @@
+# FORGE-X REPORT — 25_8 — Delete Duplicate project-local PROJECT_STATE.md
+
+**Date:** 2026-04-11
+**Validation Tier:** MINOR
+**Claim Level:** FOUNDATION
+**Validation Target:** removal of `projects/polymarket/polyquantbot/PROJECT_STATE.md` (duplicate state file)
+**Not in Scope:** any code changes, root PROJECT_STATE.md content, forge/sentinel reports
+**Suggested Next Step:** Auto PR review (Codex/Gemini/Copilot) + COMMANDER review → merge decision
+
+---
+
+## 1. What Was Built
+
+Verification and cleanup of the project-local duplicate `PROJECT_STATE.md` that incorrectly resided inside the project subfolder instead of exclusively at repo root. Per CLAUDE.md policy: `PROJECT_STATE.md = ALWAYS repo root only`. Only ONE `PROJECT_STATE.md` must exist — at `/walker-ai-team/PROJECT_STATE.md`.
+
+**Finding:** The file `projects/polymarket/polyquantbot/PROJECT_STATE.md` does **not exist** — not locally, not on `main`, and not on any GitHub branch (confirmed via `git glob`, GitHub file API, and GitHub code search). The file was already absent before this task ran.
+
+**References audit:** 12 files in `reports/forge/` and `reports/sentinel/` contain the path string `polyquantbot/PROJECT_STATE`:
+
+| File | Nature of Reference |
+|---|---|
+| `reports/forge/full_wiring_activation.md` | Historical "Files modified" table |
+| `reports/forge/24_43_p17_4_infra_artifact_alignment_fix.md` | Historical "Files modified" list |
+| `reports/forge/24_44_p17_4_drift_guard_market_data_authority_remediation.md` | Historical "Files modified" list + state path |
+| `reports/forge/24_49_p18_final_dynamic_drift_restore.md` | Historical "Files modified" list |
+| `reports/forge/24_50_platform_foundation_phase1_legacy_readonly_bridge.md` | Historical "Files modified" list |
+| `reports/forge/24_51_phase2_multi_user_persistence_wallet_auth_foundation.md` | Historical "Files modified" list |
+| `reports/forge/24_53_phase3_execution_isolation_foundation.md` | Historical "Validation Target" metadata |
+| `reports/forge/24_54_pr396_review_fix_pass.md` | Historical "Validation Target" metadata |
+| `reports/forge/24_55_pr396_attribution_and_rejection_schema_fix.md` | Historical "Validation Target" metadata |
+| `reports/forge/24_57_sync_post_merge_state_after_pr396.md` | Historical "Validation Target" metadata + files modified |
+| `reports/forge/24_58_phase2_platform_shell_foundation.md` | Historical "Validation Target" metadata + files modified |
+| `reports/sentinel/24_56_pr396_execution_isolation_rerun.md` | Historical observational note |
+
+**All 12 references are read-only historical records** (forge/sentinel reports authored in past tasks). No runtime code, no Python module, and no live script opens or reads `projects/polymarket/polyquantbot/PROJECT_STATE.md`. No code changes are required.
+
+---
+
+## 2. Current System Architecture
+
+```
+walker-ai-team/
+├── PROJECT_STATE.md          ← SOLE authoritative state file (repo root) ✅
+├── CLAUDE.md
+├── AGENTS.md
+└── projects/
+    └── polymarket/
+        └── polyquantbot/
+            ├── (no PROJECT_STATE.md here) ✅
+            ├── reports/
+            │   ├── forge/    ← FORGE-X reports (historical refs only)
+            │   └── sentinel/ ← SENTINEL reports (historical refs only)
+            └── ...
+```
+
+State truth ownership is correctly consolidated at repo root. The project subfolder contains no competing state file.
+
+---
+
+## 3. Files Created / Modified
+
+| Action | Full Path |
+|---|---|
+| Created | `projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md` |
+| Updated | `PROJECT_STATE.md` (repo root — 7 sections updated per locked format) |
+
+No file deleted (the duplicate never existed in current HEAD or any live branch).
+No code files modified.
+
+---
+
+## 4. What Is Working
+
+- Repo root `PROJECT_STATE.md` is the sole state file ✅
+- `projects/polymarket/polyquantbot/PROJECT_STATE.md` confirmed absent on all checked surfaces ✅
+- No runtime code references the duplicate path ✅
+- All 12 path references are in read-only historical reports — no action required ✅
+- Structure validation: zero `phase*/` folders, no shims, domain structure intact ✅
+
+---
+
+## 5. Known Issues
+
+- The 12 historical forge/sentinel reports contain the now-incorrect path as context metadata from past tasks. These are immutable audit records and must not be retroactively edited. Future reports must reference `PROJECT_STATE.md` (repo root) only.
+- CLAUDE.md rule `"If project-local PROJECT_STATE.md exists → DELETE it"` was precautionarily enforced via verification. The file was not present, so no deletion commit was required.
+
+---
+
+## 6. What Is Next
+
+MINOR tier: Auto PR review (Codex/Gemini/Copilot) + COMMANDER review required.
+Source: `projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md`
+Tier: MINOR
+
+COMMANDER merge decision required for PR on branch `claude/delete-duplicate-state-file-ncZ72`.


### PR DESCRIPTION
## Summary

- Verified `projects/polymarket/polyquantbot/PROJECT_STATE.md` does not exist on any branch (local, `main`, or GitHub-wide) — no deletion commit required
- Audited 12 files referencing the duplicate path; all are read-only historical forge/sentinel reports — no code changes required
- Repo root `PROJECT_STATE.md` confirmed as sole authoritative state file per CLAUDE.md policy
- Forge report and PROJECT_STATE.md updated

## Report

`projects/polymarket/polyquantbot/reports/forge/25_8_delete_duplicate_project_state.md`

## Validation Tier

MINOR — no runtime code touched

## Done Criteria

- [x] `projects/polymarket/polyquantbot/PROJECT_STATE.md` — confirmed absent (no deletion needed)
- [x] No dangling code references to project-local path (12 refs are read-only historical reports)
- [x] Structure validation: zero `phase*/` folders, no shims, domain structure intact
- [x] `PROJECT_STATE.md` (repo root) updated
- [x] Forge report `25_8_delete_duplicate_project_state.md` created with all 6 mandatory sections

## Test Plan

- [ ] COMMANDER review: confirm file is absent, historical report references are acceptable as-is
- [ ] Auto PR review (Codex/Gemini/Copilot) baseline
- [ ] Merge decision by COMMANDER