### PR TITLE
feat(monitoring): add signing-boundary monitoring (Phase 6.4.6)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-14 22:37
-🔄 Status       : PR #498 state-truth regression fixed by restoring merged 6.4.3/6.4.4 completed entries while preserving Phase 6.4.5 SENTINEL-approved status pending COMMANDER final merge decision.
+📅 Last Updated : 2026-04-14 22:47
+🔄 Status       : Phase 6.4.6 FORGE-X narrow signing-boundary monitoring integration is complete on source branch with deterministic ALLOW/BLOCK/HALT behavior and focused regression coverage; SENTINEL MAJOR validation is the required next gate.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -13,17 +13,17 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- COMMANDER decision gate pending for Phase 6.4.5 post-SENTINEL approval.
+- Phase 6.4.6 signing-boundary monitoring narrow integration implemented on `SecureSigningEngine.sign_with_trace` and pending SENTINEL MAJOR validation before merge.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout beyond the current four narrow Phase 6.4 target paths (transport, authorizer, gateway, exchange integration).
+- Platform-wide monitoring rollout beyond the current five narrow Phase 6.4 target paths (transport, authorizer, gateway, exchange integration, signing boundary).
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_26_pr498_project_state_truth_regression_fix.md. Tier: MINOR.
+- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
@@ -34,5 +34,5 @@
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, correction logic, or background automation are implemented.
 - Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation or correction logic, background automation, or external DB are implemented.
 - Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope.
