### PR TITLE
Phase 4.1: deterministic non-executing execution adapter (mapping-only)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,13 +1,15 @@
 # PROJECT_STATE.md
-## Walker AI DevOps
-
 ## 📅 Last Updated
-2026-04-12 18:40
+2026-04-12 20:34
 
 ## 🔄 Status
-✅ **SENTINEL APPROVED — Phase 3.8 (MAJOR, NARROW INTEGRATION)** rerun validation confirms deterministic default-off controlled readiness unlock only; no order/wallet/signing/capital/runtime side-effect path introduced.
+✅ **FORGE-X COMPLETE — Phase 4.1 (STANDARD, NARROW INTEGRATION)** deterministic execution adapter now maps activated internal decisions into explicit external-order-ready non-executing order contracts with deterministic blocking and no runtime side effects.
 
 ## ✅ COMPLETED
+- **Phase 4.1 execution adapter (mapping-only boundary)** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py` with explicit deterministic contracts (`ExecutionOrderSpec`, `ExecutionOrderTrace`, `ExecutionOrderBuildResult`) and deterministic blocked outcomes for invalid top-level input, invalid decision contract, upstream not allowed, decision not ready, and non-activating enforcement.
+- Added `ExecutionAdapter` (`build_order`, `build_order_with_trace`) and typed adapter input (`ExecutionAdapterDecisionInput`) with explicit deterministic side/routing/symbol mapping to external-order-ready fields and hard `non_executing=True` enforcement.
+- **Phase 4.1 tests added** in `projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py` covering valid mapping, deterministic blocking paths, mapping correctness, deterministic equality, non-execution field safety, and None/dict/wrong-object input safety.
+- **Phase 3.8 baseline remains green** in `projects/polymarket/polyquantbot/tests/test_phase3_8_execution_activation_gate_20260412.py`.
 - **SENTINEL rerun validation complete (PR #439, Phase 3.8)** in `projects/polymarket/polyquantbot/reports/sentinel/24_77_phase3_8_execution_activation_gate_validation_rerun.md` with verdict **APPROVED (98/100)**, zero critical findings, deterministic default-off gating confirmed, and execution boundary preserved as controlled-readiness only.
 - **Phase 3.8 execution activation gate (controlled unlock layer)** implemented in `projects/polymarket/polyquantbot/platform/execution/execution_activation_gate.py` with deterministic explicit activation contracts (`ExecutionActivationDecision`, `ExecutionActivationTrace`, `ExecutionActivationBuildResult`) and deterministic blocked outcomes for invalid contracts/inputs, upstream blocked decisions, disabled activation policy, disallowed activation mode, already-ready source, non-activating enforcement, and simulation-only enforcement.
 - Added `ExecutionActivationGate` (`evaluate`, `evaluate_with_trace`) and typed activation inputs (`ExecutionActivationDecisionInput`, `ExecutionActivationPolicyInput`) with explicit default-off policy semantics and deterministic local-only policy evaluation.
@@ -40,12 +42,13 @@
 ## 📋 NOT STARTED
 - **Phase 2 task 2.10:** Fly.io staging deploy.
 - **Phase 2 tasks 2.11–2.13:** multi-user DB schema, audit/event log schema, wallet context abstraction.
-- **Phase 3 remaining tasks (3.7, 3.9–3.11), Phase 4 Multi-User Public Architecture (4.1–4.11), and Phases 5–6** remain not started.
+- **Phase 3 remaining tasks (3.7, 3.9–3.11), Phase 4 Multi-User Public Architecture (4.2–4.11), and Phases 5–6** remain not started.
 
 ## 🎯 NEXT PRIORITY
-- COMMANDER merge decision on PR #439 (SENTINEL APPROVED). Source: projects/polymarket/polyquantbot/reports/sentinel/24_77_phase3_8_execution_activation_gate_validation_rerun.md. Tier: MAJOR
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md. Tier: STANDARD
 
 ## ⚠️ KNOWN ISSUES
+- Execution adapter remains intentionally non-executing and mapping-only (`non_executing=True` enforced); no gateway/execution engine/order submission/wallet/signing/capital/network wiring yet.
 - Path-based test portability issues (manual port override required in CI).
 - Non-activating constraint remains in place.
 - Dual-mode routing remains non-runtime and structural-only.

--- a/projects/polymarket/polyquantbot/platform/execution/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/execution/__init__.py
@@ -1,5 +1,17 @@
 """Deterministic pre-execution intent modeling contracts."""
 
+from .execution_adapter import (
+    ADAPTER_BLOCK_DECISION_NOT_READY,
+    ADAPTER_BLOCK_INVALID_DECISION_CONTRACT,
+    ADAPTER_BLOCK_INVALID_DECISION_INPUT,
+    ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED,
+    ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED,
+    ExecutionAdapter,
+    ExecutionAdapterDecisionInput,
+    ExecutionOrderBuildResult,
+    ExecutionOrderSpec,
+    ExecutionOrderTrace,
+)
 from .execution_activation_gate import (
     ACTIVATION_BLOCK_ACTIVATION_DISABLED,
     ACTIVATION_BLOCK_ACTIVATION_MODE_NOT_ALLOWED,
@@ -81,6 +93,16 @@ from .execution_plan import (
 )
 
 __all__ = [
+    "ADAPTER_BLOCK_DECISION_NOT_READY",
+    "ADAPTER_BLOCK_INVALID_DECISION_CONTRACT",
+    "ADAPTER_BLOCK_INVALID_DECISION_INPUT",
+    "ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED",
+    "ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED",
+    "ExecutionAdapter",
+    "ExecutionAdapterDecisionInput",
+    "ExecutionOrderBuildResult",
+    "ExecutionOrderSpec",
+    "ExecutionOrderTrace",
     "ACTIVATION_BLOCK_ACTIVATION_DISABLED",
     "ACTIVATION_BLOCK_ACTIVATION_MODE_NOT_ALLOWED",
     "ACTIVATION_BLOCK_ALREADY_READY_FOR_EXECUTION",

--- a/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .execution_decision import ExecutionDecision
+
+ADAPTER_BLOCK_INVALID_DECISION_INPUT = "invalid_decision_input"
+ADAPTER_BLOCK_INVALID_DECISION_CONTRACT = "invalid_decision_contract"
+ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED = "upstream_not_allowed"
+ADAPTER_BLOCK_DECISION_NOT_READY = "decision_not_ready"
+ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED = "non_activating_required"
+
+
+_SIDE_TO_EXTERNAL_SIDE: dict[str, str] = {
+    "BUY": "BUY",
+    "SELL": "SELL",
+    "YES": "BUY",
+    "NO": "SELL",
+}
+
+_ROUTING_MODE_TO_EXECUTION_MODE: dict[str, str] = {
+    "platform-gateway-shadow": "LIMIT",
+    "platform-gateway-primary": "LIMIT",
+    "legacy-only": "MARKET",
+    "disabled": "MARKET",
+}
+
+
+@dataclass(frozen=True)
+class ExecutionAdapterDecisionInput:
+    decision: ExecutionDecision
+    source_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionOrderSpec:
+    market_id: str
+    outcome: str
+    side: str
+    size: float
+    order_type: str
+    limit_price: float | None
+    slippage_bps: int | None
+    routing_mode: str
+    execution_mode: str
+    external_symbol: str
+    external_side: str
+    external_order_type: str
+    non_executing: bool
+
+
+@dataclass(frozen=True)
+class ExecutionOrderTrace:
+    order_created: bool
+    blocked_reason: str | None
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+    mapping_notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionOrderBuildResult:
+    order: ExecutionOrderSpec | None
+    trace: ExecutionOrderTrace
+
+
+class ExecutionAdapter:
+    """Phase 4.1 deterministic adapter from internal decision to external-order-ready spec."""
+
+    def build_order(self, decision_input: ExecutionAdapterDecisionInput) -> ExecutionOrderSpec | None:
+        return self.build_order_with_trace(decision_input=decision_input).order
+
+    def build_order_with_trace(
+        self,
+        *,
+        decision_input: ExecutionAdapterDecisionInput,
+    ) -> ExecutionOrderBuildResult:
+        if not isinstance(decision_input, ExecutionAdapterDecisionInput):
+            return _blocked_result(
+                blocked_reason=ADAPTER_BLOCK_INVALID_DECISION_INPUT,
+                upstream_trace_refs={
+                    "contract_errors": {
+                        "decision_input": {
+                            "expected_type": "ExecutionAdapterDecisionInput",
+                            "actual_type": type(decision_input).__name__,
+                        }
+                    }
+                },
+                mapping_notes={"contract_name": "decision_input"},
+            )
+
+        decision_error = _validate_decision(decision_input.decision)
+        if decision_error is not None:
+            return _blocked_result(
+                blocked_reason=ADAPTER_BLOCK_INVALID_DECISION_CONTRACT,
+                upstream_trace_refs={
+                    "decision_input": dict(decision_input.source_trace_refs),
+                    "contract_errors": {"decision": decision_error},
+                },
+                mapping_notes={"decision_error": decision_error},
+            )
+
+        decision = decision_input.decision
+        if not decision.allowed:
+            return _blocked_result(
+                blocked_reason=ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED,
+                upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                mapping_notes={"upstream_blocked_reason": decision.blocked_reason},
+            )
+
+        if not decision.ready_for_execution:
+            return _blocked_result(
+                blocked_reason=ADAPTER_BLOCK_DECISION_NOT_READY,
+                upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                mapping_notes={"ready_for_execution": decision.ready_for_execution},
+            )
+
+        if decision.non_activating is not True:
+            return _blocked_result(
+                blocked_reason=ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED,
+                upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                mapping_notes={"non_activating": decision.non_activating},
+            )
+
+        external_side = _SIDE_TO_EXTERNAL_SIDE[decision.side]
+        mapped_execution_mode = _ROUTING_MODE_TO_EXECUTION_MODE[decision.routing_mode]
+        external_symbol = _build_external_symbol(decision.market_id, decision.outcome)
+
+        order = ExecutionOrderSpec(
+            market_id=decision.market_id,
+            outcome=decision.outcome,
+            side=decision.side,
+            size=decision.size,
+            order_type=mapped_execution_mode,
+            limit_price=None,
+            slippage_bps=None,
+            routing_mode=decision.routing_mode,
+            execution_mode=mapped_execution_mode,
+            external_symbol=external_symbol,
+            external_side=external_side,
+            external_order_type=mapped_execution_mode,
+            non_executing=True,
+        )
+
+        return ExecutionOrderBuildResult(
+            order=order,
+            trace=ExecutionOrderTrace(
+                order_created=True,
+                blocked_reason=None,
+                upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                mapping_notes={
+                    "side_to_external_side": {decision.side: external_side},
+                    "routing_mode_to_execution_mode": {decision.routing_mode: mapped_execution_mode},
+                    "symbol_mapping": {
+                        "market_id": decision.market_id,
+                        "outcome": decision.outcome,
+                        "external_symbol": external_symbol,
+                    },
+                    "non_executing_enforced": True,
+                    "external_effects": "none",
+                },
+            ),
+        )
+
+
+def _validate_decision(decision: ExecutionDecision) -> str | None:
+    if not isinstance(decision, ExecutionDecision):
+        return "decision_contract_required"
+    if not isinstance(decision.allowed, bool):
+        return "allowed_must_be_bool"
+    if not isinstance(decision.ready_for_execution, bool):
+        return "ready_for_execution_must_be_bool"
+    if not isinstance(decision.non_activating, bool):
+        return "non_activating_must_be_bool"
+    if not isinstance(decision.market_id, str) or not decision.market_id.strip():
+        return "market_id_required"
+    if not isinstance(decision.outcome, str) or not decision.outcome.strip():
+        return "outcome_required"
+    if not isinstance(decision.side, str) or decision.side not in _SIDE_TO_EXTERNAL_SIDE:
+        return "side_invalid"
+    if not isinstance(decision.routing_mode, str) or decision.routing_mode not in _ROUTING_MODE_TO_EXECUTION_MODE:
+        return "routing_mode_invalid"
+    if not isinstance(decision.size, (int, float)) or decision.size < 0:
+        return "size_must_be_non_negative"
+    return None
+
+
+def _build_external_symbol(market_id: str, outcome: str) -> str:
+    return f"{market_id}::{outcome.upper()}"
+
+
+def _blocked_result(
+    *,
+    blocked_reason: str,
+    upstream_trace_refs: dict[str, Any],
+    mapping_notes: dict[str, Any] | None,
+) -> ExecutionOrderBuildResult:
+    return ExecutionOrderBuildResult(
+        order=None,
+        trace=ExecutionOrderTrace(
+            order_created=False,
+            blocked_reason=blocked_reason,
+            upstream_trace_refs=upstream_trace_refs,
+            mapping_notes=mapping_notes,
+        ),
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md
@@ -1,0 +1,76 @@
+# Forge Report — Phase 4.1 Execution Adapter (Internal Plan → External Order Mapping, Non-Executing)
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py`, `projects/polymarket/polyquantbot/platform/execution/__init__.py`, `projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py`, and Phase 3.8 baseline `projects/polymarket/polyquantbot/tests/test_phase3_8_execution_activation_gate_20260412.py`.  
+**Not in Scope:** Execution engine modification, gateway wiring, exchange client integration, order submission, signing, wallet access, capital movement, async behavior changes, network/SDK calls, external lookups, and live-price/gas/fee fetches.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review optional if used. Source: `projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Added deterministic non-executing adapter module: `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py`.
+- Introduced explicit adapter contracts:
+  - `ExecutionOrderSpec`
+  - `ExecutionOrderTrace`
+  - `ExecutionOrderBuildResult`
+- Added typed input contract:
+  - `ExecutionAdapterDecisionInput`
+- Implemented `ExecutionAdapter` with:
+  - `build_order(decision_input) -> ExecutionOrderSpec | None`
+  - `build_order_with_trace(...) -> ExecutionOrderBuildResult`
+- Added deterministic blocking constants:
+  - `invalid_decision_input`
+  - `invalid_decision_contract`
+  - `upstream_not_allowed`
+  - `decision_not_ready`
+  - `non_activating_required`
+- Exported adapter contracts and constants via `projects/polymarket/polyquantbot/platform/execution/__init__.py`.
+
+## 2) Current system architecture
+- Phase 4.1 adds a strict mapping-only boundary after execution decision/activation outputs and before any future external execution layer.
+- The adapter flow is deterministic and local-only:
+  1. Validate top-level adapter input contract.
+  2. Validate upstream decision contract fields.
+  3. Enforce `allowed=True`, `ready_for_execution=True`, and `non_activating=True` (safe boundary requirement in this phase).
+  4. Perform explicit deterministic mapping:
+     - internal `side` → `external_side`
+     - internal `routing_mode` → mapped `execution_mode` and order type (`LIMIT`/`MARKET`)
+     - (`market_id`, `outcome`) → `external_symbol`
+  5. Produce `ExecutionOrderSpec` with `non_executing=True` always.
+- No runtime execution behavior is introduced; this phase remains preparatory contract mapping only.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Valid activated decision produces deterministic external-order-ready `ExecutionOrderSpec`.
+- Invalid top-level input is blocked deterministically (no crash).
+- Invalid decision contract is blocked deterministically (no crash).
+- Upstream `allowed=False` propagates blocked result.
+- `ready_for_execution=False` blocks deterministically.
+- `non_activating=False` blocks deterministically.
+- Deterministic equality confirmed for identical input.
+- Mapping correctness verified for side/order type/symbol mapping.
+- `ExecutionOrderSpec` enforces `non_executing=True` and does not include wallet/signing/network/capital execution fields.
+- None/dict/wrong-object inputs return deterministic blocked outputs without exceptions.
+
+## 5) Known issues
+- Container pytest still emits `PytestConfigWarning: Unknown config option: asyncio_mode`.
+- Path-based test portability still depends on explicit `PYTHONPATH=/workspace/walker-ai-team` in this environment.
+- Adapter currently maps to external-order-ready contract only; execution runtime/gateway/wallet/signing/capital integration remains intentionally out of scope.
+
+## 6) What is next
+- COMMANDER review required before merge (STANDARD tier).
+- Auto PR review can be used as optional support on changed files.
+- Keep claim level at NARROW INTEGRATION: this phase covers only deterministic mapping boundary for external-order-ready contracts, not runtime execution.
+
+---
+
+**Report Timestamp:** 2026-04-12 20:34 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 4.1 — Execution Adapter (Internal Plan → External Order Mapping, Non-Executing)

--- a/projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import fields, replace
+
+from projects.polymarket.polyquantbot.platform.execution.execution_adapter import (
+    ADAPTER_BLOCK_DECISION_NOT_READY,
+    ADAPTER_BLOCK_INVALID_DECISION_CONTRACT,
+    ADAPTER_BLOCK_INVALID_DECISION_INPUT,
+    ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED,
+    ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED,
+    ExecutionAdapter,
+    ExecutionAdapterDecisionInput,
+    ExecutionOrderSpec,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import ExecutionDecision
+
+VALID_DECISION = ExecutionDecision(
+    allowed=True,
+    blocked_reason=None,
+    market_id="MKT-4-1",
+    outcome="YES",
+    side="YES",
+    size=5.0,
+    routing_mode="platform-gateway-shadow",
+    execution_mode="paper-prep-only",
+    ready_for_execution=True,
+    non_activating=True,
+)
+
+VALID_DECISION_INPUT = ExecutionAdapterDecisionInput(
+    decision=VALID_DECISION,
+    source_trace_refs={"decision_trace_id": "DEC-4-1"},
+)
+
+
+def test_phase4_1_valid_activated_decision_produces_order_spec() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(decision_input=VALID_DECISION_INPUT)
+
+    assert result.order is not None
+    assert result.trace.order_created is True
+    assert result.trace.blocked_reason is None
+    assert result.order.non_executing is True
+
+
+def test_phase4_1_invalid_decision_contract_blocked_deterministically() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(
+        decision_input=ExecutionAdapterDecisionInput(
+            decision=None,  # type: ignore[arg-type]
+        )
+    )
+
+    assert result.order is None
+    assert result.trace.order_created is False
+    assert result.trace.blocked_reason == ADAPTER_BLOCK_INVALID_DECISION_CONTRACT
+
+
+def test_phase4_1_invalid_top_level_input_blocked_deterministically() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(
+        decision_input=None,  # type: ignore[arg-type]
+    )
+
+    assert result.order is None
+    assert result.trace.order_created is False
+    assert result.trace.blocked_reason == ADAPTER_BLOCK_INVALID_DECISION_INPUT
+
+
+def test_phase4_1_upstream_blocked_decision_propagates() -> None:
+    adapter = ExecutionAdapter()
+    blocked_decision = replace(VALID_DECISION, allowed=False, blocked_reason="risk_blocked")
+
+    result = adapter.build_order_with_trace(
+        decision_input=ExecutionAdapterDecisionInput(decision=blocked_decision)
+    )
+
+    assert result.order is None
+    assert result.trace.blocked_reason == ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED
+
+
+def test_phase4_1_ready_for_execution_false_blocked() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(
+        decision_input=ExecutionAdapterDecisionInput(
+            decision=replace(VALID_DECISION, ready_for_execution=False)
+        )
+    )
+
+    assert result.order is None
+    assert result.trace.blocked_reason == ADAPTER_BLOCK_DECISION_NOT_READY
+
+
+def test_phase4_1_non_activating_false_blocked() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(
+        decision_input=ExecutionAdapterDecisionInput(
+            decision=replace(VALID_DECISION, non_activating=False)
+        )
+    )
+
+    assert result.order is None
+    assert result.trace.blocked_reason == ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED
+
+
+def test_phase4_1_deterministic_mapping_same_input_same_output() -> None:
+    adapter = ExecutionAdapter()
+
+    first = adapter.build_order_with_trace(decision_input=VALID_DECISION_INPUT)
+    second = adapter.build_order_with_trace(decision_input=VALID_DECISION_INPUT)
+
+    assert first == second
+
+
+def test_phase4_1_mapping_correctness_side_order_type_symbol() -> None:
+    adapter = ExecutionAdapter()
+
+    result = adapter.build_order_with_trace(decision_input=VALID_DECISION_INPUT)
+
+    assert result.order is not None
+    assert result.order.external_side == "BUY"
+    assert result.order.order_type == "LIMIT"
+    assert result.order.external_order_type == "LIMIT"
+    assert result.order.execution_mode == "LIMIT"
+    assert result.order.external_symbol == "MKT-4-1::YES"
+
+
+def test_phase4_1_no_execution_network_wallet_fields_introduced() -> None:
+    field_names = {item.name for item in fields(ExecutionOrderSpec)}
+
+    assert "wallet_address" not in field_names
+    assert "signature" not in field_names
+    assert "private_key" not in field_names
+    assert "submit_order" not in field_names
+    assert "network_client" not in field_names
+    assert "capital_transfer" not in field_names
+
+
+def test_phase4_1_none_dict_wrong_object_inputs_do_not_crash() -> None:
+    adapter = ExecutionAdapter()
+
+    none_input_result = adapter.build_order_with_trace(
+        decision_input=None,  # type: ignore[arg-type]
+    )
+    assert none_input_result.trace.blocked_reason == ADAPTER_BLOCK_INVALID_DECISION_INPUT
+
+    dict_input_result = adapter.build_order_with_trace(
+        decision_input={"decision": VALID_DECISION},  # type: ignore[arg-type]
+    )
+    assert dict_input_result.trace.blocked_reason == ADAPTER_BLOCK_INVALID_DECISION_INPUT
+
+    wrong_inner_result = adapter.build_order_with_trace(
+        decision_input=ExecutionAdapterDecisionInput(
+            decision=object(),  # type: ignore[arg-type]
+        )
+    )
+    assert wrong_inner_result.trace.blocked_reason == ADAPTER_BLOCK_INVALID_DECISION_CONTRACT


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, non-executing adapter boundary that maps an approved `ExecutionDecision` into an explicit external-order-ready contract without performing any network/wallet/signing/execution actions.
- Enforce a safe mapping-only phase (Phase 4.1) that deterministically blocks invalid inputs/contracts and preserves the non-execution guarantee (`non_executing=True`).

### Description
- Added `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py` containing `ExecutionAdapter`, typed contracts `ExecutionOrderSpec`, `ExecutionOrderTrace`, `ExecutionOrderBuildResult`, and input `ExecutionAdapterDecisionInput`, plus deterministic blocking constants (`invalid_decision_input`, `invalid_decision_contract`, `upstream_not_allowed`, `decision_not_ready`, `non_activating_required`).
- Implemented explicit, deterministic mappings: internal `side -> external_side`, `routing_mode -> execution_mode/order_type` (`LIMIT`/`MARKET`), and `(market_id, outcome) -> external_symbol`, and enforced `non_executing=True` on produced specs.
- Exported adapter symbols via `projects/polymarket/polyquantbot/platform/execution/__init__.py` and added the Phase 4.1 forge report at `projects/polymarket/polyquantbot/reports/forge/24_78_phase4_1_execution_adapter.md` and tests at `projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py`.
- Updated `PROJECT_STATE.md` (only allowed sections) to record completion and next-priority handoff for COMMANDER review; claim level remains NARROW INTEGRATION and Validation Tier = STANDARD.

### Testing
- Ran static compile check with `python -m py_compile` on the new module and related files (passed).
- Ran targeted tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q` for Phase 4.1 and Phase 3.8 files (`projects/polymarket/polyquantbot/tests/test_phase4_1_execution_adapter_20260412.py` and `projects/polymarket/polyquantbot/tests/test_phase3_8_execution_activation_gate_20260412.py`) and observed `24 passed, 1 warning` (the warning is `PytestConfigWarning: Unknown config option: asyncio_mode`).
- Verified determinism, mapping correctness, deterministic blocking paths, and that no wallet/network/execution fields or external calls are introduced (tests cover None/dict/wrong-object safety and field-safety checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc016df4a4832ea8a4ffa8d109cde7)