### PR TITLE
Phase 6.4.5: add deterministic monitoring to ExchangeIntegration.execute_with_trace (ALLOW/BLOCK/HALT)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-14 21:40
-🔄 Status       : Phase 6.4.5 FORGE-X implementation completed for exchange-path narrow monitoring integration at ExchangeIntegration.execute_with_trace; deterministic ALLOW/BLOCK/HALT contract now extends to one additional execution path pending required SENTINEL MAJOR validation.
+📅 Last Updated : 2026-04-14 22:05
+🔄 Status       : Phase 6.4.5 FORGE-X implementation remains complete on source branch with SENTINEL required before merge; PR #497 state truth regression corrected by restoring completed Phase 6.1 and Phase 6.2 entries.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -9,6 +9,8 @@
 - Phase 5.5 wallet-capital boundary implemented with strict capital gating and controlled wallet access without fund transfer.
 - Phase 5.6 fund settlement boundary implemented with strict policy-gated real settlement and deterministic single-shot transfer interface.
 - SENTINEL validation completed for Phase 5.2–5.6 major-gated work.
+- Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory ledger records and reconciliation checks.
+- Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence, deterministic reload, and read-only audit filtering.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 (runtime/code path) with SENTINEL APPROVED validation recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration implemented in FORGE-X scope at ExchangeIntegration.execute_with_trace with focused ALLOW/BLOCK/HALT tests and three-path regression preservation; awaiting SENTINEL gate.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,23 +1,19 @@
-📅 Last Updated : 2026-04-14 22:05
-🔄 Status       : Phase 6.4.5 FORGE-X implementation remains complete on source branch with SENTINEL required before merge; PR #497 state truth regression corrected by restoring completed Phase 6.1 and Phase 6.2 entries.
+📅 Last Updated : 2026-04-14 22:37
+🔄 Status       : PR #498 state-truth regression fixed by restoring merged 6.4.3/6.4.4 completed entries while preserving Phase 6.4.5 SENTINEL-approved status pending COMMANDER final merge decision.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
-- Phase 5.2 execution transport layer implemented with deterministic gating for real vs simulated submission.
-- Phase 5.3 exchange integration boundary implemented with deterministic real-network gates and explicit signing boundary contracts.
-- Phase 5.4 secure signing boundary implemented with strict real-signing policy checks and abstracted key reference handling.
-- Phase 5.5 wallet-capital boundary implemented with strict capital gating and controlled wallet access without fund transfer.
-- Phase 5.6 fund settlement boundary implemented with strict policy-gated real settlement and deterministic single-shot transfer interface.
+- Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented with deterministic policy gates.
 - SENTINEL validation completed for Phase 5.2–5.6 major-gated work.
-- Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory ledger records and reconciliation checks.
-- Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence, deterministic reload, and read-only audit filtering.
+- Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory records.
+- Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 (runtime/code path) with SENTINEL APPROVED validation recorded in PR #495 (97/100).
-- Phase 6.4.5 exchange-path monitoring narrow integration implemented in FORGE-X scope at ExchangeIntegration.execute_with_trace with focused ALLOW/BLOCK/HALT tests and three-path regression preservation; awaiting SENTINEL gate.
+- Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
+- Phase 6.4.5 exchange-path monitoring narrow integration validated by SENTINEL as APPROVED (100/100, 0 critical) on declared target path.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.4.5 MAJOR validation handoff pending SENTINEL review before merge.
+- COMMANDER decision gate pending for Phase 6.4.5 post-SENTINEL approval.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
@@ -27,7 +23,7 @@
 - Platform-wide monitoring rollout beyond the current four narrow Phase 6.4 target paths (transport, authorizer, gateway, exchange integration).
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md. Tier: MAJOR.
+- COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md. Tier: MINOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-14 21:14
-🔄 Status       : Post-merge truth corrected for Phase 6.4.4 attribution: runtime/code path merged on main via PR #493 and SENTINEL approval path recorded via PR #495; accepted three-path narrow execution baseline remains preserved.
+📅 Last Updated : 2026-04-14 21:40
+🔄 Status       : Phase 6.4.5 FORGE-X implementation completed for exchange-path narrow monitoring integration at ExchangeIntegration.execute_with_trace; deterministic ALLOW/BLOCK/HALT contract now extends to one additional execution path pending required SENTINEL MAJOR validation.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -9,23 +9,23 @@
 - Phase 5.5 wallet-capital boundary implemented with strict capital gating and controlled wallet access without fund transfer.
 - Phase 5.6 fund settlement boundary implemented with strict policy-gated real settlement and deterministic single-shot transfer interface.
 - SENTINEL validation completed for Phase 5.2–5.6 major-gated work.
-- Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory ledger records and reconciliation checks.
-- Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence, deterministic reload, and read-only audit filtering.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 (runtime/code path) with SENTINEL APPROVED validation recorded in PR #495 (97/100). Accepted three-path narrow execution baseline preserved: ExecutionTransport.submit_with_trace (6.4.2), LiveExecutionAuthorizer.authorize_with_trace (6.4.3), and ExecutionGateway.simulate_execution_with_trace (6.4.4).
+- Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 (runtime/code path) with SENTINEL APPROVED validation recorded in PR #495 (97/100).
+- Phase 6.4.5 exchange-path monitoring narrow integration implemented in FORGE-X scope at ExchangeIntegration.execute_with_trace with focused ALLOW/BLOCK/HALT tests and three-path regression preservation; awaiting SENTINEL gate.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.4.5 MAJOR validation handoff pending SENTINEL review before merge.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout beyond the current three narrow Phase 6.4 target paths (transport, authorizer, gateway).
+- Platform-wide monitoring rollout beyond the current four narrow Phase 6.4 target paths (transport, authorizer, gateway, exchange integration).
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: reports/forge/25_24_post_pr493_495_truth_sync.md. Tier: MINOR.
+- SENTINEL validation required before merge. Source: reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
@@ -36,5 +36,5 @@
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, correction logic, or background automation are implemented.
 - Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation or correction logic, background automation, or external DB are implemented.
 - Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope.
-- Phase 6.4 narrow monitoring remains intentionally scoped to three execution-related paths only (transport, authorizer, gateway) and excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
+- Phase 6.4 narrow monitoring remains intentionally scoped to four execution-related paths only (transport, authorizer, gateway, exchange integration) and excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
 - [DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning — carried forward as non-runtime hygiene backlog.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-14 21:14
+**Last Updated:** 2026-04-14 21:40
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-14 21:14
+**Last Updated:** 2026-04-14 21:40
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -54,6 +54,7 @@
 | 6.4.2 | Runtime Monitoring Narrow Integration | ✅ Done | Merged truth preserved for ExecutionTransport.submit_with_trace narrow integration after SENTINEL APPROVED (95/100). |
 | 6.4.3 | Authorizer-Path Monitoring Narrow Integration | ✅ Done | Merged via PR #491. SENTINEL APPROVED (99/100). Narrow scope: LiveExecutionAuthorizer.authorize_with_trace + ExecutionTransport.submit_with_trace preserved. No platform-wide rollout. |
 | 6.4.4 | Gateway-Path Monitoring Narrow Integration Expansion | ✅ Done | Runtime/code path merged via PR #493. SENTINEL APPROVED validation path recorded in PR #495 (97/100). Accepted narrow three-path execution monitoring baseline: ExecutionTransport.submit_with_trace + LiveExecutionAuthorizer.authorize_with_trace + ExecutionGateway.simulate_execution_with_trace. No platform-wide rollout. |
+| 6.4.5 | Exchange-Path Monitoring Narrow Integration Expansion | 🚧 In Progress | FORGE-X runtime/code implementation completed on source branch for ExchangeIntegration.execute_with_trace with deterministic ALLOW/BLOCK/HALT integration and focused tests; SENTINEL MAJOR validation required before merge. Accepted baseline paths (6.4.2/6.4.3/6.4.4) preserved. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/execution/exchange_integration.py
+++ b/projects/polymarket/polyquantbot/platform/execution/exchange_integration.py
@@ -4,6 +4,13 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib import error, parse, request
 
+from .monitoring_circuit_breaker import (
+    MONITORING_DECISION_ALLOW,
+    MONITORING_DECISION_BLOCK,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
 from .execution_transport import ExecutionTransportResult
 
 EXCHANGE_NETWORK_MODE_REAL = "REAL"
@@ -19,6 +26,9 @@ EXCHANGE_EXECUTION_BLOCK_INVALID_ENDPOINT = "invalid_endpoint"
 EXCHANGE_EXECUTION_BLOCK_INVALID_HTTP_METHOD = "invalid_http_method"
 EXCHANGE_EXECUTION_BLOCK_SIGNING_REQUIRED_MISSING = "signing_required_missing"
 EXCHANGE_EXECUTION_BLOCK_ENVIRONMENT_NOT_ALLOWED = "environment_not_allowed"
+EXCHANGE_EXECUTION_BLOCK_MONITORING_EVALUATION_REQUIRED = "monitoring_evaluation_required"
+EXCHANGE_EXECUTION_BLOCK_MONITORING_ANOMALY = "monitoring_anomaly_block"
+EXCHANGE_EXECUTION_HALT_MONITORING_ANOMALY = "monitoring_anomaly_halt"
 
 _ALLOWED_HTTP_METHODS = {"POST", "PUT"}
 
@@ -26,6 +36,9 @@ _ALLOWED_HTTP_METHODS = {"POST", "PUT"}
 @dataclass(frozen=True)
 class ExchangeExecutionTransportInput:
     transport_result: ExecutionTransportResult
+    monitoring_input: MonitoringContractInput | None = None
+    monitoring_circuit_breaker: MonitoringCircuitBreaker | None = None
+    monitoring_required: bool = False
     upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -173,6 +186,65 @@ class ExchangeIntegration:
                 upstream_trace_refs=upstream_trace_refs,
             )
 
+        monitoring_result = None
+        if transport_input.monitoring_required:
+            if not isinstance(transport_input.monitoring_input, MonitoringContractInput):
+                return _blocked_build_result(
+                    blocked_reason=EXCHANGE_EXECUTION_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    execution_attempted=False,
+                    network_used=EXCHANGE_NETWORK_MODE_SIMULATED,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {
+                            "monitoring_input": {
+                                "expected_type": "MonitoringContractInput",
+                                "actual_type": type(transport_input.monitoring_input).__name__,
+                            }
+                        },
+                    },
+                )
+            if transport_input.monitoring_circuit_breaker is not None and not isinstance(
+                transport_input.monitoring_circuit_breaker,
+                MonitoringCircuitBreaker,
+            ):
+                return _blocked_build_result(
+                    blocked_reason=EXCHANGE_EXECUTION_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    execution_attempted=False,
+                    network_used=EXCHANGE_NETWORK_MODE_SIMULATED,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {
+                            "monitoring_circuit_breaker": {
+                                "expected_type": "MonitoringCircuitBreaker",
+                                "actual_type": type(transport_input.monitoring_circuit_breaker).__name__,
+                            }
+                        },
+                    },
+                )
+
+            breaker = transport_input.monitoring_circuit_breaker or MonitoringCircuitBreaker()
+            monitoring_result = breaker.evaluate(transport_input.monitoring_input)
+            upstream_trace_refs["monitoring"] = {
+                "decision": monitoring_result.decision,
+                "primary_anomaly": monitoring_result.primary_anomaly,
+                "anomalies": list(monitoring_result.anomalies),
+                "eval_ref": monitoring_result.event.eval_ref,
+            }
+            if monitoring_result.decision == MONITORING_DECISION_HALT:
+                return _blocked_build_result(
+                    blocked_reason=EXCHANGE_EXECUTION_HALT_MONITORING_ANOMALY,
+                    execution_attempted=False,
+                    network_used=EXCHANGE_NETWORK_MODE_SIMULATED,
+                    upstream_trace_refs=upstream_trace_refs,
+                )
+            if monitoring_result.decision == MONITORING_DECISION_BLOCK:
+                return _blocked_build_result(
+                    blocked_reason=EXCHANGE_EXECUTION_BLOCK_MONITORING_ANOMALY,
+                    execution_attempted=False,
+                    network_used=EXCHANGE_NETWORK_MODE_SIMULATED,
+                    upstream_trace_refs=upstream_trace_refs,
+                )
+
         if policy_input.network_enabled is not True:
             return _blocked_build_result(
                 blocked_reason=EXCHANGE_EXECUTION_BLOCK_NETWORK_DISABLED,
@@ -253,7 +325,14 @@ class ExchangeIntegration:
                     execution_attempted=True,
                     blocked_reason=None,
                     upstream_trace_refs=upstream_trace_refs,
-                    exchange_notes={"network_mode": EXCHANGE_NETWORK_MODE_SIMULATED},
+                    exchange_notes={
+                        "network_mode": EXCHANGE_NETWORK_MODE_SIMULATED,
+                        "monitoring_decision": (
+                            monitoring_result.decision
+                            if monitoring_result is not None
+                            else MONITORING_DECISION_ALLOW
+                        ),
+                    },
                 ),
             )
 
