### PR TITLE
Phase 6.1: Execution Ledger & Reconciliation Foundation (MAJOR)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-13 03:16
+2026-04-13 03:25
 
 ## Status
 — **FORGE-X COMPLETE (PENDING SENTINEL) — Phase 6.1 execution ledger and read-only reconciliation foundation implemented (MAJOR, FOUNDATION)**
@@ -22,6 +22,7 @@ Deterministic append-only in-memory execution traceability is now available acro
 - **Phase 5.6 fund settlement boundary** implemented with strict policy-gated real settlement, deterministic single-shot transfer interface, and explicit simulated-safe settlement mode.
 - **SENTINEL validation (PR #457)** completed with APPROVED verdict (96/100) for MAJOR-tier NARROW INTEGRATION scope.
 - **Phase 6.1 execution ledger & reconciliation foundation** implemented with deterministic append-only in-memory ledger records and read-only reconciliation checks (no persistence, no correction logic, no automation).
+- **Phase 6.1 reconciliation input hardening** added deterministic invalid-input handling for malformed capital snapshots (`invalid_capital_snapshot`) to preserve non-crashing read-only reconciliation behavior.
 
 ## IN PROGRESS
 - Awaiting SENTINEL validation for Phase 6.1 execution ledger & reconciliation foundation (MAJOR, FOUNDATION).

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,10 +1,12 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-13 03:04
+2026-04-13 03:16
+
 ## Status
-— **SENTINEL APPROVED — Phase 5.6 fund settlement boundary validated (MAJOR, NARROW INTEGRATION)**
-Real fund movement boundary remains strict single-shot settlement with explicit deterministic gates; no hidden transfer path, no retry/batching/async automation, and no lifecycle expansion detected.
+— **FORGE-X COMPLETE (PENDING SENTINEL) — Phase 6.1 execution ledger and read-only reconciliation foundation implemented (MAJOR, FOUNDATION)**
+Deterministic append-only in-memory execution traceability is now available across transport → exchange → signing → capital → settlement with strict blocking constants and deterministic reconciliation checks; no persistence, correction logic, or automation path introduced.
+
 ## COMPLETED
 - **Phase 5.2 execution transport layer** implemented with deterministic gating for real submission vs simulated submission.
 - **Phase 5.2 transport policy gates** enforce transport enablement, explicit real submission permission, LIVE-mode requirement, dry-run forcing, single-order limits, idempotency, audit log, and operator confirmation requirements.
@@ -19,17 +21,24 @@ Real fund movement boundary remains strict single-shot settlement with explicit 
 - **SENTINEL validation (PR #455)** completed with APPROVED verdict (93/100) for MAJOR-tier NARROW INTEGRATION scope.
 - **Phase 5.6 fund settlement boundary** implemented with strict policy-gated real settlement, deterministic single-shot transfer interface, and explicit simulated-safe settlement mode.
 - **SENTINEL validation (PR #457)** completed with APPROVED verdict (96/100) for MAJOR-tier NARROW INTEGRATION scope.
+- **Phase 6.1 execution ledger & reconciliation foundation** implemented with deterministic append-only in-memory ledger records and read-only reconciliation checks (no persistence, no correction logic, no automation).
+
 ## IN PROGRESS
+- Awaiting SENTINEL validation for Phase 6.1 execution ledger & reconciliation foundation (MAJOR, FOUNDATION).
 - Awaiting COMMANDER final merge decision for PR #457 after SENTINEL approval.
+
 ## NOT STARTED
 - Full wallet lifecycle implementation (secret loading/storage/rotation).
 - Portfolio management logic and multi-wallet orchestration.
 - Automation/retry/batching for settlement and wallet operations.
-- Reconciliation and external persistence for settlement lifecycle.
+- External persistence for settlement and execution-ledger lifecycle.
+- Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1).
+
 ## NEXT PRIORITY
-COMMANDER merge decision required for PR #457 after SENTINEL APPROVED verdict.
-Source: projects/polymarket/polyquantbot/reports/sentinel/24_95_phase5_6_fund_settlement_validation_pr457.md
+SENTINEL validation required for Phase 6.1 execution ledger & reconciliation foundation before merge.
+Source: reports/forge/24_96_phase6_1_execution_ledger.md
 Tier: MAJOR
+
 ## KNOWN ISSUES
 - Pytest emits `PytestConfigWarning: Unknown config option: asyncio_mode` in this container.
 - Phase 5.2 only supports single-order transport and intentionally excludes retry/batching/async workers.
@@ -37,4 +46,5 @@ Tier: MAJOR
 - Phase 5.4 introduces secure signing boundary only; wallet lifecycle and capital movement remain intentionally unimplemented.
 - Phase 5.5 introduces wallet boundary and capital control layer only; no real fund movement, no portfolio logic, and no automation are implemented in this phase.
 - Phase 5.6 introduces first real settlement boundary only; still single-shot with no retry, no batching, no async automation, and no portfolio lifecycle management.
+- Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, no correction logic, and no background automation are implemented.
 - Pytest import collection requires `PYTHONPATH=.` in this container for `projects.*` test module imports.

--- a/projects/polymarket/polyquantbot/platform/safety/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/safety/__init__.py
@@ -1,0 +1,16 @@
+"""Phase 6 safety foundation contracts and utilities."""
+
+from .execution_ledger import (
+    LEDGER_ALLOWED_STAGES,
+    LEDGER_BLOCK_INVALID_STAGE,
+    LEDGER_BLOCK_INVALID_UPSTREAM_REFS,
+    LEDGER_BLOCK_MISSING_SNAPSHOT,
+    ExecutionLedger,
+    LedgerBuildResult,
+    LedgerEntry,
+    LedgerRecordInput,
+    LedgerTrace,
+    ReconciliationCheckResult,
+    ReconciliationEngine,
+    ReconciliationInput,
+)

--- a/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
+++ b/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
@@ -184,6 +184,18 @@ class ReconciliationEngine:
                 reconciliation_notes={"execution_id": reconciliation_input.execution_id},
             )
 
+        if not isinstance(reconciliation_input.capital_snapshot, dict):
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="invalid_capital_snapshot",
+                expected_balance=None,
+                observed_balance=None,
+                reconciliation_notes={
+                    "execution_id": reconciliation_input.execution_id,
+                    "actual_type": type(reconciliation_input.capital_snapshot).__name__,
+                },
+            )
+
         balance_before = _to_float(reconciliation_input.capital_snapshot.get("balance_before"))
         if balance_before is None:
             balance_before = _to_float(reconciliation_input.capital_snapshot.get("available"))

