### PR TITLE
Phase 6.4.4: add gateway-path monitoring (ExecutionGateway.simulate_execution_with_trace)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-14 20:41
-🔄 Status       : Phase 6.4.4 gateway-path monitoring narrow expansion implemented on source branch; deterministic ALLOW/BLOCK/HALT monitoring now wired for ExecutionGateway.simulate_execution_with_trace pending SENTINEL validation.
+📅 Last Updated : 2026-04-14 20:58
+🔄 Status       : Phase 6.4.4 gateway-path monitoring narrow expansion validated by SENTINEL as APPROVED (97/100, Critical 0); merge decision pending COMMANDER review.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -14,7 +14,7 @@
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100). Accepted two-path narrow baseline preserved: ExecutionTransport.submit_with_trace (6.4.2) and LiveExecutionAuthorizer.authorize_with_trace (6.4.3).
 
 🔧 IN PROGRESS
-- Phase 6.4.4 gateway-path monitoring narrow integration implementation completed on source branch and awaiting SENTINEL MAJOR validation (target path: ExecutionGateway.simulate_execution_with_trace).
+- Phase 6.4.4 gateway-path monitoring narrow expansion completed and SENTINEL-validated on source branch; awaiting COMMANDER merge/promotion decision.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
@@ -24,7 +24,7 @@
 - Platform-wide monitoring rollout beyond the current three narrow Phase 6.4 target paths (transport, authorizer, gateway).
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge for Phase 6.4.4 gateway monitoring expansion. Source: projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md. Tier: MAJOR.
+- COMMANDER final review and merge decision for Phase 6.4.4 after SENTINEL APPROVED verdict. Source: projects/polymarket/polyquantbot/reports/sentinel/25_22_phase6_4_4_gateway_monitoring_validation.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 10:30
-🔄 Status       : Phase 6.4 two-path narrow monitoring baseline merged on main (PR #491). Accepted narrow scope: ExecutionTransport.submit_with_trace and LiveExecutionAuthorizer.authorize_with_trace. No further SENTINEL required for this baseline.
+📅 Last Updated : 2026-04-14 20:41
+🔄 Status       : Phase 6.4.4 gateway-path monitoring narrow expansion implemented on source branch; deterministic ALLOW/BLOCK/HALT monitoring now wired for ExecutionGateway.simulate_execution_with_trace pending SENTINEL validation.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -11,20 +11,20 @@
 - SENTINEL validation completed for Phase 5.2–5.6 major-gated work.
 - Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory ledger records and reconciliation checks.
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence, deterministic reload, and read-only audit filtering.
-- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100). Accepted two-path narrow baseline: ExecutionTransport.submit_with_trace (6.4.2) and LiveExecutionAuthorizer.authorize_with_trace (6.4.3).
+- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100). Accepted two-path narrow baseline preserved: ExecutionTransport.submit_with_trace (6.4.2) and LiveExecutionAuthorizer.authorize_with_trace (6.4.3).
 
 🔧 IN PROGRESS
-- None.
+- Phase 6.4.4 gateway-path monitoring narrow integration implementation completed on source branch and awaiting SENTINEL MAJOR validation (target path: ExecutionGateway.simulate_execution_with_trace).
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout beyond the current two narrow Phase 6.4 target paths.
+- Platform-wide monitoring rollout beyond the current three narrow Phase 6.4 target paths (transport, authorizer, gateway).
 
 🎯 NEXT PRIORITY
-- COMMANDER review for MINOR FOUNDATION repo-root truth sync after PR #491 merge. Source: projects/polymarket/polyquantbot/reports/forge/25_22_post_pr491_truth_sync.md. Tier: MINOR.
+- SENTINEL validation required before merge for Phase 6.4.4 gateway monitoring expansion. Source: projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
@@ -35,5 +35,5 @@
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, correction logic, or background automation are implemented.
 - Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation or correction logic, background automation, or external DB are implemented.
 - Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope.
