### PR TITLE
Phase 3.4: add deterministic non-activating Execution Planning Layer (Intent → Plan)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,12 +2,16 @@
 ## Walker AI DevOps
 
 ## 📅 Last Updated
-2026-04-12 16:27
+2026-04-12 16:37
 
 ## 🔄 Status
-✅ **Phase 3.3 COMPLETE (STANDARD, NARROW INTEGRATION)** execution-intent contracts hardened with deterministic top-level runtime contract validation (None/dict/wrong-object blocked without crash). Non-activating boundary remains enforced.
+✅ **Phase 3.4 COMPLETE (STANDARD, NARROW INTEGRATION)** deterministic non-activating execution planning layer added (Intent → Plan contract), with contract-safe blocking and no runtime activation path.
 
 ## ✅ COMPLETED
+- **Phase 3.4 execution planning layer** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_plan.py` with explicit non-activating `ExecutionPlan` contract, deterministic trace metadata, and deterministic blocked outcomes for invalid top-level or invalid field-level planning inputs.
+- Added `ExecutionPlanBuilder` (`build_from_intent`, `build_with_trace`) and typed planning inputs (`ExecutionPlanIntentInput`, `ExecutionPlanMarketContextInput`) with explicit side/routing/size/market/outcome validation and context-mismatch/planning-allowed guards.
+- **Phase 3.4 tests added** in `projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py` covering valid path, deterministic blocking for invalid contracts/fields, determinism checks, non-activating enforcement, and safety checks for None/dict/wrong-object inputs.
+- **Phase 3.3 baseline remains green** in `projects/polymarket/polyquantbot/tests/test_phase3_3_execution_intent_contract_hardening_20260412.py`.
 - **Phase 3.3 execution intent contract hardening rerun (PR #434 fix)** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_intent.py` with explicit runtime validation for top-level builder contracts (`readiness_input`, `routing_input`, `signal_input`) returning deterministic blocked results instead of exceptions.
 - Added explicit top-level contract block constant `INTENT_BLOCK_INVALID_READINESS_CONTRACT` and preserved deterministic routing/signal contract block paths.
 - **Phase 3.3 tests expanded** in `projects/polymarket/polyquantbot/tests/test_phase3_3_execution_intent_contract_hardening_20260412.py` covering `None`, dict, and wrong-object top-level contract rejection (no exceptions), plus valid path/readiness/risk/determinism/activation constraints.
@@ -23,18 +27,18 @@
 ## 📋 NOT STARTED
 - **Phase 2 task 2.10:** Fly.io staging deploy.
 - **Phase 2 tasks 2.11–2.13:** multi-user DB schema, audit/event log schema, wallet context abstraction.