@@ -282,7 +361,14 @@ class ExchangeIntegration:
                 execution_attempted=True,
                 blocked_reason=None,
                 upstream_trace_refs=upstream_trace_refs,
-                exchange_notes={"network_mode": EXCHANGE_NETWORK_MODE_REAL},
+                exchange_notes={
+                    "network_mode": EXCHANGE_NETWORK_MODE_REAL,
+                    "monitoring_decision": (
+                        monitoring_result.decision
+                        if monitoring_result is not None
+                        else MONITORING_DECISION_ALLOW
+                    ),
+                },
             ),
         )
 
@@ -330,6 +416,30 @@ def _validate_transport_input(transport_input: ExchangeExecutionTransportInput) 
             "field": "upstream_trace_refs",
             "expected_type": "dict",
             "actual_type": type(transport_input.upstream_trace_refs).__name__,
+        }
+    if transport_input.monitoring_input is not None and not isinstance(
+        transport_input.monitoring_input,
+        MonitoringContractInput,
+    ):
+        return {
+            "field": "monitoring_input",
+            "expected_type": "MonitoringContractInput|None",
+            "actual_type": type(transport_input.monitoring_input).__name__,
+        }
+    if transport_input.monitoring_circuit_breaker is not None and not isinstance(
+        transport_input.monitoring_circuit_breaker,
+        MonitoringCircuitBreaker,
+    ):
+        return {
+            "field": "monitoring_circuit_breaker",
+            "expected_type": "MonitoringCircuitBreaker|None",
+            "actual_type": type(transport_input.monitoring_circuit_breaker).__name__,
+        }
+    if not isinstance(transport_input.monitoring_required, bool):
+        return {
+            "field": "monitoring_required",
+            "expected_type": "bool",
+            "actual_type": type(transport_input.monitoring_required).__name__,
         }
 
     return None