--- a/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
+++ b/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+import hashlib
+import json
+from typing import Any
+
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import ExecutionTransportResult
+from projects.polymarket.polyquantbot.platform.execution.exchange_integration import ExchangeExecutionResult
+from projects.polymarket.polyquantbot.platform.execution.fund_settlement import FundSettlementResult
+from projects.polymarket.polyquantbot.platform.execution.secure_signing import SigningResult
+from projects.polymarket.polyquantbot.platform.execution.wallet_capital import WalletCapitalResult
+
+LEDGER_BLOCK_INVALID_STAGE = "invalid_stage"
+LEDGER_BLOCK_MISSING_SNAPSHOT = "missing_snapshot"
+LEDGER_BLOCK_INVALID_UPSTREAM_REFS = "invalid_upstream_refs"
+
+LEDGER_ALLOWED_STAGES = {"transport", "exchange", "signing", "capital", "settlement"}
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    entry_id: str
+    timestamp_ref: str
+    execution_id: str | None
+    stage: str
+    status: str
+    data_snapshot: dict[str, Any]
+    upstream_refs: dict[str, Any]
+    hash: str
+
+
+@dataclass(frozen=True)
+class LedgerTrace:
+    record_attempted: bool
+    blocked_reason: str | None
+    trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LedgerBuildResult:
+    entry: LedgerEntry | None
+    trace: LedgerTrace
+
+
+@dataclass(frozen=True)
+class ReconciliationCheckResult:
+    consistent: bool
+    mismatch_reason: str | None
+    expected_balance: float | None
+    observed_balance: float | None
+    reconciliation_notes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LedgerRecordInput:
+    timestamp_ref: str
+    execution_id: str | None
+    stage: str
+    status: str
+    data_snapshot: dict[str, Any]
+    upstream_refs: dict[str, Any]
+    snapshot_source: (
+        ExecutionTransportResult
+        | ExchangeExecutionResult
+        | SigningResult
+        | WalletCapitalResult
+        | FundSettlementResult
+        | None
+    ) = None
+
+
+@dataclass(frozen=True)
+class ReconciliationInput:
+    execution_id: str | None
+    capital_snapshot: dict[str, Any]
+    settlement_result: FundSettlementResult | None
+
+
+class ExecutionLedger:
+    """Phase 6.1 deterministic in-memory append-only execution ledger."""
+
+    def __init__(self) -> None:
+        self._entries: list[LedgerEntry] = []
+
+    def record(self, record_input: LedgerRecordInput) -> LedgerEntry | None:
+        return self.record_with_trace(record_input=record_input).entry
+
+    def record_with_trace(self, *, record_input: LedgerRecordInput) -> LedgerBuildResult:
+        if not isinstance(record_input, LedgerRecordInput):
+            return LedgerBuildResult(
+                entry=None,
+                trace=LedgerTrace(
+                    record_attempted=False,
+                    blocked_reason=LEDGER_BLOCK_MISSING_SNAPSHOT,
+                    trace_refs={
+                        "contract_error": {
+                            "expected_type": "LedgerRecordInput",
+                            "actual_type": type(record_input).__name__,
+                        }
+                    },
+                ),
+            )
+
+        block_reason = _validate_record_input(record_input=record_input)
+        if block_reason is not None:
+            return LedgerBuildResult(
+                entry=None,
+                trace=LedgerTrace(
+                    record_attempted=False,
+                    blocked_reason=block_reason,
+                    trace_refs={
+                        "execution_id": record_input.execution_id,
+                        "stage": record_input.stage,
+                    },
+                ),
+            )
+
+        snapshot_hash = _stable_hash(record_input.data_snapshot)
+        upstream_refs = _copy_dict(record_input.upstream_refs)
+        entry_id = _build_entry_id(
+            timestamp_ref=record_input.timestamp_ref,
+            execution_id=record_input.execution_id,
+            stage=record_input.stage,
+            status=record_input.status,
+            snapshot_hash=snapshot_hash,
+            upstream_refs=upstream_refs,
+        )
+
+        entry = LedgerEntry(
+            entry_id=entry_id,
+            timestamp_ref=record_input.timestamp_ref,
+            execution_id=record_input.execution_id,
+            stage=record_input.stage,
+            status=record_input.status,
+            data_snapshot=_copy_dict(record_input.data_snapshot),
+            upstream_refs=upstream_refs,
+            hash=snapshot_hash,
+        )
+        self._entries.append(entry)
+
+        return LedgerBuildResult(
+            entry=entry,
+            trace=LedgerTrace(
+                record_attempted=True,
+                blocked_reason=None,
+                trace_refs={
+                    "entry_id": entry.entry_id,
+                    "stage": entry.stage,
+                    "execution_id": entry.execution_id,
+                },
+            ),
+        )
+
+    def get_all_entries(self) -> tuple[LedgerEntry, ...]:
+        return tuple(self._entries)
+
+    def get_entries_by_execution_id(self, execution_id: str) -> tuple[LedgerEntry, ...]:
+        return tuple(entry for entry in self._entries if entry.execution_id == execution_id)
+
+
+class ReconciliationEngine:
+    """Read-only deterministic reconciliation for Phase 6.1 foundation."""
+
+    def check_consistency(self, reconciliation_input: ReconciliationInput) -> ReconciliationCheckResult:
+        if not isinstance(reconciliation_input, ReconciliationInput):
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="invalid_reconciliation_input",
+                expected_balance=None,
+                observed_balance=None,
+                reconciliation_notes={
+                    "expected_type": "ReconciliationInput",
+                    "actual_type": type(reconciliation_input).__name__,
+                },
+            )
+
+        if reconciliation_input.settlement_result is None:
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="missing_settlement_result",
+                expected_balance=None,
+                observed_balance=None,
+                reconciliation_notes={"execution_id": reconciliation_input.execution_id},
+            )
+
+        balance_before = _to_float(reconciliation_input.capital_snapshot.get("balance_before"))
+        if balance_before is None:
+            balance_before = _to_float(reconciliation_input.capital_snapshot.get("available"))
+
+        settlement = reconciliation_input.settlement_result
+        if balance_before is None or settlement.balance_before is None or settlement.balance_after is None:
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="missing_balance_fields",
+                expected_balance=None,
+                observed_balance=settlement.balance_after,
+                reconciliation_notes={"execution_id": reconciliation_input.execution_id},
+            )
+
+        amount = settlement.amount if settlement.amount is not None else 0.0
+        expected_balance = balance_before - amount if settlement.settled else balance_before
+        observed_balance = settlement.balance_after
+
+        if settlement.balance_before != balance_before:
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="balance_before_mismatch",
+                expected_balance=expected_balance,
+                observed_balance=observed_balance,
+                reconciliation_notes={
+                    "capital_balance_before": balance_before,
+                    "settlement_balance_before": settlement.balance_before,
+                },
+            )
+
+        if expected_balance != observed_balance:
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="balance_after_mismatch",
+                expected_balance=expected_balance,
+                observed_balance=observed_balance,
+                reconciliation_notes={
+                    "amount": amount,
+                    "settled": settlement.settled,
+                },
+            )
+
+        return ReconciliationCheckResult(
+            consistent=True,
+            mismatch_reason=None,
+            expected_balance=expected_balance,
+            observed_balance=observed_balance,
+            reconciliation_notes={
+                "execution_id": reconciliation_input.execution_id,
+                "deterministic": True,
+            },
+        )
+
+
+def _validate_record_input(*, record_input: LedgerRecordInput) -> str | None:
+    if record_input.stage not in LEDGER_ALLOWED_STAGES:
+        return LEDGER_BLOCK_INVALID_STAGE
+
+    if not isinstance(record_input.data_snapshot, dict) or len(record_input.data_snapshot) == 0:
+        return LEDGER_BLOCK_MISSING_SNAPSHOT
+
+    if not isinstance(record_input.upstream_refs, dict) or not _is_mapping_serializable(record_input.upstream_refs):
+        return LEDGER_BLOCK_INVALID_UPSTREAM_REFS
+
+    if record_input.snapshot_source is not None and not isinstance(
+        record_input.snapshot_source,
+        (
+            ExecutionTransportResult,
+            ExchangeExecutionResult,
+            SigningResult,
+            WalletCapitalResult,
+            FundSettlementResult,
+        ),
+    ):
+        return LEDGER_BLOCK_INVALID_UPSTREAM_REFS
+
+    return None
+
+
+def _build_entry_id(
+    *,
+    timestamp_ref: str,
+    execution_id: str | None,
+    stage: str,
+    status: str,
+    snapshot_hash: str,
+    upstream_refs: dict[str, Any],
+) -> str:
+    deterministic_payload = {
+        "timestamp_ref": timestamp_ref,
+        "execution_id": execution_id,
+        "stage": stage,
+        "status": status,
+        "snapshot_hash": snapshot_hash,
+        "upstream_refs": upstream_refs,
+    }
+    return hashlib.sha256(_canonical_json(deterministic_payload).encode("utf-8")).hexdigest()
+
+
+def _stable_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=_json_default)
+
+
+def _json_default(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    return str(value)
+
+
+def _is_mapping_serializable(value: dict[str, Any]) -> bool:
+    for key in value.keys():
+        if not isinstance(key, str) or key == "":
+            return False
+    try:
+        _canonical_json(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _copy_dict(source: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(_canonical_json(source))
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
@@ -80,6 +80,7 @@
 - Execution-id filtering is validated through deterministic retrieval from ledger state.
 - Reconciliation success and mismatch branches are both validated.
 - Invalid ledger/reconciliation inputs fail safely and do not crash.
+- Reconciliation input contract hardening now explicitly blocks non-dict `capital_snapshot` with deterministic `invalid_capital_snapshot` output (no crash path).
 - No persistence side effects were introduced in implementation.
 
 ## 5) Known issues
@@ -102,8 +103,8 @@
 1. `python -m py_compile projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/platform/safety/__init__.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
 3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py` → PASS
-4. `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task" projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS (no matches)
+4. `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task" projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py || true` → PASS (no matches)
 
-**Report Timestamp:** 2026-04-13 03:16 UTC  
+**Report Timestamp:** 2026-04-13 03:25 UTC  
 **Role:** FORGE-X (NEXUS)  
 **Task:** Phase 6.1 — Execution Ledger & Reconciliation Foundation (MAJOR)

--- a/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
@@ -1,0 +1,109 @@
+# Forge Report — Phase 6.1 Execution Ledger & Reconciliation Foundation (MAJOR)
+
+**Validation Tier:** MAJOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/safety/execution_ledger.py`, `projects/polymarket/polyquantbot/platform/safety/__init__.py`, `projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py`, plus baseline `projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py`.  
+**Not in Scope:** External persistence (DB/file/cloud), settlement correction, balance mutation outside read-only checks, background reconciliation, retry automation, queue/stream processing, and execution triggering.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Added new safety module: `projects/polymarket/polyquantbot/platform/safety/execution_ledger.py`.
+- Added safety package exports: `projects/polymarket/polyquantbot/platform/safety/__init__.py`.
+- Implemented immutable-style append-only ledger contracts:
+  - `LedgerEntry`
+  - `LedgerTrace`
+  - `LedgerBuildResult`
+  - `ReconciliationCheckResult`
+- Implemented input contracts:
+  - `LedgerRecordInput`
+  - `ReconciliationInput`
+- Implemented `ExecutionLedger` with required methods:
+  - `record(record_input)`
+  - `record_with_trace(...)`
+  - `get_all_entries()`
+  - `get_entries_by_execution_id(execution_id)`
+- Implemented `ReconciliationEngine` with required method:
+  - `check_consistency(reconciliation_input)`
+- Added deterministic blocking constants:
+  - `invalid_stage`
+  - `missing_snapshot`
+  - `invalid_upstream_refs`
+- Added deterministic hashing and stable entry-id construction:
+  - reproducible hash over canonical `data_snapshot`
+  - reproducible `entry_id` over canonical record payload
+- Added Phase 6.1 tests:
+  - `projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py`
+
+## 2) Current system architecture
+- Phase 6.1 introduces a new read-only safety foundation downstream of Phase 5.6 outputs.
+- Ledger accepts snapshot contracts from the exact upstream result types:
+  - `ExecutionTransportResult`
+  - `ExchangeExecutionResult`
+  - `SigningResult`
+  - `WalletCapitalResult`
+  - `FundSettlementResult`
+- Ledger behavior is append-only in-memory:
+  - entries are appended
+  - no delete API
+  - no mutation API
+  - retrieval methods return immutable tuple views
+- Reconciliation is deterministic and read-only:
+  - compares capital snapshot vs settlement balance transitions
+  - validates `balance_before` alignment
+  - validates deterministic expected `balance_after`
+  - returns mismatch results only (no correction path)
+- Boundary guarantees preserved:
+  - no persistence side effects
+  - no retry/batching/background tasks
+  - no execution triggering
+  - no balance mutation
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/safety/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Valid ledger records are accepted for all five required stages: `transport`, `exchange`, `signing`, `capital`, `settlement`.
+- Deterministic properties are validated:
+  - same input yields same `entry_id`
+  - same input yields same snapshot hash
+- Safety blocks are enforced for:
+  - invalid stage
+  - missing snapshot
+  - malformed upstream refs
+- Append-only behavior is validated through multi-entry accumulation and stable retrieval.
+- Execution-id filtering is validated through deterministic retrieval from ledger state.
+- Reconciliation success and mismatch branches are both validated.
+- Invalid ledger/reconciliation inputs fail safely and do not crash.
+- No persistence side effects were introduced in implementation.
+
+## 5) Known issues
+- This phase intentionally remains in-memory and does not include persistence.
+- This phase intentionally does not introduce correction/mutation logic for reconciliation mismatches.
+- Container pytest still emits `PytestConfigWarning: Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- SENTINEL validation required (MAJOR tier) before merge, focused on:
+  - deterministic ledger hashes and entry IDs
+  - strict append-only behavior
+  - strict stage/snapshot/ref blocking behavior
+  - read-only reconciliation mismatch detection
+  - evidence that no persistence/mutation/automation paths exist
+- COMMANDER merge decision must wait for SENTINEL verdict.
+
+---
+
+**Validation Commands Run:**
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/platform/safety/__init__.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
+3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py` → PASS
+4. `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task" projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS (no matches)
+
+**Report Timestamp:** 2026-04-13 03:16 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.1 — Execution Ledger & Reconciliation Foundation (MAJOR)

--- a/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import (
+    EXECUTION_TRANSPORT_MODE_SIMULATED,
+    ExecutionTransportResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.exchange_integration import (
+    EXCHANGE_NETWORK_MODE_SIMULATED,
+    ExchangeExecutionResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.fund_settlement import (
+    FUND_SETTLEMENT_STATUS_COMPLETED,
+    FundSettlementResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.secure_signing import (
+    SIGNING_METHOD_SIMULATED,
+    SigningResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.wallet_capital import (
+    CAPITAL_ALLOCATION_SCOPE_SINGLE,
+    WalletCapitalResult,
+)
+from projects.polymarket.polyquantbot.platform.safety.execution_ledger import (
+    LEDGER_BLOCK_INVALID_STAGE,
+    LEDGER_BLOCK_INVALID_UPSTREAM_REFS,
+    LEDGER_BLOCK_MISSING_SNAPSHOT,
+    ExecutionLedger,
+    LedgerRecordInput,
+    ReconciliationEngine,
+    ReconciliationInput,
+)
+
+
+def _sample_transport_result() -> ExecutionTransportResult:
+    return ExecutionTransportResult(
+        submitted=True,
+        success=True,
+        blocked_reason=None,
+        execution_authorized=True,
+        request_payload={"order": "A"},
+        exchange_response={"status": "accepted"},
+        transport_mode=EXECUTION_TRANSPORT_MODE_SIMULATED,
+        simulated=True,
+        non_executing=True,
+    )
+
+
+def _sample_exchange_result() -> ExchangeExecutionResult:
+    return ExchangeExecutionResult(
+        executed=True,
+        success=True,
+        blocked_reason=None,
+        execution_id="exec-001",
+        request_payload={"order": "A"},
+        signed_payload={"sig": "mock"},
+        exchange_response={"accepted": True},
+        network_used=EXCHANGE_NETWORK_MODE_SIMULATED,
+        signing_used=True,
+        simulated=True,
+        non_executing=True,
+    )
+
+
+def _sample_signing_result() -> SigningResult:
+    return SigningResult(
+        signed=True,
+        success=True,
+        blocked_reason=None,
+        signature="sig-001",
+        payload_hash="payload-001",
+        signing_scheme="HMAC",
+        key_reference="key-001",
+        signing_method=SIGNING_METHOD_SIMULATED,
+        simulated=True,
+        non_executing=True,
+    )
+
+
+def _sample_wallet_capital_result() -> WalletCapitalResult:
+    return WalletCapitalResult(
+        capital_authorized=True,
+        success=True,
+        blocked_reason=None,
+        wallet_id="wallet-001",
+        capital_amount=100.0,
+        currency="USDC",
+        allocation_scope=CAPITAL_ALLOCATION_SCOPE_SINGLE,
+        capital_locked=True,
+        balance_snapshot={"available": 1000.0, "balance_before": 1000.0},
+        simulated=True,
+        non_executing=True,
+    )
+
+
+def _sample_settlement_result() -> FundSettlementResult:
+    return FundSettlementResult(
+        settled=True,
+        success=True,
+        blocked_reason=None,
+        settlement_id="settlement-001",
+        wallet_id="wallet-001",
+        amount=100.0,
+        currency="USDC",
+        transfer_reference="tx-001",
+        settlement_status=FUND_SETTLEMENT_STATUS_COMPLETED,
+        balance_before=1000.0,
+        balance_after=900.0,
+        simulated=False,
+        non_executing=False,
+    )
+
+
+def test_phase6_1_valid_ledger_record_for_all_stages() -> None:
+    ledger = ExecutionLedger()
+
+    stage_inputs = [
+        (
+            "transport",
+            {"transport": _sample_transport_result()},
+            _sample_transport_result(),
+        ),
+        (
+            "exchange",
+            {"exchange": _sample_exchange_result()},
+            _sample_exchange_result(),
+        ),
+        (
+            "signing",
+            {"signing": _sample_signing_result()},
+            _sample_signing_result(),
+        ),
+        (
+            "capital",
+            {"capital": _sample_wallet_capital_result()},
+            _sample_wallet_capital_result(),
+        ),
+        (
+            "settlement",
+            {"settlement": _sample_settlement_result()},
+            _sample_settlement_result(),
+        ),
+    ]
+
+    for stage, snapshot, source in stage_inputs:
+        build = ledger.record_with_trace(
+            record_input=LedgerRecordInput(
+                timestamp_ref="2026-04-13T00:00:00Z",
+                execution_id="exec-001",
+                stage=stage,
+                status="accepted",
+                data_snapshot=snapshot,
+                upstream_refs={"phase": "6.1", "stage": stage},
+                snapshot_source=source,
+            )
+        )
+        assert build.entry is not None
+        assert build.entry.stage == stage
+        assert build.trace.blocked_reason is None
+
+    assert len(ledger.get_all_entries()) == 5
+
+
+def test_phase6_1_deterministic_entry_id_and_hash() -> None:
+    input_payload = LedgerRecordInput(
+        timestamp_ref="2026-04-13T00:00:01Z",
+        execution_id="exec-det-1",
+        stage="transport",
+        status="ok",
+        data_snapshot={"payload": {"a": 1, "b": 2}},
+        upstream_refs={"trace": "x-1"},
+        snapshot_source=_sample_transport_result(),
+    )
+
+    ledger_a = ExecutionLedger()
+    ledger_b = ExecutionLedger()
+
+    first = ledger_a.record_with_trace(record_input=input_payload)
+    second = ledger_b.record_with_trace(record_input=input_payload)
+
+    assert first.entry is not None
+    assert second.entry is not None
+    assert first.entry.entry_id == second.entry.entry_id
+    assert first.entry.hash == second.entry.hash
+
+
+def test_phase6_1_invalid_stage_is_blocked() -> None:
+    ledger = ExecutionLedger()
+
+    build = ledger.record_with_trace(
+        record_input=LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:02Z",
+            execution_id="exec-002",
+            stage="routing",
+            status="blocked",
+            data_snapshot={"x": 1},
+            upstream_refs={"phase": "6.1"},
+            snapshot_source=_sample_transport_result(),
+        )
+    )
+
+    assert build.entry is None
+    assert build.trace.blocked_reason == LEDGER_BLOCK_INVALID_STAGE
+
+
+def test_phase6_1_missing_snapshot_is_blocked() -> None:
+    ledger = ExecutionLedger()
+
+    build = ledger.record_with_trace(
+        record_input=LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:03Z",
+            execution_id="exec-003",
+            stage="exchange",
+            status="blocked",
+            data_snapshot={},
+            upstream_refs={"phase": "6.1"},
+            snapshot_source=_sample_exchange_result(),
+        )
+    )
+
+    assert build.entry is None
+    assert build.trace.blocked_reason == LEDGER_BLOCK_MISSING_SNAPSHOT
+
+
+def test_phase6_1_append_only_behavior_and_retrieval() -> None:
+    ledger = ExecutionLedger()
+
+    first = ledger.record(
+        LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:04Z",
+            execution_id="exec-100",
+            stage="transport",
+            status="ok",
+            data_snapshot={"step": 1},
+            upstream_refs={"src": "A"},
+            snapshot_source=_sample_transport_result(),
+        )
+    )
+    second = ledger.record(
+        LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:05Z",
+            execution_id="exec-100",
+            stage="exchange",
+            status="ok",
+            data_snapshot={"step": 2},
+            upstream_refs={"src": "B"},
+            snapshot_source=_sample_exchange_result(),
+        )
+    )
+    third = ledger.record(
+        LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:06Z",
+            execution_id="exec-other",
+            stage="signing",
+            status="ok",
+            data_snapshot={"step": 3},
+            upstream_refs={"src": "C"},
+            snapshot_source=_sample_signing_result(),
+        )
+    )
+
+    assert first is not None and second is not None and third is not None
+    all_entries = ledger.get_all_entries()
+    filtered = ledger.get_entries_by_execution_id("exec-100")
+
+    assert len(all_entries) == 3
+    assert len(filtered) == 2
+    assert filtered[0].entry_id == first.entry_id
+    assert filtered[1].entry_id == second.entry_id
+
+
+def test_phase6_1_reconciliation_success_case() -> None:
+    engine = ReconciliationEngine()
+
+    result = engine.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-200",
+            capital_snapshot={"balance_before": 1000.0},
+            settlement_result=_sample_settlement_result(),
+        )
+    )
+
+    assert result.consistent is True
+    assert result.mismatch_reason is None
+    assert result.expected_balance == 900.0
+    assert result.observed_balance == 900.0
+
+
+def test_phase6_1_reconciliation_mismatch_case() -> None:
+    engine = ReconciliationEngine()
+
+    mismatched_settlement = replace(_sample_settlement_result(), balance_after=899.0)
+    result = engine.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-201",
+            capital_snapshot={"balance_before": 1000.0},
+            settlement_result=mismatched_settlement,
+        )
+    )
+
+    assert result.consistent is False
+    assert result.mismatch_reason == "balance_after_mismatch"
+    assert result.expected_balance == 900.0
+    assert result.observed_balance == 899.0
+
+
+def test_phase6_1_invalid_inputs_do_not_crash() -> None:
+    ledger = ExecutionLedger()
+    reconciliation = ReconciliationEngine()
+
+    invalid_record_input = ledger.record_with_trace(record_input=None)  # type: ignore[arg-type]
+    invalid_upstream_refs = ledger.record_with_trace(
+        record_input=LedgerRecordInput(
+            timestamp_ref="2026-04-13T00:00:08Z",
+            execution_id="exec-err",
+            stage="capital",
+            status="blocked",
+            data_snapshot={"x": 1},
+            upstream_refs={"": "invalid"},
+            snapshot_source=_sample_wallet_capital_result(),
+        )
+    )
+    invalid_reconciliation = reconciliation.check_consistency(None)  # type: ignore[arg-type]
+
+    assert invalid_record_input.entry is None
+    assert invalid_record_input.trace.blocked_reason == LEDGER_BLOCK_MISSING_SNAPSHOT
+    assert invalid_upstream_refs.entry is None
+    assert invalid_upstream_refs.trace.blocked_reason == LEDGER_BLOCK_INVALID_UPSTREAM_REFS
+    assert invalid_reconciliation.consistent is False
+    assert invalid_reconciliation.mismatch_reason == "invalid_reconciliation_input"

