### PR TITLE
Phase 6.3: Add deterministic KillSwitchController, contracts, tests, and report

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -23,18 +23,18 @@ Deterministic policy-driven halt decisions are now available to block execution/
 - **SENTINEL validation (PR #457)** completed with APPROVED verdict (96/100) for MAJOR-tier NARROW INTEGRATION scope.
 - **Phase 6.1 execution ledger & reconciliation foundation** implemented with deterministic append-only in-memory ledger records and read-only reconciliation checks (no persistence, no correction logic, no automation).
 - **Phase 6.1 reconciliation input hardening** added deterministic invalid-input handling for malformed capital snapshots (`invalid_capital_snapshot`) to preserve non-crashing read-only reconciliation behavior.
+- **Phase 6.2 persistent ledger & audit trail foundation** implemented with append-only local-file persistence, deterministic reload into `LedgerEntry` tuples, deterministic audit filtering, and strict block reasons for malformed records/hash mismatches (no correction logic, no background automation, no external DB).
 - **Phase 6.3 kill-switch & execution-halt foundation** implemented with deterministic `KillSwitchController` arm/disarm/evaluate contracts, explicit operator/system halt triggers, fail-closed contract validation for pre-execution progression blocking, and side-effect-free `evaluate()` behavior (including policy-disabled probe path).
 
 ## IN PROGRESS
 - Awaiting SENTINEL validation for Phase 6.3 kill-switch & execution-halt foundation (MAJOR, FOUNDATION).
-- Awaiting SENTINEL validation for Phase 6.1 execution ledger & reconciliation foundation (MAJOR, FOUNDATION).
+- Awaiting SENTINEL validation for Phase 6.2 persistent ledger & audit trail foundation (MAJOR, FOUNDATION).
 
 ## NOT STARTED
 - Full wallet lifecycle implementation (secret loading/storage/rotation).
 - Portfolio management logic and multi-wallet orchestration.
 - Automation/retry/batching for settlement and wallet operations.
-- External persistence for settlement and execution-ledger lifecycle.
-- Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1).
+- Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1 and Phase 6.2).
 
 ## NEXT PRIORITY
 SENTINEL validation required for Phase 6.3 kill-switch & execution-halt foundation before merge.
@@ -49,5 +49,6 @@ Tier: MAJOR
 - Phase 5.5 introduces wallet boundary and capital control layer only; no real fund movement, no portfolio logic, and no automation are implemented in this phase.
 - Phase 5.6 introduces first real settlement boundary only; still single-shot with no retry, no batching, no async automation, and no portfolio lifecycle management.
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, no correction logic, and no background automation are implemented.
+- Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation/correction logic, no background automation, and no external DB are implemented.
 - Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope in this phase.
 - Pytest import collection requires `PYTHONPATH=.` in this container for `projects.*` test module imports.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,11 +1,11 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-13 03:25
+2026-04-13 17:21
 
 ## Status
-— **FORGE-X COMPLETE (PENDING SENTINEL) — Phase 6.1 execution ledger and read-only reconciliation foundation implemented (MAJOR, FOUNDATION)**
-Deterministic append-only in-memory execution traceability is now available across transport → exchange → signing → capital → settlement with strict blocking constants and deterministic reconciliation checks; no persistence, correction logic, or automation path introduced.
+— **FORGE-X COMPLETE (PENDING SENTINEL) — Phase 6.3 kill-switch and deterministic execution-halt foundation implemented (MAJOR, FOUNDATION)**
+Deterministic policy-driven halt decisions are now available to block execution/transport/settlement progression with explicit operator/system halt paths, typed contracts, auditable trace output, and a side-effect-free `evaluate()` probe path; runtime orchestration integration remains intentionally out of scope.
 
 ## COMPLETED
 - **Phase 5.2 execution transport layer** implemented with deterministic gating for real submission vs simulated submission.
