### PR TITLE
fix: harden Phase 6.1 reconciliation input validation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-13 03:16
+2026-04-13 03:25
 
 ## Status
 — **FORGE-X COMPLETE (PENDING SENTINEL) — Phase 6.1 execution ledger and read-only reconciliation foundation implemented (MAJOR, FOUNDATION)**
@@ -22,6 +22,7 @@ Deterministic append-only in-memory execution traceability is now available acro
 - **Phase 5.6 fund settlement boundary** implemented with strict policy-gated real settlement, deterministic single-shot transfer interface, and explicit simulated-safe settlement mode.
 - **SENTINEL validation (PR #457)** completed with APPROVED verdict (96/100) for MAJOR-tier NARROW INTEGRATION scope.
 - **Phase 6.1 execution ledger & reconciliation foundation** implemented with deterministic append-only in-memory ledger records and read-only reconciliation checks (no persistence, no correction logic, no automation).
+- **Phase 6.1 reconciliation input hardening** added deterministic invalid-input handling for malformed capital snapshots (`invalid_capital_snapshot`) to preserve non-crashing read-only reconciliation behavior.
 
 ## IN PROGRESS
 - Awaiting SENTINEL validation for Phase 6.1 execution ledger & reconciliation foundation (MAJOR, FOUNDATION).

--- a/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
+++ b/projects/polymarket/polyquantbot/platform/safety/execution_ledger.py
@@ -184,6 +184,18 @@ class ReconciliationEngine:
                 reconciliation_notes={"execution_id": reconciliation_input.execution_id},
             )
 
+        if not isinstance(reconciliation_input.capital_snapshot, dict):
+            return ReconciliationCheckResult(
+                consistent=False,
+                mismatch_reason="invalid_capital_snapshot",
+                expected_balance=None,
+                observed_balance=None,
+                reconciliation_notes={
+                    "execution_id": reconciliation_input.execution_id,
+                    "actual_type": type(reconciliation_input.capital_snapshot).__name__,
+                },
+            )
+
         balance_before = _to_float(reconciliation_input.capital_snapshot.get("balance_before"))
         if balance_before is None:
             balance_before = _to_float(reconciliation_input.capital_snapshot.get("available"))

--- a/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md
@@ -80,6 +80,7 @@
 - Execution-id filtering is validated through deterministic retrieval from ledger state.
 - Reconciliation success and mismatch branches are both validated.
 - Invalid ledger/reconciliation inputs fail safely and do not crash.
+- Reconciliation input contract hardening now explicitly blocks non-dict `capital_snapshot` with deterministic `invalid_capital_snapshot` output (no crash path).
 - No persistence side effects were introduced in implementation.
 
 ## 5) Known issues
@@ -102,8 +103,8 @@
 1. `python -m py_compile projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/platform/safety/__init__.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS
 3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py` → PASS
-4. `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task" projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` → PASS (no matches)
+4. `rg -n "sqlite|postgres|redis|open\(|write\(|persist|background|thread|asyncio.create_task" projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py || true` → PASS (no matches)
 
-**Report Timestamp:** 2026-04-13 03:16 UTC  
+**Report Timestamp:** 2026-04-13 03:25 UTC  
 **Role:** FORGE-X (NEXUS)  
 **Task:** Phase 6.1 — Execution Ledger & Reconciliation Foundation (MAJOR)

--- a/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py
@@ -322,6 +322,20 @@ def test_phase6_1_invalid_inputs_do_not_crash() -> None:
         )
     )
     invalid_reconciliation = reconciliation.check_consistency(None)  # type: ignore[arg-type]
+    invalid_capital_snapshot = reconciliation.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-err-2",
+            capital_snapshot="not-a-dict",  # type: ignore[arg-type]
+            settlement_result=_sample_settlement_result(),
+        )
+    )
+    missing_settlement_result = reconciliation.check_consistency(
+        ReconciliationInput(
+            execution_id="exec-err-3",
+            capital_snapshot={"balance_before": 1000.0},
+            settlement_result=None,
+        )
+    )
 
     assert invalid_record_input.entry is None
     assert invalid_record_input.trace.blocked_reason == LEDGER_BLOCK_MISSING_SNAPSHOT
@@ -329,3 +343,7 @@ def test_phase6_1_invalid_inputs_do_not_crash() -> None:
     assert invalid_upstream_refs.trace.blocked_reason == LEDGER_BLOCK_INVALID_UPSTREAM_REFS
     assert invalid_reconciliation.consistent is False
     assert invalid_reconciliation.mismatch_reason == "invalid_reconciliation_input"
+    assert invalid_capital_snapshot.consistent is False
+    assert invalid_capital_snapshot.mismatch_reason == "invalid_capital_snapshot"
+    assert missing_settlement_result.consistent is False
+    assert missing_settlement_result.mismatch_reason == "missing_settlement_result"


### PR DESCRIPTION
### Motivation
- Introduce Phase 6.1 in-memory deterministic execution ledger and read-only reconciliation foundation to provide auditable execution traceability across `transport → exchange → signing → capital → settlement` without persistence or mutation.
- Harden reconciliation input handling to ensure malformed `capital_snapshot` values are deterministically rejected and do not cause crashes during read-only checks.

### Description
- Added new safety module `projects/polymarket/polyquantbot/platform/safety/execution_ledger.py` implementing `LedgerEntry`, `LedgerTrace`, `LedgerBuildResult`, `ReconciliationCheckResult`, `LedgerRecordInput`, `ReconciliationInput`, `ExecutionLedger` (with `record`, `record_with_trace`, `get_all_entries`, `get_entries_by_execution_id`) and `ReconciliationEngine` (with `check_consistency`) plus deterministic hashing and append-only behavior. 
- Added package export `projects/polymarket/polyquantbot/platform/safety/__init__.py` and tests `projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` covering valid stages, determinism, blocking rules, append-only retrieval, reconciliation success/mismatch, and invalid-input safety. 
- Implemented deterministic blocking constants `LEDGER_BLOCK_INVALID_STAGE`, `LEDGER_BLOCK_MISSING_SNAPSHOT`, and `LEDGER_BLOCK_INVALID_UPSTREAM_REFS`, and enforced allowed stages `transport|exchange|signing|capital|settlement` with canonical JSON hashing for reproducible `entry_id` and snapshot hashes. 
- Hardened `ReconciliationEngine.check_consistency` to return a deterministic `invalid_capital_snapshot` result when `capital_snapshot` is not a dict, and updated Forge report `projects/polymarket/polyquantbot/reports/forge/24_96_phase6_1_execution_ledger.md` and `PROJECT_STATE.md` to reflect the hardening pass. 

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/safety/execution_ledger.py projects/polymarket/polyquantbot/platform/safety/__init__.py projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` which passed. 
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_1_execution_ledger_20260413.py` which passed (`8 passed`) and `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase5_6_fund_settlement_20260413.py` which passed (`14 passed`); both runs show an unrelated `PytestConfigWarning: Unknown config option: asyncio_mode`. 
- Performed repository scan for persistence/background patterns with `rg` which produced no matches indicating no external persistence or background task usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc61f6e11c832ebc675826cffd43e8)