-- Phase 6.4 narrow monitoring remains intentionally scoped to four execution-related paths only (transport, authorizer, gateway, exchange integration) and excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
+- Phase 6.4 narrow monitoring remains intentionally scoped to five execution-related paths only (transport, authorizer, gateway, exchange integration, signing boundary) and excludes platform-wide rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation.
 - [DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning — carried forward as non-runtime hygiene backlog.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-14 22:47
-🔄 Status       : Phase 6.4.6 FORGE-X narrow signing-boundary monitoring integration is complete on source branch with deterministic ALLOW/BLOCK/HALT behavior and focused regression coverage; SENTINEL MAJOR validation is the required next gate.
+📅 Last Updated : 2026-04-14 22:56
+🔄 Status       : Phase 6.4.6 SENTINEL validation completed as APPROVED (99/100, 0 critical) for narrow signing-boundary monitoring integration on the source branch; COMMANDER final decision is the next gate.
 
 ✅ COMPLETED
 - AGENTS.md roadmap rules insertion completed as MINOR FOUNDATION sync work.
@@ -10,10 +10,10 @@
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration validated by SENTINEL as APPROVED (100/100, 0 critical) on declared target path.
+- Phase 6.4.6 signing-boundary monitoring narrow integration validated by SENTINEL as APPROVED (99/100, 0 critical) on `SecureSigningEngine.sign_with_trace`.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.4.6 signing-boundary monitoring narrow integration implemented on `SecureSigningEngine.sign_with_trace` and pending SENTINEL MAJOR validation before merge.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
@@ -23,7 +23,7 @@
 - Platform-wide monitoring rollout beyond the current five narrow Phase 6.4 target paths (transport, authorizer, gateway, exchange integration, signing boundary).
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md. Tier: MAJOR.
+- COMMANDER final decision required on MAJOR validation result for source branch `feature/monitoring-phase6-4-signing-path-expansion-20260415`. Source: projects/polymarket/polyquantbot/reports/sentinel/25_24_phase6_4_6_signing_monitoring_validation.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-14 21:40
+**Last Updated:** 2026-04-14 22:47
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-14 21:40
+**Last Updated:** 2026-04-14 22:47
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -54,7 +54,8 @@
 | 6.4.2 | Runtime Monitoring Narrow Integration | ✅ Done | Merged truth preserved for ExecutionTransport.submit_with_trace narrow integration after SENTINEL APPROVED (95/100). |
 | 6.4.3 | Authorizer-Path Monitoring Narrow Integration | ✅ Done | Merged via PR #491. SENTINEL APPROVED (99/100). Narrow scope: LiveExecutionAuthorizer.authorize_with_trace + ExecutionTransport.submit_with_trace preserved. No platform-wide rollout. |
 | 6.4.4 | Gateway-Path Monitoring Narrow Integration Expansion | ✅ Done | Runtime/code path merged via PR #493. SENTINEL APPROVED validation path recorded in PR #495 (97/100). Accepted narrow three-path execution monitoring baseline: ExecutionTransport.submit_with_trace + LiveExecutionAuthorizer.authorize_with_trace + ExecutionGateway.simulate_execution_with_trace. No platform-wide rollout. |
-| 6.4.5 | Exchange-Path Monitoring Narrow Integration Expansion | 🚧 In Progress | FORGE-X runtime/code implementation completed on source branch for ExchangeIntegration.execute_with_trace with deterministic ALLOW/BLOCK/HALT integration and focused tests; SENTINEL MAJOR validation required before merge. Accepted baseline paths (6.4.2/6.4.3/6.4.4) preserved. |
+| 6.4.5 | Exchange-Path Monitoring Narrow Integration Expansion | ✅ Done | Narrow runtime integration on `ExchangeIntegration.execute_with_trace` completed and validated by SENTINEL APPROVED (100/100, 0 critical) on source path. |
+| 6.4.6 | Signing-Boundary Monitoring Narrow Integration Expansion | 🚧 In Progress | FORGE-X runtime/code implementation completed on source branch for `SecureSigningEngine.sign_with_trace` with deterministic ALLOW/BLOCK/HALT integration and focused tests; SENTINEL MAJOR validation required before merge. Accepted baseline paths (6.4.2/6.4.3/6.4.4/6.4.5) preserved. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/execution/secure_signing.py
+++ b/projects/polymarket/polyquantbot/platform/execution/secure_signing.py
@@ -6,6 +6,12 @@ import json
 from typing import Any, Callable
 
 from .exchange_integration import ExchangeExecutionResult
+from .monitoring_circuit_breaker import (
+    MONITORING_DECISION_BLOCK,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
 
 SIGNING_METHOD_REAL = "REAL_SIGNING"
 SIGNING_METHOD_SIMULATED = "SIMULATED_SIGNING"
@@ -19,11 +25,17 @@ SIGNING_BLOCK_KEY_NOT_REGISTERED = "key_not_registered"
 SIGNING_BLOCK_KEY_ACCESS_DENIED = "key_access_denied"
 SIGNING_BLOCK_AUDIT_MISSING = "audit_missing"
 SIGNING_BLOCK_OPERATOR_APPROVAL_MISSING = "operator_approval_missing"
+SIGNING_BLOCK_MONITORING_EVALUATION_REQUIRED = "monitoring_evaluation_required"
+SIGNING_BLOCK_MONITORING_ANOMALY = "monitoring_anomaly_block"
+SIGNING_HALT_MONITORING_ANOMALY = "monitoring_anomaly_halt"
 
 
 @dataclass(frozen=True)
 class SigningExecutionInput:
     exchange_result: ExchangeExecutionResult
+    monitoring_input: MonitoringContractInput | None = None
+    monitoring_circuit_breaker: MonitoringCircuitBreaker | None = None
+    monitoring_required: bool = False
     upstream_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -149,6 +161,69 @@ class SecureSigningEngine:
                 key_reference=policy_input.key_reference,
                 upstream_trace_refs={**upstream_trace_refs, "validation_error": validation_error},
             )
+
+        if signing_input.monitoring_required:
+            if not isinstance(signing_input.monitoring_input, MonitoringContractInput):
+                return _blocked_build_result(
+                    blocked_reason=SIGNING_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    signing_attempted=False,
+                    signing_scheme=policy_input.signing_scheme,
+                    key_reference=policy_input.key_reference,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {
+                            "monitoring_input": {
+                                "expected_type": "MonitoringContractInput",
+                                "actual_type": type(signing_input.monitoring_input).__name__,
+                            }
+                        },
+                    },
+                )
+            if signing_input.monitoring_circuit_breaker is not None and not isinstance(
+                signing_input.monitoring_circuit_breaker,
+                MonitoringCircuitBreaker,
+            ):
+                return _blocked_build_result(
+                    blocked_reason=SIGNING_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    signing_attempted=False,
+                    signing_scheme=policy_input.signing_scheme,
+                    key_reference=policy_input.key_reference,
+                    upstream_trace_refs={
+                        **upstream_trace_refs,
+                        "contract_errors": {
+                            "monitoring_circuit_breaker": {
+                                "expected_type": "MonitoringCircuitBreaker",
+                                "actual_type": type(signing_input.monitoring_circuit_breaker).__name__,
+                            }
+                        },
+                    },
+                )
+
+            breaker = signing_input.monitoring_circuit_breaker or MonitoringCircuitBreaker()
+            monitoring_result = breaker.evaluate(signing_input.monitoring_input)
+            upstream_trace_refs["monitoring"] = {
+                "decision": monitoring_result.decision,
+                "primary_anomaly": monitoring_result.primary_anomaly,
+                "anomalies": list(monitoring_result.anomalies),
+                "eval_ref": monitoring_result.event.eval_ref,
+            }
+
+            if monitoring_result.decision == MONITORING_DECISION_HALT:
+                return _blocked_build_result(
+                    blocked_reason=SIGNING_HALT_MONITORING_ANOMALY,
+                    signing_attempted=False,
+                    signing_scheme=policy_input.signing_scheme,
+                    key_reference=policy_input.key_reference,
+                    upstream_trace_refs=upstream_trace_refs,
+                )
+            if monitoring_result.decision == MONITORING_DECISION_BLOCK:
+                return _blocked_build_result(
+                    blocked_reason=SIGNING_BLOCK_MONITORING_ANOMALY,
+                    signing_attempted=False,
+                    signing_scheme=policy_input.signing_scheme,
+                    key_reference=policy_input.key_reference,
+                    upstream_trace_refs=upstream_trace_refs,
+                )
 
         block_reason = _determine_blocked_reason(signing_input.exchange_result, policy_input)
         if block_reason is not None:

--- a/projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md
@@ -1,0 +1,61 @@
+# Forge Report — Phase 6.4.6 Signing Monitoring Expansion
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/secure_signing.py::SecureSigningEngine.sign_with_trace` as the exact real signing-boundary runtime method used for real-signing authorization/execution handoff.  
+**Not in Scope:** Platform-wide monitoring rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, settlement automation, or refactor of existing 6.4.2/6.4.3/6.4.4/6.4.5 monitored paths.  
+**Suggested Next Step:** SENTINEL MAJOR validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Identified and integrated monitoring on the exact signing-boundary runtime method: `SecureSigningEngine.sign_with_trace(...)`.
+- Added deterministic monitoring decision enforcement on this path only:
+  - `ALLOW` → signing flow continues to existing signing gates.
+  - `BLOCK` → signing is prevented with `monitoring_anomaly_block`.
+  - `HALT` → signing is prevented with `monitoring_anomaly_halt`.
+- Extended `SigningExecutionInput` with narrow monitoring contract fields (`monitoring_input`, `monitoring_circuit_breaker`, `monitoring_required`) for signing-boundary integration only.
+- Added focused 6.4.6 tests for ALLOW/BLOCK/HALT behavior and regression coverage for the four already-accepted monitored paths (transport, authorizer, gateway, exchange integration).
+
+## 2) Current system architecture
+- Deterministic runtime monitoring now covers five narrow execution-adjacent paths:
+  1. `projects/polymarket/polyquantbot/platform/execution/execution_transport.py::ExecutionTransport.submit_with_trace`
+  2. `projects/polymarket/polyquantbot/platform/execution/live_execution_authorizer.py::LiveExecutionAuthorizer.authorize_with_trace`
+  3. `projects/polymarket/polyquantbot/platform/execution/execution_gateway.py::ExecutionGateway.simulate_execution_with_trace`
+  4. `projects/polymarket/polyquantbot/platform/execution/exchange_integration.py::ExchangeIntegration.execute_with_trace`
+  5. `projects/polymarket/polyquantbot/platform/execution/secure_signing.py::SecureSigningEngine.sign_with_trace` (new 6.4.6 target)
+- On the new 6.4.6 path, monitoring is evaluated after input contract validation and before existing signing policy block checks and signature materialization.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/secure_signing.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- `SecureSigningEngine.sign_with_trace` now enforces deterministic ALLOW/BLOCK/HALT monitoring outcomes.
+- ALLOW pass-through preserves signing execution and monitoring trace details.
+- BLOCK and HALT both deterministically prevent signing and return the correct blocked reason.
+- Regression coverage confirms the four already-accepted monitored paths remain operational and behaviorally intact.
+- `PROJECT_STATE.md` now reflects Phase 6.4.6 in-progress truth and sets SENTINEL MAJOR validation as the next gate.
+
+## 5) Known issues
+- Integration remains intentionally narrow to one signing-boundary method; platform-wide rollout is still out of scope.
+- Existing pytest warning (`Unknown config option: asyncio_mode`) remains deferred non-runtime hygiene backlog.
+
+## 6) What is next
+- SENTINEL MAJOR validation on `SecureSigningEngine.sign_with_trace` claimed path before merge.
+- COMMANDER final decision after SENTINEL verdict.
+
+---
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/secure_signing.py projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_5_exchange_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_4_gateway_monitoring_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_4_3_authorizer_monitoring_20260414.py projects/polymarket/polyquantbot/tests/test_phase5_2_execution_transport_20260412.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-14 22:47 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** expand phase 6.4 runtime monitoring to signing boundary path  
+**Branch:** `feature/monitoring-phase6-4-signing-path-expansion-20260415`

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_24_phase6_4_6_signing_monitoring_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_24_phase6_4_6_signing_monitoring_validation.md
@@ -1,0 +1,105 @@
+# Sentinel Validation Report — Phase 6.4.6 Signing-Boundary Monitoring Expansion
+
+## Environment
+- Role: SENTINEL (NEXUS)
+- Repository: `/workspace/walker-ai-team`
+- Branch context: `feature/monitoring-phase6-4-signing-path-expansion-20260415` (Codex worktree HEAD resolves as `work`, accepted by policy)
+- Validation date (UTC): 2026-04-14
+- Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+
+## Validation Context
+- Source forge report: `projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md`
+- Validation target: `projects/polymarket/polyquantbot/platform/execution/secure_signing.py::SecureSigningEngine.sign_with_trace`
+- Declared not in scope: platform-wide monitoring rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, settlement automation, and refactor of existing 6.4.2/6.4.3/6.4.4/6.4.5 monitored paths.
+- Objective: verify deterministic ALLOW/BLOCK/HALT monitoring decisions at the signing boundary without silent rollout expansion.
+
+## Phase 0 Checks
+- ✅ Forge report exists at exact declared path and naming format is valid (`25_28_phase6_4_6_signing_monitoring_expansion.md`).
+- ✅ Forge report contains all six required sections (What was built; Current system architecture; Files created/modified; What is working; Known issues; What is next).
+- ✅ Forge report declares required metadata: Validation Tier, Claim Level, Validation Target, Not in Scope, Suggested Next Step.
+- ✅ `PROJECT_STATE.md` includes full timestamp format (`YYYY-MM-DD HH:MM`) and preserves truthful 6.4.5 merged baseline while showing 6.4.6 pending SENTINEL gate prior to this validation.
+- ✅ MAJOR handoff consistency confirmed via forge metadata and state Next Priority.
+- ✅ py_compile evidence exists in forge report and was independently re-run successfully.
+- ✅ pytest evidence exists in forge report and was independently re-run successfully.
+
+## Findings
+1. **Target-path monitoring gate is present and positioned correctly (after contract validation, before signing policy gates).**
+   - Evidence: `sign_with_trace` performs input type checks, contract validation, then monitoring enforcement before `_determine_blocked_reason` and payload signing flow.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/secure_signing.py:149-228`
+
+2. **ALLOW decision deterministically continues signing flow.**
+   - Evidence: monitoring decision only blocks on `HALT`/`BLOCK`; ALLOW falls through to signing policy evaluation and signing result creation.
+   - Runtime proof: pytest test `test_phase6_4_6_signing_monitoring_allow_pass_through` passes and confirms signed success with trace decision `ALLOW`.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/secure_signing.py:198-228`
+     - `projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py:146-159`
+
+3. **BLOCK decision deterministically prevents signing with fixed reason `monitoring_anomaly_block`.**
+   - Evidence: explicit branch maps `MONITORING_DECISION_BLOCK` to `SIGNING_BLOCK_MONITORING_ANOMALY`.
+   - Runtime proof: pytest test `test_phase6_4_6_signing_monitoring_block_prevents_signing` passes and validates blocked_reason + anomaly trace.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/secure_signing.py:220-227`
+     - `projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py:162-181`
+
+4. **HALT decision deterministically prevents signing with fixed reason `monitoring_anomaly_halt`.**
+   - Evidence: explicit branch maps `MONITORING_DECISION_HALT` to `SIGNING_HALT_MONITORING_ANOMALY`.
+   - Runtime proof: pytest test `test_phase6_4_6_signing_monitoring_halt_stops_signing` passes and validates blocked_reason + anomaly trace.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/secure_signing.py:211-219`
+     - `projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py:183-202`
+
+5. **Malformed monitoring contract input handling is deterministic and fail-closed on target path.**
+   - Evidence: when `monitoring_required=True`, invalid/missing `MonitoringContractInput` or invalid `MonitoringCircuitBreaker` returns `monitoring_evaluation_required` without signing.
+   - Runtime proof: ad-hoc negative contract exercise confirms deterministic blocked reason for missing and malformed monitoring fields.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/secure_signing.py:158-194`
+
+6. **No silent platform-wide rollout detected from this increment; scope remains narrow to declared target path while prior four integrations remain intact.**
+   - Evidence: focused tests validate pre-existing monitored paths continue to pass (`submit_with_trace`, `authorize_with_trace`, `simulate_execution_with_trace`, `execute_with_trace`) and pass under combined suite.
+   - Runtime proof: regression test `test_phase6_4_6_existing_four_monitored_paths_remain_intact` passes in the combined pytest run.
+   - File evidence:
+     - `projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py:205-305`
+
+## Score Breakdown
+- Phase 0 handoff completeness: 20/20
+- Target-path implementation correctness: 20/20
+- Deterministic ALLOW/BLOCK/HALT behavior: 20/20
+- Regression integrity for prior narrow integrations: 20/20
+- Negative-path resilience and deterministic fail-closed behavior: 15/15
+- Hygiene/operational confidence: 4/5 (pytest config warning persists, non-runtime)
+
+**Total Score: 99/100**
+
+## Critical Issues
+- None.
+
+## Status
+- **Verdict: APPROVED**
+- Critical count: **0**
+
+## PR Gate Result
+- Gate result: **PASS** for source branch continuation.
+- PR target policy: source branch only (`feature/monitoring-phase6-4-signing-path-expansion-20260415`), never `main`.
+
+## Broader Audit Finding
+- Existing warning `PytestConfigWarning: Unknown config option: asyncio_mode` remains present; treated as deferred non-runtime hygiene and not a blocker for this narrow MAJOR validation.
+
+## Reasoning
+The declared NARROW INTEGRATION claim is upheld. Monitoring enforcement is wired into the exact claimed method (`SecureSigningEngine.sign_with_trace`), with deterministic behavior proven for ALLOW/BLOCK/HALT and deterministic fail-closed handling for malformed monitoring contract inputs. Regression verification confirms previously accepted narrow monitored paths remain intact. No critical contradiction to scope or safety rules was found.
+
+## Fix Recommendations
+1. Optional hygiene follow-up: align pytest configuration to remove `asyncio_mode` unknown-option warning.
+2. Keep future monitoring expansions explicitly phase-scoped to avoid accidental claim-level inflation.
+
+## Out-of-scope Advisory
+- Platform-wide monitoring rollout, scheduler generalization, wallet lifecycle, portfolio orchestration, and settlement automation remain correctly out of scope for this validation.
+
+## Deferred Minor Backlog
+- `[DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning — carried forward as non-runtime hygiene backlog.`
+
+## Telegram Visual Preview
+- `Phase 6.4.6 SENTINEL Verdict: APPROVED (99/100, 0 critical).`
+- `Target validated: SecureSigningEngine.sign_with_trace monitoring ALLOW/BLOCK/HALT deterministic behavior confirmed.`
+- `Next gate: COMMANDER final decision on source branch PR path.`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.execution.exchange_integration import (
+    ExchangeExecutionResult,
+    ExchangeExecutionPolicyInput,
+    ExchangeExecutionTransportInput,
+    ExchangeIntegration,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import ExecutionDecision
+from projects.polymarket.polyquantbot.platform.execution.execution_gateway import (
+    ExecutionGateway,
+    ExecutionGatewayDecisionInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_mode_controller import MODE_LIVE
+from projects.polymarket.polyquantbot.platform.execution.execution_transport import (
+    ExecutionTransport,
+    ExecutionTransportAuthorizationInput,
+    ExecutionTransportPolicyInput,
+    ExecutionTransportResult,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_authorizer import (
+    LiveExecutionAuthorizationPolicyInput,
+    LiveExecutionAuthorizer,
+    LiveExecutionReadinessInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.live_execution_guardrails import LiveExecutionReadinessDecision
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_KILL_SWITCH_TRIGGERED,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.secure_signing import (
+    SIGNING_BLOCK_MONITORING_ANOMALY,
+    SIGNING_HALT_MONITORING_ANOMALY,
+    SecureSigningEngine,
+    SigningExecutionInput,
+    SigningPolicyInput,
+)
+
+
+VALID_MONITORING_INPUT = MonitoringContractInput(
+    policy_ref="phase6_4_6_policy",
+    eval_ref="phase6_4_6_eval",
+    timestamp_ms=1713206000000,
+    exposure_ratio=0.10,
+    position_notional_usd=100.0,
+    total_capital_usd=1_000.0,
+    data_freshness_ms=120,
+    quality_score=0.93,
+    signal_dedup_ok=True,
+    kill_switch_armed=True,
+    kill_switch_triggered=False,
+    monitoring_enabled=True,
+    quality_guard_enabled=True,
+    exposure_guard_enabled=True,
+    max_exposure_ratio=0.10,
+    max_data_freshness_ms=500,
+    min_quality_score=0.80,
+    trace_refs={"target_path": "secure_signing.sign_with_trace"},
+)
+
+VALID_TRANSPORT_RESULT = ExecutionTransportResult(
+    submitted=True,
+    success=True,
+    blocked_reason=None,
+    execution_authorized=True,
+    request_payload={"client_order_id": "CID-6-4-6-001", "side": "BUY", "size": 10},
+    exchange_response={"transport": "ok"},
+    transport_mode="REAL",
+    simulated=False,
+    non_executing=False,
+)
+
+VALID_EXCHANGE_INPUT = ExchangeExecutionTransportInput(
+    transport_result=VALID_TRANSPORT_RESULT,
+    monitoring_input=VALID_MONITORING_INPUT,
+    monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+    monitoring_required=True,
+    upstream_trace_refs={"phase": "6.4.6"},
+)
+
+VALID_EXCHANGE_POLICY = ExchangeExecutionPolicyInput(
+    network_enabled=True,
+    allow_real_network=True,
+    endpoint_url="https://api.exchange.local/orders",
+    http_method="POST",
+    signing_required=True,
+    signing_key_present=True,
+    signing_scheme="ed25519",
+    wallet_reference="wallet-ref-001",
+    request_timeout_ms=500,
+    allow_testnet=False,
+    environment="prod",
+    allowed_environments=["prod", "staging"],
+    policy_trace_refs={"policy": "phase6.4.6.exchange"},
+)
+
+
+def _build_valid_signing_input() -> SigningExecutionInput:
+    return SigningExecutionInput(
+        exchange_result=ExchangeExecutionResult(
+            executed=True,
+            success=True,
+            blocked_reason=None,
+            execution_id="EXE-6-4-6-001",
+            request_payload={"execution_id": "EXE-6-4-6-001", "order": {"side": "BUY", "size": 1}},
+            signed_payload={"execution_id": "EXE-6-4-6-001", "request": {"side": "BUY", "size": 1}},
+            exchange_response={"status": "ok"},
+            network_used="REAL",
+            signing_used=True,
+            simulated=False,
+            non_executing=False,
+        ),
+        monitoring_input=VALID_MONITORING_INPUT,
+        monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+        monitoring_required=True,
+        upstream_trace_refs={"phase": "6.4.6"},
+    )
+
+
+VALID_POLICY_INPUT = SigningPolicyInput(
+    signing_enabled=True,
+    allow_real_signing=True,
+    signing_scheme="ed25519",
+    allowed_schemes=["ed25519", "secp256k1"],
+    key_reference="key-ref-001",
+    key_registry_enabled=True,
+    key_registered=True,
+    key_access_granted=True,
+    allow_external_signer=True,
+    external_signer_used=False,
+    simulated_signing_force=False,
+    audit_required=True,
+    audit_attached=True,
+    operator_approval_required=True,
+    operator_approval_present=True,
+    policy_trace_refs={"policy": "phase6.4.6.signing"},
+)
+
+
+def test_phase6_4_6_signing_monitoring_allow_pass_through() -> None:
+    engine = SecureSigningEngine(real_signing_enabled=True)
+
+    build = engine.sign_with_trace(
+        signing_input=_build_valid_signing_input(),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.signed is True
+    assert build.result.success is True
+    assert build.result.blocked_reason is None
+    assert build.trace.signing_attempted is True
+    assert build.trace.upstream_trace_refs["monitoring"]["decision"] == "ALLOW"
+
+
+def test_phase6_4_6_signing_monitoring_block_prevents_signing() -> None:
+    engine = SecureSigningEngine(real_signing_enabled=True)
+    breaker = MonitoringCircuitBreaker()
+
+    build = engine.sign_with_trace(
+        signing_input=replace(
+            _build_valid_signing_input(),
+            monitoring_input=replace(VALID_MONITORING_INPUT, exposure_ratio=0.11),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.signed is False
+    assert build.result.blocked_reason == SIGNING_BLOCK_MONITORING_ANOMALY
+    assert build.trace.signing_attempted is False
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_EXPOSURE_THRESHOLD_BREACH
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_6_signing_monitoring_halt_stops_signing() -> None:
+    engine = SecureSigningEngine(real_signing_enabled=True)
+    breaker = MonitoringCircuitBreaker()
+
+    build = engine.sign_with_trace(
+        signing_input=replace(
+            _build_valid_signing_input(),
+            monitoring_input=replace(VALID_MONITORING_INPUT, kill_switch_triggered=True),
+            monitoring_circuit_breaker=breaker,
+        ),
+        policy_input=VALID_POLICY_INPUT,
+    )
+
+    assert build.result is not None
+    assert build.result.signed is False
+    assert build.result.blocked_reason == SIGNING_HALT_MONITORING_ANOMALY
+    assert build.trace.signing_attempted is False
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_KILL_SWITCH_TRIGGERED
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_6_existing_four_monitored_paths_remain_intact() -> None:
+    authorizer = LiveExecutionAuthorizer()
+    gateway = ExecutionGateway()
+    transport = ExecutionTransport()
+    exchange = ExchangeIntegration(real_network_enabled=False)
+
+    auth_build = authorizer.authorize_with_trace(
+        readiness_input=LiveExecutionReadinessInput(
+            readiness_decision=LiveExecutionReadinessDecision(
+                live_ready=True,
+                allowed=True,
+                blocked_reason=None,
+                selected_mode=MODE_LIVE,
+                guardrail_passed=True,
+                kill_switch_armed=True,
+                simulated=True,
+                non_executing=True,
+            ),
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.3"},
+        ),
+        policy_input=LiveExecutionAuthorizationPolicyInput(
+            explicit_execution_enable=True,
+            authorization_scope="single_market_first_path",
+            allowed_scopes=("single_market_first_path",),
+            single_market_only=True,
+            target_market_id="market-6-4-6",
+            wallet_binding_required=True,
+            wallet_binding_present=True,
+            audit_required=True,
+            audit_attached=True,
+            operator_approval_required=True,
+            operator_approval_present=True,
+            kill_switch_must_remain_armed=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.3"},
+        ),
+    )
+    assert auth_build.decision is not None
+    assert auth_build.decision.execution_authorized is True
+
+    gateway_build = gateway.simulate_execution_with_trace(
+        decision_input=ExecutionGatewayDecisionInput(
+            decision=ExecutionDecision(
+                allowed=True,
+                blocked_reason=None,
+                market_id="MKT-6-4-6",
+                outcome="YES",
+                side="YES",
+                size=5.0,
+                routing_mode="platform-gateway-shadow",
+                execution_mode="paper-prep-only",
+                ready_for_execution=True,
+                non_activating=True,
+            ),
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            monitoring_required=True,
+            source_trace_refs={"phase": "6.4.4"},
+        )
+    )
+    assert gateway_build.result is not None
+    assert gateway_build.result.accepted is True
+
+    transport_build = transport.submit_with_trace(
+        authorization_input=ExecutionTransportAuthorizationInput(
+            authorization=auth_build.decision,
+            gateway_result=gateway_build.result,
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            source_trace_refs={"phase": "6.4.2"},
+        ),
+        policy_input=ExecutionTransportPolicyInput(
+            transport_enabled=True,
+            execution_mode=MODE_LIVE,
+            dry_run_force=False,
+            allow_real_submission=True,
+            single_submission_only=True,
+            max_orders=1,
+            require_idempotency=True,
+            idempotency_key_present=True,
+            audit_log_required=True,
+            audit_log_attached=True,
+            operator_confirm_required=True,
+            operator_confirm_present=True,
+            monitoring_required=True,
+            policy_trace_refs={"phase": "6.4.2"},
+        ),
+    )
+    assert transport_build.result is not None
+    assert transport_build.result.submitted is True
+    assert transport_build.result.success is True
+
+    exchange_build = exchange.execute_with_trace(
+        transport_input=ExchangeExecutionTransportInput(
+            transport_result=transport_build.result,
+            monitoring_input=VALID_MONITORING_INPUT,
+            monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+            monitoring_required=True,
+            upstream_trace_refs={"phase": "6.4.5"},
+        ),
+        policy_input=VALID_EXCHANGE_POLICY,
+    )
+    assert exchange_build.result is not None
+    assert exchange_build.result.executed is True
+    assert exchange_build.result.success is True


### PR DESCRIPTION
### Motivation
- Add deterministic ALLOW / BLOCK / HALT monitoring at the real signing boundary to expand Phase 6.4 narrow-path runtime safety coverage. 
- Keep prior narrow monitored paths unchanged (transport, authorizer, gateway, exchange) while limiting scope to the exact signing method. 
- Surface a clear next gate for SENTINEL MAJOR validation on the signing-boundary integration before merge.

### Description
- Integrated monitoring into the exact signing-boundary runtime method `SecureSigningEngine.sign_with_trace(...)` and evaluate `MonitoringContractInput`/`MonitoringCircuitBreaker` before existing signing policy checks. 
- Extended `SigningExecutionInput` with narrow monitoring fields (`monitoring_input`, `monitoring_circuit_breaker`, `monitoring_required`) and added deterministic blocked reasons `monitoring_evaluation_required`, `monitoring_anomaly_block`, and `monitoring_anomaly_halt`. 
- Added focused Phase 6.4.6 unit tests at `projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py` for ALLOW pass-through, BLOCK prevention, HALT behavior, and regression coverage verifying the four previously accepted monitored paths remain intact. 
- Created the FORGE report `projects/polymarket/polyquantbot/reports/forge/25_28_phase6_4_6_signing_monitoring_expansion.md` and updated `PROJECT_STATE.md` and `ROADMAP.md` to record Phase 6.4.6 in-progress status and next gate to SENTINEL; changes committed on branch `feature/monitoring-phase6-4-signing-path-expansion-20260415`.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/execution/secure_signing.py projects/polymarket/polyquantbot/tests/test_phase6_4_6_signing_monitoring_20260415.py` and it passed. 
- Ran `PYTHONPATH=. pytest -q` for the focused test set (`test_phase6_4_6_signing_monitoring_20260415.py`, `test_phase6_4_5_exchange_monitoring_20260415.py`, `test_phase6_4_4_gateway_monitoring_20260415.py`, `test_phase6_4_3_authorizer_monitoring_20260414.py`, `test_phase5_2_execution_transport_20260412.py`) with result `32 passed, 1 warning` (non-runtime pytest config warning). 
- Ran `find . -type d -name 'phase*'` to confirm no `phase*/` folders were introduced and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec38f5fb08325a8f5f85d8cc91dcb)