### PR TITLE
Phase 3.2: Add deterministic pre-execution ExecutionIntent modeling layer

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,12 +2,14 @@
 ## Walker AI DevOps
 
 ## 📅 Last Updated
-2026-04-12 12:00
+2026-04-12 16:02
 
 ## 🔄 Status
-✅ **Phase 3.1 COMPLETE & MERGED** (null-safety hardened, staged extraction pattern enforced, all null paths return `missing_execution_context` deterministically, 3 regression tests passing). SENTINEL validation approved (100/100, 0 critical).
+✅ **Phase 3.2 COMPLETE (STANDARD, NARROW INTEGRATION)** deterministic, non-activating `ExecutionIntent` modeling layer added after readiness validation boundary and before future execution engine wiring. No runtime execution/order/wallet/capital activation introduced.
 
 ## ✅ COMPLETED
+- **Phase 3.2 execution intent modeling** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_intent.py` with deterministic `ExecutionIntent`, `ExecutionIntentTrace`, and `ExecutionIntentBuilder` (readiness-gated, risk-decision enforced, block reason propagation, null-safe extraction).
+- **Phase 3.2 tests added** in `projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py` covering readiness-pass creation, readiness-fail block, null-safety, deterministic output, risk bypass prevention, and activation-flag absence.
 - **Phase 3.1 null-safety hardened** (fix_execution_readiness_null_safety_final_pr427): staged extraction pattern enforced in `execution_readiness_gate.py`; `asdict()` never called without prior null guard; all null scenarios (`facade_resolution=None`, `context_envelope=None`, `execution_context=None`) return `missing_execution_context` deterministically; 3 explicit regression tests added and passing.
 - **Phase 2.9 dual-mode routing contract** remains implemented with explicit modes: disabled, legacy-only, platform-gateway-shadow, and platform-gateway-primary (structural-only).
 - Negative tests added for malformed mode parsing (`invalid_gateway_mode`) and legacy route adapter bypass (`adapter_not_used_in_gateway_path`).
@@ -23,18 +25,16 @@
 ## 📋 NOT STARTED
 - **Phase 2 task 2.10:** Fly.io staging deploy.
 - **Phase 2 tasks 2.11–2.13:** multi-user DB schema, audit/event log schema, wallet context abstraction.
-- **Phase 3 Execution-Safe MVP (3.1–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
+- **Phase 3 remaining tasks (3.3–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
 
 ## 🎯 NEXT PRIORITY
-- **Phase 3.2: Execution Intent Modeling**
-  - Execution intent layer
-  - Pre-execution
-  - Non-activating
+- Auto PR review + COMMANDER review required. Source: projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 - Path-based test portability issues (manual port override required in CI).
 - Non-activating constraint remains in place.
 - Dual-mode routing still FOUNDATION-only (no live/public activation, runtime traffic switching, or execution-path enablement delivered).
+- Execution intent layer is intentionally standalone (no gateway/runtime wiring yet) until later execution-engine phases.
 - Async pytest plugin unavailable in current container; async adapter assertions covered via `asyncio.run(...)` in focused tests.
 - ContextResolver remains read-only by design; persistence-side ensure/write behavior is explicit-call only.
 - `execution_context_repository` and `audit_event_repository` bundle fields remain unused in current bridge/facade path.

--- a/projects/polymarket/polyquantbot/platform/execution/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/execution/__init__.py
@@ -1,0 +1,19 @@
+"""Deterministic pre-execution intent modeling contracts."""
+
+from .execution_intent import (
+    INTENT_BLOCK_READINESS_FAILED,
+    INTENT_BLOCK_RISK_VALIDATION_FAILED,
+    ExecutionIntent,
+    ExecutionIntentBuilder,
+    ExecutionIntentBuildResult,
+    ExecutionIntentTrace,
+)
+
+__all__ = [
+    "INTENT_BLOCK_READINESS_FAILED",
+    "INTENT_BLOCK_RISK_VALIDATION_FAILED",
+    "ExecutionIntent",
+    "ExecutionIntentBuilder",
+    "ExecutionIntentBuildResult",
+    "ExecutionIntentTrace",
+]

--- a/projects/polymarket/polyquantbot/platform/execution/execution_intent.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_intent.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+INTENT_BLOCK_READINESS_FAILED = "readiness_failed"
+INTENT_BLOCK_RISK_VALIDATION_FAILED = "risk_validation_failed"
+
+
+@dataclass(frozen=True)
+class ExecutionIntent:
+    market_id: str
+    outcome: str
+    side: str
+    size: float
+    price: float | None
+    confidence: float | None
+    source_signal_id: str | None
+    routing_mode: str
+    risk_validated: bool
+    readiness_passed: bool
+
+
+@dataclass(frozen=True)
+class ExecutionIntentTrace:
+    intent_created: bool
+    blocked_reason: str | None
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionIntentBuildResult:
+    intent: ExecutionIntent | None
+    trace: ExecutionIntentTrace
+
+
+class ExecutionIntentBuilder:
+    """Phase 3.2 deterministic, non-activating intent modeling builder."""
+
+    def build_from_readiness(
+        self,
+        readiness_result: Any,
+        routing_result: Any,
+        signal: Any,
+    ) -> ExecutionIntent | None:
+        return self.build_with_trace(
+            readiness_result=readiness_result,
+            routing_result=routing_result,
+            signal=signal,
+        ).intent
+
+    def build_with_trace(
+        self,
+        *,
+        readiness_result: Any,
+        routing_result: Any,
+        signal: Any,
+    ) -> ExecutionIntentBuildResult:
+        readiness_can_execute = bool(_extract_field(readiness_result, "can_execute", False))
+        readiness_block_reason = _extract_field(readiness_result, "block_reason", None)
+        risk_decision = _extract_risk_decision(readiness_result)
+        risk_validated = risk_decision == "ALLOW"
+
+        upstream_trace_refs: dict[str, Any] = {
+            "readiness": {
+                "can_execute": readiness_can_execute,
+                "block_reason": readiness_block_reason,
+                "risk_validation_decision": risk_decision,
+            },
+            "routing": {
+                "selected_mode": _extract_routing_mode(routing_result),
+            },
+            "signal": {
+                "source_signal_id": _extract_field(signal, "source_signal_id", None),
+            },
+        }
+
+        if not readiness_can_execute:
+            return ExecutionIntentBuildResult(
+                intent=None,
+                trace=ExecutionIntentTrace(
+                    intent_created=False,
+                    blocked_reason=str(readiness_block_reason or INTENT_BLOCK_READINESS_FAILED),
+                    upstream_trace_refs=upstream_trace_refs,
+                ),
+            )
+
+        if not risk_validated:
+            return ExecutionIntentBuildResult(
+                intent=None,
+                trace=ExecutionIntentTrace(
+                    intent_created=False,
+                    blocked_reason=INTENT_BLOCK_RISK_VALIDATION_FAILED,
+                    upstream_trace_refs=upstream_trace_refs,
+                ),
+            )
+
+        intent = ExecutionIntent(
+            market_id=str(_extract_field(signal, "market_id", "")),
+            outcome=str(_extract_field(signal, "outcome", "")),
+            side=str(_extract_field(signal, "side", "BUY")),
+            size=float(_extract_field(signal, "size", 0.0)),
+            price=_coerce_optional_float(_extract_field(signal, "price", None)),
+            confidence=_coerce_optional_float(_extract_field(signal, "confidence", None)),
+            source_signal_id=_coerce_optional_str(_extract_field(signal, "source_signal_id", None)),
+            routing_mode=_extract_routing_mode(routing_result),
+            risk_validated=risk_validated,
+            readiness_passed=readiness_can_execute,
+        )
+
+        return ExecutionIntentBuildResult(
+            intent=intent,
+            trace=ExecutionIntentTrace(
+                intent_created=True,
+                blocked_reason=None,
+                upstream_trace_refs=upstream_trace_refs,
+            ),
+        )
+
+
+def _extract_field(source: Any, key: str, default: Any) -> Any:
+    if source is None:
+        return default
+    if isinstance(source, dict):
+        return source.get(key, default)
+    return getattr(source, key, default)
+
+
+def _extract_routing_mode(routing_result: Any) -> str:
+    return str(
+        _extract_field(routing_result, "selected_mode", None)
+        or _extract_field(routing_result, "routing_mode", None)
+        or "unknown"
+    )
+
+
+def _extract_risk_decision(readiness_result: Any) -> str | None:
+    readiness_checks = _extract_field(readiness_result, "readiness_checks", None)
+    if isinstance(readiness_checks, dict):
+        decision = readiness_checks.get("risk_validation_decision")
+        if decision is None:
+            return None
+        return str(decision)
+    return None
+
+
+def _coerce_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md
@@ -1,0 +1,64 @@
+# Forge Report — Phase 3.2 Execution Intent Modeling
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_intent.py` and `projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py` with Phase 3.1 boundary regression coverage retained  
+**Not in Scope:** Runtime execution wiring, gateway activation, order placement, wallet interaction, capital movement, or modifications to `execution_readiness_gate.py`  
+**Suggested Next Step:** Auto PR review + COMMANDER review required. Source: `projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md`. Tier: STANDARD
+
+---
+
+## 1) What was built
+- Added new deterministic pre-execution modeling module:  
+  `projects/polymarket/polyquantbot/platform/execution/execution_intent.py`
+- Introduced dataclasses:
+  - `ExecutionIntent`
+  - `ExecutionIntentTrace`
+  - `ExecutionIntentBuildResult`
+- Introduced `ExecutionIntentBuilder` with required method:
+  - `build_from_readiness(readiness_result, routing_result, signal) -> ExecutionIntent | None`
+- Implemented strict gating behavior:
+  - No intent creation when `readiness_result.can_execute == False`
+  - No intent creation when risk validation decision is not `ALLOW`
+  - Block reason propagation when intent is not created
+  - Deterministic output for same input
+- Added focused test suite:  
+  `projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py`
+
+## 2) Current system architecture
+- Execution-safe flow remains non-activating:
+  1. Routing mode resolution (`platform/gateway/public_app_gateway.py`)
+  2. Readiness/risk boundary checks (`platform/gateway/execution_readiness_gate.py`)
+  3. **New intent modeling layer** (`platform/execution/execution_intent.py`)
+  4. Future execution engine (not implemented in this task)
+- This task adds a standalone pre-execution contract for “what would be executed” without introducing runtime side effects.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_intent.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- `ExecutionIntent` is constructible when readiness input indicates execution-safe pass and risk decision is `ALLOW`.
+- Intent creation is blocked deterministically when readiness does not pass.
+- Null upstream inputs are handled safely and produce deterministic blocked trace output.
+- Determinism confirmed: identical inputs produce equal build result output.
+- No activation flags were introduced into `ExecutionIntent`.
+- Phase 3.1 baseline boundary tests remain green alongside Phase 3.2 tests.
+
+## 5) Known issues
+- Intent modeling is intentionally not wired into runtime gateway/execution path yet (by scope).
+- Existing environment warning persists: pytest config includes unknown `asyncio_mode` option in this container setup.
+
+## 6) What is next
+- COMMANDER review for STANDARD tier completion and scope verification.
+- Optional auto PR review for additional confidence on changed files.
+- If approved, proceed to next Phase 3 execution-safe MVP step without enabling activation.
+
+---
+
+**Report Timestamp:** 2026-04-12 16:02 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 3.2 — Execution Intent Modeling (Pre-Execution Layer)

