### PR TITLE
feat: phase 6.4 runtime monitoring circuit breaker on execution transport path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,11 +1,11 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-14 14:58
+2026-04-14 08:17
 
 ## Status
-— **POST-MERGE TRUTH SYNC COMPLETE — Phase 6.3 carry-forward reset merged via PR #479 (MINOR, FOUNDATION)**
-Repository truth is now synchronized to merged-main reality: Phase 6.3 approved carry-forward truth remains preserved, and Phase 6.4.1 remains aligned approved/spec-level only with no runtime delivery claim.
+— **PHASE 6.4 RUNTIME MONITORING PATH IMPLEMENTED (MAJOR, NARROW INTEGRATION)**
+Deterministic anomaly evaluation now gates one explicit execution-control runtime path (`ExecutionTransport.submit_with_trace`) and can block/halt submission based on Phase 6.4 policy contract outcomes.
 
 ## COMPLETED
 - **AGENTS.md roadmap rules insertion** — `## ROADMAP RULE (LOCKED)` and `## ROADMAP COMPLETION GATE` inserted at correct locations; insertion-only, no existing content modified (MINOR, FOUNDATION).
@@ -20,9 +20,10 @@ Repository truth is now synchronized to merged-main reality: Phase 6.3 approved 
 - **Phase 6.3 kill-switch & execution-halt foundation** preserved as approved carry-forward truth and merged to `main` via PR #479.
 - **Phase 6.4.1 monitoring & circuit breaker FOUNDATION spec contract fix** remains aligned approved/spec-level truth (SENTINEL APPROVED 100/100) and is not claimed as runtime delivered.
 - **Post-merge repo truth sync** completed for `PROJECT_STATE.md` and `ROADMAP.md` to reflect merged PR #479 reality only.
+- **Phase 6.4 runtime monitoring and circuit-breaker path** implemented as NARROW INTEGRATION on `ExecutionTransport.submit_with_trace`, including deterministic anomaly precedence, exposure-breach block behavior, kill-switch anomaly halt enforcement, and monitoring event recording.
 
 ## IN PROGRESS
-- None.
+- SENTINEL validation handoff for Phase 6.4 runtime monitoring and circuit-breaker path (MAJOR).
 
 ## NOT STARTED
 - Full wallet lifecycle implementation (secret loading/storage/rotation).
@@ -31,7 +32,7 @@ Repository truth is now synchronized to merged-main reality: Phase 6.3 approved 
 - Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1 and Phase 6.2).
 
 ## NEXT PRIORITY
-COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_15_post_merge_truth_sync.md. Tier: MINOR
+SENTINEL validation required before merge. Source: reports/forge/25_16_phase6_4_runtime_circuit_breaker.md. Tier: MAJOR
 
 ## KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry/batching/async workers.
@@ -42,4 +43,4 @@ COMMANDER review required before merge. Auto PR review optional if used. Source:
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, no correction logic, and no background automation are implemented.
 - Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation/correction logic, no background automation, and no external DB are implemented.
 - Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope.
-- Phase 6.4.1 remains spec-contract only; runtime monitoring, persistence, alerting, scheduler wiring, and execution-halting behavior remain intentionally out of scope.
+- Phase 6.4 runtime delivery is intentionally narrow to one execution-control path (`ExecutionTransport.submit_with_trace`) and does not yet provide platform-wide monitoring rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, or settlement automation.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,11 +1,11 @@
 # PROJECT_STATE.md
 
 ## Last Updated
-2026-04-14 08:17
+2026-04-14 08:27
 
 ## Status
-— **PHASE 6.4 RUNTIME MONITORING PATH IMPLEMENTED (MAJOR, NARROW INTEGRATION)**
-Deterministic anomaly evaluation now gates one explicit execution-control runtime path (`ExecutionTransport.submit_with_trace`) and can block/halt submission based on Phase 6.4 policy contract outcomes.
+— **PHASE 6.4 RUNTIME MONITORING PATH SENTINEL-VALIDATED (MAJOR, NARROW INTEGRATION)**
+SENTINEL validated deterministic anomaly evaluation plus halt/block enforcement on `ExecutionTransport.submit_with_trace` and issued APPROVED verdict for the declared narrow runtime target.
 
 ## COMPLETED
 - **AGENTS.md roadmap rules insertion** — `## ROADMAP RULE (LOCKED)` and `## ROADMAP COMPLETION GATE` inserted at correct locations; insertion-only, no existing content modified (MINOR, FOUNDATION).
@@ -21,9 +21,10 @@ Deterministic anomaly evaluation now gates one explicit execution-control runtim
 - **Phase 6.4.1 monitoring & circuit breaker FOUNDATION spec contract fix** remains aligned approved/spec-level truth (SENTINEL APPROVED 100/100) and is not claimed as runtime delivered.
 - **Post-merge repo truth sync** completed for `PROJECT_STATE.md` and `ROADMAP.md` to reflect merged PR #479 reality only.
 - **Phase 6.4 runtime monitoring and circuit-breaker path** implemented as NARROW INTEGRATION on `ExecutionTransport.submit_with_trace`, including deterministic anomaly precedence, exposure-breach block behavior, kill-switch anomaly halt enforcement, and monitoring event recording.