@@ -23,10 +23,11 @@ Deterministic append-only in-memory execution traceability is now available acro
 - **SENTINEL validation (PR #457)** completed with APPROVED verdict (96/100) for MAJOR-tier NARROW INTEGRATION scope.
 - **Phase 6.1 execution ledger & reconciliation foundation** implemented with deterministic append-only in-memory ledger records and read-only reconciliation checks (no persistence, no correction logic, no automation).
 - **Phase 6.1 reconciliation input hardening** added deterministic invalid-input handling for malformed capital snapshots (`invalid_capital_snapshot`) to preserve non-crashing read-only reconciliation behavior.
+- **Phase 6.3 kill-switch & execution-halt foundation** implemented with deterministic `KillSwitchController` arm/disarm/evaluate contracts, explicit operator/system halt triggers, fail-closed contract validation for pre-execution progression blocking, and side-effect-free `evaluate()` behavior (including policy-disabled probe path).
 
 ## IN PROGRESS
+- Awaiting SENTINEL validation for Phase 6.3 kill-switch & execution-halt foundation (MAJOR, FOUNDATION).
 - Awaiting SENTINEL validation for Phase 6.1 execution ledger & reconciliation foundation (MAJOR, FOUNDATION).
-- Awaiting COMMANDER final merge decision for PR #457 after SENTINEL approval.
 
 ## NOT STARTED
 - Full wallet lifecycle implementation (secret loading/storage/rotation).
@@ -36,8 +37,8 @@ Deterministic append-only in-memory execution traceability is now available acro
 - Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1).
 
 ## NEXT PRIORITY
-SENTINEL validation required for Phase 6.1 execution ledger & reconciliation foundation before merge.
-Source: reports/forge/24_96_phase6_1_execution_ledger.md
+SENTINEL validation required for Phase 6.3 kill-switch & execution-halt foundation before merge.
+Source: reports/forge/24_97_phase6_3_kill_switch.md
 Tier: MAJOR
 
 ## KNOWN ISSUES
@@ -48,4 +49,5 @@ Tier: MAJOR
 - Phase 5.5 introduces wallet boundary and capital control layer only; no real fund movement, no portfolio logic, and no automation are implemented in this phase.
 - Phase 5.6 introduces first real settlement boundary only; still single-shot with no retry, no batching, no async automation, and no portfolio lifecycle management.
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, no correction logic, and no background automation are implemented.
+- Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope in this phase.
 - Pytest import collection requires `PYTHONPATH=.` in this container for `projects.*` test module imports.

--- a/projects/polymarket/polyquantbot/platform/safety/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/safety/__init__.py
@@ -14,6 +14,24 @@ from .execution_ledger import (
     ReconciliationEngine,
     ReconciliationInput,
 )