--- a/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
@@ -322,6 +322,20 @@ def test_phase6_1_invalid_inputs_do_not_crash() -> None:
         )
     )
     invalid_reconciliation = reconciliation.check_consistency(None)  # type: ignore[arg-type]
+    invalid_capital_snapshot = reconciliation.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-err-2",
+            capital_snapshot="not-a-dict",  # type: ignore[arg-type]
+            settlement_result=_sample_settlement_result(),
+        )
+    )
+    missing_settlement_result = reconciliation.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-err-3",
+            capital_snapshot={"balance_before": 1000.0},
+            settlement_result=None,
+        )
+    )
 
     assert invalid_record_input.entry is None
     assert invalid_record_input.trace.blocked_reason == LEDGER_BLOCK_MISSING_SNAPSHOT
@@ -329,3 +343,7 @@ def test_phase6_1_invalid_inputs_do_not_crash() -> None:
     assert invalid_upstream_refs.trace.blocked_reason == LEDGER_BLOCK_INVALID_UPSTREAM_REFS
     assert invalid_reconciliation.consistent is False
     assert invalid_reconciliation.mismatch_reason == "invalid_reconciliation_input"
+    assert invalid_capital_snapshot.consistent is False
+    assert invalid_capital_snapshot.mismatch_reason == "invalid_capital_snapshot"
+    assert missing_settlement_result.consistent is False
+    assert missing_settlement_result.mismatch_reason == "missing_settlement_result"