-- **Phase 3 remaining tasks (3.4–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
+- **Phase 3 remaining tasks (3.5–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
 
 ## 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/24_71_phase3_3_execution_intent_contract_hardening.md. Tier: STANDARD
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 - Path-based test portability issues (manual port override required in CI).
 - Non-activating constraint remains in place.
 - Dual-mode routing remains non-runtime and structural-only.
 - Execution intent layer remains intentionally standalone (no gateway/runtime wiring yet) until later execution-engine phases.
+- Execution plan layer remains intentionally pre-execution only (no gateway/execution engine/order object/runtime orchestration wiring yet).
 - Async pytest plugin unavailable in current container; async adapter assertions covered via `asyncio.run(...)` in focused tests.
 - ContextResolver remains read-only by design; persistence-side ensure/write behavior is explicit-call only.
 - `execution_context_repository` and `audit_event_repository` bundle fields remain unused in current bridge/facade path.
 - P17 proof lifecycle still uses lazy expiration enforcement at execution boundary; background expired-row cleanup remains deferred.
-

--- a/projects/polymarket/polyquantbot/platform/execution/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/execution/__init__.py
@@ -14,6 +14,20 @@ from .execution_intent import (
     ExecutionIntentSignalInput,
     ExecutionIntentTrace,
 )
+from .execution_plan import (
+    PLAN_BLOCK_INVALID_INTENT_CONTRACT,
+    PLAN_BLOCK_INVALID_INTENT_INPUT,
+    PLAN_BLOCK_INVALID_MARKET_CONTEXT,
+    PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT,
+    PLAN_BLOCK_MARKET_CONTEXT_MISMATCH,
+    PLAN_BLOCK_MARKET_NOT_PLANNABLE,
+    ExecutionPlan,
+    ExecutionPlanBuilder,
+    ExecutionPlanBuildResult,
+    ExecutionPlanIntentInput,
+    ExecutionPlanMarketContextInput,
+    ExecutionPlanTrace,
+)
 
 __all__ = [
     "INTENT_BLOCK_INVALID_ROUTING_CONTRACT",
@@ -28,4 +42,16 @@ __all__ = [
     "ExecutionIntentRoutingInput",
     "ExecutionIntentSignalInput",
     "ExecutionIntentTrace",
+    "PLAN_BLOCK_INVALID_INTENT_CONTRACT",
+    "PLAN_BLOCK_INVALID_INTENT_INPUT",
+    "PLAN_BLOCK_INVALID_MARKET_CONTEXT",
+    "PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT",
+    "PLAN_BLOCK_MARKET_CONTEXT_MISMATCH",
+    "PLAN_BLOCK_MARKET_NOT_PLANNABLE",
+    "ExecutionPlan",
+    "ExecutionPlanBuilder",
+    "ExecutionPlanBuildResult",
+    "ExecutionPlanIntentInput",
+    "ExecutionPlanMarketContextInput",
+    "ExecutionPlanTrace",
 ]

--- a/projects/polymarket/polyquantbot/platform/execution/execution_plan.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_plan.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+PLAN_BLOCK_INVALID_INTENT_CONTRACT = "invalid_intent_contract"
+PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT = "invalid_market_context_contract"
+PLAN_BLOCK_INVALID_INTENT_INPUT = "invalid_intent_input"
+PLAN_BLOCK_INVALID_MARKET_CONTEXT = "invalid_market_context"
+PLAN_BLOCK_MARKET_CONTEXT_MISMATCH = "market_context_mismatch"
+PLAN_BLOCK_MARKET_NOT_PLANNABLE = "market_not_plannable"
+
+_ALLOWED_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
+_ALLOWED_ROUTING_MODES: frozenset[str] = frozenset(
+    {
+        "disabled",
+        "legacy-only",
+        "platform-gateway-shadow",
+        "platform-gateway-primary",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ExecutionPlanIntentInput:
+    market_id: str
+    outcome: str
+    side: str
+    size: float
+    routing_mode: str
+    limit_price_hint: float | None = None
+    source_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionPlanMarketContextInput:
+    market_id: str
+    outcome: str
+    planning_allowed: bool
+    execution_mode_label: str
+    reference_price: float | None = None
+    slippage_bps_hint: int | None = None
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    market_id: str
+    outcome: str
+    side: str
+    size: float
+    routing_mode: str
+    execution_mode: str
+    limit_price: float | None
+    slippage_bps: int | None
+    plan_ready: bool
+    non_activating: bool
+
+
+@dataclass(frozen=True)
+class ExecutionPlanTrace:
+    plan_created: bool
+    blocked_reason: str | None
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+    planning_notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionPlanBuildResult:
+    plan: ExecutionPlan | None
+    trace: ExecutionPlanTrace
+
+
+class ExecutionPlanBuilder:
+    """Phase 3.4 deterministic, non-activating execution planning builder."""
+
+    def build_from_intent(
+        self,
+        intent_input: ExecutionPlanIntentInput,
+        market_context_input: ExecutionPlanMarketContextInput,
+    ) -> ExecutionPlan | None:
+        return self.build_with_trace(
+            intent_input=intent_input,
+            market_context_input=market_context_input,
+        ).plan
+
+    def build_with_trace(
+        self,
+        *,
+        intent_input: ExecutionPlanIntentInput,
+        market_context_input: ExecutionPlanMarketContextInput,
+    ) -> ExecutionPlanBuildResult:
+        if not isinstance(intent_input, ExecutionPlanIntentInput):
+            return _blocked_invalid_contract_result(
+                blocked_reason=PLAN_BLOCK_INVALID_INTENT_CONTRACT,
+                contract_name="intent",
+                contract_input=intent_input,
+            )
+
+        if not isinstance(market_context_input, ExecutionPlanMarketContextInput):
+            return _blocked_invalid_contract_result(
+                blocked_reason=PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT,
+                contract_name="market_context",
+                contract_input=market_context_input,
+            )
+
+        upstream_trace_refs: dict[str, Any] = {
+            "intent": dict(intent_input.source_trace_refs),
+            "market_context": dict(market_context_input.upstream_trace_refs),
+        }
+
+        intent_error = _validate_intent_input(intent_input)
+        if intent_error is not None:
+            return ExecutionPlanBuildResult(
+                plan=None,
+                trace=ExecutionPlanTrace(
+                    plan_created=False,
+                    blocked_reason=PLAN_BLOCK_INVALID_INTENT_INPUT,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {"intent": intent_error},
+                    },
+                    planning_notes={"intent_error": intent_error},
+                ),
+            )
+
+        context_error = _validate_market_context_input(market_context_input)
+        if context_error is not None:
+            return ExecutionPlanBuildResult(
+                plan=None,
+                trace=ExecutionPlanTrace(
+                    plan_created=False,
+                    blocked_reason=PLAN_BLOCK_INVALID_MARKET_CONTEXT,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {"market_context": context_error},
+                    },
+                    planning_notes={"market_context_error": context_error},
+                ),
+            )
+
+        if (
+            intent_input.market_id != market_context_input.market_id
+            or intent_input.outcome != market_context_input.outcome
+        ):
+            return ExecutionPlanBuildResult(
+                plan=None,
+                trace=ExecutionPlanTrace(
+                    plan_created=False,
+                    blocked_reason=PLAN_BLOCK_MARKET_CONTEXT_MISMATCH,
+                    upstream_trace_refs=upstream_trace_refs,
+                    planning_notes={
+                        "intent_market_id": intent_input.market_id,
+                        "context_market_id": market_context_input.market_id,
+                        "intent_outcome": intent_input.outcome,
+                        "context_outcome": market_context_input.outcome,
+                    },
+                ),
+            )
+
+        if not market_context_input.planning_allowed:
+            return ExecutionPlanBuildResult(
+                plan=None,
+                trace=ExecutionPlanTrace(
+                    plan_created=False,
+                    blocked_reason=PLAN_BLOCK_MARKET_NOT_PLANNABLE,
+                    upstream_trace_refs=upstream_trace_refs,
+                    planning_notes={"planning_allowed": False},
+                ),
+            )
+
+        plan = ExecutionPlan(
+            market_id=intent_input.market_id,
+            outcome=intent_input.outcome,
+            side=intent_input.side,
+            size=intent_input.size,
+            routing_mode=intent_input.routing_mode,
+            execution_mode=market_context_input.execution_mode_label,
+            limit_price=_derive_limit_price(intent_input, market_context_input),
+            slippage_bps=_derive_slippage_bps(market_context_input),
+            plan_ready=True,
+            non_activating=True,
+        )
+
+        return ExecutionPlanBuildResult(
+            plan=plan,
+            trace=ExecutionPlanTrace(
+                plan_created=True,
+                blocked_reason=None,
+                upstream_trace_refs=upstream_trace_refs,
+                planning_notes={
+                    "limit_price_source": _limit_price_source(intent_input, market_context_input),
+                    "execution_mode_label": market_context_input.execution_mode_label,
+                    "non_activating": True,
+                },
+            ),
+        )
+
+
+def _validate_intent_input(intent_input: ExecutionPlanIntentInput) -> str | None:
+    if not intent_input.market_id.strip():
+        return "market_id_required"
+    if not intent_input.outcome.strip():
+        return "outcome_required"
+    if intent_input.side not in _ALLOWED_SIDES:
+        return "side_not_allowed"
+    if intent_input.routing_mode not in _ALLOWED_ROUTING_MODES:
+        return "routing_mode_not_allowed"
+    if intent_input.size < 0:
+        return "size_must_be_non_negative"
+    if intent_input.limit_price_hint is not None and intent_input.limit_price_hint < 0:
+        return "limit_price_hint_must_be_non_negative"
+    return None
+
+
+def _validate_market_context_input(
+    market_context_input: ExecutionPlanMarketContextInput,
+) -> str | None:
+    if not market_context_input.market_id.strip():
+        return "market_id_required"
+    if not market_context_input.outcome.strip():
+        return "outcome_required"
+    if not market_context_input.execution_mode_label.strip():
+        return "execution_mode_label_required"
+    if (
+        market_context_input.slippage_bps_hint is not None
+        and market_context_input.slippage_bps_hint < 0
+    ):
+        return "slippage_bps_hint_must_be_non_negative"
+    if market_context_input.reference_price is not None and market_context_input.reference_price < 0:
+        return "reference_price_must_be_non_negative"
+    return None
+
+
+def _derive_limit_price(
+    intent_input: ExecutionPlanIntentInput,
+    market_context_input: ExecutionPlanMarketContextInput,
+) -> float | None:
+    if intent_input.limit_price_hint is not None:
+        return intent_input.limit_price_hint
+    return market_context_input.reference_price
+
+
+def _derive_slippage_bps(market_context_input: ExecutionPlanMarketContextInput) -> int | None:
+    if market_context_input.slippage_bps_hint is not None:
+        return market_context_input.slippage_bps_hint
+    return 0
+
+
+def _limit_price_source(
+    intent_input: ExecutionPlanIntentInput,
+    market_context_input: ExecutionPlanMarketContextInput,
+) -> str:
+    if intent_input.limit_price_hint is not None:
+        return "intent_limit_price_hint"
+    if market_context_input.reference_price is not None:
+        return "market_context_reference_price"
+    return "none"
+
+
+def _blocked_invalid_contract_result(
+    *,
+    blocked_reason: str,
+    contract_name: str,
+    contract_input: Any,
+) -> ExecutionPlanBuildResult:
+    return ExecutionPlanBuildResult(
+        plan=None,
+        trace=ExecutionPlanTrace(
+            plan_created=False,
+            blocked_reason=blocked_reason,
+            upstream_trace_refs={
+                "contract_errors": {
+                    contract_name: "invalid_contract_object",
+                },
+                "invalid_contract_input": {
+                    contract_name: _describe_contract_input(contract_input),
+                },
+            },
+            planning_notes={"contract_name": contract_name},
+        ),
+    )
+
+
+def _describe_contract_input(contract_input: Any) -> dict[str, Any]:
+    if contract_input is None:
+        return {"type": "NoneType", "value": None}
+    if isinstance(contract_input, dict):
+        return {
+            "type": "dict",
+            "keys": sorted([str(key) for key in contract_input.keys()]),
+        }
+    return {
+        "type": type(contract_input).__name__,
+        "repr": repr(contract_input),
+    }

--- a/projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md
@@ -1,0 +1,65 @@
+# Forge Report — Phase 3.4 Execution Planning Layer (Intent → Plan, Non-Activating)
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_plan.py`, `projects/polymarket/polyquantbot/platform/execution/__init__.py`, and `projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py` plus Phase 3.3 baseline test.  
+**Not in Scope:** Runtime activation, execution engine wiring, gateway integration, order object creation, order submission, wallet interaction, signing, capital allocation, readiness gate behavior changes, orchestration expansion.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review optional if used. Source: `projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Added deterministic pre-execution planning contracts in `execution_plan.py`:
+  - `ExecutionPlan`
+  - `ExecutionPlanTrace`
+  - `ExecutionPlanBuildResult`
+  - typed inputs: `ExecutionPlanIntentInput`, `ExecutionPlanMarketContextInput`
+- Added `ExecutionPlanBuilder` with:
+  - `build_from_intent(intent_input, market_context_input) -> ExecutionPlan | None`
+  - `build_with_trace(...) -> ExecutionPlanBuildResult`
+- Implemented deterministic planning semantics only:
+  - plan-level fields for routing/execution mode/limit price/slippage placeholder
+  - explicit non-activating enforcement (`non_activating=True`)
+  - deterministic block paths for invalid contracts, invalid intent/context fields, mismatched market/outcome, and non-plannable context
+
+## 2) Current system architecture
+- Execution layer remains pre-execution and non-activating:
+  1. Runtime contract object validation for intent/context
+  2. Intent input validation (market/outcome/side/routing/size)
+  3. Market context validation (market/outcome/execution mode/slippage/reference price)
+  4. Cross-contract match guard (intent market/outcome must match context)
+  5. Non-plannable context block handling
+  6. Deterministic `ExecutionPlan` materialization with trace metadata only
+- No runtime/exchange interaction added. No wallet/signing/order/capital path added.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_plan.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Valid intent + valid market context deterministically produce an `ExecutionPlan`.
+- Invalid top-level inputs (`None`, dict, wrong object) are blocked deterministically without exception.
+- Invalid side/routing/size/market/outcome inputs are blocked deterministically.
+- Invalid market context contract and non-plannable context are blocked deterministically.
+- `non_activating` is always `True` for created plans.
+- No wallet/signing/activation submission fields are introduced in `ExecutionPlan`.
+- Planning metadata (`planning_notes`, trace refs) remains deterministic for identical input.
+- Phase 3.3 baseline remains green with Phase 3.4 tests.
+
+## 5) Known issues
+- Container pytest still reports `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- Path-based test portability remains dependent on explicit `PYTHONPATH=/workspace/walker-ai-team` in this environment.
+
+## 6) What is next
+- COMMANDER review for STANDARD tier validation and scope confirmation.
+- Optional auto PR review focused on changed planning contracts/tests and direct exports.
+- Continue to next phase without enabling any activation/runtime execution behavior.
+
+---
+
+**Report Timestamp:** 2026-04-12 16:37 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 3.4 — Execution Planning Layer (Intent → Plan, Still Non-Activating)

--- a/projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import fields
+
+from projects.polymarket.polyquantbot.platform.execution.execution_plan import (
+    PLAN_BLOCK_INVALID_INTENT_CONTRACT,
+    PLAN_BLOCK_INVALID_INTENT_INPUT,
+    PLAN_BLOCK_INVALID_MARKET_CONTEXT,
+    PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT,
+    PLAN_BLOCK_MARKET_CONTEXT_MISMATCH,
+    PLAN_BLOCK_MARKET_NOT_PLANNABLE,
+    ExecutionPlan,
+    ExecutionPlanBuilder,
+    ExecutionPlanIntentInput,
+    ExecutionPlanMarketContextInput,
+)
+
+
+VALID_INTENT = ExecutionPlanIntentInput(
+    market_id="MKT-3-4",
+    outcome="YES",
+    side="BUY",
+    size=8.0,
+    routing_mode="platform-gateway-shadow",
+    limit_price_hint=0.47,
+    source_trace_refs={"intent_trace_id": "INT-3-4"},
+)
+
+VALID_MARKET_CONTEXT = ExecutionPlanMarketContextInput(
+    market_id="MKT-3-4",
+    outcome="YES",
+    planning_allowed=True,
+    execution_mode_label="paper-prep-only",
+    reference_price=0.46,
+    slippage_bps_hint=12,
+    upstream_trace_refs={"market_trace_id": "MKT-TRACE-3-4"},
+)
+
+
+def test_phase3_4_valid_intent_produces_plan() -> None:
+    builder = ExecutionPlanBuilder()
+
+    result = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+
+    assert result.plan is not None
+    assert result.plan.market_id == "MKT-3-4"
+    assert result.plan.execution_mode == "paper-prep-only"
+    assert result.trace.plan_created is True
+    assert result.trace.blocked_reason is None
+
+
+def test_phase3_4_invalid_intent_contract_blocked_deterministically() -> None:
+    builder = ExecutionPlanBuilder()
+    result = builder.build_with_trace(
+        intent_input=None,  # type: ignore[arg-type]
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+
+    assert result.plan is None
+    assert result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_CONTRACT
+
+
+def test_phase3_4_invalid_market_context_contract_blocked_deterministically() -> None:
+    builder = ExecutionPlanBuilder()
+    result = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input={"market_id": "MKT-3-4"},  # type: ignore[arg-type]
+    )
+
+    assert result.plan is None
+    assert result.trace.blocked_reason == PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT
+
+
+def test_phase3_4_deterministic_equality_for_same_valid_input() -> None:
+    builder = ExecutionPlanBuilder()
+    first = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    second = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+
+    assert first == second
+
+
+def test_phase3_4_non_activating_always_true() -> None:
+    builder = ExecutionPlanBuilder()
+    plan = builder.build_from_intent(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+
+    assert plan is not None
+    assert plan.non_activating is True
+    assert plan.plan_ready is True
+
+
+def test_phase3_4_no_wallet_signing_activation_fields_introduced() -> None:
+    field_names = {item.name for item in fields(ExecutionPlan)}
+
+    assert "wallet_address" not in field_names
+    assert "private_key" not in field_names
+    assert "signature" not in field_names
+    assert "order_submission_hook" not in field_names
+    assert "activate_runtime_execution" not in field_names
+
+
+def test_phase3_4_invalid_side_routing_size_market_outcome_blocked() -> None:
+    builder = ExecutionPlanBuilder()
+
+    invalid_side_result = builder.build_with_trace(
+        intent_input=ExecutionPlanIntentInput(
+            market_id="MKT-3-4",
+            outcome="YES",
+            side="HOLD",
+            size=1.0,
+            routing_mode="platform-gateway-shadow",
+        ),
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert invalid_side_result.plan is None
+    assert invalid_side_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_INPUT
+
+    invalid_routing_result = builder.build_with_trace(
+        intent_input=ExecutionPlanIntentInput(
+            market_id="MKT-3-4",
+            outcome="YES",
+            side="BUY",
+            size=1.0,
+            routing_mode="unknown",
+        ),
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert invalid_routing_result.plan is None
+    assert invalid_routing_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_INPUT
+
+    invalid_size_result = builder.build_with_trace(
+        intent_input=ExecutionPlanIntentInput(
+            market_id="MKT-3-4",
+            outcome="YES",
+            side="BUY",
+            size=-0.5,
+            routing_mode="platform-gateway-shadow",
+        ),
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert invalid_size_result.plan is None
+    assert invalid_size_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_INPUT
+
+    invalid_market_result = builder.build_with_trace(
+        intent_input=ExecutionPlanIntentInput(
+            market_id=" ",
+            outcome="YES",
+            side="BUY",
+            size=1.0,
+            routing_mode="platform-gateway-shadow",
+        ),
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert invalid_market_result.plan is None
+    assert invalid_market_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_INPUT
+
+    invalid_outcome_result = builder.build_with_trace(
+        intent_input=ExecutionPlanIntentInput(
+            market_id="MKT-3-4",
+            outcome=" ",
+            side="BUY",
+            size=1.0,
+            routing_mode="platform-gateway-shadow",
+        ),
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert invalid_outcome_result.plan is None
+    assert invalid_outcome_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_INPUT
+
+
+def test_phase3_4_market_context_validation_and_mismatch_blocked() -> None:
+    builder = ExecutionPlanBuilder()
+    invalid_context = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=ExecutionPlanMarketContextInput(
+            market_id="MKT-3-4",
+            outcome="YES",
+            planning_allowed=True,
+            execution_mode_label="",
+            reference_price=0.50,
+            slippage_bps_hint=10,
+        ),
+    )
+
+    assert invalid_context.plan is None
+    assert invalid_context.trace.blocked_reason == PLAN_BLOCK_INVALID_MARKET_CONTEXT
+
+    mismatch = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=ExecutionPlanMarketContextInput(
+            market_id="MKT-OTHER",
+            outcome="YES",
+            planning_allowed=True,
+            execution_mode_label="paper-prep-only",
+        ),
+    )
+    assert mismatch.plan is None
+    assert mismatch.trace.blocked_reason == PLAN_BLOCK_MARKET_CONTEXT_MISMATCH
+
+    blocked_not_plannable = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=ExecutionPlanMarketContextInput(
+            market_id="MKT-3-4",
+            outcome="YES",
+            planning_allowed=False,
+            execution_mode_label="paper-prep-only",
+        ),
+    )
+    assert blocked_not_plannable.plan is None
+    assert blocked_not_plannable.trace.blocked_reason == PLAN_BLOCK_MARKET_NOT_PLANNABLE
+
+
+def test_phase3_4_planning_metadata_is_deterministic() -> None:
+    builder = ExecutionPlanBuilder()
+    first = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    second = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+
+    assert first.trace.planning_notes == second.trace.planning_notes
+    assert first.trace.upstream_trace_refs == second.trace.upstream_trace_refs
+
+
+def test_phase3_4_none_dict_wrong_object_inputs_do_not_crash() -> None:
+    builder = ExecutionPlanBuilder()
+
+    none_result = builder.build_with_trace(
+        intent_input=VALID_INTENT,
+        market_context_input=None,  # type: ignore[arg-type]
+    )
+    assert none_result.plan is None
+    assert none_result.trace.blocked_reason == PLAN_BLOCK_INVALID_MARKET_CONTEXT_CONTRACT
+
+    dict_result = builder.build_with_trace(
+        intent_input={"market_id": "MKT-3-4"},  # type: ignore[arg-type]
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert dict_result.plan is None
+    assert dict_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_CONTRACT
+
+    wrong_object_result = builder.build_with_trace(
+        intent_input=object(),  # type: ignore[arg-type]
+        market_context_input=VALID_MARKET_CONTEXT,
+    )
+    assert wrong_object_result.plan is None
+    assert wrong_object_result.trace.blocked_reason == PLAN_BLOCK_INVALID_INTENT_CONTRACT


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, pre-execution planning layer that converts an execution intent into an explicit plan contract without enabling any runtime activation, wallet/signing fields, or exchange interaction.
- Ensure planning is strictly non-activating and deterministic so identical inputs always yield identical planning outputs or deterministic blocked results.
- Keep the change scoped to planning contracts and tests only (Validation Tier: `STANDARD`, Claim Level: `NARROW INTEGRATION`).

### Description
- Added `projects/polymarket/polyquantbot/platform/execution/execution_plan.py` implementing `ExecutionPlan`, `ExecutionPlanTrace`, `ExecutionPlanBuildResult`, typed inputs (`ExecutionPlanIntentInput`, `ExecutionPlanMarketContextInput`), and `ExecutionPlanBuilder` with `build_from_intent` and `build_with_trace` that enforce deterministic validation and blocked outcomes.  Planning outputs preserve `non_activating=True` and include deterministic planning metadata (limit price source, slippage placeholder, execution mode label). 
- Validation rules ensure explicit allowed `side` and `routing_mode`, non-negative `size`, non-empty `market_id`/`outcome`, market/context matching, and `planning_allowed` gating; no wallet, signing, order submission, or runtime side effects are introduced. 
- Exported new planning contracts/constants from `projects/polymarket/polyquantbot/platform/execution/__init__.py`, added tests at `projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py`, created the forge report `projects/polymarket/polyquantbot/reports/forge/24_72_phase3_4_execution_planning_layer.md`, and updated `PROJECT_STATE.md` (allowed sections only). 

### Testing
- `python -m py_compile` on the new/changed files: `projects/polymarket/polyquantbot/platform/execution/execution_plan.py`, `projects/polymarket/polyquantbot/platform/execution/__init__.py`, and the new test file — result: PASS. 
- `pytest` run for Phase 3.4 tests plus Phase 3.3 baseline with repository path set: `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_4_execution_planning_layer_20260412.py projects/polymarket/polyquantbot/tests/test_phase3_3_execution_intent_contract_hardening_20260412.py` — result: PASS (25 passed). 
- Note: an initial pytest invocation in this container failed module collection until `PYTHONPATH` was set, after which the full test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc1f3984c832e8fb7cdf13f8d7d13)