### PR TITLE
Phase 6.4 next-candidate evaluation: add narrow monitoring at ExecutionAdapter.build_order_with_trace

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-📅 Last Updated : 2026-04-15 05:42
+📅 Last Updated : 2026-04-15 12:00
 🔄 Status       : Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented on source branch and now requires SENTINEL validation before merge/promotion.
 
 ✅ COMPLETED
@@ -8,10 +8,11 @@
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
-- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498.
-- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502.
-- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505.
-- Phase 6.4.8 settlement-boundary monitoring narrow integration and Phase 6.4.9 orchestration-entry monitoring narrow integration are merged, establishing the accepted eight-path execution-adjacent monitoring baseline.
+- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, and ExchangeIntegration.execute_with_trace.
+- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, and SecureSigningEngine.sign_with_trace.
+- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, and WalletCapitalController.authorize_capital_with_trace.
+- Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace while preserving the prior six accepted monitored paths.
+- Phase 6.4.9 orchestration-entry monitoring narrow integration merged with accepted eight-path runtime baseline by adding ExecutionActivationGate.evaluate_with_trace while preserving the prior seven accepted monitored paths.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,32 +1,30 @@
-📅 Last Updated : 2026-04-15 12:57
-🔄 Status       : Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented on source branch and now requires SENTINEL validation before merge/promotion.
+📅 Last Updated : 2026-04-15 13:22
+🔄 Status       : SENTINEL validation for Phase 6.4.10 adapter-boundary monitoring expansion is APPROVED (96/100, Critical 0); source branch now awaits COMMANDER final decision.
 
 ✅ COMPLETED
-- Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented with deterministic policy gates.
-- SENTINEL validation completed for Phase 5.2–5.6 major-gated work.
+- Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
 - Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory records.
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
-- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, and ExchangeIntegration.execute_with_trace.
-- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, and SecureSigningEngine.sign_with_trace.
-- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, and WalletCapitalController.authorize_capital_with_trace.
-- Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace while preserving the prior six accepted monitored paths.
-- Phase 6.4.9 orchestration-entry monitoring narrow integration merged with accepted eight-path runtime baseline by adding ExecutionActivationGate.evaluate_with_trace while preserving the prior seven accepted monitored paths.
+- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
+- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline.
+- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline.
+- Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
+- Phase 6.4.9 orchestration-entry monitoring narrow integration merged; Phase 6.4.10 adapter-boundary monitoring validation is now APPROVED on source branch with accepted nine-path narrow baseline pending COMMANDER decision.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented at ExecutionAdapter.build_order_with_trace and pending SENTINEL validation.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no wallet lifecycle expansion, no portfolio orchestration, and no settlement automation beyond the exact named boundary method.
+- Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no wallet lifecycle expansion, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md. Tier: MAJOR.
+- COMMANDER final decision (merge/hold/rework) on source branch. Source: projects/polymarket/polyquantbot/reports/sentinel/25_28_phase6_4_10_adapter_monitoring_validation.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-📅 Last Updated : 2026-04-15 12:00
+📅 Last Updated : 2026-04-15 12:57
 🔄 Status       : Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented on source branch and now requires SENTINEL validation before merge/promotion.
 
 ✅ COMPLETED
@@ -23,7 +23,7 @@
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout beyond the current narrow target paths.
+- Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no wallet lifecycle expansion, no portfolio orchestration, and no settlement automation beyond the exact named boundary method.
 
 🎯 NEXT PRIORITY
 - SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md. Tier: MAJOR.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 12:00
-🔄 Status       : Phase 6.4.9 orchestration-entry monitoring narrow integration has completed SENTINEL validation (APPROVED 96/100, Critical 0) on source branch and is pending COMMANDER final merge decision.
+📅 Last Updated : 2026-04-15 05:42
+🔄 Status       : Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented on source branch and now requires SENTINEL validation before merge/promotion.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented with deterministic policy gates.
@@ -8,24 +8,24 @@
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
-- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, and ExchangeIntegration.execute_with_trace.
-- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, and SecureSigningEngine.sign_with_trace.
-- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, and WalletCapitalController.authorize_capital_with_trace.
-- Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace while preserving the prior six accepted monitored paths.
+- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498.
+- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502.
+- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505.
+- Phase 6.4.8 settlement-boundary monitoring narrow integration and Phase 6.4.9 orchestration-entry monitoring narrow integration are merged, establishing the accepted eight-path execution-adjacent monitoring baseline.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.4.9 orchestration-entry monitoring narrow integration completed SENTINEL validation on source branch; pending COMMANDER decision for merge/promotion.
+- Phase 6.4.10 adapter-boundary monitoring narrow integration is implemented at ExecutionAdapter.build_order_with_trace and pending SENTINEL validation.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading, storage, and rotation.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout beyond the current Phase 6.4 narrow target paths (transport, authorizer, gateway, exchange integration, signing boundary, capital boundary, settlement boundary, orchestration-entry boundary).
+- Platform-wide monitoring rollout beyond the current narrow target paths.
 
 🎯 NEXT PRIORITY