+- **SENTINEL validation for Phase 6.4 runtime monitoring narrow integration** completed with **APPROVED** verdict (report: `projects/polymarket/polyquantbot/reports/sentinel/25_17_phase6_4_runtime_monitoring_validation.md`).
 
 ## IN PROGRESS
-- SENTINEL validation handoff for Phase 6.4 runtime monitoring and circuit-breaker path (MAJOR).
+- COMMANDER merge decision and PR review flow for Phase 6.4 runtime monitoring narrow integration.
 
 ## NOT STARTED
 - Full wallet lifecycle implementation (secret loading/storage/rotation).
@@ -32,7 +33,7 @@ Deterministic anomaly evaluation now gates one explicit execution-control runtim
 - Reconciliation mutation/correction workflow (intentionally excluded from Phase 6.1 and Phase 6.2).
 
 ## NEXT PRIORITY
-SENTINEL validation required before merge. Source: reports/forge/25_16_phase6_4_runtime_circuit_breaker.md. Tier: MAJOR
+COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/sentinel/25_17_phase6_4_runtime_monitoring_validation.md. Tier: MAJOR
 
 ## KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry/batching/async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Walker AI Trading Team — Project Roadmap
 
-**Updated: 2026-04-14 14:58 UTC (FORGE-X post-merge truth sync after PR #479)**
+**Updated: 2026-04-14 08:17 UTC (FORGE-X Phase 6.4 runtime monitoring narrow integration update)**
 
 ## Active Projects
 
@@ -28,17 +28,19 @@
 | 6.1 | Execution Ledger (In-memory) | Done |
 | 6.2 | Persistent Ledger & Audit Trail | Done |
 | 6.3 | Kill Switch & Execution Halt Foundation | Preserved approved carry-forward truth merged to `main` (PR #479) |
-| 6.4.1 | Monitoring & Circuit Breaker FOUNDATION Spec Contract | Aligned approved/spec-level truth only (SENTINEL APPROVED 100/100); runtime delivery not claimed |
+| 6.4.1 | Monitoring & Circuit Breaker FOUNDATION Spec Contract | Done — approved/spec contract remains baseline (SENTINEL APPROVED 100/100) |
+| 6.4.2 | Runtime Monitoring & Circuit Breaker (Single Path) | In Progress — narrow integration on execution-control path (`ExecutionTransport.submit_with_trace`) with SENTINEL gate pending |
 
 ### Anchor State
 - Real execution enabled.
 - Persistent audit trail foundation present.
 - Phase 6.3 kill-switch FOUNDATION remains preserved approved carry-forward truth after merged PR #479.
-- Phase 6.4.1 remains aligned approved/spec-level truth only with unchanged non-runtime scope.
+- Phase 6.4.1 spec contract remains authoritative baseline.
+- Phase 6.4.2 now introduces first runtime monitoring/circuit-breaker narrow integration on one declared execution-control path only.
 
 ### Next Milestone
-- COMMANDER review of this post-merge repo-truth sync update.
-- Continue Phase 6 planning/execution from merged-main truth baseline without expanding 6.4.1 into runtime claims.
+- SENTINEL validation of Phase 6.4 runtime narrow integration before merge.
+- After SENTINEL verdict, continue staged rollout for broader monitoring coverage only if explicitly approved.
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/execution/execution_transport.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_transport.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    MONITORING_DECISION_ALLOW,
+    MONITORING_DECISION_BLOCK,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+
 from .execution_gateway import ExecutionGatewayResult
 from .execution_mode_controller import MODE_LIVE
 from .live_execution_authorizer import LiveExecutionAuthorizationDecision
@@ -21,12 +29,17 @@ EXECUTION_TRANSPORT_BLOCK_MULTIPLE_ORDERS_NOT_ALLOWED = "multiple_orders_not_all
 EXECUTION_TRANSPORT_BLOCK_IDEMPOTENCY_REQUIRED = "idempotency_required"
 EXECUTION_TRANSPORT_BLOCK_AUDIT_LOG_MISSING = "audit_log_missing"
 EXECUTION_TRANSPORT_BLOCK_OPERATOR_CONFIRMATION_MISSING = "operator_confirmation_missing"
+EXECUTION_TRANSPORT_BLOCK_MONITORING_EVALUATION_REQUIRED = "monitoring_evaluation_required"
+EXECUTION_TRANSPORT_BLOCK_MONITORING_ANOMALY = "monitoring_anomaly_block"
+EXECUTION_TRANSPORT_HALT_MONITORING_ANOMALY = "monitoring_anomaly_halt"
 
 
 @dataclass(frozen=True)
 class ExecutionTransportAuthorizationInput:
     authorization: LiveExecutionAuthorizationDecision
     gateway_result: ExecutionGatewayResult
+    monitoring_input: MonitoringContractInput | None = None
+    monitoring_circuit_breaker: MonitoringCircuitBreaker | None = None
     source_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -44,6 +57,7 @@ class ExecutionTransportPolicyInput:
     audit_log_attached: bool
     operator_confirm_required: bool
     operator_confirm_present: bool
+    monitoring_required: bool = False
     policy_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -253,6 +267,50 @@ class ExecutionTransport:
                 transport_notes={"operator_confirm_required": policy_input.operator_confirm_required},
             )
 
+        monitoring_result = None
+        if policy_input.monitoring_required:
+            if not isinstance(authorization_input.monitoring_input, MonitoringContractInput):
+                return _blocked_build_result(
+                    blocked_reason=EXECUTION_TRANSPORT_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    execution_authorized=True,
+                    transport_mode=EXECUTION_TRANSPORT_MODE_SIMULATED,
+                    transport_attempted=False,
+                    upstream_trace_refs=upstream_trace_refs,
+                    transport_notes={"monitoring_required": True},
+                )
+            breaker = authorization_input.monitoring_circuit_breaker or MonitoringCircuitBreaker()
+            monitoring_result = breaker.evaluate(authorization_input.monitoring_input)
+            upstream_trace_refs["monitoring"] = {
+                "decision": monitoring_result.decision,
+                "primary_anomaly": monitoring_result.primary_anomaly,
+                "anomalies": list(monitoring_result.anomalies),
+                "eval_ref": monitoring_result.event.eval_ref,
+            }
+            if monitoring_result.decision == MONITORING_DECISION_HALT:
+                return _blocked_build_result(
+                    blocked_reason=EXECUTION_TRANSPORT_HALT_MONITORING_ANOMALY,
+                    execution_authorized=True,
+                    transport_mode=EXECUTION_TRANSPORT_MODE_SIMULATED,
+                    transport_attempted=False,
+                    upstream_trace_refs=upstream_trace_refs,
+                    transport_notes={
+                        "monitoring_decision": monitoring_result.decision,
+                        "primary_anomaly": monitoring_result.primary_anomaly,
+                    },
+                )
+            if monitoring_result.decision == MONITORING_DECISION_BLOCK:
+                return _blocked_build_result(
+                    blocked_reason=EXECUTION_TRANSPORT_BLOCK_MONITORING_ANOMALY,
+                    execution_authorized=True,
+                    transport_mode=EXECUTION_TRANSPORT_MODE_SIMULATED,
+                    transport_attempted=False,
+                    upstream_trace_refs=upstream_trace_refs,
+                    transport_notes={
+                        "monitoring_decision": monitoring_result.decision,
+                        "primary_anomaly": monitoring_result.primary_anomaly,
+                    },
+                )
+
         request_payload = self._build_request_payload(authorization_input)
 
         if policy_input.dry_run_force:
@@ -276,7 +334,14 @@ class ExecutionTransport:
                     transport_attempted=True,
                     blocked_reason=EXECUTION_TRANSPORT_BLOCK_DRY_RUN_FORCED,
                     upstream_trace_refs=upstream_trace_refs,
-                    transport_notes={"dry_run_force": True},
+                    transport_notes={
+                        "dry_run_force": True,
+                        "monitoring_decision": (
+                            monitoring_result.decision
+                            if monitoring_result is not None
+                            else MONITORING_DECISION_ALLOW
+                        ),
+                    },
                 ),
             )
 