--- a/projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import fields
+
+from projects.polymarket.polyquantbot.platform.execution.execution_intent import (
+    INTENT_BLOCK_RISK_VALIDATION_FAILED,
+    ExecutionIntent,
+    ExecutionIntentBuilder,
+)
+
+
+def _signal() -> dict[str, object]:
+    return {
+        "market_id": "MKT-3-2",
+        "outcome": "YES",
+        "side": "BUY",
+        "size": 42.0,
+        "price": 0.61,
+        "confidence": 0.78,
+        "source_signal_id": "SIG-3-2",
+    }
+
+
+def test_phase3_2_intent_created_when_readiness_passed() -> None:
+    builder = ExecutionIntentBuilder()
+    result = builder.build_with_trace(
+        readiness_result={
+            "can_execute": True,
+            "block_reason": "phase3_2_ready",
+            "readiness_checks": {"risk_validation_decision": "ALLOW"},
+        },
+        routing_result={"selected_mode": "platform-gateway-shadow"},
+        signal=_signal(),
+    )
+
+    assert result.intent is not None
+    assert result.intent.market_id == "MKT-3-2"
+    assert result.intent.readiness_passed is True
+    assert result.intent.risk_validated is True
+    assert result.trace.intent_created is True
+    assert result.trace.blocked_reason is None
+
+
+def test_phase3_2_intent_blocked_when_readiness_false() -> None:
+    builder = ExecutionIntentBuilder()
+    result = builder.build_with_trace(
+        readiness_result={
+            "can_execute": False,
+            "block_reason": "readiness_not_passed",
+            "readiness_checks": {"risk_validation_decision": "ALLOW"},
+        },
+        routing_result={"selected_mode": "platform-gateway-shadow"},
+        signal=_signal(),
+    )
+
+    assert result.intent is None
+    assert result.trace.intent_created is False
+    assert result.trace.blocked_reason == "readiness_not_passed"
+
+
+def test_phase3_2_null_safety_for_upstream_inputs() -> None:
+    builder = ExecutionIntentBuilder()
+    result = builder.build_with_trace(
+        readiness_result=None,
+        routing_result=None,
+        signal=None,
+    )
+
+    assert result.intent is None
+    assert result.trace.intent_created is False
+    assert result.trace.blocked_reason == "readiness_failed"
+    assert result.trace.upstream_trace_refs["routing"]["selected_mode"] == "unknown"
+
+
+def test_phase3_2_output_is_deterministic_for_same_inputs() -> None:
+    builder = ExecutionIntentBuilder()
+    readiness = {
+        "can_execute": True,
+        "block_reason": None,
+        "readiness_checks": {"risk_validation_decision": "ALLOW"},
+    }
+    routing = {"selected_mode": "platform-gateway-primary"}
+    signal = _signal()
+
+    first = builder.build_with_trace(readiness_result=readiness, routing_result=routing, signal=signal)
+    second = builder.build_with_trace(readiness_result=readiness, routing_result=routing, signal=signal)
+
+    assert first == second
+
+
+def test_phase3_2_risk_validation_cannot_be_bypassed() -> None:
+    builder = ExecutionIntentBuilder()
+    result = builder.build_with_trace(
+        readiness_result={
+            "can_execute": True,
+            "block_reason": None,
+            "readiness_checks": {"risk_validation_decision": "BLOCK"},
+        },
+        routing_result={"selected_mode": "platform-gateway-primary"},
+        signal=_signal(),
+    )
+
+    assert result.intent is None
+    assert result.trace.blocked_reason == INTENT_BLOCK_RISK_VALIDATION_FAILED
+
+
+def test_phase3_2_execution_intent_has_no_activation_flags() -> None:
+    field_names = {item.name for item in fields(ExecutionIntent)}
+
+    assert "runtime_activation_allowed" not in field_names
+    assert "activation_requested" not in field_names


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, non-activating pre-execution model that describes “what would be executed” without any runtime activation, order placement, wallet interaction, or capital movement. 
- Place the modeling layer after the Phase 3.1 readiness/risk boundary and before any future execution engine so intent creation is decisively gated by readiness and risk decisions. 
- Deliver a standalone modeling contract to enable later wiring while preserving Phase 3.1 non-activating guarantees. 