+
+from .persistent_ledger import (
+    PERSISTENT_LEDGER_BLOCK_HASH_MISMATCH,
+    PERSISTENT_LEDGER_BLOCK_INVALID_CONFIG,
+    PERSISTENT_LEDGER_BLOCK_INVALID_LEDGER_ENTRY,
+    PERSISTENT_LEDGER_BLOCK_MALFORMED_RECORD,
+    PERSISTENT_LEDGER_BLOCK_MISSING_STORAGE_PATH,
+    PERSISTENT_LEDGER_BLOCK_QUERY_NOT_ALLOWED,
+    PERSISTENT_LEDGER_BLOCK_RELOAD_NOT_ALLOWED,
+    AuditTrailQueryInput,
+    AuditTrailQueryResult,
+    AuditTrailRecord,
+    PersistentExecutionLedger,
+    PersistentLedgerConfig,
+    PersistentLedgerLoadResult,
+    PersistentLedgerWriteResult,
+)
+
 from .kill_switch import (
     KILL_SWITCH_BLOCK_ACTIVE,
     KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT,

--- a/projects/polymarket/polyquantbot/platform/safety/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/safety/__init__.py
@@ -14,3 +14,21 @@ from .execution_ledger import (
     ReconciliationEngine,
     ReconciliationInput,
 )
+from .kill_switch import (
+    KILL_SWITCH_BLOCK_ACTIVE,
+    KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT,
+    KILL_SWITCH_BLOCK_NOT_ARMED,
+    KILL_SWITCH_BLOCK_OPERATOR_ARM_NOT_ALLOWED,
+    KILL_SWITCH_BLOCK_OPERATOR_HALT,
+    KILL_SWITCH_BLOCK_OPERATOR_REQUEST_MISSING,
+    KILL_SWITCH_BLOCK_POLICY_DISABLED,
+    KILL_SWITCH_BLOCK_SYSTEM_HALT,
+    KILL_SWITCH_SCOPE_ALL,
+    KillSwitchBuildResult,
+    KillSwitchController,
+    KillSwitchDecision,
+    KillSwitchEvaluationInput,
+    KillSwitchPolicyInput,
+    KillSwitchState,
+    KillSwitchTrace,
+)

--- a/projects/polymarket/polyquantbot/platform/safety/kill_switch.py
+++ b/projects/polymarket/polyquantbot/platform/safety/kill_switch.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+KILL_SWITCH_SCOPE_ALL = "all"
+
+KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT = "invalid_kill_switch_input_contract"
+KILL_SWITCH_BLOCK_POLICY_DISABLED = "kill_switch_policy_disabled"
+KILL_SWITCH_BLOCK_NOT_ARMED = "kill_switch_not_armed"
+KILL_SWITCH_BLOCK_OPERATOR_ARM_NOT_ALLOWED = "operator_arm_not_allowed"
+KILL_SWITCH_BLOCK_OPERATOR_DISARM_NOT_ALLOWED = "operator_disarm_not_allowed"
+KILL_SWITCH_BLOCK_OPERATOR_REQUEST_MISSING = "operator_arm_request_missing"
+KILL_SWITCH_BLOCK_DISARM_REQUEST_MISSING = "operator_disarm_request_missing"
+KILL_SWITCH_BLOCK_ACTIVE = "kill_switch_halt_active"
+KILL_SWITCH_BLOCK_OPERATOR_HALT = "operator_halt_active"
+KILL_SWITCH_BLOCK_SYSTEM_HALT = "system_halt_active"
+
+
+@dataclass(frozen=True)
+class KillSwitchState:
+    armed: bool
+    halt_active: bool
+    halt_reason: str | None
+    halt_scope: str
+    operator_triggered: bool
+    system_triggered: bool
+
+
+@dataclass(frozen=True)
+class KillSwitchDecision:
+    execution_blocked: bool
+    settlement_blocked: bool
+    transport_blocked: bool
+    allowed_to_proceed: bool
+    blocked_reason: str | None
+    state: KillSwitchState
+
+
+@dataclass(frozen=True)
+class KillSwitchTrace:
+    evaluation_attempted: bool
+    blocked_reason: str | None
+    trace_refs: dict[str, Any] = field(default_factory=dict)
+    halt_notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class KillSwitchBuildResult:
+    decision: KillSwitchDecision | None
+    trace: KillSwitchTrace
+
+
+@dataclass(frozen=True)
+class KillSwitchPolicyInput:
+    kill_switch_enabled: bool
+    allow_operator_arm: bool
+    allow_operator_disarm: bool
+    operator_request_arm: bool
+    operator_request_disarm: bool = False
+    operator_halt_reason: str | None = None
+    policy_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KillSwitchEvaluationInput:
+    execution_requested: bool
+    settlement_requested: bool
+    transport_requested: bool
+    system_halt_requested: bool = False
+    system_halt_reason: str | None = None
+    halt_scope: str = KILL_SWITCH_SCOPE_ALL
+    upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+class KillSwitchController:
+    """Phase 6.3 deterministic kill-switch and execution-halt controller."""
+
+    def __init__(self) -> None:
+        self._state = KillSwitchState(
+            armed=False,
+            halt_active=False,
+            halt_reason=None,
+            halt_scope=KILL_SWITCH_SCOPE_ALL,
+            operator_triggered=False,
+            system_triggered=False,
+        )
+
+    def evaluate(
+        self,
+        evaluation_input: KillSwitchEvaluationInput,
+        policy_input: KillSwitchPolicyInput,
+    ) -> KillSwitchDecision | None:
+        return self._evaluate_internal(
+            evaluation_input=evaluation_input,
+            policy_input=policy_input,
+            mutate_state=False,
+        ).decision
+
+    def evaluate_with_trace(
+        self,
+        *,
+        evaluation_input: KillSwitchEvaluationInput,
+        policy_input: KillSwitchPolicyInput,
+    ) -> KillSwitchBuildResult:
+        return self._evaluate_internal(
+            evaluation_input=evaluation_input,
+            policy_input=policy_input,
+            mutate_state=True,
+        )
+
+    def _evaluate_internal(
+        self,
+        *,
+        evaluation_input: KillSwitchEvaluationInput,
+        policy_input: KillSwitchPolicyInput,
+        mutate_state: bool,
+    ) -> KillSwitchBuildResult:
+        if not isinstance(evaluation_input, KillSwitchEvaluationInput):
+            return _blocked_result(
+                state=self._state,
+                blocked_reason=KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT,
+                evaluation_attempted=False,
+                trace_refs={
+                    "contract_errors": {
+                        "evaluation_input": {
+                            "expected_type": "KillSwitchEvaluationInput",
+                            "actual_type": type(evaluation_input).__name__,
+                        }
+                    }
+                },
+            )
+
+        if not isinstance(policy_input, KillSwitchPolicyInput):
+            return _blocked_result(
+                state=self._state,
+                blocked_reason=KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT,
+                evaluation_attempted=False,
+                trace_refs={
+                    "contract_errors": {
+                        "policy_input": {
+                            "expected_type": "KillSwitchPolicyInput",
+                            "actual_type": type(policy_input).__name__,
+                        }
+                    }
+                },
+            )
+
+        trace_refs: dict[str, Any] = {
+            "policy": dict(policy_input.policy_trace_refs),
+            "evaluation": dict(evaluation_input.upstream_trace_refs),
+            "scope": evaluation_input.halt_scope,
+        }
+        active_state = self._state
+
+        if policy_input.kill_switch_enabled is not True:
+            next_state = KillSwitchState(
+                armed=False,
+                halt_active=False,
+                halt_reason=KILL_SWITCH_BLOCK_POLICY_DISABLED,
+                halt_scope=evaluation_input.halt_scope,
+                operator_triggered=False,
+                system_triggered=False,
+            )
+            if mutate_state:
+                self._state = next_state
+            return _decision_result(
+                state=next_state,
+                execution_requested=evaluation_input.execution_requested,
+                settlement_requested=evaluation_input.settlement_requested,
+                transport_requested=evaluation_input.transport_requested,
+                blocked_reason=KILL_SWITCH_BLOCK_POLICY_DISABLED,
+                evaluation_attempted=True,
+                trace_refs=trace_refs,
+                halt_notes={"kill_switch_enabled": False},
+            )
+
+        if evaluation_input.system_halt_requested:
+            system_reason = _normalized_reason(
+                evaluation_input.system_halt_reason,
+                fallback=KILL_SWITCH_BLOCK_SYSTEM_HALT,
+            )
+            next_state = KillSwitchState(
+                armed=True,
+                halt_active=True,
+                halt_reason=system_reason,
+                halt_scope=evaluation_input.halt_scope,
+                operator_triggered=False,
+                system_triggered=True,
+            )
+            if mutate_state:
+                self._state = next_state
+            active_state = next_state
+
+        if active_state.halt_active:
+            return _decision_result(
+                state=active_state,
+                execution_requested=evaluation_input.execution_requested,
+                settlement_requested=evaluation_input.settlement_requested,
+                transport_requested=evaluation_input.transport_requested,
+                blocked_reason=active_state.halt_reason or KILL_SWITCH_BLOCK_ACTIVE,
+                evaluation_attempted=True,
+                trace_refs=trace_refs,
+                halt_notes={"halt_source": _halt_source(active_state)},
+            )
+
+        if active_state.armed is not True:
+            return _decision_result(
+                state=active_state,
+                execution_requested=evaluation_input.execution_requested,
+                settlement_requested=evaluation_input.settlement_requested,
+                transport_requested=evaluation_input.transport_requested,
+                blocked_reason=KILL_SWITCH_BLOCK_NOT_ARMED,
+                evaluation_attempted=True,
+                trace_refs=trace_refs,
+                halt_notes={"armed": False},
+            )
+
+        return KillSwitchBuildResult(
+            decision=KillSwitchDecision(
+                execution_blocked=False,
+                settlement_blocked=False,
+                transport_blocked=False,
+                allowed_to_proceed=True,
+                blocked_reason=None,
+                state=active_state,
+            ),
+            trace=KillSwitchTrace(
+                evaluation_attempted=True,
+                blocked_reason=None,
+                trace_refs=trace_refs,
+                halt_notes={"status": "safe_to_proceed"},
+            ),
+        )
+
+    def arm(self, policy_input: KillSwitchPolicyInput) -> KillSwitchState:
+        if not isinstance(policy_input, KillSwitchPolicyInput):
+            return self._state
+
+        if policy_input.kill_switch_enabled is not True:
+            self._state = KillSwitchState(
+                armed=False,
+                halt_active=False,
+                halt_reason=KILL_SWITCH_BLOCK_POLICY_DISABLED,
+                halt_scope=KILL_SWITCH_SCOPE_ALL,
+                operator_triggered=False,
+                system_triggered=False,
+            )
+            return self._state
+
+        if policy_input.allow_operator_arm is not True:
+            self._state = KillSwitchState(
+                armed=False,
+                halt_active=True,
+                halt_reason=KILL_SWITCH_BLOCK_OPERATOR_ARM_NOT_ALLOWED,
+                halt_scope=KILL_SWITCH_SCOPE_ALL,
+                operator_triggered=True,
+                system_triggered=False,
+            )
+            return self._state
+
+        if policy_input.operator_request_arm is not True:
+            self._state = KillSwitchState(
+                armed=False,
+                halt_active=True,
+                halt_reason=KILL_SWITCH_BLOCK_OPERATOR_REQUEST_MISSING,
+                halt_scope=KILL_SWITCH_SCOPE_ALL,
+                operator_triggered=True,
+                system_triggered=False,
+            )
+            return self._state
+
+        self._state = KillSwitchState(
+            armed=True,
+            halt_active=True,
+            halt_reason=_normalized_reason(
+                policy_input.operator_halt_reason,
+                fallback=KILL_SWITCH_BLOCK_OPERATOR_HALT,
+            ),
+            halt_scope=KILL_SWITCH_SCOPE_ALL,
+            operator_triggered=True,
+            system_triggered=False,
+        )
+        return self._state
+
+    def disarm(self, policy_input: KillSwitchPolicyInput) -> KillSwitchState:
+        if not isinstance(policy_input, KillSwitchPolicyInput):
+            return self._state
+
+        if policy_input.kill_switch_enabled is not True:
+            self._state = KillSwitchState(
+                armed=False,
+                halt_active=False,
+                halt_reason=KILL_SWITCH_BLOCK_POLICY_DISABLED,
+                halt_scope=KILL_SWITCH_SCOPE_ALL,
+                operator_triggered=False,
+                system_triggered=False,
+            )
+            return self._state
+
+        if policy_input.allow_operator_disarm is not True:
+            return self._state
+
+        if policy_input.operator_request_disarm is not True:
+            return self._state
+
+        self._state = KillSwitchState(
+            armed=False,
+            halt_active=False,
+            halt_reason=None,
+            halt_scope=KILL_SWITCH_SCOPE_ALL,
+            operator_triggered=False,
+            system_triggered=False,
+        )
+        return self._state
+
+
+def _decision_result(
+    *,
+    state: KillSwitchState,
+    execution_requested: bool,
+    settlement_requested: bool,
+    transport_requested: bool,
+    blocked_reason: str,
+    evaluation_attempted: bool,
+    trace_refs: dict[str, Any],
+    halt_notes: dict[str, Any] | None = None,
+) -> KillSwitchBuildResult:
+    execution_blocked = execution_requested
+    settlement_blocked = settlement_requested
+    transport_blocked = transport_requested
+    return KillSwitchBuildResult(
+        decision=KillSwitchDecision(
+            execution_blocked=execution_blocked,
+            settlement_blocked=settlement_blocked,
+            transport_blocked=transport_blocked,
+            allowed_to_proceed=not (execution_blocked or settlement_blocked or transport_blocked),
+            blocked_reason=blocked_reason,
+            state=state,
+        ),
+        trace=KillSwitchTrace(
+            evaluation_attempted=evaluation_attempted,
+            blocked_reason=blocked_reason,
+            trace_refs=trace_refs,
+            halt_notes=halt_notes,
+        ),
+    )
+
+
+def _blocked_result(
+    *,
+    state: KillSwitchState,
+    blocked_reason: str,
+    evaluation_attempted: bool,
+    trace_refs: dict[str, Any],
+) -> KillSwitchBuildResult:
+    return KillSwitchBuildResult(
+        decision=KillSwitchDecision(
+            execution_blocked=True,
+            settlement_blocked=True,
+            transport_blocked=True,
+            allowed_to_proceed=False,
+            blocked_reason=blocked_reason,
+            state=state,
+        ),
+        trace=KillSwitchTrace(
+            evaluation_attempted=evaluation_attempted,
+            blocked_reason=blocked_reason,
+            trace_refs=trace_refs,
+            halt_notes={"contract_error": True},
+        ),
+    )
+
+
+def _normalized_reason(reason: str | None, *, fallback: str) -> str:
+    normalized = (reason or "").strip()
+    if normalized:
+        return normalized
+    return fallback
+
+
+def _halt_source(state: KillSwitchState) -> str:
+    if state.system_triggered:
+        return "system"
+    if state.operator_triggered:
+        return "operator"
+    return "unknown"

--- a/projects/polymarket/polyquantbot/reports/forge/24_97_phase6_3_kill_switch.md
+++ b/projects/polymarket/polyquantbot/reports/forge/24_97_phase6_3_kill_switch.md
@@ -1,0 +1,85 @@
+# Forge Report — Phase 6.3 Kill Switch & Execution Halt System (MAJOR)
+
+**Validation Tier:** MAJOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/safety/kill_switch.py`, `projects/polymarket/polyquantbot/platform/safety/__init__.py`, and `projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py`.  
+**Not in Scope:** Runtime wiring into execution loop, auto-resume orchestration, background monitoring loops, transport/settlement invocation, persistent ledger mutation, and authorization bypass logic.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/24_97_phase6_3_kill_switch.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Added deterministic stop-control module: `projects/polymarket/polyquantbot/platform/safety/kill_switch.py`.
+- Added kill-switch contracts:
+  - `KillSwitchState`
+  - `KillSwitchDecision`
+  - `KillSwitchTrace`
+  - `KillSwitchBuildResult`
+- Added kill-switch input contracts:
+  - `KillSwitchPolicyInput`
+  - `KillSwitchEvaluationInput`
+- Implemented `KillSwitchController` with required methods:
+  - `evaluate(evaluation_input, policy_input)`
+  - `evaluate_with_trace(...)`
+  - `arm(policy_input)`
+  - `disarm(policy_input)`
+- Refined controller evaluation path so `evaluate(...)` is side-effect free (read-only decision path), while `evaluate_with_trace(...)` remains the explicit state-mutating evaluation entrypoint.
+- Added deterministic blocked-reason constants for policy-disabled, unarmed, operator-trigger, system-trigger, and invalid-contract branches.
+- Added export wiring to safety package in `projects/polymarket/polyquantbot/platform/safety/__init__.py`.
+- Added MAJOR-phase tests in `projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py`.
+
+## 2) Current system architecture
+- Phase 6.3 introduces a standalone safety-layer controller under `platform/safety`.
+- Controller is explicit-input only:
+  - no execution calls
+  - no settlement calls
+  - no transport calls
+  - no persistent writes
+- Deterministic state machine behavior:
+  - `arm(...)` transitions into explicit halted state when policy permits operator arm request.
+  - `disarm(...)` only clears halted/armed state when policy explicitly permits operator disarm request.
+  - `evaluate_with_trace(...)` computes block/allow decision using only typed policy/evaluation contracts and current controller state.
+- Halt decisions are explicit and auditable:
+  - trace refs include policy/evaluation refs
+  - halt notes include source context
+  - blocked reason is deterministic and serialized through decision + trace.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/safety/kill_switch.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/safety/__init__.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/24_97_phase6_3_kill_switch.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Operator arm path deterministically forces halt-active state and blocks execution/settlement/transport progression.
+- Operator disarm path requires explicit policy permission and explicit disarm request to clear halted state.
+- System-triggered halt path deterministically overrides to halt-active and blocks progression with traceable reason.
+- Policy-disabled evaluation path deterministically resets kill-switch active state and returns blocked decision with explicit policy-disabled reason.
+- Invalid contract inputs are fail-closed and non-crashing.
+- Equal state + equal inputs produce equal outputs (determinism proof via test).
+- `evaluate(...)` no longer mutates controller state when probing a system-halt decision.
+- `evaluate(...)` remains side-effect free even when policy-disabled decisions return a disarmed decision snapshot.
+
+## 5) Known issues
+- Phase 6.3 is FOUNDATION-only and intentionally not yet integrated into runtime execution orchestration.
+- Scope-level blocking in this phase is currently represented as `halt_scope` metadata and does not yet implement per-subscope selective block routing.
+- Container pytest still emits `PytestConfigWarning: Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- SENTINEL validation required before merge (MAJOR tier), focusing on:
+  - deterministic halt-state transitions
+  - strict block-before-proceed behavior for execution/settlement/transport requests
+  - explicit operator arm/disarm policy gating
+  - evidence of non-bypass and no side-effect execution/settlement invocation
+- After SENTINEL verdict, COMMANDER decides merge/promotion.
+
+---
+
+**Validation Commands Run:**
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/safety/kill_switch.py projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py` → PASS
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py` → PASS (8 passed, 1 warning)
+
+**Report Timestamp:** 2026-04-13 17:21 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.3 — Kill Switch & Execution Halt System (MAJOR)

--- a/projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.safety.kill_switch import (
+    KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT,
+    KILL_SWITCH_BLOCK_NOT_ARMED,
+    KILL_SWITCH_BLOCK_OPERATOR_HALT,
+    KILL_SWITCH_BLOCK_POLICY_DISABLED,
+    KillSwitchController,
+    KillSwitchEvaluationInput,
+    KillSwitchPolicyInput,
+)
+
+
+VALID_POLICY = KillSwitchPolicyInput(
+    kill_switch_enabled=True,
+    allow_operator_arm=True,
+    allow_operator_disarm=True,
+    operator_request_arm=True,
+    operator_request_disarm=False,
+    operator_halt_reason=None,
+    policy_trace_refs={"phase": "6.3"},
+)
+
+VALID_EVALUATION = KillSwitchEvaluationInput(
+    execution_requested=True,
+    settlement_requested=True,
+    transport_requested=True,
+    system_halt_requested=False,
+    halt_scope="all",
+    upstream_trace_refs={"path": "transport-exchange-signing-capital-settlement"},
+)
+
+
+def test_phase6_3_operator_arm_forces_halt_decision() -> None:
+    controller = KillSwitchController()
+
+    state = controller.arm(VALID_POLICY)
+    assert state.armed is True
+    assert state.halt_active is True
+    assert state.halt_reason == KILL_SWITCH_BLOCK_OPERATOR_HALT
+
+    build = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+
+    assert build.decision is not None
+    assert build.decision.allowed_to_proceed is False
+    assert build.decision.execution_blocked is True
+    assert build.decision.settlement_blocked is True
+    assert build.decision.transport_blocked is True
+    assert build.decision.blocked_reason == KILL_SWITCH_BLOCK_OPERATOR_HALT
+    assert build.trace.evaluation_attempted is True
+
+
+def test_phase6_3_disarm_reopens_progression_when_policy_allows() -> None:
+    controller = KillSwitchController()
+
+    controller.arm(VALID_POLICY)
+    disarmed = controller.disarm(
+        replace(
+            VALID_POLICY,
+            operator_request_disarm=True,
+            operator_request_arm=False,
+        )
+    )
+    assert disarmed.halt_active is False
+
+    build = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+
+    assert build.decision is not None
+    assert build.decision.blocked_reason == KILL_SWITCH_BLOCK_NOT_ARMED
+
+
+def test_phase6_3_system_halt_is_deterministic_and_blocks_transport_path() -> None:
+    controller = KillSwitchController()
+
+    build = controller.evaluate_with_trace(
+        evaluation_input=replace(
+            VALID_EVALUATION,
+            system_halt_requested=True,
+            system_halt_reason="exchange_timeout_guard",
+        ),
+        policy_input=VALID_POLICY,
+    )
+
+    assert build.decision is not None
+    assert build.decision.allowed_to_proceed is False
+    assert build.decision.transport_blocked is True
+    assert build.decision.state.system_triggered is True
+    assert build.decision.blocked_reason == "exchange_timeout_guard"
+
+
+def test_phase6_3_policy_disabled_blocks_progression_and_resets_state() -> None:
+    controller = KillSwitchController()
+
+    controller.arm(VALID_POLICY)
+    build = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=replace(VALID_POLICY, kill_switch_enabled=False),
+    )
+
+    assert build.decision is not None
+    assert build.decision.blocked_reason == KILL_SWITCH_BLOCK_POLICY_DISABLED
+    assert build.decision.state.armed is False
+    assert build.decision.state.halt_active is False
+
+
+def test_phase6_3_invalid_input_contract_is_blocked_without_crash() -> None:
+    controller = KillSwitchController()
+
+    invalid_eval = controller.evaluate_with_trace(
+        evaluation_input=None,  # type: ignore[arg-type]
+        policy_input=VALID_POLICY,
+    )
+    invalid_policy = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=None,  # type: ignore[arg-type]
+    )
+
+    assert invalid_eval.decision is not None
+    assert invalid_eval.decision.blocked_reason == KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT
+    assert invalid_policy.decision is not None
+    assert invalid_policy.decision.blocked_reason == KILL_SWITCH_BLOCK_INVALID_INPUT_CONTRACT
+
+
+def test_phase6_3_deterministic_same_inputs_same_outputs() -> None:
+    controller = KillSwitchController()
+
+    controller.arm(VALID_POLICY)
+    first = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+
+    controller = KillSwitchController()
+    controller.arm(VALID_POLICY)
+    second = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+
+    assert first == second
+
+
+def test_phase6_3_evaluate_is_side_effect_free() -> None:
+    controller = KillSwitchController()
+
+    decision = controller.evaluate(
+        evaluation_input=replace(
+            VALID_EVALUATION,
+            system_halt_requested=True,
+            system_halt_reason="side_effect_probe",
+        ),
+        policy_input=VALID_POLICY,
+    )
+    assert decision is not None
+    assert decision.blocked_reason == "side_effect_probe"
+
+    follow_up = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+    assert follow_up.decision is not None
+    assert follow_up.decision.blocked_reason == KILL_SWITCH_BLOCK_NOT_ARMED
+
+
+def test_phase6_3_evaluate_policy_disabled_does_not_mutate_state() -> None:
+    controller = KillSwitchController()
+    controller.arm(VALID_POLICY)
+
+    decision = controller.evaluate(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=replace(VALID_POLICY, kill_switch_enabled=False),
+    )
+    assert decision is not None
+    assert decision.blocked_reason == KILL_SWITCH_BLOCK_POLICY_DISABLED
+    assert decision.state.armed is False
+
+    follow_up = controller.evaluate_with_trace(
+        evaluation_input=VALID_EVALUATION,
+        policy_input=VALID_POLICY,
+    )
+    assert follow_up.decision is not None
+    assert follow_up.decision.blocked_reason == KILL_SWITCH_BLOCK_OPERATOR_HALT


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, auditable kill-switch to block execution/transport/settlement progression under explicit policy and operator/system triggers.
- Provide a side-effect-free probe path for safety checks while offering an explicit mutating evaluation path for operator/system actions.
- Surface the new safety capability in project state, exports, and validation artifacts for SENTINEL review prior to runtime integration.

### Description
- Added `projects/polymarket/polyquantbot/platform/safety/kill_switch.py` implementing `KillSwitchController`, input contracts (`KillSwitchPolicyInput`, `KillSwitchEvaluationInput`), state/decision/trace dataclasses, and deterministic block constants like `KILL_SWITCH_BLOCK_POLICY_DISABLED` and `KILL_SWITCH_BLOCK_OPERATOR_HALT`.
- Implemented two evaluation entrypoints: side-effect-free `evaluate(...)` and mutating `evaluate_with_trace(...)`, plus explicit `arm(...)` and `disarm(...)` state transition methods with policy gating.
- Exported the new contracts from `projects/polymarket/polyquantbot/platform/safety/__init__.py` and updated `PROJECT_STATE.md` to reflect Phase 6.3 status and report source.
- Added unit tests `projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py` and a Forge report `reports/forge/24_97_phase6_3_kill_switch.md` describing the design and validation notes.

### Testing
- Ran byte-compile validation with `python -m py_compile projects/polymarket/polyquantbot/platform/safety/kill_switch.py projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py` which passed.
- Ran unit tests with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_3_kill_switch_20260413.py` which passed (8 passed, 1 warning about `asyncio_mode`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd12122300832eb482dd50fb2acb56)