### PR DESCRIPTION
### Motivation
- Provide deterministic, auditable execution traceability across transport → exchange → signing → capital → settlement without introducing persistence, mutation, or automation.
- Establish a read-only reconciliation foundation that can deterministically detect balance mismatches while preserving upstream guarantees and preventing side-effects.

### Description
- Added a new in-memory safety module `projects/polymarket/polyquantbot/platform/safety/execution_ledger.py` implementing `LedgerEntry`, `LedgerTrace`, `LedgerBuildResult`, `ReconciliationCheckResult`, `LedgerRecordInput`, and `ReconciliationInput` along with `ExecutionLedger` and `ReconciliationEngine` APIs.
- Enforced append-only, deterministic behavior with canonical JSON hashing and reproducible `entry_id` construction, plus strict blocking constants `invalid_stage`, `missing_snapshot`, and `invalid_upstream_refs` and allowed stages `transport|exchange|signing|capital|settlement`.
- Exported safety contracts via `projects/polymarket/polyquantbot/platform/safety/__init__.py`, added tests at `projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py`, and created the required forge report `projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md` and `PROJECT_STATE.md` update.
- Implementation preserves integration boundaries by accepting upstream snapshot objects only and explicitly disallowing persistence, balance mutation, execution triggering, retry/background automation, or reconciliation correction.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/platform/safety/__init__.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` which passed.
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` which passed (`8 passed` with one pytest config warning).
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py` to confirm Phase 5.6 baseline remained green which passed (`14 passed`).
- Searched changed files for persistence/automation patterns with `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task"` which returned no matches, confirming no persistence or background automation was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5f5a45f0832e8207e3bcdc8f880b)