### Description
- Added new module `projects/polymarket/polyquantbot/platform/execution/execution_intent.py` with dataclasses `ExecutionIntent`, `ExecutionIntentTrace`, `ExecutionIntentBuildResult`, and `ExecutionIntentBuilder` exposing `build_from_readiness(...)` / `build_with_trace(...)`. 
- Enforced required rules: do not create an intent when `readiness_result.can_execute == False`, respect upstream risk validation (must be `ALLOW`), propagate block reasons, and use null-safe deterministic extraction to ensure same input → same output. 
- Created package exports `projects/polymarket/polyquantbot/platform/execution/__init__.py`, added focused tests at `projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py`, added forge report `projects/polymarket/polyquantbot/reports/forge/24_70_phase3_2_execution_intent_modeling.md`, and updated `PROJECT_STATE.md` to reflect Phase 3.2 completion. 
- Kept strict integration constraints: no runtime wiring into the gateway, no changes to `execution_readiness_gate.py`, and no external/order/wallet/capital calls introduced. 

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_intent.py projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py` and compilation passed. 
- Ran tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_2_execution_intent_modeling_20260412.py projects/polymarket/polyquantbot/tests/test_phase3_1_execution_safe_mvp_boundary_20260412.py` and received `16 passed, 1 warning` (the warning is an existing `asyncio_mode` pytest config warning). 
- Confirmed deterministic and null-safe behavior via tests covering intent creation on readiness pass, intent blocking on readiness fail, null-safety for upstream inputs, deterministic output equality for identical inputs, risk-bypass prevention, and absence of activation flags; all covered tests passed. 
- Verified no forbidden `phase*/` folders and no direct core-import violations in the new execution modeling files via repository grep checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb6816458832eaec1cd51d1ff718a)