### PR TITLE
Phase 3.6: deterministic execution decision aggregation (non-activating)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,12 +2,16 @@
 ## Walker AI DevOps
 
 ## 📅 Last Updated
-2026-04-12 17:18
+2026-04-12 17:55
 
 ## 🔄 Status
-✅ **Phase 3.5 COMPLETE (STANDARD, NARROW INTEGRATION)** deterministic non-activating execution risk evaluation layer added (Plan → Risk Decision contract), with deterministic policy blocking and no runtime activation path.
+✅ **Phase 3.6 COMPLETE (STANDARD, NARROW INTEGRATION)** deterministic non-activating execution decision aggregation layer added (Intent + Plan + Risk → Final Decision contract), with deterministic upstream mismatch/block propagation and no runtime activation path.
 
 ## ✅ COMPLETED
+- **Phase 3.6 execution decision aggregation layer** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_decision.py` with explicit deterministic `ExecutionDecision` final pre-execution contract, deterministic `ExecutionDecisionTrace`, and deterministic blocked outcomes for invalid top-level contracts, upstream mismatch, and upstream blocked risk decisions.
+- Added `ExecutionDecisionAggregator` (`aggregate`, `aggregate_with_trace`) and typed aggregation inputs (`ExecutionDecisionIntentInput`, `ExecutionDecisionPlanInput`, `ExecutionDecisionRiskInput`) with strict identity consistency checks and non-activating finalization (`ready_for_execution=False`, `non_activating=True`).
+- **Phase 3.6 tests added** in `projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py` covering valid path, invalid contract blocking, upstream mismatch blocking, blocked-risk propagation, deterministic equality, non-activating constraints, and None/dict/wrong-object safety.
+- **Phase 3.5 baseline remains green** in `projects/polymarket/polyquantbot/tests/test_phase3_5_execution_risk_evaluation_20260412.py`.
 - **Phase 3.5 execution risk evaluation layer** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_risk.py` with explicit deterministic `ExecutionRiskDecision` contract, deterministic trace metadata, local-only policy checks, and deterministic blocked outcomes for invalid top-level or invalid field-level risk inputs.
 - Added `ExecutionRiskEvaluator` (`evaluate`, `evaluate_with_trace`) and typed risk inputs (`ExecutionRiskPlanInput`, `ExecutionRiskPolicyInput`) with explicit plan-ready/non-activating/side/routing/execution-mode/size/slippage cap enforcement.
 - **Phase 3.5 tests added** in `projects/polymarket/polyquantbot/tests/test_phase3_5_execution_risk_evaluation_20260412.py` covering valid path, deterministic blocking for invalid contracts/fields and policy violations, non-activating enforcement, deterministic equality, and safety checks for None/dict/wrong-object inputs.
@@ -31,10 +35,10 @@
 ## 📋 NOT STARTED
 - **Phase 2 task 2.10:** Fly.io staging deploy.
 - **Phase 2 tasks 2.11–2.13:** multi-user DB schema, audit/event log schema, wallet context abstraction.