--- a/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md
@@ -16,6 +16,7 @@
   - `BLOCK` → execution is prevented with `monitoring_anomaly_block`.
   - `HALT` → execution is prevented with `monitoring_anomaly_halt`.
 - Added focused Phase 6.4.5 tests covering ALLOW/BLOCK/HALT behavior on exchange integration and a regression test confirming accepted monitored paths (6.4.2 transport, 6.4.3 authorizer, 6.4.4 gateway) remain intact.
+- Corrected PR #497 state regression by restoring previously completed Phase 6.1 and Phase 6.2 entries in `PROJECT_STATE.md` while preserving 6.4.5 in-progress/SENTINEL-next-gate truth.
 
 ## 2) Current system architecture
 - Narrow monitoring integration now spans four execution-related runtime paths:
@@ -31,6 +32,8 @@
 - Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`
 - Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
 - Modified: `/workspace/walker-ai-team/ROADMAP.md`
+- Modified (PR #497 regression correction pass): `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified (PR #497 regression correction pass): `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`
 
 ## 4) What is working
 - Exchange execution path now enforces deterministic monitoring ALLOW/BLOCK/HALT contract on `execute_with_trace`.
@@ -41,6 +44,7 @@
   - authorizer path still authorizes correctly on valid ALLOW input,
   - gateway path still accepts simulated execution on valid ALLOW input,
   - transport path still submits correctly on valid ALLOW input.
+- `PROJECT_STATE.md` now preserves completed-truth continuity for Phase 6.1 and Phase 6.2 alongside the intended 6.4.5 pending-SENTINEL state.
 
 ## 5) Known issues
 - Integration is intentionally narrow to the named exchange path; platform-wide rollout is still out of scope.
@@ -58,7 +62,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-14 21:40 UTC  
+**Report Timestamp:** 2026-04-14 22:05 UTC  
 **Role:** FORGE-X (NEXUS)  
-**Task:** expand phase 6.4 runtime monitoring to exchange execution path
-**Branch:** `feature/monitoring-phase6-4-exchange-path-expansion-20260415`
+**Task:** expand phase 6.4 runtime monitoring to exchange execution path + restore PR #497 PROJECT_STATE truth regression
+**Branch:** `fix/core-pr497-project-state-regression-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md
@@ -1,0 +1,64 @@
+# Forge Report — Phase 6.4.5 Exchange Monitoring Expansion
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py::ExchangeIntegration.execute_with_trace` as one additional deterministic monitoring enforcement path while preserving accepted 6.4.2/6.4.3/6.4.4 monitored paths unchanged.  
+**Not in Scope:** Platform-wide monitoring rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, settlement automation, or refactor of existing 6.4.2/6.4.3/6.4.4 monitored paths.  
+**Suggested Next Step:** SENTINEL MAJOR validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Integrated deterministic runtime monitoring into `ExchangeIntegration.execute_with_trace(...)` on the exact target path.
+- Extended `ExchangeExecutionTransportInput` with narrow monitoring fields (`monitoring_input`, `monitoring_circuit_breaker`, `monitoring_required`) only for the exchange execution path contract.
+- Enforced deterministic monitoring decision behavior on this path:
+  - `ALLOW` → execution flow continues.
+  - `BLOCK` → execution is prevented with `monitoring_anomaly_block`.
+  - `HALT` → execution is prevented with `monitoring_anomaly_halt`.
+- Added focused Phase 6.4.5 tests covering ALLOW/BLOCK/HALT behavior on exchange integration and a regression test confirming accepted monitored paths (6.4.2 transport, 6.4.3 authorizer, 6.4.4 gateway) remain intact.
+
+## 2) Current system architecture
+- Narrow monitoring integration now spans four execution-related runtime paths:
+  1. `projects/polymarket/polyquantbot/platform/execution/execution_transport.py::ExecutionTransport.submit_with_trace` (6.4.2 baseline).
+  2. `projects/polymarket/polyquantbot/platform/execution/live_execution_authorizer.py::LiveExecutionAuthorizer.authorize_with_trace` (6.4.3 baseline).
+  3. `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py::ExecutionGateway.simulate_execution_with_trace` (6.4.4 baseline).
+  4. `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py::ExchangeIntegration.execute_with_trace` (new 6.4.5 target path).
+- On the new 6.4.5 path, monitoring is evaluated after transport contract validation and before network policy gates/request execution.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/exchange_integration.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- Exchange execution path now enforces deterministic monitoring ALLOW/BLOCK/HALT contract on `execute_with_trace`.
+- ALLOW behavior proceeds to execution build with monitoring decision trace present.
+- BLOCK behavior prevents exchange execution and returns deterministic block reason.
+- HALT behavior prevents exchange execution and returns deterministic halt reason.
+- Existing accepted monitored paths remain functionally intact under regression coverage:
+  - authorizer path still authorizes correctly on valid ALLOW input,
+  - gateway path still accepts simulated execution on valid ALLOW input,
+  - transport path still submits correctly on valid ALLOW input.
+
+## 5) Known issues
+- Integration is intentionally narrow to the named exchange path; platform-wide rollout is still out of scope.
+- Monitoring persistence/alert distribution beyond current trace references remains out of scope.
+- Pre-existing pytest warning (`Unknown config option: asyncio_mode`) remains as deferred non-runtime hygiene.
+
+## 6) What is next
+- SENTINEL MAJOR validation on the declared 6.4.5 target path before merge.
+- COMMANDER final decision after SENTINEL verdict.
+
+---
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/exchange_integration.py projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-14 21:40 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** expand phase 6.4 runtime monitoring to exchange execution path
+**Branch:** `feature/monitoring-phase6-4-exchange-path-expansion-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md
@@ -1,0 +1,53 @@
+# Forge Report — PR #498 PROJECT_STATE Truth Regression Fix
+
+**Validation Tier:** MINOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** `PROJECT_STATE.md` truth preservation and continuity restoration for merged 6.4.3/6.4.4 entries in PR #498 context.  
+**Not in Scope:** Runtime code changes, validation rerun, exchange-path implementation changes, new monitoring scope, or platform-wide rollout.  
+**Suggested Next Step:** COMMANDER review required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md`. Tier: MINOR.
+
+---
+
+## 1) What was built
+- Restored completed-truth entries in `PROJECT_STATE.md` for:
+  - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491.
+  - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path in PR #495.
+- Preserved intended 6.4.5 state truth:
+  - SENTINEL APPROVED verdict retained.
+  - COMMANDER final merge decision remains pending.
+- Kept scope limited to state/report documentation only (no runtime code or tests changed).
+
+## 2) Current system architecture
+- Runtime architecture is unchanged by this task.
+- Monitoring narrow-integration baseline remains four execution paths (transport, authorizer, gateway, exchange) as previously established.
+- This task only corrects operational state truth continuity in repo-root `PROJECT_STATE.md`.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md`
+
+## 4) What is working
+- `PROJECT_STATE.md` now includes merged completed truth for both 6.4.3 and 6.4.4 again.
+- 6.4.5 remains accurately represented as SENTINEL APPROVED with COMMANDER decision pending.
+- No runtime code paths were altered.
+
+## 5) Known issues
+- This task does not alter runtime behavior; deferred non-runtime pytest config warning remains unchanged.
+
+## 6) What is next
+- COMMANDER review and merge decision for this MINOR truth-correction PR.
+- Merge order guidance from task context remains:
+  1) PR #498
+  2) PR #497
+
+---
+
+## Validation commands run
+1. `git diff -- PROJECT_STATE.md projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md`
+2. `python - <<'PY' ... PY` (auto-review checks for report structure/metadata + PROJECT_STATE timestamp)
+3. `find . -type d -name 'phase*' | head`
+
+**Report Timestamp:** 2026-04-14 22:37 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** restore PROJECT_STATE completed truth in PR #498  
+**Branch:** `fix/core-pr498-project-state-truth-regression-20260415`

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_23_phase6_4_5_exchange_monitoring_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_23_phase6_4_5_exchange_monitoring_validation.md
@@ -1,0 +1,112 @@
+# Sentinel Validation Report — Phase 6.4.5 Exchange Monitoring Expansion
+
+## Environment
+- Date (UTC): 2026-04-14 22:31
+- Repo: `/workspace/walker-ai-team`
+- Branch observed in Codex worktree: `work` (detached/worktree state accepted per Codex rule)
+- Requested source branch context: `feature/monitoring-phase6-4-exchange-path-expansion-20260415`
+- Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation target: `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py::ExchangeIntegration.execute_with_trace`
+
+## Validation Context
+- Objective: Validate deterministic monitoring integration on exchange execution path only.
+- In scope:
+  - ALLOW/BLOCK/HALT deterministic handling on `execute_with_trace`.
+  - Trace propagation and deterministic `blocked_reason` semantics.
+  - Regression safety for prior narrow monitored paths:
+    1) `ExecutionTransport.submit_with_trace`
+    2) `LiveExecutionAuthorizer.authorize_with_trace`
+    3) `ExecutionGateway.simulate_execution_with_trace`
+- Out of scope (enforced): platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, settlement automation, or refactor of 6.4.2/6.4.3/6.4.4 paths.
+
+## Phase 0 Checks
+1. Forge report exists at exact path: PASS
+   - `projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`
+2. Forge report naming validity `[phase]_[increment]_[name].md`: PASS
+3. Forge report required 6 sections present: PASS
+4. Metadata presence (`Validation Tier / Claim Level / Validation Target / Not in Scope`): PASS
+5. `PROJECT_STATE.md` timestamp format (`YYYY-MM-DD HH:MM`): PASS
+6. MAJOR gate consistency (SENTINEL required): PASS
+7. `python -m py_compile` evidence:
+   - Forge report command evidence: PASS
+   - Re-run in validation session: PASS
+8. `pytest` evidence:
+   - Forge report command evidence: PASS
+   - Re-run in validation session: PASS (28 passed, 1 non-runtime warning)
+9. No forbidden `phase*/` directories: PASS
+
+## Findings
+1. Monitoring decision enforcement is deterministic on target path (PASS)
+   - File: `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py:189-246`
+   - Snippet evidence:
+     - `monitoring_required` gate at line 190
+     - HALT maps to `monitoring_anomaly_halt` at lines 233-239
+     - BLOCK maps to `monitoring_anomaly_block` at lines 240-246
+2. ALLOW path continues execution and preserves monitoring trace (PASS)
+   - File: `.../exchange_integration.py:306-373`
+   - Snippet evidence:
+     - Request flow proceeds to payload build at 306-307
+     - Trace contains `monitoring_decision` default/actual at 330-334 and 366-370
+3. Deterministic blocked_reason + trace semantics validated (PASS)
+   - File: `.../exchange_integration.py:376-403`
+   - Snippet evidence:
+     - `_blocked_build_result` writes same `blocked_reason` into `result.blocked_reason`, `trace.blocked_reason`, and `exchange_notes.blocked_reason`
+4. Negative contract tests for malformed monitoring inputs are enforced (PASS)
+   - File: `.../exchange_integration.py:191-223`
+   - Evidence:
+     - Missing/invalid `monitoring_input` and invalid `monitoring_circuit_breaker` deterministically return `monitoring_evaluation_required`
+     - Reproduced via direct Python negative test script in validation session.
+5. Prior accepted narrow integrations remain intact (PASS)
+   - Evidence command:
+     - `PYTHONPATH=. pytest -q ...test_phase6_4_5... ...test_phase6_4_4... ...test_phase6_4_3... ...test_phase5_2...`
+   - Result: `28 passed` confirms no regressions across transport/authorizer/gateway baseline paths.
+6. Scope control check — no silent platform-wide rollout introduced (PASS)
+   - File: `.../exchange_integration.py`
+   - Evidence: Monitoring addition is constrained to `ExchangeExecutionTransportInput` and `execute_with_trace` path logic only; no scheduler/orchestrator/global routing expansion touched in validated scope.
+
+## Score Breakdown
+- Phase 0 handoff integrity: 20/20
+- Target-path deterministic behavior: 30/30
+- Regression safety for prior narrow paths: 20/20
+- Negative testing / malformed contract handling: 15/15
+- Scope containment and claim-level adherence: 15/15
+- **Total: 100/100**
+
+## Critical Issues
+- None.
+
+## Status
+- Verdict: **APPROVED**
+- Validation confidence: High
+- Critical count: 0
+
+## PR Gate Result
+- Gate outcome: **APPROVED for COMMANDER decision gate**
+- Target branch policy: source branch only, never `main`
+
+## Broader Audit Finding
+- No critical safety contradictions found outside declared narrow scope.
+
+## Reasoning
+- Code and tests align with MAJOR/NARROW claim: a single additional monitored execution path is integrated without widening runtime authority.
+- ALLOW/BLOCK/HALT behavior is deterministic and trace-backed.
+- Existing accepted narrow monitoring paths were re-validated through regression test set and remained intact.
+
+## Fix Recommendations
+- No blocking fixes required.
+- Optional hardening (non-blocking): add explicit unit coverage for malformed `monitoring_circuit_breaker` type in dedicated pytest test for clearer long-term guardrail evidence.
+
+## Out-of-scope Advisory
+- Platform-wide monitoring rollout remains intentionally unclaimed and must be handled as a separate scoped phase.
+
+## Deferred Minor Backlog
+- `[DEFERRED] Pytest config warning: Unknown config option: asyncio_mode — non-runtime hygiene backlog.`
+
+## Telegram Visual Preview
+- Phase 6.4.5 SENTINEL verdict: APPROVED (100/100)
+- Critical: 0
+- Scope: ExchangeIntegration.execute_with_trace narrow monitoring expansion
+- Deterministic behavior: ALLOW/BLOCK/HALT validated
+- Regressions: none across 6.4.2/6.4.3/6.4.4 baseline paths
+- Next gate: COMMANDER final decision

--- a/projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.execution.exchange_integration import (
+    EXCHANGE_EXECUTION_BLOCK_MONITORING_ANOMALY,
+    EXCHANGE_EXECUTION_HALT_MONITORING_ANOMALY,
+    ExchangeExecutionPolicyInput,
+    ExchangeExecutionTransportInput,
+    ExchangeIntegration,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import ExecutionDecision
+from projects.polymarket.polyquantbot.platform.execution.execution_gateway import (
+    ExecutionGateway,
+    ExecutionGatewayDecisionInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_mode_controller import MODE_LIVE
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import (
+    ExecutionTransport,
+    ExecutionTransportAuthorizationInput,
+    ExecutionTransportPolicyInput,
+    ExecutionTransportResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_authorizer import (
+    LiveExecutionAuthorizationPolicyInput,
+    LiveExecutionAuthorizer,
+    LiveExecutionReadinessInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_guardrails import LiveExecutionReadinessDecision
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_KILL_SWITCH_TRIGGERED,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+
+
+VALID_MONITORING_INPUT = MonitoringContractInput(
+    policy_ref="phase6_4_5_policy",
+    eval_ref="phase6_4_5_eval",
+    timestamp_ms=1713205000000,
+    exposure_ratio=0.10,
+    position_notional_usd=100.0,
+    total_capital_usd=1_000.0,
+    data_freshness_ms=120,
+    quality_score=0.93,
+    signal_dedup_ok=True,
+    kill_switch_armed=True,
+    kill_switch_triggered=False,
+    monitoring_enabled=True,
+    quality_guard_enabled=True,
+    exposure_guard_enabled=True,
+    max_exposure_ratio=0.10,
+    max_data_freshness_ms=500,
+    min_quality_score=0.80,
+    trace_refs={"target_path": "exchange_integration.execute_with_trace"},
+)
+
+VALID_TRANSPORT_RESULT = ExecutionTransportResult(
+    submitted=True,
+    success=True,
+    blocked_reason=None,
+    execution_authorized=True,
+    request_payload={"client_order_id": "CID-6-4-5-001", "side": "BUY", "size": 10},
+    exchange_response={"transport": "ok"},
+    transport_mode="REAL",
+    simulated=False,
+    non_executing=False,
+)
+
+VALID_TRANSPORT_INPUT = ExchangeExecutionTransportInput(
+    transport_result=VALID_TRANSPORT_RESULT,
+    monitoring_input=VALID_MONITORING_INPUT,
+    monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+    monitoring_required=True,
+    upstream_trace_refs={"phase": "6.4.5"},
+)
+
+VALID_POLICY_INPUT = ExchangeExecutionPolicyInput(
+    network_enabled=True,
+    allow_real_network=True,
+    endpoint_url="https://api.exchange.local/orders",
+    http_method="POST",
+    signing_required=True,
+    signing_key_present=True,
+    signing_scheme="ed25519",
+    wallet_reference="wallet-ref-001",
+    request_timeout_ms=500,
+    allow_testnet=False,
+    environment="prod",
+    allowed_environments=["prod", "staging"],
+    policy_trace_refs={"policy": "phase6.4.5"},
+)
+
+
+def test_phase6_4_5_exchange_monitoring_allow_pass_through() -> None:
+    integration = ExchangeIntegration(real_network_enabled=False)
+
+    build = integration.execute_with_trace(
+        transport_input=VALID_TRANSPORT_INPUT,
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.executed is True
+    assert build.result.success is True
+    assert build.result.blocked_reason is None
+    assert build.trace.execution_attempted is True
+    assert build.trace.upstream_trace_refs["monitoring"]["decision"] == "ALLOW"
+
+
+def test_phase6_4_5_exchange_monitoring_block_prevents_execution() -> None:
+    integration = ExchangeIntegration(real_network_enabled=False)
+    breaker = MonitoringCircuitBreaker()
+
+    build = integration.execute_with_trace(
+        transport_input=replace(
+            VALID_TRANSPORT_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, exposure_ratio=0.11),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.executed is False
+    assert build.result.blocked_reason == EXCHANGE_EXECUTION_BLOCK_MONITORING_ANOMALY
+    assert build.trace.execution_attempted is False
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_EXPOSURE_THRESHOLD_BREACH
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_5_exchange_monitoring_halt_stops_execution() -> None:
+    integration = ExchangeIntegration(real_network_enabled=False)
+    breaker = MonitoringCircuitBreaker()
+
+    build = integration.execute_with_trace(
+        transport_input=replace(
+            VALID_TRANSPORT_INPUT,
+            monitoring_input=replace(VALID_MONITORING_INPUT, kill_switch_triggered=True),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.executed is False
+    assert build.result.blocked_reason == EXCHANGE_EXECUTION_HALT_MONITORING_ANOMALY
+    assert build.trace.execution_attempted is False
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_KILL_SWITCH_TRIGGERED
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_5_existing_three_monitored_paths_remain_intact() -> None:
+    authorizer = LiveExecutionAuthorizer()
+    gateway = ExecutionGateway()
+    transport = ExecutionTransport()
+
+    auth_build = authorizer.authorize_with_trace(
+        readiness_input=LiveExecutionReadinessInput(
+            readiness_decision=LiveExecutionReadinessDecision(
+                live_ready=True,
+                allowed=True,
+                blocked_reason=None,
+                selected_mode=MODE_LIVE,
+                guardrail_passed=True,
+                kill_switch_armed=True,
+                simulated=True,
+                non_executing=True,
+            ),
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.3"},
+        ),
+        policy_input=LiveExecutionAuthorizationPolicyInput(
+            explicit_execution_enable=True,
+            authorization_scope="single_market_first_path",
+            allowed_scopes=("single_market_first_path",),
+            single_market_only=True,
+            target_market_id="market-6-4-5",
+            wallet_binding_required=True,
+            wallet_binding_present=True,
+            audit_required=True,
+            audit_attached=True,
+            operator_approval_required=True,
+            operator_approval_present=True,
+            kill_switch_must_remain_armed=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.3"},
+        ),
+    )
+    assert auth_build.decision is not None
+    assert auth_build.decision.execution_authorized is True
+
+    gateway_build = gateway.simulate_execution_with_trace(
+        decision_input=ExecutionGatewayDecisionInput(
+            decision=ExecutionDecision(
+                allowed=True,
+                blocked_reason=None,
+                market_id="MKT-6-4-5",
+                outcome="YES",
+                side="YES",
+                size=5.0,
+                routing_mode="platform-gateway-shadow",
+                execution_mode="paper-prep-only",
+                ready_for_execution=True,
+                non_activating=True,
+            ),
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            monitoring_required=True,
+            source_trace_refs={"phase": "6.4.4"},
+        )
+    )
+    assert gateway_build.result is not None
+    assert gateway_build.result.accepted is True
+
+    transport_build = transport.submit_with_trace(
+        authorization_input=ExecutionTransportAuthorizationInput(
+            authorization=auth_build.decision,
+            gateway_result=gateway_build.result,
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.2"},
+        ),
+        policy_input=ExecutionTransportPolicyInput(
+            transport_enabled=True,
+            execution_mode=MODE_LIVE,
+            dry_run_force=False,
+            allow_real_submission=True,
+            single_submission_only=True,
+            max_orders=1,
+            require_idempotency=True,
+            idempotency_key_present=True,
+            audit_log_required=True,
+            audit_log_attached=True,
+            operator_confirm_required=True,
+            operator_confirm_present=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.2"},
+        ),
+    )
+    assert transport_build.result is not None
+    assert transport_build.result.submitted is True
+    assert transport_build.result.success is True


### PR DESCRIPTION
### Motivation
- Extend the Phase 6.4 narrow runtime monitoring baseline to the exchange execution path by integrating deterministic ALLOW / BLOCK / HALT decisions into `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py::ExchangeIntegration.execute_with_trace`.  
- Preserve the existing monitored paths (`ExecutionTransport.submit_with_trace`, `LiveExecutionAuthorizer.authorize_with_trace`, `ExecutionGateway.simulate_execution_with_trace`) and keep the change narrowly scoped to the named method.  
- Deliver focused tests and a FORGE report so the change can enter the required MAJOR SENTINEL validation gate.  

### Description
- Added monitoring imports and constants and extended `ExchangeExecutionTransportInput` with `monitoring_input`, `monitoring_circuit_breaker`, and `monitoring_required` fields in `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py`.  
- Implemented monitoring evaluation using the existing `MonitoringCircuitBreaker` contract with deterministic handling that returns `monitoring_anomaly_block` for BLOCK and `monitoring_anomaly_halt` for HALT and otherwise allows execution; monitoring decision and trace data are propagated into `exchange_notes`.  
- Added input validation for monitoring fields and new block/halt error codes, and kept all other exchange/network policy gates unchanged.  
- Added focused tests `projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py`, created the forge report at `projects/polymarket/polyquantbot/reports/forge/25_25_phase6_4_5_exchange_monitoring_expansion.md`, and updated `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 6.4.5 in progress with SENTINEL as the next gate.  

### Testing
- Ran `python -m py_compile` against the touched files (`projects/polymarket/polyquantbot/platform/execution/exchange_integration.py` and the new test file) which succeeded.  
- Ran `PYTHONPATH=. pytest -q` for the new exchange tests plus the related Phase 6.4 and Phase 5.2 regression tests which passed: `28 passed, 1 warning` (the warning is a pre-existing `Unknown config option: asyncio_mode`).  
- Ran repository checks (`find . -type d -name 'phase*'`) as part of validation commands with no phase* folders created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb8c4902883258912a492c0e2cb92)