@@ -298,7 +363,14 @@ class ExecutionTransport:
                 transport_attempted=True,
                 blocked_reason=None if success else EXECUTION_TRANSPORT_BLOCK_REAL_SUBMISSION_NOT_ALLOWED,
                 upstream_trace_refs=upstream_trace_refs,
-                transport_notes={"exchange_stub_called": True},
+                transport_notes={
+                    "exchange_stub_called": True,
+                    "monitoring_decision": (
+                        monitoring_result.decision
+                        if monitoring_result is not None
+                        else MONITORING_DECISION_ALLOW
+                    ),
+                },
             ),
         )
 
@@ -329,6 +401,14 @@ def _validate_authorization_input(authorization_input: ExecutionTransportAuthori
         return "authorization_decision_required"
     if not isinstance(authorization_input.gateway_result, ExecutionGatewayResult):
         return "gateway_result_required"
+    if authorization_input.monitoring_input is not None and not isinstance(
+        authorization_input.monitoring_input, MonitoringContractInput
+    ):
+        return "monitoring_input_contract_required"
+    if authorization_input.monitoring_circuit_breaker is not None and not isinstance(
+        authorization_input.monitoring_circuit_breaker, MonitoringCircuitBreaker
+    ):
+        return "monitoring_circuit_breaker_required"
     if not isinstance(authorization_input.source_trace_refs, dict):
         return "source_trace_refs_must_be_dict"
     return None
@@ -346,6 +426,7 @@ def _validate_policy_input(policy_input: ExecutionTransportPolicyInput) -> str |
         "audit_log_attached": policy_input.audit_log_attached,
         "operator_confirm_required": policy_input.operator_confirm_required,
         "operator_confirm_present": policy_input.operator_confirm_present,
+        "monitoring_required": policy_input.monitoring_required,
     }
     for name, value in bool_fields.items():
         if not isinstance(value, bool):