-- **Phase 3 remaining tasks (3.6–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
+- **Phase 3 remaining tasks (3.7–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
 
 ## 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/24_73_phase3_5_execution_risk_evaluation.md. Tier: STANDARD
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
 - Path-based test portability issues (manual port override required in CI).
@@ -43,6 +47,7 @@
 - Execution intent layer remains intentionally standalone (no gateway/runtime wiring yet) until later execution-engine phases.
 - Execution plan layer remains intentionally pre-execution only (no gateway/execution engine/order object/runtime orchestration wiring yet).
 - Execution risk layer remains intentionally pre-execution only (no gateway/execution/order/wallet/signing/capital wiring yet).
+- Execution decision aggregation layer remains intentionally pre-execution only (`ready_for_execution=False`; no gateway/execution/order/wallet/signing/capital wiring yet).
 - Async pytest plugin unavailable in current container; async adapter assertions covered via `asyncio.run(...)` in focused tests.
 - ContextResolver remains read-only by design; persistence-side ensure/write behavior is explicit-call only.
 - `execution_context_repository` and `audit_event_repository` bundle fields remain unused in current bridge/facade path.

--- a/projects/polymarket/polyquantbot/platform/execution/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/execution/__init__.py
@@ -14,6 +14,20 @@ from .execution_intent import (
     ExecutionIntentSignalInput,
     ExecutionIntentTrace,
 )
+from .execution_decision import (
+    DECISION_BLOCK_INVALID_INTENT_CONTRACT,
+    DECISION_BLOCK_INVALID_PLAN_CONTRACT,
+    DECISION_BLOCK_INVALID_RISK_CONTRACT,
+    DECISION_BLOCK_UPSTREAM_BLOCKED,
+    DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH,
+    ExecutionDecision,
+    ExecutionDecisionAggregator,
+    ExecutionDecisionBuildResult,
+    ExecutionDecisionIntentInput,
+    ExecutionDecisionPlanInput,
+    ExecutionDecisionRiskInput,
+    ExecutionDecisionTrace,
+)
 from .execution_risk import (
     RISK_BLOCK_EXECUTION_MODE_NOT_ALLOWED,
     RISK_BLOCK_INVALID_PLAN_INPUT,
@@ -49,6 +63,18 @@ from .execution_plan import (
 )
 
 __all__ = [
+    "DECISION_BLOCK_INVALID_INTENT_CONTRACT",
+    "DECISION_BLOCK_INVALID_PLAN_CONTRACT",
+    "DECISION_BLOCK_INVALID_RISK_CONTRACT",
+    "DECISION_BLOCK_UPSTREAM_BLOCKED",
+    "DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH",
+    "ExecutionDecision",
+    "ExecutionDecisionAggregator",
+    "ExecutionDecisionBuildResult",
+    "ExecutionDecisionIntentInput",
+    "ExecutionDecisionPlanInput",
+    "ExecutionDecisionRiskInput",
+    "ExecutionDecisionTrace",
     "INTENT_BLOCK_INVALID_ROUTING_CONTRACT",
     "INTENT_BLOCK_INVALID_SIGNAL_CONTRACT",
     "INTENT_BLOCK_INVALID_READINESS_CONTRACT",

--- a/projects/polymarket/polyquantbot/platform/execution/execution_decision.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_decision.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .execution_intent import ExecutionIntent
+from .execution_plan import ExecutionPlan
+from .execution_risk import ExecutionRiskDecision
+
+DECISION_BLOCK_INVALID_INTENT_CONTRACT = "invalid_intent_contract"
+DECISION_BLOCK_INVALID_PLAN_CONTRACT = "invalid_plan_contract"
+DECISION_BLOCK_INVALID_RISK_CONTRACT = "invalid_risk_contract"
+DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH = "upstream_contract_mismatch"
+DECISION_BLOCK_UPSTREAM_BLOCKED = "upstream_blocked"
+
+
+@dataclass(frozen=True)
+class ExecutionDecisionIntentInput:
+    intent: ExecutionIntent
+    source_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionDecisionPlanInput:
+    plan: ExecutionPlan
+    source_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionDecisionRiskInput:
+    risk_decision: ExecutionRiskDecision
+    source_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionDecision:
+    allowed: bool
+    blocked_reason: str | None
+    market_id: str
+    outcome: str
+    side: str
+    size: float
+    routing_mode: str
+    execution_mode: str
+    ready_for_execution: bool
+    non_activating: bool
+
+
+@dataclass(frozen=True)
+class ExecutionDecisionTrace:
+    decision_created: bool
+    blocked_reason: str | None
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+    aggregation_notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionDecisionBuildResult:
+    decision: ExecutionDecision | None
+    trace: ExecutionDecisionTrace
+
+
+class ExecutionDecisionAggregator:
+    """Phase 3.6 deterministic, non-activating final pre-execution aggregation layer."""
+
+    def aggregate(
+        self,
+        intent_input: ExecutionDecisionIntentInput,
+        plan_input: ExecutionDecisionPlanInput,
+        risk_input: ExecutionDecisionRiskInput,
+    ) -> ExecutionDecision | None:
+        return self.aggregate_with_trace(
+            intent_input=intent_input,
+            plan_input=plan_input,
+            risk_input=risk_input,
+        ).decision
+
+    def aggregate_with_trace(
+        self,
+        *,
+        intent_input: ExecutionDecisionIntentInput,
+        plan_input: ExecutionDecisionPlanInput,
+        risk_input: ExecutionDecisionRiskInput,
+    ) -> ExecutionDecisionBuildResult:
+        if not isinstance(intent_input, ExecutionDecisionIntentInput):
+            return _blocked_invalid_contract_result(
+                blocked_reason=DECISION_BLOCK_INVALID_INTENT_CONTRACT,
+                contract_name="intent_input",
+                contract_input=intent_input,
+            )
+
+        if not isinstance(plan_input, ExecutionDecisionPlanInput):
+            return _blocked_invalid_contract_result(
+                blocked_reason=DECISION_BLOCK_INVALID_PLAN_CONTRACT,
+                contract_name="plan_input",
+                contract_input=plan_input,
+            )
+
+        if not isinstance(risk_input, ExecutionDecisionRiskInput):
+            return _blocked_invalid_contract_result(
+                blocked_reason=DECISION_BLOCK_INVALID_RISK_CONTRACT,
+                contract_name="risk_input",
+                contract_input=risk_input,
+            )
+
+        upstream_trace_refs: dict[str, Any] = {
+            "intent_input": dict(intent_input.source_trace_refs),
+            "plan_input": dict(plan_input.source_trace_refs),
+            "risk_input": dict(risk_input.source_trace_refs),
+        }
+
+        intent_error = _validate_intent(intent_input.intent)
+        if intent_error is not None:
+            return _blocked_result(
+                blocked_reason=DECISION_BLOCK_INVALID_INTENT_CONTRACT,
+                market_id="",
+                outcome="",
+                side="",
+                size=0.0,
+                routing_mode="",
+                execution_mode="",
+                upstream_trace_refs={
+                    **upstream_trace_refs,
+                    "contract_errors": {"intent_input": intent_error},
+                },
+                aggregation_notes={"intent_error": intent_error},
+            )
+
+        plan_error = _validate_plan(plan_input.plan)
+        if plan_error is not None:
+            return _blocked_result(
+                blocked_reason=DECISION_BLOCK_INVALID_PLAN_CONTRACT,
+                market_id=intent_input.intent.market_id,
+                outcome=intent_input.intent.outcome,
+                side=intent_input.intent.side,
+                size=intent_input.intent.size,
+                routing_mode=intent_input.intent.routing_mode,
+                execution_mode="",
+                upstream_trace_refs={
+                    **upstream_trace_refs,
+                    "contract_errors": {"plan_input": plan_error},
+                },
+                aggregation_notes={"plan_error": plan_error},
+            )
+
+        risk_error = _validate_risk(risk_input.risk_decision)
+        if risk_error is not None:
+            return _blocked_result(
+                blocked_reason=DECISION_BLOCK_INVALID_RISK_CONTRACT,
+                market_id=plan_input.plan.market_id,
+                outcome=plan_input.plan.outcome,
+                side=plan_input.plan.side,
+                size=plan_input.plan.size,
+                routing_mode=plan_input.plan.routing_mode,
+                execution_mode=plan_input.plan.execution_mode,
+                upstream_trace_refs={
+                    **upstream_trace_refs,
+                    "contract_errors": {"risk_input": risk_error},
+                },
+                aggregation_notes={"risk_error": risk_error},
+            )
+
+        mismatch = _find_mismatch(
+            intent=intent_input.intent,
+            plan=plan_input.plan,
+            risk_decision=risk_input.risk_decision,
+        )
+        if mismatch is not None:
+            return _blocked_result(
+                blocked_reason=DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH,
+                market_id=plan_input.plan.market_id,
+                outcome=plan_input.plan.outcome,
+                side=plan_input.plan.side,
+                size=plan_input.plan.size,
+                routing_mode=plan_input.plan.routing_mode,
+                execution_mode=plan_input.plan.execution_mode,
+                upstream_trace_refs=upstream_trace_refs,
+                aggregation_notes={"mismatch": mismatch},
+            )
+
+        if not risk_input.risk_decision.allowed:
+            return _blocked_result(
+                blocked_reason=DECISION_BLOCK_UPSTREAM_BLOCKED,
+                market_id=plan_input.plan.market_id,
+                outcome=plan_input.plan.outcome,
+                side=plan_input.plan.side,
+                size=plan_input.plan.size,
+                routing_mode=plan_input.plan.routing_mode,
+                execution_mode=plan_input.plan.execution_mode,
+                upstream_trace_refs=upstream_trace_refs,
+                aggregation_notes={"upstream_risk_blocked_reason": risk_input.risk_decision.blocked_reason},
+            )
+
+        decision = ExecutionDecision(
+            allowed=True,
+            blocked_reason=None,
+            market_id=plan_input.plan.market_id,
+            outcome=plan_input.plan.outcome,
+            side=plan_input.plan.side,
+            size=plan_input.plan.size,
+            routing_mode=plan_input.plan.routing_mode,
+            execution_mode=plan_input.plan.execution_mode,
+            ready_for_execution=False,
+            non_activating=True,
+        )
+        return ExecutionDecisionBuildResult(
+            decision=decision,
+            trace=ExecutionDecisionTrace(
+                decision_created=True,
+                blocked_reason=None,
+                upstream_trace_refs=upstream_trace_refs,
+                aggregation_notes={
+                    "aggregation_mode": "pre_execution_non_activating",
+                    "ready_for_execution": False,
+                },
+            ),
+        )
+
+
+def _validate_intent(intent: ExecutionIntent) -> str | None:
+    if not isinstance(intent, ExecutionIntent):
+        return "intent_contract_required"
+    if not intent.market_id.strip():
+        return "market_id_required"
+    if not intent.outcome.strip():
+        return "outcome_required"
+    if not intent.side.strip():
+        return "side_required"
+    if not intent.routing_mode.strip():
+        return "routing_mode_required"
+    if intent.size < 0:
+        return "size_must_be_non_negative"
+    return None
+
+
+def _validate_plan(plan: ExecutionPlan) -> str | None:
+    if not isinstance(plan, ExecutionPlan):
+        return "plan_contract_required"
+    if not plan.market_id.strip():
+        return "market_id_required"
+    if not plan.outcome.strip():
+        return "outcome_required"
+    if not plan.side.strip():
+        return "side_required"
+    if not plan.routing_mode.strip():
+        return "routing_mode_required"
+    if not plan.execution_mode.strip():
+        return "execution_mode_required"
+    if plan.size < 0:
+        return "size_must_be_non_negative"
+    return None
+
+
+def _validate_risk(risk_decision: ExecutionRiskDecision) -> str | None:
+    if not isinstance(risk_decision, ExecutionRiskDecision):
+        return "risk_contract_required"
+    if not isinstance(risk_decision.allowed, bool):
+        return "risk_allowed_must_be_bool"
+    if not isinstance(risk_decision.non_activating, bool):
+        return "risk_non_activating_must_be_bool"
+    return None
+
+
+def _find_mismatch(
+    *,
+    intent: ExecutionIntent,
+    plan: ExecutionPlan,
+    risk_decision: ExecutionRiskDecision,
+) -> dict[str, Any] | None:
+    if intent.market_id != plan.market_id:
+        return {
+            "field": "market_id",
+            "intent_value": intent.market_id,
+            "plan_value": plan.market_id,
+        }
+    if intent.outcome != plan.outcome:
+        return {
+            "field": "outcome",
+            "intent_value": intent.outcome,
+            "plan_value": plan.outcome,
+        }
+    if intent.side != plan.side:
+        return {
+            "field": "side",
+            "intent_value": intent.side,
+            "plan_value": plan.side,
+        }
+    if intent.size != plan.size:
+        return {
+            "field": "size",
+            "intent_value": intent.size,
+            "plan_value": plan.size,
+        }
+    if intent.routing_mode != plan.routing_mode:
+        return {
+            "field": "routing_mode",
+            "intent_value": intent.routing_mode,
+            "plan_value": plan.routing_mode,
+        }
+    if not risk_decision.non_activating:
+        return {
+            "field": "non_activating",
+            "risk_value": risk_decision.non_activating,
+            "required": True,
+        }
+    return None
+
+
+def _blocked_invalid_contract_result(
+    *,
+    blocked_reason: str,
+    contract_name: str,
+    contract_input: Any,
+) -> ExecutionDecisionBuildResult:
+    return _blocked_result(
+        blocked_reason=blocked_reason,
+        market_id="",
+        outcome="",
+        side="",
+        size=0.0,
+        routing_mode="",
+        execution_mode="",
+        upstream_trace_refs={
+            "contract_errors": {
+                contract_name: {
+                    "expected_type": contract_name,
+                    "actual_type": type(contract_input).__name__,
+                }
+            }
+        },
+        aggregation_notes={"contract_name": contract_name},
+    )
+
+
+def _blocked_result(
+    *,
+    blocked_reason: str,
+    market_id: str,
+    outcome: str,
+    side: str,
+    size: float,
+    routing_mode: str,
+    execution_mode: str,
+    upstream_trace_refs: dict[str, Any],
+    aggregation_notes: dict[str, Any] | None,
+) -> ExecutionDecisionBuildResult:
+    decision = ExecutionDecision(
+        allowed=False,
+        blocked_reason=blocked_reason,
+        market_id=market_id,
+        outcome=outcome,
+        side=side,
+        size=size,
+        routing_mode=routing_mode,
+        execution_mode=execution_mode,
+        ready_for_execution=False,
+        non_activating=True,
+    )
+    return ExecutionDecisionBuildResult(
+        decision=decision,
+        trace=ExecutionDecisionTrace(
+            decision_created=True,
+            blocked_reason=blocked_reason,
+            upstream_trace_refs=upstream_trace_refs,
+            aggregation_notes=aggregation_notes,
+        ),
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md
@@ -1,0 +1,72 @@
+# Forge Report — Phase 3.6 Execution Decision Aggregation (Intent + Plan + Risk → Final Decision, Non-Activating)
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_decision.py`, `projects/polymarket/polyquantbot/platform/execution/__init__.py`, `projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py`, and Phase 3.5 baseline test `projects/polymarket/polyquantbot/tests/test_phase3_5_execution_risk_evaluation_20260412.py`.  
+**Not in Scope:** Gateway wiring, execution engine integration, order object creation, order placement, wallet interaction, signing, portfolio mutation, capital movement, runtime orchestration expansion, external/network/db/exchange interactions, or new planning/risk business logic.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review optional if used. Source: `projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Added deterministic final-decision aggregation contracts in `execution_decision.py`:
+  - `ExecutionDecision`
+  - `ExecutionDecisionTrace`
+  - `ExecutionDecisionBuildResult`
+  - typed inputs: `ExecutionDecisionIntentInput`, `ExecutionDecisionPlanInput`, `ExecutionDecisionRiskInput`
+- Added deterministic `ExecutionDecisionAggregator` with:
+  - `aggregate(intent_input, plan_input, risk_input) -> ExecutionDecision | None`
+  - `aggregate_with_trace(...) -> ExecutionDecisionBuildResult`
+- Added deterministic block constants for explicit aggregation outcomes:
+  - `invalid_intent_contract`
+  - `invalid_plan_contract`
+  - `invalid_risk_contract`
+  - `upstream_contract_mismatch`
+  - `upstream_blocked`
+- Added identity-consistency checks across upstream contracts (`market_id`, `outcome`, `side`, `size`, `routing_mode`) and non-activating coherence checks.
+- Exported Phase 3.6 decision contracts and constants from `platform/execution/__init__.py`.
+
+## 2) Current system architecture
+- Phase 3.6 remains standalone and pre-execution:
+  1. Validate top-level decision input contracts (intent/plan/risk wrappers)
+  2. Validate contained upstream contract objects and required identity fields
+  3. Enforce identity-consistency checks between intent and plan
+  4. Propagate upstream blocked risk decisions deterministically
+  5. Produce final `ExecutionDecision` contract with deterministic trace visibility
+- Final contract remains non-activating by design:
+  - `ready_for_execution` is always `False`
+  - `non_activating` is always `True`
+- No runtime side effects introduced; no gateway/order/wallet/signing/capital/runtime activation paths added.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_decision.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Valid intent + plan + risk (allowed) produces deterministic allowed `ExecutionDecision`.
+- Invalid top-level contract objects (`None`, dict, wrong object) are blocked deterministically without crashes.
+- Invalid typed intent/plan/risk inner contract objects are blocked deterministically.
+- Upstream identity mismatch is blocked deterministically.
+- Upstream blocked risk decision propagates deterministically (`upstream_blocked`).
+- Allowed final decisions still keep `ready_for_execution=False`.
+- `non_activating=True` remains enforced in final decision output.
+- No wallet/signing/order-submission/activation fields were introduced in final decision contract.
+- Phase 3.6 tests pass and Phase 3.5 baseline remains green.
+
+## 5) Known issues
+- Container pytest still reports `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- Path-based test portability still depends on explicit `PYTHONPATH=/workspace/walker-ai-team` in this environment.
+
+## 6) What is next
+- COMMANDER review for STANDARD-tier scope and NARROW integration claim.
+- Optional auto PR review for changed contracts/tests and export surface.
+- Continue Phase 3 execution layering while preserving non-activating boundaries and deterministic contract behavior.
+
+---
+
+**Report Timestamp:** 2026-04-12 17:55 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 3.6 — Execution Decision Aggregator (Intent + Plan + Risk → Final Decision, Still Non-Activating)

--- a/projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import fields, replace
+
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import (
+    DECISION_BLOCK_INVALID_INTENT_CONTRACT,
+    DECISION_BLOCK_INVALID_PLAN_CONTRACT,
+    DECISION_BLOCK_INVALID_RISK_CONTRACT,
+    DECISION_BLOCK_UPSTREAM_BLOCKED,
+    DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH,
+    ExecutionDecision,
+    ExecutionDecisionAggregator,
+    ExecutionDecisionIntentInput,
+    ExecutionDecisionPlanInput,
+    ExecutionDecisionRiskInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_intent import ExecutionIntent
+from projects.polymarket.polyquantbot.platform.execution.execution_plan import ExecutionPlan
+from projects.polymarket.polyquantbot.platform.execution.execution_risk import ExecutionRiskDecision
+
+VALID_INTENT = ExecutionIntent(
+    market_id="MKT-3-6",
+    outcome="YES",
+    side="BUY",
+    size=4.0,
+    price=0.55,
+    confidence=0.81,
+    source_signal_id="SIG-3-6",
+    routing_mode="platform-gateway-shadow",
+    risk_validated=True,
+    readiness_passed=True,
+)
+
+VALID_PLAN = ExecutionPlan(
+    market_id="MKT-3-6",
+    outcome="YES",
+    side="BUY",
+    size=4.0,
+    routing_mode="platform-gateway-shadow",
+    execution_mode="paper-prep-only",
+    limit_price=0.55,
+    slippage_bps=10,
+    plan_ready=True,
+    non_activating=True,
+)
+
+VALID_RISK = ExecutionRiskDecision(
+    allowed=True,
+    risk_score=0.34,
+    blocked_reason=None,
+    risk_flags=[],
+    non_activating=True,
+)
+
+VALID_INTENT_INPUT = ExecutionDecisionIntentInput(
+    intent=VALID_INTENT,
+    source_trace_refs={"intent_trace_id": "INT-3-6"},
+)
+VALID_PLAN_INPUT = ExecutionDecisionPlanInput(
+    plan=VALID_PLAN,
+    source_trace_refs={"plan_trace_id": "PLAN-3-6"},
+)
+VALID_RISK_INPUT = ExecutionDecisionRiskInput(
+    risk_decision=VALID_RISK,
+    source_trace_refs={"risk_trace_id": "RISK-3-6"},
+)
+
+
+def test_phase3_6_valid_intent_plan_risk_allowed_produces_final_decision() -> None:
+    aggregator = ExecutionDecisionAggregator()
+
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is True
+    assert result.decision.blocked_reason is None
+    assert result.trace.decision_created is True
+
+
+def test_phase3_6_invalid_intent_contract_blocked_deterministically() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    result = aggregator.aggregate_with_trace(
+        intent_input=None,  # type: ignore[arg-type]
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is False
+    assert result.decision.blocked_reason == DECISION_BLOCK_INVALID_INTENT_CONTRACT
+
+
+def test_phase3_6_invalid_plan_contract_blocked_deterministically() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input={"plan": "bad"},  # type: ignore[arg-type]
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is False
+    assert result.decision.blocked_reason == DECISION_BLOCK_INVALID_PLAN_CONTRACT
+
+
+def test_phase3_6_invalid_risk_contract_blocked_deterministically() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=object(),  # type: ignore[arg-type]
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is False
+    assert result.decision.blocked_reason == DECISION_BLOCK_INVALID_RISK_CONTRACT
+
+
+def test_phase3_6_upstream_identity_mismatch_blocked_deterministically() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    mismatch_plan = replace(VALID_PLAN, market_id="MKT-OTHER")
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=ExecutionDecisionPlanInput(plan=mismatch_plan),
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is False
+    assert result.decision.blocked_reason == DECISION_BLOCK_UPSTREAM_CONTRACT_MISMATCH
+
+
+def test_phase3_6_upstream_blocked_risk_propagates_deterministically() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    blocked_risk = replace(VALID_RISK, allowed=False, blocked_reason="policy_block")
+
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=ExecutionDecisionRiskInput(risk_decision=blocked_risk),
+    )
+
+    assert result.decision is not None
+    assert result.decision.allowed is False
+    assert result.decision.blocked_reason == DECISION_BLOCK_UPSTREAM_BLOCKED
+
+
+def test_phase3_6_allowed_final_decision_still_not_ready_for_execution() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    decision = aggregator.aggregate(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert decision is not None
+    assert decision.allowed is True
+    assert decision.ready_for_execution is False
+
+
+def test_phase3_6_non_activating_remains_true() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert result.decision is not None
+    assert result.decision.non_activating is True
+
+
+def test_phase3_6_deterministic_equality_for_same_valid_inputs() -> None:
+    aggregator = ExecutionDecisionAggregator()
+    first = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+    second = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+
+    assert first == second
+
+
+def test_phase3_6_no_wallet_signing_activation_order_submission_fields_introduced() -> None:
+    field_names = {item.name for item in fields(ExecutionDecision)}
+
+    assert "wallet_address" not in field_names
+    assert "private_key" not in field_names
+    assert "signature" not in field_names
+    assert "submit_order" not in field_names
+    assert "order_submission_hook" not in field_names
+    assert "activate_runtime_execution" not in field_names
+
+
+def test_phase3_6_none_dict_wrong_object_inputs_do_not_crash() -> None:
+    aggregator = ExecutionDecisionAggregator()
+
+    none_result = aggregator.aggregate_with_trace(
+        intent_input=None,  # type: ignore[arg-type]
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=VALID_RISK_INPUT,
+    )
+    assert none_result.decision is not None
+    assert none_result.decision.blocked_reason == DECISION_BLOCK_INVALID_INTENT_CONTRACT
+
+    dict_result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=None,  # type: ignore[arg-type]
+        risk_input=VALID_RISK_INPUT,
+    )
+    assert dict_result.decision is not None
+    assert dict_result.decision.blocked_reason == DECISION_BLOCK_INVALID_PLAN_CONTRACT
+
+    wrong_object_result = aggregator.aggregate_with_trace(
+        intent_input=VALID_INTENT_INPUT,
+        plan_input=VALID_PLAN_INPUT,
+        risk_input=None,  # type: ignore[arg-type]
+    )
+    assert wrong_object_result.decision is not None
+    assert wrong_object_result.decision.blocked_reason == DECISION_BLOCK_INVALID_RISK_CONTRACT


### PR DESCRIPTION
### Motivation
- Provide a single authoritative, deterministic pre-execution contract that aggregates upstream pre-execution artifacts (`ExecutionIntent`, `ExecutionPlan`, `ExecutionRiskDecision`) without introducing any activation or runtime behavior.  
- Ensure deterministic blocking and traceability when upstream inputs are invalid, disagree, or risk-blocked so later runtime wiring can rely on a stable final-decision contract.  

### Description
- Added `projects/polymarket/polyquantbot/platform/execution/execution_decision.py` which defines `ExecutionDecision`, `ExecutionDecisionTrace`, `ExecutionDecisionBuildResult`, typed wrapper inputs, deterministic block constants, identity-consistency checks, and `ExecutionDecisionAggregator` with `aggregate` and `aggregate_with_trace`.  
- Aggregation enforces only deterministic checks and propagation rules (invalid contracts -> blocked, upstream blocked risk -> blocked, upstream identity mismatches -> blocked) while preserving `ready_for_execution=False` and `non_activating=True`.  
- Exported the new decision symbols from `projects/polymarket/polyquantbot/platform/execution/__init__.py`, added focused unit tests `projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py`, created the forge report `projects/polymarket/polyquantbot/reports/forge/24_74_phase3_6_execution_decision_aggregation.md`, and updated `PROJECT_STATE.md` to mark Phase 3.6 COMPLETE with STANDARD tier / NARROW INTEGRATION handoff.  

### Testing
- Ran `python -m py_compile` on the new module, package `__init__.py`, and tests which completed without errors.  
- Ran `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_6_execution_decision_aggregation_20260412.py` and the test file passed.  
- Re-ran Phase 3.5 baseline tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase3_5_execution_risk_evaluation_20260412.py` and the baseline remained green; all relevant automated tests passed (with a non-blocking pytest config warning observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd8c45ef4832e8f22b0c979bc5a42)