-- COMMANDER final review/decision required on SENTINEL result. Source: projects/polymarket/polyquantbot/reports/sentinel/25_27_phase6_4_9_orchestration_entry_monitoring_validation.md. Tier: MAJOR.
+- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 05:42
+**Last Updated:** 2026-04-15 12:00
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 05:42
+**Last Updated:** 2026-04-15 12:00
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 12:00
+**Last Updated:** 2026-04-15 12:57
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 12:00
+**Last Updated:** 2026-04-15 12:57
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 11:02
+**Last Updated:** 2026-04-15 05:42
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 11:02
+**Last Updated:** 2026-04-15 05:42
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -58,7 +58,8 @@
 | 6.4.6 | Signing-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth confirmed after PR #501 and PR #502 at declared narrow scope. Accepted five execution-related runtime paths: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace. Explicit exclusions preserved: no platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, or settlement automation. |
 | 6.4.7 | Capital-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth confirmed after PR #504 and PR #505 at declared narrow scope. Accepted six execution-related runtime paths: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, WalletCapitalController.authorize_capital_with_trace. Explicit exclusions preserved: no platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, or settlement automation. |
 | 6.4.8 | Settlement-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow settlement boundary at FundSettlementEngine.settle_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Seven-path baseline preserved through settlement boundary; no platform-wide monitoring rollout claimed. |