-- Phase 6.4 two-path narrow monitoring baseline excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
+- Phase 6.4 narrow monitoring remains intentionally scoped to three execution-related paths only (transport, authorizer, gateway) and excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
 - [DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning — carried forward as non-runtime hygiene backlog.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 10:30
+**Last Updated:** 2026-04-14 20:41
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 10:30
+**Last Updated:** 2026-04-14 20:41
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -53,6 +53,7 @@
 | 6.4.1 | Monitoring & Circuit Breaker FOUNDATION Spec Contract | 🚧 In Progress | Approved at spec level only; runtime-wide delivery is not claimed. |
 | 6.4.2 | Runtime Monitoring Narrow Integration | ✅ Done | Merged truth preserved for ExecutionTransport.submit_with_trace narrow integration after SENTINEL APPROVED (95/100). |
 | 6.4.3 | Authorizer-Path Monitoring Narrow Integration | ✅ Done | Merged via PR #491. SENTINEL APPROVED (99/100). Narrow scope: LiveExecutionAuthorizer.authorize_with_trace + ExecutionTransport.submit_with_trace preserved. No platform-wide rollout. |
+| 6.4.4 | Gateway-Path Monitoring Narrow Integration Expansion | 🚧 In Progress | Source-branch implementation complete for ExecutionGateway.simulate_execution_with_trace with deterministic ALLOW/BLOCK/HALT contract; SENTINEL required before merge. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/execution/execution_gateway.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_gateway.py
@@ -16,12 +16,22 @@ from .execution_adapter import (
     ExecutionAdapterDecisionInput,
 )
 from .execution_decision import ExecutionDecision
+from .monitoring_circuit_breaker import (
+    MONITORING_DECISION_ALLOW,
+    MONITORING_DECISION_BLOCK,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
 
 GATEWAY_BLOCK_INVALID_GATEWAY_INPUT = "invalid_gateway_input"
 GATEWAY_BLOCK_INVALID_DECISION_CONTRACT = "invalid_decision_contract"
 GATEWAY_BLOCK_ADAPTER_BLOCKED = "adapter_blocked"
 GATEWAY_BLOCK_EXCHANGE_INTERFACE_BLOCKED = "exchange_interface_blocked"
 GATEWAY_BLOCK_MOCK_RESPONSE_REJECTED = "mock_response_rejected"
+GATEWAY_BLOCK_MONITORING_EVALUATION_REQUIRED = "monitoring_evaluation_required"
+GATEWAY_BLOCK_MONITORING_ANOMALY = "monitoring_anomaly_block"
+GATEWAY_HALT_MONITORING_ANOMALY = "monitoring_anomaly_halt"
 
 GATEWAY_EXECUTION_STATUS_ACCEPTED = "SIMULATED_EXECUTION_ACCEPTED"
 GATEWAY_EXECUTION_STATUS_BLOCKED = "SIMULATED_EXECUTION_BLOCKED"
@@ -31,6 +41,9 @@ GATEWAY_EXECUTION_STATUS_REJECTED = "SIMULATED_EXECUTION_REJECTED"
 @dataclass(frozen=True)
 class ExecutionGatewayDecisionInput:
     decision: ExecutionDecision
+    monitoring_input: MonitoringContractInput | None = None
+    monitoring_circuit_breaker: MonitoringCircuitBreaker | None = None
+    monitoring_required: bool = False
     source_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -108,6 +121,69 @@ class ExecutionGateway:
                 gateway_notes={"decision_error": decision_error},
             )
 
+        gateway_trace_refs: dict[str, Any] = {
+            "gateway_input": dict(decision_input.source_trace_refs),
+        }
+        monitoring_result = None
+        if decision_input.monitoring_required:
+            if not isinstance(decision_input.monitoring_input, MonitoringContractInput):
+                return _blocked_build_result(
+                    blocked_reason=GATEWAY_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    upstream_trace_refs={
+                        **gateway_trace_refs,
+                        "contract_errors": {
+                            "monitoring_input": {
+                                "expected_type": "MonitoringContractInput",
+                                "actual_type": type(decision_input.monitoring_input).__name__,
+                            }
+                        },
+                    },
+                    gateway_notes={"monitoring_required": True},
+                )
+            if decision_input.monitoring_circuit_breaker is not None and not isinstance(
+                decision_input.monitoring_circuit_breaker, MonitoringCircuitBreaker
+            ):
+                return _blocked_build_result(
+                    blocked_reason=GATEWAY_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    upstream_trace_refs={
+                        **gateway_trace_refs,
+                        "contract_errors": {
+                            "monitoring_circuit_breaker": {
+                                "expected_type": "MonitoringCircuitBreaker",
+                                "actual_type": type(decision_input.monitoring_circuit_breaker).__name__,
+                            }
+                        },
+                    },
+                    gateway_notes={"contract_name": "monitoring_circuit_breaker"},
+                )
+
+            breaker = decision_input.monitoring_circuit_breaker or MonitoringCircuitBreaker()
+            monitoring_result = breaker.evaluate(decision_input.monitoring_input)
+            gateway_trace_refs["monitoring"] = {
+                "decision": monitoring_result.decision,
+                "primary_anomaly": monitoring_result.primary_anomaly,
+                "anomalies": list(monitoring_result.anomalies),
+                "eval_ref": monitoring_result.event.eval_ref,
+            }
+            if monitoring_result.decision == MONITORING_DECISION_HALT:
+                return _blocked_build_result(
+                    blocked_reason=GATEWAY_HALT_MONITORING_ANOMALY,
+                    upstream_trace_refs=gateway_trace_refs,
+                    gateway_notes={
+                        "monitoring_decision": monitoring_result.decision,
+                        "primary_anomaly": monitoring_result.primary_anomaly,
+                    },
+                )
+            if monitoring_result.decision == MONITORING_DECISION_BLOCK:
+                return _blocked_build_result(
+                    blocked_reason=GATEWAY_BLOCK_MONITORING_ANOMALY,
+                    upstream_trace_refs=gateway_trace_refs,
+                    gateway_notes={
+                        "monitoring_decision": monitoring_result.decision,
+                        "primary_anomaly": monitoring_result.primary_anomaly,
+                    },
+                )
+
         adapter_result = self._adapter.build_order_with_trace(
             decision_input=ExecutionAdapterDecisionInput(
                 decision=decision_input.decision,
@@ -119,7 +195,7 @@ class ExecutionGateway:
             return _blocked_build_result(
                 blocked_reason=GATEWAY_BLOCK_ADAPTER_BLOCKED,
                 upstream_trace_refs={
-                    "gateway_input": dict(decision_input.source_trace_refs),
+                    **gateway_trace_refs,
                     "adapter_trace": adapter_result.trace.upstream_trace_refs,
                 },
                 gateway_notes={
@@ -131,7 +207,7 @@ class ExecutionGateway:
             order_input=ExchangeClientOrderInput(
                 order=adapter_result.order,
                 source_trace_refs={
-                    "gateway_input": dict(decision_input.source_trace_refs),
+                    **gateway_trace_refs,
                     "adapter_trace": dict(adapter_result.trace.upstream_trace_refs),
                 },
             )
@@ -141,7 +217,7 @@ class ExecutionGateway:
             return _blocked_build_result(
                 blocked_reason=GATEWAY_BLOCK_EXCHANGE_INTERFACE_BLOCKED,
                 upstream_trace_refs={
-                    "gateway_input": dict(decision_input.source_trace_refs),
+                    **gateway_trace_refs,
                     "adapter_trace": adapter_result.trace.upstream_trace_refs,
                     "exchange_trace": interface_result.trace.upstream_trace_refs,
                 },
@@ -155,7 +231,7 @@ class ExecutionGateway:
             return _blocked_build_result(
                 blocked_reason=GATEWAY_BLOCK_MOCK_RESPONSE_REJECTED,
                 upstream_trace_refs={
-                    "gateway_input": dict(decision_input.source_trace_refs),
+                    **gateway_trace_refs,
                     "adapter_trace": adapter_result.trace.upstream_trace_refs,
                     "exchange_trace": interface_result.trace.upstream_trace_refs,
                 },
@@ -185,7 +261,7 @@ class ExecutionGateway:
                 gateway_completed=True,
                 blocked_reason=None,
                 upstream_trace_refs={
-                    "gateway_input": dict(decision_input.source_trace_refs),
+                    **gateway_trace_refs,
                     "adapter_trace": adapter_result.trace.upstream_trace_refs,
                     "exchange_trace": interface_result.trace.upstream_trace_refs,
                 },
@@ -194,6 +270,9 @@ class ExecutionGateway:
                     "exchange_interface_blocked_reason": None,
                     "response_code": response.response_code,
                     "response_status": response.status,
+                    "monitoring_decision": (
+                        monitoring_result.decision if monitoring_result is not None else MONITORING_DECISION_ALLOW
+                    ),
                 },
             ),
         )

--- a/projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md
@@ -1,0 +1,61 @@
+# Forge Report — Phase 6.4.4 Gateway Monitoring Expansion
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py::ExecutionGateway.simulate_execution_with_trace` as a single additional deterministic monitoring enforcement path, while preserving the accepted 6.4.2 and 6.4.3 paths unchanged.  
+**Not in Scope:** Platform-wide monitoring rollout, exchange/network boundary monitoring, wallet lifecycle, portfolio orchestration, scheduler generalization, settlement automation, and refactor of existing `ExecutionTransport.submit_with_trace` / `LiveExecutionAuthorizer.authorize_with_trace` behavior.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Added deterministic monitoring integration to `ExecutionGateway.simulate_execution_with_trace(...)` using the existing monitoring circuit-breaker contract.
+- Extended `ExecutionGatewayDecisionInput` with narrow monitoring inputs (`monitoring_input`, `monitoring_circuit_breaker`, `monitoring_required`) without widening integration scope beyond the target method.
+- Enforced deterministic monitoring outcomes:
+  - `ALLOW` → gateway flow continues.
+  - `BLOCK` → gateway returns `monitoring_anomaly_block`.
+  - `HALT` → gateway returns `monitoring_anomaly_halt`.
+- Added focused phase 6.4.4 tests for gateway ALLOW/BLOCK/HALT behavior and a regression test proving accepted 6.4.2 + 6.4.3 monitored paths remain intact.
+
+## 2) Current system architecture
+- Narrow runtime monitoring integration now exists on exactly three execution-related paths:
+  1. `projects/polymarket/polyquantbot/platform/execution/execution_transport.py::ExecutionTransport.submit_with_trace` (accepted 6.4.2 baseline).
+  2. `projects/polymarket/polyquantbot/platform/execution/live_execution_authorizer.py::LiveExecutionAuthorizer.authorize_with_trace` (accepted 6.4.3 baseline).
+  3. `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py::ExecutionGateway.simulate_execution_with_trace` (new 6.4.4 target path in this task).
+- For the 6.4.4 target path, monitoring evaluation occurs after gateway input/decision contract checks and before adapter/exchange gateway flow.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_gateway.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- Gateway path now applies deterministic monitoring decision contract with explicit trace propagation.
+- Gateway ALLOW path proceeds through adapter and exchange mock response with monitoring decision recorded in gateway trace.
+- Gateway BLOCK path prevents execution build and returns deterministic block reason.
+- Gateway HALT path prevents execution build and returns deterministic halt reason.
+- Existing accepted monitored paths remain functionally intact under regression coverage:
+  - authorizer path still authorizes under valid ALLOW input.
+  - transport path still submits successfully under valid ALLOW input.
+
+## 5) Known issues
+- Integration remains intentionally narrow; no platform-wide rollout is claimed.
+- Monitoring event persistence and broader operational alerting remain out of scope.
+- Pre-existing pytest warning (`Unknown config option: asyncio_mode`) persists as deferred hygiene backlog.
+
+## 6) What is next
+- SENTINEL MAJOR validation on the declared target path before merge decision.
+- If SENTINEL approves, COMMANDER decides merge/promotion.
+
+---
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_gateway.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase4_3_execution_gateway_20260412.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-14 20:41 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** expand phase 6.4 runtime monitoring to gateway execution path

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_22_phase6_4_4_gateway_monitoring_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_22_phase6_4_4_gateway_monitoring_validation.md
@@ -1,0 +1,113 @@
+# Sentinel Report — Phase 6.4.4 Gateway Monitoring Expansion Validation
+
+## Environment
+- Repo: `https://github.com/bayuewalker/walker-ai-team`
+- Branch: `feature/monitoring-phase6-4-third-path-expansion-20260415` (Codex worktree HEAD alias: `work`)
+- Validation Date (UTC): `2026-04-14`
+- Validation Role: SENTINEL (NEXUS)
+- Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py::ExecutionGateway.simulate_execution_with_trace`
+- Not in Scope: platform-wide monitoring rollout, exchange/network boundary monitoring, wallet lifecycle, portfolio orchestration, scheduler generalization, settlement automation, and refactor of existing ExecutionTransport.submit_with_trace / LiveExecutionAuthorizer.authorize_with_trace behavior
+
+## Validation Context
+This validation audits whether gateway-path monitoring was integrated narrowly and deterministically on `simulate_execution_with_trace`, while preserving existing accepted narrow monitoring paths (transport + authorizer) with no scope widening.
+
+## Phase 0 Checks
+1. Forge report exists at exact source path:
+   - `projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md` ✅
+2. Forge report naming validity (`[phase]_[increment]_[name].md`) ✅
+3. Six required forge sections present (`What was built`, `Current system architecture`, `Files created / modified`, `What is working`, `Known issues`, `What is next`) ✅
+4. Required forge metadata present (Validation Tier / Claim Level / Validation Target / Not in Scope) ✅
+5. `PROJECT_STATE.md` timestamp format verified (`YYYY-MM-DD HH:MM`) ✅ (`2026-04-14 20:41` pre-validation)
+6. MAJOR gate consistency (forge next step explicitly requires SENTINEL validation before merge) ✅
+7. `python -m py_compile` evidence present in forge report and revalidated by SENTINEL command run ✅
+8. `pytest` evidence present in forge report and revalidated by SENTINEL command run ✅
+
+Executed commands:
+- `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_gateway.py projects/polymarket/polyquantbot/platform/execution/execution_transport.py projects/polymarket/polyquantbot/platform/execution/live_execution_authorizer.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py`
+- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase4_3_execution_gateway_20260412.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py`
+  - Result: `34 passed, 1 warning` (`Unknown config option: asyncio_mode` pre-existing deferred hygiene warning)
+- `find . -type d -name 'phase*'`
+  - Result: none
+- Additional negative contract probes via inline Python execution for malformed gateway monitoring inputs
+
+## Findings
+### F1 — Target-path monitoring integration is present and deterministic (PASS)
+Evidence:
+- Monitoring gate only executes when `decision_input.monitoring_required` is true.
+- ALLOW path proceeds to adapter/exchange build flow.
+- BLOCK maps to `monitoring_anomaly_block`.
+- HALT maps to `monitoring_anomaly_halt`.
+- Monitoring trace fields (`decision`, `primary_anomaly`, `anomalies`, `eval_ref`) are propagated under `trace.upstream_trace_refs["monitoring"]`.
+
+Primary code evidence:
+- `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py` lines in monitoring gate and decision mapping block.
+
+### F2 — Malformed monitoring contract inputs fail closed with deterministic reason (PASS)
+Evidence:
+- `monitoring_required=True` + invalid `monitoring_input` type returns blocked reason `monitoring_evaluation_required` with explicit contract error payload.
+- `monitoring_required=True` + valid monitoring input + invalid breaker type returns blocked reason `monitoring_evaluation_required` with explicit breaker contract error payload.
+- Negative probes executed and observed deterministic outputs:
+  - `{'monitoring_input': {'expected_type': 'MonitoringContractInput', 'actual_type': 'dict'}}`
+  - `{'monitoring_circuit_breaker': {'expected_type': 'MonitoringCircuitBreaker', 'actual_type': 'str'}}`
+
+### F3 — Existing accepted narrow integrations remain intact (PASS)
+Evidence:
+- Regression test `test_phase6_4_4_existing_two_monitored_paths_remain_intact` verifies:
+  - `LiveExecutionAuthorizer.authorize_with_trace` still authorizes under valid ALLOW monitoring context.
+  - `ExecutionTransport.submit_with_trace` still submits under valid ALLOW monitoring context.
+- Combined validation test suite passed: 34/34.
+
+### F4 — Scope remains narrow; no silent platform-wide rollout introduced (PASS)
+Evidence:
+- Gateway changes are localized to `ExecutionGatewayDecisionInput` and `ExecutionGateway.simulate_execution_with_trace` flow.
+- Existing monitoring integrations in authorizer and transport remain explicit and independent; no new global orchestrator rollout hooks were introduced in validated scope.
+
+## Score Breakdown
+- Pre-handoff compliance: 20/20
+- Target-path behavior correctness: 30/30
+- Deterministic BLOCK/HALT semantics + trace propagation: 20/20
+- Regression protection for existing narrow integrations: 15/15
+- Negative/failure-path robustness for malformed monitoring inputs: 10/10
+- Hygiene deductions: -3 (pre-existing pytest config warning)
+
+**Final Score: 97/100**
+
+## Critical Issues
+- None.
+
+## Status
+**APPROVED**
+
+## PR Gate Result
+- Gate Decision: **OPEN FOR COMMANDER REVIEW**
+- Merge target policy preserved: source branch to same source branch context; never direct-to-main from SENTINEL.
+
+## Broader Audit Finding
+- No critical contradiction between declared claim (NARROW INTEGRATION) and observed code behavior.
+- No evidence of unscoped monitoring rollout detected in validated files/tests.
+
+## Reasoning
+The implemented gateway-path monitoring is deterministic and fail-closed where contract violations occur. Decision handling for ALLOW/BLOCK/HALT is explicit and test-backed. Regression coverage confirms previously accepted 6.4.2/6.4.3 narrow integrations are still intact. Because no critical safety contradiction was found and the MAJOR validation target was met with evidence, verdict is APPROVED.
+
+## Fix Recommendations
+1. Optional hygiene follow-up: clean pytest config (`asyncio_mode`) warning in a dedicated non-runtime task.
+2. Keep future monitoring expansions explicitly claim-scoped per path to avoid integration overclaim drift.
+
+## Out-of-scope Advisory
+- Platform-wide monitoring rollout still intentionally absent (as declared).
+- No verdict extension to wallet lifecycle, settlement automation, scheduler generalization, or orchestration-wide routing.
+
+## Deferred Minor Backlog
+- `[DEFERRED] Pytest config emits Unknown config option: asyncio_mode — carried forward as non-runtime hygiene backlog.`
+
+## Telegram Visual Preview
+```text
+SENTINEL Phase 6.4.4 Verdict: APPROVED (97/100)
+Target: ExecutionGateway.simulate_execution_with_trace
+Result: Deterministic ALLOW/BLOCK/HALT confirmed, malformed monitoring contracts fail closed,
+        prior narrow integrations (authorizer + transport) remain intact.
+Critical: 0
+Next Gate: COMMANDER final decision.
+```

--- a/projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import ExecutionDecision
+from projects.polymarket.polyquantbot.platform.execution.execution_gateway import (
+    GATEWAY_BLOCK_MONITORING_ANOMALY,
+    GATEWAY_EXECUTION_STATUS_ACCEPTED,
+    GATEWAY_HALT_MONITORING_ANOMALY,
+    ExecutionGateway,
+    ExecutionGatewayDecisionInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_mode_controller import MODE_LIVE
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import (
+    ExecutionTransport,
+    ExecutionTransportAuthorizationInput,
+    ExecutionTransportPolicyInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_authorizer import (
+    LiveExecutionAuthorizationPolicyInput,
+    LiveExecutionAuthorizer,
+    LiveExecutionReadinessInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_guardrails import LiveExecutionReadinessDecision
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_KILL_SWITCH_TRIGGERED,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+
+
+VALID_DECISION = ExecutionDecision(
+    allowed=True,
+    blocked_reason=None,
+    market_id="MKT-6-4-4",
+    outcome="YES",
+    side="YES",
+    size=9.5,
+    routing_mode="platform-gateway-shadow",
+    execution_mode="paper-prep-only",
+    ready_for_execution=True,
+    non_activating=True,
+)
+
+VALID_MONITORING_INPUT = MonitoringContractInput(
+    policy_ref="phase6_4_4_policy",
+    eval_ref="phase6_4_4_eval",
+    timestamp_ms=1713200000000,
+    exposure_ratio=0.10,
+    position_notional_usd=100.0,
+    total_capital_usd=1_000.0,
+    data_freshness_ms=100,
+    quality_score=0.95,
+    signal_dedup_ok=True,
+    kill_switch_armed=True,
+    kill_switch_triggered=False,
+    monitoring_enabled=True,
+    quality_guard_enabled=True,
+    exposure_guard_enabled=True,
+    max_exposure_ratio=0.10,
+    max_data_freshness_ms=500,
+    min_quality_score=0.80,
+    trace_refs={"target_path": "execution_gateway.simulate_execution_with_trace"},
+)
+
+VALID_GATEWAY_INPUT = ExecutionGatewayDecisionInput(
+    decision=VALID_DECISION,
+    monitoring_input=VALID_MONITORING_INPUT,
+    monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+    monitoring_required=True,
+    source_trace_refs={"phase": "6.4.4"},
+)
+
+
+def test_phase6_4_4_gateway_monitoring_allow_pass_through() -> None:
+    gateway = ExecutionGateway()
+
+    result = gateway.simulate_execution_with_trace(decision_input=VALID_GATEWAY_INPUT)
+
+    assert result.result is not None
+    assert result.result.accepted is True
+    assert result.result.blocked_reason is None
+    assert result.result.execution_status == GATEWAY_EXECUTION_STATUS_ACCEPTED
+    assert result.trace.gateway_completed is True
+    assert result.trace.upstream_trace_refs["monitoring"]["decision"] == "ALLOW"
+
+
+def test_phase6_4_4_gateway_monitoring_block_prevents_execution() -> None:
+    gateway = ExecutionGateway()
+    breaker = MonitoringCircuitBreaker()
+
+    result = gateway.simulate_execution_with_trace(
+        decision_input=replace(
+            VALID_GATEWAY_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, exposure_ratio=0.11),
+            monitoring_circuit_breaker=breaker,
+        )
+    )
+
+    assert result.result is not None
+    assert result.result.accepted is False
+    assert result.result.blocked_reason == GATEWAY_BLOCK_MONITORING_ANOMALY
+    assert result.trace.gateway_completed is False
+    assert result.trace.gateway_notes is not None
+    assert result.trace.gateway_notes["primary_anomaly"] == ANOMALY_EXPOSURE_THRESHOLD_BREACH
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_4_gateway_monitoring_halt_stops_execution() -> None:
+    gateway = ExecutionGateway()
+    breaker = MonitoringCircuitBreaker()
+
+    result = gateway.simulate_execution_with_trace(
+        decision_input=replace(
+            VALID_GATEWAY_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, kill_switch_triggered=True),
+            monitoring_circuit_breaker=breaker,
+        )
+    )
+
+    assert result.result is not None
+    assert result.result.accepted is False
+    assert result.result.blocked_reason == GATEWAY_HALT_MONITORING_ANOMALY
+    assert result.trace.gateway_completed is False
+    assert result.trace.gateway_notes is not None
+    assert result.trace.gateway_notes["primary_anomaly"] == ANOMALY_KILL_SWITCH_TRIGGERED
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_4_existing_two_monitored_paths_remain_intact() -> None:
+    authorizer = LiveExecutionAuthorizer()
+    gateway = ExecutionGateway()
+
+    readiness_result = authorizer.authorize_with_trace(
+        readiness_input=LiveExecutionReadinessInput(
+            readiness_decision=LiveExecutionReadinessDecision(
+                live_ready=True,
+                allowed=True,
+                blocked_reason=None,
+                selected_mode=MODE_LIVE,
+                guardrail_passed=True,
+                kill_switch_armed=True,
+                simulated=True,
+                non_executing=True,
+            ),
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.3"},
+        ),
+        policy_input=LiveExecutionAuthorizationPolicyInput(
+            explicit_execution_enable=True,
+            authorization_scope="single_market_first_path",
+            allowed_scopes=("single_market_first_path",),
+            single_market_only=True,
+            target_market_id="market-6-4-4",
+            wallet_binding_required=True,
+            wallet_binding_present=True,
+            audit_required=True,
+            audit_attached=True,
+            operator_approval_required=True,
+            operator_approval_present=True,
+            kill_switch_must_remain_armed=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.3"},
+        ),
+    )
+
+    assert readiness_result.decision is not None
+    assert readiness_result.decision.execution_authorized is True
+
+    transport = ExecutionTransport()
+    gateway_build_result = gateway.simulate_execution_with_trace(decision_input=VALID_GATEWAY_INPUT)
+    assert gateway_build_result.result is not None
+
+    transport_result = transport.submit_with_trace(
+        authorization_input=ExecutionTransportAuthorizationInput(
+            authorization=readiness_result.decision,
+            gateway_result=gateway_build_result.result,
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.2"},
+        ),
+        policy_input=ExecutionTransportPolicyInput(
+            transport_enabled=True,
+            execution_mode=MODE_LIVE,
+            dry_run_force=False,
+            allow_real_submission=True,
+            single_submission_only=True,
+            max_orders=1,
+            require_idempotency=True,
+            idempotency_key_present=True,
+            audit_log_required=True,
+            audit_log_attached=True,
+            operator_confirm_required=True,
+            operator_confirm_present=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.2"},
+        ),
+    )
+
+    assert transport_result.result is not None
+    assert transport_result.result.submitted is True
+    assert transport_result.result.success is True
+    assert transport_result.result.blocked_reason is None


### PR DESCRIPTION
### Motivation
- Expand deterministic ALLOW / BLOCK / HALT runtime monitoring coverage by wiring the same narrow monitoring contract into the gateway execution path without changing the already-accepted transport and authorizer monitored paths.  
- Keep the integration narrowly scoped to `ExecutionGateway.simulate_execution_with_trace` and prepare the change for required MAJOR / SENTINEL validation before merge.  

### Description
- Extended `ExecutionGatewayDecisionInput` with `monitoring_input`, `monitoring_circuit_breaker`, and `monitoring_required`, and added monitoring-related constants and block/halt reasons in `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py`.  
- Implemented pre-adapter monitoring evaluation (contract validation, `MonitoringCircuitBreaker.evaluate`) and deterministic enforcement returning `monitoring_anomaly_block` or `monitoring_anomaly_halt` as appropriate, plus monitoring decision trace propagation on ALLOW.  
- Added focused Phase 6.4.4 tests at `projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py` covering ALLOW pass-through, BLOCK prevention, HALT behavior, and a regression test confirming existing 6.4.2/6.4.3 monitored paths remain unchanged.  
- Created the FORGE report `projects/polymarket/polyquantbot/reports/forge/25_23_phase6_4_4_gateway_monitoring_expansion.md` and updated `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 6.4.4 on the source branch and to set the next gate to SENTINEL (MAJOR).  

### Testing
- Ran compilation check: `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_gateway.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py` and it passed.  
- Ran focused pytest: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase4_3_execution_gateway_20260412.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py` and all tests passed (`34 passed, 1 warning` for pytest config hygiene).  
- Pre-flight checks passed: no `phase*/` folders created and no risk constants changed; next gate: SENTINEL MAJOR validation required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea5d4e9108325a8061ce004c4c997)