--- a/projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py
+++ b/projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import isfinite
+from typing import Any
+
+MONITORING_DECISION_ALLOW = "ALLOW"
+MONITORING_DECISION_BLOCK = "BLOCK"
+MONITORING_DECISION_HALT = "HALT"
+
+ANOMALY_EXPOSURE_THRESHOLD_BREACH = "EXPOSURE_THRESHOLD_BREACH"
+ANOMALY_EXPOSURE_INPUT_INCONSISTENT = "EXPOSURE_INPUT_INCONSISTENT"
+ANOMALY_DATA_STALENESS_BREACH = "DATA_STALENESS_BREACH"
+ANOMALY_QUALITY_SCORE_BREACH = "QUALITY_SCORE_BREACH"
+ANOMALY_SIGNAL_DEDUP_FAILURE = "SIGNAL_DEDUP_FAILURE"
+ANOMALY_KILL_SWITCH_TRIGGERED = "KILL_SWITCH_TRIGGERED"
+ANOMALY_MONITORING_DISABLED = "MONITORING_DISABLED"
+ANOMALY_INVALID_CONTRACT_INPUT = "INVALID_CONTRACT_INPUT"
+
+_ANOMALY_PRECEDENCE: tuple[str, ...] = (
+    ANOMALY_INVALID_CONTRACT_INPUT,
+    ANOMALY_MONITORING_DISABLED,
+    ANOMALY_KILL_SWITCH_TRIGGERED,
+    ANOMALY_EXPOSURE_INPUT_INCONSISTENT,
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_DATA_STALENESS_BREACH,
+    ANOMALY_QUALITY_SCORE_BREACH,
+    ANOMALY_SIGNAL_DEDUP_FAILURE,
+)
+
+
+@dataclass(frozen=True)
+class MonitoringContractInput:
+    policy_ref: str
+    eval_ref: str
+    timestamp_ms: int
+    exposure_ratio: float
+    position_notional_usd: float
+    total_capital_usd: float
+    data_freshness_ms: int
+    quality_score: float
+    signal_dedup_ok: bool
+    kill_switch_armed: bool
+    kill_switch_triggered: bool
+    monitoring_enabled: bool
+    quality_guard_enabled: bool
+    exposure_guard_enabled: bool
+    max_exposure_ratio: float
+    max_data_freshness_ms: int
+    min_quality_score: float
+    trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MonitoringCircuitBreakerEvent:
+    policy_ref: str
+    eval_ref: str
+    timestamp_ms: int
+    decision: str
+    primary_anomaly: str | None
+    anomalies: tuple[str, ...]
+    trace_refs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MonitoringCircuitBreakerResult:
+    decision: str
+    primary_anomaly: str | None
+    anomalies: tuple[str, ...]
+    should_halt_execution: bool
+    should_block_execution: bool
+    event: MonitoringCircuitBreakerEvent
+
+
+class MonitoringCircuitBreaker:
+    """Phase 6.4 runtime anomaly evaluator for a narrow execution-control path."""
+
+    def __init__(self) -> None:
+        self._events: list[MonitoringCircuitBreakerEvent] = []
+
+    def evaluate(self, contract_input: MonitoringContractInput) -> MonitoringCircuitBreakerResult:
+        anomalies = self._collect_anomalies(contract_input)
+        primary_anomaly = _first_precedence_anomaly(anomalies)
+        decision = _decision_for(primary_anomaly)
+        event = MonitoringCircuitBreakerEvent(
+            policy_ref=getattr(contract_input, "policy_ref", "invalid_input"),
+            eval_ref=getattr(contract_input, "eval_ref", "invalid_input"),
+            timestamp_ms=getattr(contract_input, "timestamp_ms", 0),
+            decision=decision,
+            primary_anomaly=primary_anomaly,
+            anomalies=anomalies,
+            trace_refs=_trace_dict_or_empty(getattr(contract_input, "trace_refs", {})),
+        )
+        self._events.append(event)
+        return MonitoringCircuitBreakerResult(
+            decision=decision,
+            primary_anomaly=primary_anomaly,
+            anomalies=anomalies,
+            should_halt_execution=decision == MONITORING_DECISION_HALT,
+            should_block_execution=decision in {MONITORING_DECISION_BLOCK, MONITORING_DECISION_HALT},
+            event=event,
+        )
+
+    def get_events(self) -> tuple[MonitoringCircuitBreakerEvent, ...]:
+        return tuple(self._events)
+
+    def _collect_anomalies(self, contract_input: MonitoringContractInput) -> tuple[str, ...]:
+        if not isinstance(contract_input, MonitoringContractInput):
+            return (ANOMALY_INVALID_CONTRACT_INPUT,)
+
+        anomalies: set[str] = set()
+        contract_errors = _validate_contract_input(contract_input)
+        if contract_errors:
+            anomalies.add(ANOMALY_INVALID_CONTRACT_INPUT)
+
+        if contract_input.monitoring_enabled is not True:
+            anomalies.add(ANOMALY_MONITORING_DISABLED)
+
+        if contract_input.kill_switch_armed and contract_input.kill_switch_triggered:
+            anomalies.add(ANOMALY_KILL_SWITCH_TRIGGERED)
+
+        if contract_input.exposure_guard_enabled:
+            if contract_input.total_capital_usd <= 0 or contract_input.position_notional_usd < 0:
+                anomalies.add(ANOMALY_EXPOSURE_INPUT_INCONSISTENT)
+            if contract_input.exposure_ratio > contract_input.max_exposure_ratio:
+                anomalies.add(ANOMALY_EXPOSURE_THRESHOLD_BREACH)
+
+        if contract_input.quality_guard_enabled:
+            if contract_input.data_freshness_ms > contract_input.max_data_freshness_ms:
+                anomalies.add(ANOMALY_DATA_STALENESS_BREACH)
+            if contract_input.quality_score < contract_input.min_quality_score:
+                anomalies.add(ANOMALY_QUALITY_SCORE_BREACH)
+            if contract_input.signal_dedup_ok is not True:
+                anomalies.add(ANOMALY_SIGNAL_DEDUP_FAILURE)
+
+        return tuple(sorted(anomalies, key=_precedence_index))
+
+
+def _validate_contract_input(contract_input: MonitoringContractInput) -> dict[str, str]:
+    errors: dict[str, str] = {}
+
+    if not isinstance(contract_input.policy_ref, str) or contract_input.policy_ref.strip() == "":
+        errors["policy_ref"] = "must_be_non_empty_str"
+    if not isinstance(contract_input.eval_ref, str) or contract_input.eval_ref.strip() == "":
+        errors["eval_ref"] = "must_be_non_empty_str"
+    if not isinstance(contract_input.timestamp_ms, int) or contract_input.timestamp_ms <= 0:
+        errors["timestamp_ms"] = "must_be_positive_int"
+
+    for name in ("exposure_ratio", "quality_score", "max_exposure_ratio", "min_quality_score"):
+        value = getattr(contract_input, name)
+        if not isinstance(value, (int, float)) or not isfinite(float(value)):
+            errors[name] = "must_be_finite_number"
+
+    if not isinstance(contract_input.exposure_ratio, (int, float)) or contract_input.exposure_ratio < 0:
+        errors["exposure_ratio"] = "must_be_non_negative"
+    if not isinstance(contract_input.max_exposure_ratio, (int, float)) or contract_input.max_exposure_ratio != 0.10:
+        errors["max_exposure_ratio"] = "must_equal_0_10"
+
+    if not isinstance(contract_input.data_freshness_ms, int) or contract_input.data_freshness_ms < 0:
+        errors["data_freshness_ms"] = "must_be_non_negative_int"
+    if not isinstance(contract_input.max_data_freshness_ms, int) or contract_input.max_data_freshness_ms < 0:
+        errors["max_data_freshness_ms"] = "must_be_non_negative_int"
+
+    if not isinstance(contract_input.quality_score, (int, float)) or not 0.0 <= float(contract_input.quality_score) <= 1.0:
+        errors["quality_score"] = "must_be_between_0_and_1"
+    if not isinstance(contract_input.min_quality_score, (int, float)) or not 0.0 <= float(contract_input.min_quality_score) <= 1.0:
+        errors["min_quality_score"] = "must_be_between_0_and_1"
+
+    bool_fields = (
+        "signal_dedup_ok",
+        "kill_switch_armed",
+        "kill_switch_triggered",
+        "monitoring_enabled",
+        "quality_guard_enabled",
+        "exposure_guard_enabled",
+    )
+    for field_name in bool_fields:
+        if not isinstance(getattr(contract_input, field_name), bool):
+            errors[field_name] = "must_be_bool"
+
+    if not isinstance(contract_input.trace_refs, dict):
+        errors["trace_refs"] = "must_be_dict"
+
+    return errors
+
+
+def _precedence_index(anomaly: str) -> int:
+    try:
+        return _ANOMALY_PRECEDENCE.index(anomaly)
+    except ValueError:
+        return len(_ANOMALY_PRECEDENCE)
+
+
+def _first_precedence_anomaly(anomalies: tuple[str, ...]) -> str | None:
+    return anomalies[0] if anomalies else None
+
+
+def _decision_for(primary_anomaly: str | None) -> str:
+    if primary_anomaly in {
+        ANOMALY_INVALID_CONTRACT_INPUT,
+        ANOMALY_KILL_SWITCH_TRIGGERED,
+    }:
+        return MONITORING_DECISION_HALT
+    if primary_anomaly in {
+        ANOMALY_MONITORING_DISABLED,
+        ANOMALY_EXPOSURE_INPUT_INCONSISTENT,
+        ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+        ANOMALY_DATA_STALENESS_BREACH,
+        ANOMALY_QUALITY_SCORE_BREACH,
+        ANOMALY_SIGNAL_DEDUP_FAILURE,
+    }:
+        return MONITORING_DECISION_BLOCK
+    return MONITORING_DECISION_ALLOW
+
+
+def _trace_dict_or_empty(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    return {}

--- a/projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md
@@ -1,0 +1,70 @@
+# Forge Report — Phase 6.4 Runtime Monitoring and Circuit Breaker (Single Path Integration)
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** Phase 6.4 runtime monitoring and circuit-breaker integration on one execution-control path: `projects/polymarket/polyquantbot/platform/execution/execution_transport.py::ExecutionTransport.submit_with_trace`, including deterministic anomaly-to-decision evaluation and halt/block enforcement.  
+**Not in Scope:** Platform-wide monitoring rollout, alerting/UI polish, scheduler generalization, wallet lifecycle, portfolio management, settlement batching/retry automation, unrelated execution refactors, and broad orchestration rewiring.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Implemented first runtime Phase 6.4 monitoring evaluator in `projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py` with:
+  - deterministic anomaly taxonomy,
+  - strict anomaly precedence,
+  - deterministic `ALLOW` / `BLOCK` / `HALT` decisions,
+  - in-memory event recording for path-level traceability.
+- Wired monitoring evaluation into the real execution-control target path:
+  - `ExecutionTransport.submit_with_trace(...)` now enforces monitoring decisions when `monitoring_required=True`.
+  - `BLOCK` and `HALT` decisions now deterministically stop submission before exchange call on this path.
+- Added focused tests for:
+  - anomaly precedence (`INVALID_CONTRACT_INPUT` precedence),
+  - exposure breach block behavior,
+  - execution halt enforcement on kill-switch anomaly.
+
+## 2) Current system architecture
+- Declared target flow for this increment:
+  - `LiveExecutionAuthorizationDecision` + gateway output
+  - -> `ExecutionTransport.submit_with_trace(...)`
+  - -> (new) `MonitoringCircuitBreaker.evaluate(...)`
+  - -> deterministic `ALLOW/BLOCK/HALT`
+  - -> allow/stop exchange transport on this exact path.
+- Narrow integration boundary:
+  - only execution transport path is runtime-wired in this task,
+  - evaluator remains deterministic and side-effect-minimal except explicit event record append.
+- No architecture expansion into wallet lifecycle, portfolio orchestration, or settlement automation.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py`
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_transport.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md`
+
+## 4) What is working
+- Monitoring evaluator returns deterministic outcomes for identical inputs.
+- Monitoring-required execution transport path no longer allows bypass when monitoring input is missing.
+- Exposure threshold breach (`> 10%`) deterministically blocks execution on target path.
+- Kill-switch-triggered anomaly deterministically halts execution path before exchange submission.
+- Existing Phase 5.2 execution transport tests remain passing after integration.
+
+## 5) Known issues
+- Runtime monitoring integration is intentionally limited to one path (`ExecutionTransport.submit_with_trace`) and is not yet platform-wide.
+- Event recording is in-memory only for this increment (no external persistence layer introduced).
+- Pytest still emits pre-existing environment warning for unknown `asyncio_mode` config option.
+
+## 6) What is next
+- SENTINEL validation on this MAJOR narrow integration path before merge decision.
+- If validated and approved by COMMANDER, decide whether to expand Phase 6.4 coverage to additional runtime paths in a separate scoped task.
+
+---
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py projects/polymarket/polyquantbot/platform/execution/execution_transport.py`
+2. `PYTHONPATH=. python -m pytest projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py -q --tb=short`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-14 08:17 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.4 runtime monitoring and circuit-breaker implementation on target execution-control path

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_17_phase6_4_runtime_monitoring_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_17_phase6_4_runtime_monitoring_validation.md
@@ -1,0 +1,65 @@
+# SENTINEL Report — Phase 6.4 Runtime Monitoring Narrow Integration Validation
+
+**Validation Tier:** MAJOR  
+**Claim Level Evaluated:** NARROW INTEGRATION  
+**Source Forge Report:** `projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md`  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_transport.py::ExecutionTransport.submit_with_trace` deterministic anomaly evaluation and halt/block enforcement before exchange submission  
+**Not in Scope Confirmed:** Platform-wide monitoring rollout, alerting/UI polish, scheduler generalization, wallet lifecycle, portfolio management, settlement batching/retry automation, unrelated execution refactors, broad orchestration rewiring  
+**Verdict:** **APPROVED**  
+**Score:** **95/100**
+
+## Phase 0 — Context and artifact integrity
+- Required target artifacts are present and readable:
+  - `projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md`
+  - `projects/polymarket/polyquantbot/platform/execution/execution_transport.py`
+  - `projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py`
+  - `projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py`
+- Tier/claim/target alignment is internally consistent with MAJOR + NARROW INTEGRATION.
+
+## Phase 1 — Contract and deterministic decision validation
+- `MonitoringCircuitBreaker.evaluate(...)` deterministically derives anomalies, selects one primary anomaly by strict precedence, and maps to `ALLOW/BLOCK/HALT`.
+- Invalid input contract deterministically produces `ANOMALY_INVALID_CONTRACT_INPUT` and `HALT` decision.
+- Decision path is side-effect-minimal and explicit (event append only).
+
+## Phase 2 — Runtime wiring proof on declared target path
+- In `ExecutionTransport.submit_with_trace(...)`, monitoring is evaluated when `policy_input.monitoring_required=True`.
+- If monitoring input is missing/invalid while required, the transport is blocked with explicit reason `monitoring_evaluation_required`.
+- `HALT` and `BLOCK` monitoring decisions are both enforced before any exchange submission call.
+
+## Phase 3 — Negative-path and break-attempt checks
+- Exposure breach (`exposure_ratio > max_exposure_ratio`) test confirms deterministic block behavior with `monitoring_anomaly_block`.
+- Kill-switch triggered anomaly test confirms deterministic halt behavior with `monitoring_anomaly_halt`.
+- Precedence test confirms `INVALID_CONTRACT_INPUT` dominates lower-priority anomalies.
+
+## Phase 4 — Bypass resistance and safety behavior
+- No bypass path found in the target function once `monitoring_required=True` is set.
+- Exchange transport stub is reached only after monitoring gates pass.
+- `trace.upstream_trace_refs["monitoring"]` records decision/anomalies/eval_ref for deterministic auditability on this narrow path.
+
+## Phase 5 — Scope discipline and claim-level compliance
+- Integration is narrow and correctly limited to one execution-control path (`submit_with_trace`).
+- No evidence of overclaim into platform-wide monitoring runtime rollout.
+- Claim Level remains accurate as NARROW INTEGRATION.
+
+## Phase 6 — Validation commands and observed results
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py projects/polymarket/polyquantbot/platform/execution/execution_transport.py projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py` → PASS  
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py` → PASS (16 passed, 1 warning: pre-existing `asyncio_mode` config warning)  
+3. `find . -type d -name 'phase*'` → PASS (no forbidden phase directories found)
+
+## Phase 7 — Findings summary
+### Critical findings
+- None.
+
+### Non-critical findings
+1. Environment continues to emit pre-existing `PytestConfigWarning: Unknown config option: asyncio_mode`; no impact to validated target behavior.
+
+## Phase 8 — Final verdict and gate decision
+**APPROVED** for declared MAJOR/NARROW validation target.
+
+Rationale:
+- Deterministic anomaly evaluation is implemented and runtime-wired on the exact declared path.
+- Halt/block enforcement is proven before exchange submission on that path.
+- Negative-path tests and regression checks passed without contradictions.
+
+Merge gate note:
+- COMMANDER review/decision is now the next gate.

--- a/projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import math
+
+from projects.polymarket.polyquantbot.platform.execution.execution_gateway import ExecutionGatewayResult
+from projects.polymarket.polyquantbot.platform.execution.execution_mode_controller import MODE_LIVE
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import (
+    EXECUTION_TRANSPORT_BLOCK_MONITORING_ANOMALY,
+    EXECUTION_TRANSPORT_HALT_MONITORING_ANOMALY,
+    ExecutionTransport,
+    ExecutionTransportAuthorizationInput,
+    ExecutionTransportPolicyInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_INVALID_CONTRACT_INPUT,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_authorizer import (
+    LiveExecutionAuthorizationDecision,
+)
+
+VALID_AUTHORIZATION = LiveExecutionAuthorizationDecision(
+    execution_authorized=True,
+    allowed=True,
+    blocked_reason=None,
+    selected_mode=MODE_LIVE,
+    authorization_scope="phase6_4_runtime_path",
+    kill_switch_armed=True,
+    audit_required=True,
+    audit_attached=True,
+    simulated=False,
+    non_executing=False,
+)
+
+VALID_GATEWAY = ExecutionGatewayResult(
+    accepted=True,
+    blocked_reason=None,
+    execution_status="SIMULATED_EXECUTION_ACCEPTED",
+    request_built=True,
+    response_status="SIMULATED_ACCEPTED",
+    client_order_id="CID-6-4-001",
+    simulated=True,
+    non_executing=True,
+)
+
+VALID_MONITORING_INPUT = MonitoringContractInput(
+    policy_ref="phase6_4_policy",
+    eval_ref="phase6_4_eval",
+    timestamp_ms=1713120000000,
+    exposure_ratio=0.10,
+    position_notional_usd=100.0,
+    total_capital_usd=1_000.0,
+    data_freshness_ms=150,
+    quality_score=0.95,
+    signal_dedup_ok=True,
+    kill_switch_armed=True,
+    kill_switch_triggered=False,
+    monitoring_enabled=True,
+    quality_guard_enabled=True,
+    exposure_guard_enabled=True,
+    max_exposure_ratio=0.10,
+    max_data_freshness_ms=500,
+    min_quality_score=0.80,
+    trace_refs={"target_path": "execution_transport.submit_with_trace"},
+)
+
+VALID_AUTHORIZATION_INPUT = ExecutionTransportAuthorizationInput(
+    authorization=VALID_AUTHORIZATION,
+    gateway_result=VALID_GATEWAY,
+    monitoring_input=VALID_MONITORING_INPUT,
+    monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+    source_trace_refs={"phase": "6.4"},
+)
+
+VALID_POLICY_INPUT = ExecutionTransportPolicyInput(
+    transport_enabled=True,
+    execution_mode=MODE_LIVE,
+    dry_run_force=False,
+    allow_real_submission=True,
+    single_submission_only=True,
+    max_orders=1,
+    require_idempotency=True,
+    idempotency_key_present=True,
+    audit_log_required=True,
+    audit_log_attached=True,
+    operator_confirm_required=True,
+    operator_confirm_present=True,
+    monitoring_required=True,
+    policy_trace_refs={"policy": "6.4"},
+)
+
+
+def test_phase6_4_anomaly_precedence_invalid_input_overrides_monitoring_disabled() -> None:
+    breaker = MonitoringCircuitBreaker()
+
+    result = breaker.evaluate(
+        replace(
+            VALID_MONITORING_INPUT,
+            monitoring_enabled=False,
+            quality_score=math.nan,
+        )
+    )
+
+    assert result.decision == MONITORING_DECISION_HALT
+    assert result.primary_anomaly == ANOMALY_INVALID_CONTRACT_INPUT
+    assert result.anomalies[0] == ANOMALY_INVALID_CONTRACT_INPUT
+
+
+def test_phase6_4_exposure_breach_blocks_execution_transport_target_path() -> None:
+    transport = ExecutionTransport()
+    breaker = MonitoringCircuitBreaker()
+
+    result = transport.submit_with_trace(
+        authorization_input=replace(
+            VALID_AUTHORIZATION_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, exposure_ratio=0.11),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert result.result is not None
+    assert result.result.submitted is False
+    assert result.result.blocked_reason == EXECUTION_TRANSPORT_BLOCK_MONITORING_ANOMALY
+    assert result.trace.transport_attempted is False
+    assert result.trace.transport_notes is not None
+    assert result.trace.transport_notes["primary_anomaly"] == ANOMALY_EXPOSURE_THRESHOLD_BREACH
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_kill_switch_anomaly_halts_execution_transport_target_path() -> None:
+    transport = ExecutionTransport()
+    breaker = MonitoringCircuitBreaker()
+
+    result = transport.submit_with_trace(
+        authorization_input=replace(
+            VALID_AUTHORIZATION_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, kill_switch_triggered=True),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert result.result is not None
+    assert result.result.submitted is False
+    assert result.result.non_executing is True
+    assert result.result.blocked_reason == EXECUTION_TRANSPORT_HALT_MONITORING_ANOMALY
+    assert result.trace.transport_attempted is False
+    assert len(breaker.get_events()) == 1


### PR DESCRIPTION
### Motivation
- Deliver a narrow Phase 6.4 runtime integration so the approved 6.4.1 spec contract is enforced on one explicit execution-control path.  
- Ensure deterministic anomaly evaluation maps to deterministic `ALLOW` / `BLOCK` / `HALT` decisions that can prevent exchange submission on the target path.  
- Keep scope limited to a single runtime path to reduce blast radius while providing testable runtime safety behavior for SENTINEL validation.

### Description
- Added a deterministic evaluator `MonitoringCircuitBreaker` and typed contract `MonitoringContractInput` in `projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py` implementing fixed anomaly taxonomy, strict precedence, and ALLOW/BLOCK/HALT mapping.  
- Wired monitoring into the execution-control path by extending `ExecutionTransportAuthorizationInput`/`ExecutionTransportPolicyInput` and enforcing monitoring when `monitoring_required=True` inside `ExecutionTransport.submit_with_trace`, returning deterministic block/halt build results before any exchange submission.  
- Added focused unit tests `projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py` that verify anomaly precedence, exposure-breach blocking, and kill-switch halt behavior on the declared target path.  
- Added a FORGE report `projects/polymarket/polyquantbot/reports/forge/25_16_phase6_4_runtime_circuit_breaker.md` and updated `PROJECT_STATE.md` and `ROADMAP.md` to record the narrow integration status and the SENTINEL handoff requirement.

### Testing
- `python -m py_compile projects/polymarket/polyquantbot/platform/execution/monitoring_circuit_breaker.py projects/polymarket/polyquantbot/platform/execution/execution_transport.py` — pass.  
- `PYTHONPATH=. python -m pytest projects/polymarket/polyquantbot/tests/test_phase6_4_runtime_circuit_breaker_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py -q --tb=short` — `16 passed` with one `pytest` config warning about `asyncio_mode` (environment), no failures.  
- `find . -type d -name 'phase*'` — verified no forbidden `phase*/` folders present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf73338508325b4c8218c737b54c3)