-| 6.4.9 | Orchestration-Entry Monitoring Narrow Integration Expansion | 🚧 In Progress | FORGE-X scope active for narrow orchestration-entry boundary at ExecutionActivationGate.evaluate_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Existing seven accepted monitored paths are preserved; no platform-wide monitoring rollout claimed. |
+| 6.4.9 | Orchestration-Entry Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow orchestration-entry boundary at ExecutionActivationGate.evaluate_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Accepted eight-path baseline now includes transport, authorizer, gateway, exchange, signing, capital, settlement, and orchestration-entry boundaries. No platform-wide monitoring rollout claimed. |
+| 6.4.10 | Adapter-Boundary Monitoring Narrow Integration Expansion | 🚧 In Progress | FORGE-X scope active for the next exact execution-adjacent boundary at ExecutionAdapter.build_order_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Scope remains single-method and excludes platform-wide rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, and broad settlement automation. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py
+++ b/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py
@@ -4,12 +4,21 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .execution_decision import ExecutionDecision
+from .monitoring_circuit_breaker import (
+    MONITORING_DECISION_BLOCK,
+    MONITORING_DECISION_HALT,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
 
 ADAPTER_BLOCK_INVALID_DECISION_INPUT = "invalid_decision_input"
 ADAPTER_BLOCK_INVALID_DECISION_CONTRACT = "invalid_decision_contract"
 ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED = "upstream_not_allowed"
 ADAPTER_BLOCK_DECISION_NOT_READY = "decision_not_ready"
 ADAPTER_BLOCK_NON_ACTIVATING_REQUIRED = "non_activating_required"
+ADAPTER_BLOCK_MONITORING_EVALUATION_REQUIRED = "monitoring_evaluation_required"
+ADAPTER_BLOCK_MONITORING_ANOMALY = "monitoring_anomaly_block"
+ADAPTER_HALT_MONITORING_ANOMALY = "monitoring_anomaly_halt"
 
 
 _SIDE_TO_EXTERNAL_SIDE: dict[str, str] = {
@@ -30,6 +39,9 @@ _ROUTING_MODE_TO_EXECUTION_MODE: dict[str, str] = {
 @dataclass(frozen=True)
 class ExecutionAdapterDecisionInput:
     decision: ExecutionDecision
+    monitoring_input: MonitoringContractInput | None = None
+    monitoring_circuit_breaker: MonitoringCircuitBreaker | None = None
+    monitoring_required: bool = False
     source_trace_refs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -101,6 +113,70 @@ class ExecutionAdapter:
             )
 
         decision = decision_input.decision
+        monitoring_trace: dict[str, Any] | None = None
+        if decision_input.monitoring_required:
+            if not isinstance(decision_input.monitoring_input, MonitoringContractInput):
+                return _blocked_result(
+                    blocked_reason=ADAPTER_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                    mapping_notes={
+                        "monitoring_required": True,
+                        "contract_errors": {
+                            "monitoring_input": {
+                                "expected_type": "MonitoringContractInput",
+                                "actual_type": type(decision_input.monitoring_input).__name__,
+                            }
+                        },
+                    },
+                )
+
+            if decision_input.monitoring_circuit_breaker is not None and not isinstance(
+                decision_input.monitoring_circuit_breaker,
+                MonitoringCircuitBreaker,
+            ):
+                return _blocked_result(
+                    blocked_reason=ADAPTER_BLOCK_MONITORING_EVALUATION_REQUIRED,
+                    upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                    mapping_notes={
+                        "monitoring_required": True,
+                        "contract_errors": {
+                            "monitoring_circuit_breaker": {
+                                "expected_type": "MonitoringCircuitBreaker",
+                                "actual_type": type(decision_input.monitoring_circuit_breaker).__name__,
+                            }
+                        },
+                    },
+                )
+
+            breaker = decision_input.monitoring_circuit_breaker or MonitoringCircuitBreaker()
+            monitoring_result = breaker.evaluate(decision_input.monitoring_input)
+            monitoring_trace = {
+                "decision": monitoring_result.decision,
+                "anomaly_count": len(monitoring_result.anomalies),
+                "primary_anomaly": (
+                    monitoring_result.anomalies[0] if monitoring_result.anomalies else None
+                ),
+            }
+
+            if monitoring_result.decision == MONITORING_DECISION_HALT:
+                return _blocked_result(
+                    blocked_reason=ADAPTER_HALT_MONITORING_ANOMALY,
+                    upstream_trace_refs={
+                        "decision_input": dict(decision_input.source_trace_refs),
+                        "monitoring": monitoring_trace,
+                    },
+                    mapping_notes={"monitoring_required": True},
+                )
+            if monitoring_result.decision == MONITORING_DECISION_BLOCK:
+                return _blocked_result(
+                    blocked_reason=ADAPTER_BLOCK_MONITORING_ANOMALY,
+                    upstream_trace_refs={
+                        "decision_input": dict(decision_input.source_trace_refs),
+                        "monitoring": monitoring_trace,
+                    },
+                    mapping_notes={"monitoring_required": True},
+                )
+
         if not decision.allowed:
             return _blocked_result(
                 blocked_reason=ADAPTER_BLOCK_UPSTREAM_NOT_ALLOWED,
@@ -147,7 +223,10 @@ class ExecutionAdapter:
             trace=ExecutionOrderTrace(
                 order_created=True,
                 blocked_reason=None,
-                upstream_trace_refs={"decision_input": dict(decision_input.source_trace_refs)},
+                upstream_trace_refs={
+                    "decision_input": dict(decision_input.source_trace_refs),
+                    **({"monitoring": monitoring_trace} if monitoring_trace is not None else {}),
+                },
                 mapping_notes={
                     "side_to_external_side": {decision.side: external_side},
                     "routing_mode_to_execution_mode": {decision.routing_mode: mapped_execution_mode},

--- a/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
@@ -29,6 +29,7 @@
   - `monitoring_circuit_breaker`
   - `monitoring_required`
 - Added focused tests for ALLOW pass-through order build, BLOCK prevention, and HALT stop behavior on the adapter boundary.
+- Applied PR #512 repo-truth regression fix by restoring non-regressed repo-root timestamps and preserving explicit merged truth wording for 6.4.5–6.4.9 in `PROJECT_STATE.md` and `ROADMAP.md`.
 
 ## 2) Current system architecture
 - Monitoring remains execution-adjacent and narrow, with no platform-wide rollout claim.
@@ -57,6 +58,7 @@
 - Adapter-boundary BLOCK monitoring contract deterministically prevents order build with `monitoring_anomaly_block`.
 - Adapter-boundary HALT monitoring contract deterministically prevents order build with `monitoring_anomaly_halt`.
 - Integration remains exact-method scoped and does not introduce multi-method rollout.
+- Repo-root truth rollback is corrected: timestamps are restored and explicit merged baseline wording for 6.4.5–6.4.9 remains preserved.
 
 ## 5) Known issues
 - Existing pytest warning persists: `Unknown config option: asyncio_mode` (non-runtime hygiene backlog).
@@ -80,7 +82,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 05:42 UTC  
+**Report Timestamp:** 2026-04-15 12:00 UTC  
 **Role:** FORGE-X (NEXUS)  
 **Task:** evaluate next exact narrow execution-adjacent monitoring candidate after merged Phase 6.4.9 and integrate only if justified  
 **Branch:** `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
@@ -83,7 +83,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 05:57 UTC  
+**Report Timestamp:** 2026-04-15 12:57 UTC  
 **Role:** FORGE-X (NEXUS)  
 **Task:** evaluate next exact narrow execution-adjacent monitoring candidate after merged Phase 6.4.9 and integrate only if justified  
-**Branch:** `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`
+**Branch:** `codex/evaluate-next-monitoring-candidate-after-phase-6.4.9-2026-04-15`

--- a/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
@@ -29,7 +29,8 @@
   - `monitoring_circuit_breaker`
   - `monitoring_required`
 - Added focused tests for ALLOW pass-through order build, BLOCK prevention, and HALT stop behavior on the adapter boundary.
-- Applied PR #512 repo-truth regression fix by restoring non-regressed repo-root timestamps and preserving explicit merged truth wording for 6.4.5–6.4.9 in `PROJECT_STATE.md` and `ROADMAP.md`.
+- Applied PR #512 repo-truth regression fix by restoring current non-regressed repo-root timestamps and preserving explicit merged truth wording for 6.4.5–6.4.9 in `PROJECT_STATE.md` and `ROADMAP.md`.
+- Restored explicit exclusion wording in `PROJECT_STATE.md`: no platform-wide monitoring rollout, no scheduler generalization, no wallet lifecycle expansion, no portfolio orchestration, and no settlement automation beyond the exact named boundary method.
 
 ## 2) Current system architecture
 - Monitoring remains execution-adjacent and narrow, with no platform-wide rollout claim.
@@ -82,7 +83,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 12:00 UTC  
+**Report Timestamp:** 2026-04-15 05:57 UTC  
 **Role:** FORGE-X (NEXUS)  
 **Task:** evaluate next exact narrow execution-adjacent monitoring candidate after merged Phase 6.4.9 and integrate only if justified  
 **Branch:** `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md
@@ -1,0 +1,86 @@
+# Forge Report — Phase 6.4 Next Candidate Evaluation (Post-6.4.9)
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py::ExecutionAdapter.build_order_with_trace`  
+**Not in Scope:** platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, broad portfolio orchestration, broad settlement automation, multi-method rollout, or refactor of existing 6.4.2–6.4.9 paths.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Re-evaluated the execution stack after merged Phase 6.4.9 against the accepted eight-path narrow monitoring baseline:
+  1. `ExecutionTransport.submit_with_trace`
+  2. `LiveExecutionAuthorizer.authorize_with_trace`
+  3. `ExecutionGateway.simulate_execution_with_trace`
+  4. `ExchangeIntegration.execute_with_trace`
+  5. `SecureSigningEngine.sign_with_trace`
+  6. `WalletCapitalController.authorize_capital_with_trace`
+  7. `FundSettlementEngine.settle_with_trace`
+  8. `ExecutionActivationGate.evaluate_with_trace`
+- Determined one remaining exact execution-adjacent candidate method is still narrow enough for expansion without broadening scope: `ExecutionAdapter.build_order_with_trace`.
+- Implemented deterministic ALLOW/BLOCK/HALT monitoring for `ExecutionAdapter.build_order_with_trace` only.
+- Added adapter-boundary monitoring constants:
+  - `ADAPTER_BLOCK_MONITORING_EVALUATION_REQUIRED`
+  - `ADAPTER_BLOCK_MONITORING_ANOMALY`
+  - `ADAPTER_HALT_MONITORING_ANOMALY`
+- Extended `ExecutionAdapterDecisionInput` with narrow monitoring fields:
+  - `monitoring_input`
+  - `monitoring_circuit_breaker`
+  - `monitoring_required`
+- Added focused tests for ALLOW pass-through order build, BLOCK prevention, and HALT stop behavior on the adapter boundary.
+
+## 2) Current system architecture
+- Monitoring remains execution-adjacent and narrow, with no platform-wide rollout claim.
+- Existing accepted eight monitored boundaries remain unchanged.
+- One additional exact method is now integrated: `ExecutionAdapter.build_order_with_trace`.
+- Why this method is the next narrow boundary:
+  - It is runtime-significant because it is the deterministic conversion point from execution decision to external-order-ready spec.
+  - It is execution-adjacent (inside `platform/execution/` and directly in the order submission chain).
+  - It is narrower than orchestration rollout because integration is scoped to one method contract only.
+  - It is not wallet lifecycle expansion, scheduler generalization, portfolio orchestration, or settlement automation.
+  - It is non-duplicative: no prior accepted 6.4.2–6.4.9 path covered this adapter mapping boundary.
+- Deterministic monitoring decision flow for the target method:
+  - `ALLOW` → continue existing adapter mapping and emit order build trace.
+  - `BLOCK` → return blocked build with `monitoring_anomaly_block`.
+  - `HALT` → return blocked build with `monitoring_anomaly_halt`.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/execution/execution_adapter.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- Adapter-boundary ALLOW monitoring contract builds an order successfully and records monitoring decision metadata.
+- Adapter-boundary BLOCK monitoring contract deterministically prevents order build with `monitoring_anomaly_block`.
+- Adapter-boundary HALT monitoring contract deterministically prevents order build with `monitoring_anomaly_halt`.
+- Integration remains exact-method scoped and does not introduce multi-method rollout.
+
+## 5) Known issues
+- Existing pytest warning persists: `Unknown config option: asyncio_mode` (non-runtime hygiene backlog).
+- Broader monitoring rollout remains intentionally out of scope.
+
+## 6) What is next
+- SENTINEL validation must verify the declared target method behavior and narrow-scope preservation.
+- COMMANDER decides merge/hold/rework after SENTINEL verdict.
+
+---
+
+## Validation declaration
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py::ExecutionAdapter.build_order_with_trace`
+- Not in Scope: platform-wide rollout, scheduler generalization, wallet lifecycle expansion, broad portfolio orchestration, broad settlement automation, and multi-method rollout.
+- Suggested Next Step: SENTINEL validation required.
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_adapter.py projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-15 05:42 UTC  
+**Role:** FORGE-X (NEXUS)  
+**Task:** evaluate next exact narrow execution-adjacent monitoring candidate after merged Phase 6.4.9 and integrate only if justified  
+**Branch:** `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_28_phase6_4_10_adapter_monitoring_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_28_phase6_4_10_adapter_monitoring_validation.md
@@ -1,0 +1,113 @@
+# Sentinel Validation Report — Phase 6.4.10 Adapter-Boundary Monitoring Expansion
+
+## Environment
+- Role: SENTINEL (NEXUS)
+- Date (UTC): 2026-04-15 13:20
+- Repository: `/workspace/walker-ai-team`
+- Branch context: `work` (Codex worktree; source branch declared by COMMANDER: `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`)
+- Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py::ExecutionAdapter.build_order_with_trace`
+- Source Forge Report: `projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md`
+
+## Validation Context
+This validation audited the declared narrow integration at adapter-boundary (`ExecutionAdapter.build_order_with_trace`), verified deterministic ALLOW/BLOCK/HALT behavior and blocked_reason semantics, and re-checked that the prior accepted eight monitored paths remain intact without widening into a platform-wide monitoring rollout.
+
+## Phase 0 Checks
+1. Forge report exists at exact path: **PASS**.
+2. Forge report naming pattern `[phase]_[increment]_[name].md`: **PASS** (`25_37_phase6_4_next_candidate_evaluation.md`).
+3. All 6 required FORGE sections present: **PASS** (`1) What was built` through `6) What is next`).
+4. Metadata declared (Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next Step): **PASS**.
+5. `PROJECT_STATE.md` has full timestamp and truthful 6.4.9 merged baseline preserved while 6.4.10 awaited SENTINEL: **PASS**.
+6. FORGE MAJOR gate consistency (report + state both require SENTINEL before merge): **PASS**.
+7. `python -m py_compile` evidence exists in FORGE report and revalidated by SENTINEL: **PASS**.
+8. `pytest` evidence exists in FORGE report and revalidated by SENTINEL with successful invocation: **PASS**.
+9. Forbidden `phase*/` directories check (`find . -type d -name 'phase*'`): **PASS** (none found).
+10. Required FORGE final-output lines (`Report:` / `State:` / `Validation Tier:`) are not directly auditable from repository files: **NOTE** (non-blocking, inferred from committed artifacts).
+
+## Findings
+1. **Target integration exists on the exact claimed method and remains narrow.**
+   - Evidence: adapter monitoring inputs and breaker contract were added only on `ExecutionAdapterDecisionInput` and consumed inside `build_order_with_trace`, with no platform-wide scheduler/runtime orchestration additions in this task commit set.
+   - File+line evidence:
+     - `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py:40-45` (new narrow input fields)
+     - `projects/polymarket/polyquantbot/platform/execution/execution_adapter.py:117-178` (monitoring-gated logic in target method only)
+     - `git show --name-only --pretty=format: 95fd64c` showed code touched only `execution_adapter.py` plus task report/state files.
+   - Result: **PASS**.
+
+2. **ALLOW/BLOCK/HALT handling is deterministic on the target path.**
+   - Evidence (code):
+     - HALT deterministically maps to `ADAPTER_HALT_MONITORING_ANOMALY` at `execution_adapter.py:161-169`.
+     - BLOCK deterministically maps to `ADAPTER_BLOCK_MONITORING_ANOMALY` at `execution_adapter.py:170-178`.
+     - ALLOW continues normal order mapping/build path at `execution_adapter.py:180-242`.
+   - Evidence (tests):
+     - `test_phase6_4_10_adapter_monitoring_allow_builds_order` asserts ALLOW pass-through and monitoring decision trace at `tests/test_phase6_4_10_adapter_monitoring_20260415.py:64-73`.
+     - `test_phase6_4_10_adapter_monitoring_block_prevents_order_build` asserts deterministic BLOCK reason and anomaly trace at `...:75-91`.
+     - `test_phase6_4_10_adapter_monitoring_halt_prevents_order_build` asserts deterministic HALT reason and anomaly trace at `...:94-110`.
+   - Runtime proof: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py` → `3 passed`.
+   - Result: **PASS**.
+
+3. **Negative malformed-contract behavior fails closed with deterministic reason.**
+   - Evidence (code): missing/invalid monitoring input or invalid monitoring breaker under `monitoring_required=True` returns `monitoring_evaluation_required` at `execution_adapter.py:117-149`.
+   - Runtime probe: executed targeted Python contract probe; both malformed monitoring_input and malformed breaker cases returned `monitoring_evaluation_required` and `order_created=False`.
+   - Result: **PASS**.
+
+4. **Trace propagation and blocked_reason semantics are deterministic and evidence-backed.**
+   - Evidence: monitoring trace dictionary is explicitly composed with deterministic fields (`decision`, `anomaly_count`, `primary_anomaly`) at `execution_adapter.py:153-159` and propagated in blocked and allow traces at `execution_adapter.py:164-176` and `226-229`.
+   - Result: **PASS**.
+
+5. **Previously accepted eight monitored paths remain intact (no regression evidence in declared narrow baseline).**
+   - Structural evidence: each accepted path still defines the corresponding monitored method and monitoring gate semantics in code:
+     1. `execution_transport.py::submit_with_trace`
+     2. `live_execution_authorizer.py::authorize_with_trace`
+     3. `execution_gateway.py::simulate_execution_with_trace`
+     4. `exchange_integration.py::execute_with_trace`
+     5. `secure_signing.py::sign_with_trace`
+     6. `wallet_capital.py::authorize_capital_with_trace`
+     7. `fund_settlement.py::settle_with_trace`
+     8. `execution_activation_gate.py::evaluate_with_trace`
+   - Runtime proof: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_9_orchestration_entry_monitoring_20260415.py` → `4 passed`, preserving prior accepted path interactions.
+   - Result: **PASS**.
+
+## Score Breakdown
+- Phase 0 pre-handoff integrity: 20/20
+- Target-path correctness (`ExecutionAdapter.build_order_with_trace`): 30/30
+- Deterministic ALLOW/BLOCK/HALT + blocked_reason semantics: 20/20
+- Regression integrity for accepted eight-path baseline: 20/20
+- Negative testing / malformed contract handling: 8/10
+- Evidence quality and traceability adjustment: **-2** (FORGE final-output lines not directly auditable from repo files)
+
+**Total Score: 96/100**
+
+## Critical Issues
+- None.
+
+## Status
+- Verdict: **APPROVED**
+- Critical count: **0**
+- Rationale: the declared narrow adapter-boundary integration is present, deterministic behavior is runtime-proven, malformed contract inputs fail closed, and no critical safety contradiction was found in-scope.
+
+## PR Gate Result
+- Gate decision: **APPROVED FOR COMMANDER REVIEW**
+- Source branch target (authoritative task context): `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`
+- Policy guard: PR target must remain source branch, never `main`.
+
+## Broader Audit Finding
+- Non-critical hygiene warning persists in pytest config: `PytestConfigWarning: Unknown config option: asyncio_mode`.
+
+## Reasoning
+The implementation adds monitoring exactly at the claimed adapter-boundary method and does not claim or introduce platform-wide monitoring rollout. Deterministic mapping of monitoring decisions to blocked reasons is explicit in code and backed by passing tests and runtime probes. Regression signals for prior accepted narrow integrations remain intact within declared claim level and scope.
+
+## Fix Recommendations
+- Optional hygiene follow-up: add committed tests for malformed monitoring input and invalid breaker types in the `test_phase6_4_10_adapter_monitoring_20260415.py` module (currently proven via SENTINEL runtime probe).
+
+## Out-of-scope Advisory
+- Platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, broad portfolio orchestration, and broad settlement automation remain out of scope and were not used as blockers.
+
+## Deferred Minor Backlog
+- [DEFERRED] Pytest config warning `Unknown config option: asyncio_mode` remains backlog-only and non-blocking for this validation.
+
+## Telegram Visual Preview
+- GO-LIVE: APPROVED (96/100, Critical 0)
+- Scope: Phase 6.4.10 narrow monitoring integration at adapter-boundary (`ExecutionAdapter.build_order_with_trace`)
+- Integrity: ALLOW/BLOCK/HALT deterministic, malformed contracts fail closed, accepted eight-path baseline preserved
+- Next: COMMANDER final decision on source branch path

--- a/projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from projects.polymarket.polyquantbot.platform.execution.execution_adapter import (
+    ADAPTER_BLOCK_MONITORING_ANOMALY,
+    ADAPTER_HALT_MONITORING_ANOMALY,
+    ExecutionAdapter,
+    ExecutionAdapterDecisionInput,
+)
+from projects.polymarket.polyquantbot.platform.execution.execution_decision import ExecutionDecision
+from projects.polymarket.polyquantbot.platform.execution.monitoring_circuit_breaker import (
+    ANOMALY_EXPOSURE_THRESHOLD_BREACH,
+    ANOMALY_KILL_SWITCH_TRIGGERED,
+    MonitoringCircuitBreaker,
+    MonitoringContractInput,
+)
+
+VALID_MONITORING_INPUT = MonitoringContractInput(
+    policy_ref="phase6_4_10_policy",
+    eval_ref="phase6_4_10_eval",
+    timestamp_ms=1713208200000,
+    exposure_ratio=0.10,
+    position_notional_usd=100.0,
+    total_capital_usd=1_000.0,
+    data_freshness_ms=100,
+    quality_score=0.94,
+    signal_dedup_ok=True,
+    kill_switch_armed=True,
+    kill_switch_triggered=False,
+    monitoring_enabled=True,
+    quality_guard_enabled=True,
+    exposure_guard_enabled=True,
+    max_exposure_ratio=0.10,
+    max_data_freshness_ms=500,
+    min_quality_score=0.80,
+    trace_refs={"target_path": "execution_adapter.build_order_with_trace"},
+)
+
+VALID_DECISION = ExecutionDecision(
+    allowed=True,
+    blocked_reason=None,
+    market_id="MKT-6-4-10",
+    outcome="YES",
+    side="BUY",
+    size=5.0,
+    routing_mode="platform-gateway-shadow",
+    execution_mode="paper-prep-only",
+    ready_for_execution=True,
+    non_activating=True,
+)
+
+
+def _decision_input() -> ExecutionAdapterDecisionInput:
+    return ExecutionAdapterDecisionInput(
+        decision=VALID_DECISION,
+        monitoring_input=VALID_MONITORING_INPUT,
+        monitoring_circuit_breaker=MonitoringCircuitBreaker(),
+        monitoring_required=True,
+        source_trace_refs={"phase": "6.4.10"},
+    )
+
+
+def test_phase6_4_10_adapter_monitoring_allow_builds_order() -> None:
+    adapter = ExecutionAdapter()
+
+    build = adapter.build_order_with_trace(decision_input=_decision_input())
+
+    assert build.order is not None
+    assert build.trace.order_created is True
+    assert build.trace.blocked_reason is None
+    assert build.trace.upstream_trace_refs["monitoring"]["decision"] == "ALLOW"
+
+
+def test_phase6_4_10_adapter_monitoring_block_prevents_order_build() -> None:
+    adapter = ExecutionAdapter()
+    breaker = MonitoringCircuitBreaker()
+
+    build = adapter.build_order_with_trace(
+        decision_input=replace(
+            _decision_input(),
+            monitoring_input=replace(VALID_MONITORING_INPUT, exposure_ratio=0.11),
+            monitoring_circuit_breaker=breaker,
+        )
+    )
+
+    assert build.order is None
+    assert build.trace.order_created is False
+    assert build.trace.blocked_reason == ADAPTER_BLOCK_MONITORING_ANOMALY
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_EXPOSURE_THRESHOLD_BREACH
+    assert len(breaker.get_events()) == 1
+
+
+def test_phase6_4_10_adapter_monitoring_halt_prevents_order_build() -> None:
+    adapter = ExecutionAdapter()
+    breaker = MonitoringCircuitBreaker()
+
+    build = adapter.build_order_with_trace(
+        decision_input=replace(
+            _decision_input(),
+            monitoring_input=replace(VALID_MONITORING_INPUT, kill_switch_triggered=True),
+            monitoring_circuit_breaker=breaker,
+        )
+    )
+
+    assert build.order is None
+    assert build.trace.order_created is False
+    assert build.trace.blocked_reason == ADAPTER_HALT_MONITORING_ANOMALY
+    assert build.trace.upstream_trace_refs["monitoring"]["primary_anomaly"] == ANOMALY_KILL_SWITCH_TRIGGERED
+    assert len(breaker.get_events()) == 1


### PR DESCRIPTION
### Motivation
- Re-evaluate the execution stack after merged Phase 6.4.9 to find a single, exact execution-adjacent boundary narrow enough for another ALLOW/BLOCK/HALT monitoring expansion without broadening scope.
- Identify and target the deterministic adapter mapping point where internal decision becomes external-order-ready as the next narrow candidate for monitoring integration.

### Description
- Implement deterministic ALLOW/BLOCK/HALT monitoring on the exact method `ExecutionAdapter.build_order_with_trace` by adding monitoring imports, adapter-specific monitoring constants, monitoring fields to `ExecutionAdapterDecisionInput`, monitoring evaluation with `MonitoringCircuitBreaker`, and deterministic mapping of monitoring decisions to blocked reasons.  
- Preserve ALLOW path trace metadata by attaching monitoring trace data to upstream trace refs on successful builds and return blocked `ExecutionOrderBuildResult` with explicit reasons for BLOCK/HALT outcomes.  
- Add focused tests `projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py` that verify ALLOW pass-through, BLOCK prevention, and HALT behavior for the adapter boundary.  
- Add forge report `projects/polymarket/polyquantbot/reports/forge/25_37_phase6_4_next_candidate_evaluation.md` and update `PROJECT_STATE.md` and `ROADMAP.md` to reflect the new adapter-boundary narrow integration (Phase 6.4.10) pending SENTINEL validation; changes committed on branch `feature/monitoring-phase6-4-next-candidate-evaluation-20260415`. 

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/execution/execution_adapter.py projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py` and it passed.  
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_4_10_adapter_monitoring_20260415.py` and all tests passed (3 passed) with one non-blocking pytest config warning `Unknown config option: asyncio_mode`.  
- Confirmed repository state and no forbidden `phase*/` directories as part of the automated checks used during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df24af33a88325949cb74e5a7de361)