### PR TITLE
Open Phase 6.5.1 — Wallet lifecycle foundation: secret-loading contract

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 15:44
-🔄 Status       : Phase 6.5.1 wallet lifecycle foundation lane opened after Phase 6.4.10 closeout with a narrow secret-loading contract implementation (ownership and activation constrained only), pending MAJOR-tier SENTINEL validation.
+📅 Last Updated : 2026-04-15 17:13
+🔄 Status       : PR #517 hardening pass completed for Phase 6.5.1: wallet secret-loading contract preserves ownership/activation constraints and env-secret checks while removing plaintext secret exposure from result surface; pending MAJOR-tier SENTINEL validation.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -15,7 +15,7 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5.1 wallet lifecycle foundation lane opened at narrow scope: wallet secret loading contract with ownership/activation constraints only.
+- Phase 6.5.1 wallet lifecycle foundation lane remains in progress at narrow scope: secret-loading contract hardened to expose safe availability signals only (no plaintext secret return).
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading/storage expansion, secure rotation, and production orchestration.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 15:11
-🔄 Status       : Phase 6.4.10 post-merge execution-path re-evaluation completed; accepted nine-path narrow monitoring baseline remains the scope boundary and no additional exact execution-adjacent candidate is currently justified without broadening rollout scope.
+📅 Last Updated : 2026-04-15 15:44
+🔄 Status       : Phase 6.5.1 wallet lifecycle foundation lane opened after Phase 6.4.10 closeout with a narrow secret-loading contract implementation (ownership and activation constrained only), pending MAJOR-tier SENTINEL validation.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -15,16 +15,17 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.1 wallet lifecycle foundation lane opened at narrow scope: wallet secret loading contract with ownership/activation constraints only.
 
 📋 NOT STARTED
-- Full wallet lifecycle implementation including secret loading, storage, and rotation.
+- Full wallet lifecycle implementation including secret loading/storage expansion, secure rotation, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
-- Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no wallet lifecycle expansion, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
+- Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_40_phase6_4_final_candidate_evaluation.md. Tier: MINOR.
+- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 17:13
-🔄 Status       : PR #517 hardening pass completed for Phase 6.5.1: wallet secret-loading contract preserves ownership/activation constraints and env-secret checks while removing plaintext secret exposure from result surface; pending MAJOR-tier SENTINEL validation.
+📅 Last Updated : 2026-04-15 17:19
+🔄 Status       : SENTINEL validation completed for Phase 6.5.1 wallet secret-loading contract (NARROW INTEGRATION target: WalletSecretLoader.load_secret) with APPROVED verdict (98/100, 0 critical); awaiting COMMANDER final decision.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -11,11 +11,11 @@
 - Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline.
 - Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline.
 - Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.4.9 orchestration-entry monitoring narrow integration and Phase 6.4.10 adapter-boundary monitoring narrow integration are merged on main with accepted nine-path execution-related runtime baseline.
+- Phase 6.5.1 wallet lifecycle foundation secret-loading contract narrow validation completed with SENTINEL APPROVED verdict (source: projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md).
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5.1 wallet lifecycle foundation lane remains in progress at narrow scope: secret-loading contract hardened to expose safe availability signals only (no plaintext secret return).
+- Phase 6.5 wallet lifecycle foundation remains in staged narrow delivery mode; only secret-loading contract slice has completed MAJOR validation.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secret loading/storage expansion, secure rotation, and production orchestration.
@@ -25,7 +25,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- SENTINEL validation required before merge. Source: projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md. Tier: MAJOR.
+- COMMANDER review and merge decision for Phase 6.5.1 SENTINEL output. Source: projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md. Tier: MAJOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 14:45
+**Last Updated:** 2026-04-15 15:44
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 14:45
+**Last Updated:** 2026-04-15 15:44
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -60,6 +60,7 @@
 | 6.4.8 | Settlement-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow settlement boundary at FundSettlementEngine.settle_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Seven-path baseline preserved through settlement boundary; no platform-wide monitoring rollout claimed. |
 | 6.4.9 | Orchestration-Entry Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow orchestration-entry boundary at ExecutionActivationGate.evaluate_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Accepted eight-path baseline now includes transport, authorizer, gateway, exchange, signing, capital, settlement, and orchestration-entry boundaries. No platform-wide monitoring rollout claimed. |
 | 6.4.10 | Adapter-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted after PR #513 and PR #514 at declared narrow scope. Accepted nine execution-related runtime paths: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, WalletCapitalController.authorize_capital_with_trace, FundSettlementEngine.settle_with_trace, ExecutionActivationGate.evaluate_with_trace, ExecutionAdapter.build_order_with_trace. Explicit exclusions preserved: no platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, and no settlement automation beyond exact named boundary methods. |
+| 6.5.1 | Wallet Lifecycle Foundation — Secret Loading Contract | 🚧 In Progress | New execution-adjacent non-monitoring lane opened at narrow scope: deterministic wallet secret loading contract with ownership + activation constraints only. Explicit exclusions preserved: no secret rotation automation, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, or broad lifecycle rollout. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -28,7 +28,6 @@ class WalletSecretLoadResult:
     wallet_binding_id: str
     owner_user_id: str
     secret_loaded: bool
-    secret_value: str | None
     secret_fingerprint: str | None
     notes: dict[str, Any] | None = None
 
@@ -74,7 +73,6 @@ class WalletSecretLoader:
                 wallet_binding_id=policy.wallet_binding_id,
                 owner_user_id=policy.owner_user_id,
                 secret_loaded=True,
-                secret_value=secret_value,
                 secret_fingerprint=_secret_fingerprint(secret_value),
                 notes={"secret_env_var": policy.secret_env_var},
             )
@@ -112,7 +110,6 @@ def _blocked_result(
         wallet_binding_id=policy.wallet_binding_id,
         owner_user_id=policy.owner_user_id,
         secret_loaded=False,
-        secret_value=None,
         secret_fingerprint=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any
+
+WALLET_SECRET_LOAD_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_SECRET_LOAD_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_SECRET_LOAD_BLOCK_SECRET_MISSING = "secret_missing"
+WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
+
+
+@dataclass(frozen=True)
+class WalletSecretLoadPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+    secret_env_var: str
+
+
+@dataclass(frozen=True)
+class WalletSecretLoadResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    secret_loaded: bool
+    secret_value: str | None
+    secret_fingerprint: str | None
+    notes: dict[str, Any] | None = None
+
+
+class WalletSecretLoader:
+    """Phase 6.5.1 narrow wallet lifecycle foundation: secret loading contract only."""
+
+    def load_secret(self, policy: WalletSecretLoadPolicy) -> WalletSecretLoadResult:
+        contract_error = _validate_policy(policy)
+        if contract_error is not None:
+            return _blocked_result(
+                policy=policy,
+                blocked_reason=WALLET_SECRET_LOAD_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_result(
+                policy=policy,
+                blocked_reason=WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_result(
+                policy=policy,
+                blocked_reason=WALLET_SECRET_LOAD_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        try:
+            secret_value = os.environ.get(policy.secret_env_var, "")
+            if not secret_value:
+                return _blocked_result(
+                    policy=policy,
+                    blocked_reason=WALLET_SECRET_LOAD_BLOCK_SECRET_MISSING,
+                    notes={"secret_env_var": policy.secret_env_var},
+                )
+
+            return WalletSecretLoadResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                secret_loaded=True,
+                secret_value=secret_value,
+                secret_fingerprint=_secret_fingerprint(secret_value),
+                notes={"secret_env_var": policy.secret_env_var},
+            )
+        except Exception as exc:  # explicit, deterministic block with no silent failure
+            return _blocked_result(
+                policy=policy,
+                blocked_reason=WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR,
+                notes={"error_type": type(exc).__name__},
+            )
+
+
+def _validate_policy(policy: WalletSecretLoadPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if not isinstance(policy.secret_env_var, str) or not policy.secret_env_var.strip():
+        return "secret_env_var_required"
+    return None
+
+
+def _blocked_result(
+    *,
+    policy: WalletSecretLoadPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletSecretLoadResult:
+    return WalletSecretLoadResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        secret_loaded=False,
+        secret_value=None,
+        secret_fingerprint=None,
+        notes=notes,
+    )
+
+
+def _secret_fingerprint(secret_value: str) -> str:
+    return hashlib.sha256(secret_value.encode("utf-8")).hexdigest()[:16]

--- a/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md
@@ -10,20 +10,21 @@
 
 ## 1) What was built
 - Opened a new execution-adjacent and non-monitoring lane under Phase 6 by selecting exactly one narrow wallet lifecycle foundation slice: **wallet secret loading contract with ownership + activation constraints**.
-- Implemented `WalletSecretLoader` with deterministic block reasons and explicit contract validation:
+- Hardened `WalletSecretLoader` so success returns only safe signals (`secret_loaded`, deterministic `secret_fingerprint`, metadata notes) and never returns plaintext secret material.
+- Preserved deterministic block reasons and explicit contract validation:
   - input contract validation
   - owner/requester identity match requirement
   - wallet activation requirement
   - env-secret presence requirement
   - deterministic secret fingerprinting on success
-- Added focused tests covering success and the three narrow block paths (ownership mismatch, inactive wallet, and missing secret).
+- Updated focused tests to prove safe behavior without asserting raw secret return while preserving the three narrow block paths (ownership mismatch, inactive wallet, and missing secret).
 
 ## 2) Current system architecture
 - The new lane is isolated in `platform/wallet_auth` and does not alter execution orchestration, settlement, or portfolio flow.
 - Integration scope is narrow and local:
   - `WalletSecretLoadPolicy` defines the minimal policy contract for secret loading.
   - `WalletSecretLoader.load_secret` enforces ownership and activation before reading env-bound secret data.
-  - `WalletSecretLoadResult` returns deterministic status + reason and avoids silent failures.
+  - `WalletSecretLoadResult` returns deterministic status + reason plus safe metadata only; plaintext secret output is removed from the result surface.
 - No lifecycle scheduler, rotation workflow, multi-wallet registry, or runtime-wide activation orchestration was introduced.
 
 ## 3) Files created / modified (full paths)
@@ -31,16 +32,14 @@
 - Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
 - Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md`
 - Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
-- Modified: `/workspace/walker-ai-team/ROADMAP.md`
 
 ## 4) What is working
-- Secret loading succeeds only when the policy contract is valid, requester owns the wallet, wallet is active, and the configured env secret exists.
+- Secret loading succeeds only when the policy contract is valid, requester owns the wallet, wallet is active, and the configured env secret exists; success is signaled without returning raw secret value.
 - Secret loading deterministically blocks with explicit reason codes when ownership mismatches, wallet is inactive, or secret is missing.
 - The selected slice is implemented as one named runtime surface only (`WalletSecretLoader.load_secret`) and remains separated from Phase 6.4 monitoring boundaries.
 
 ## 5) Known issues
-- This slice intentionally returns secret value directly in result for narrow contract testing; downstream secure handling/redaction policies are not implemented in this lane.
-- Secret rotation, persistent wallet state transitions, and multi-wallet lifecycle orchestration remain intentionally out of scope.
+- Secret rotation, persistent wallet state transitions, secure vault integration, and multi-wallet lifecycle orchestration remain intentionally out of scope.
 - Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
 
 ## 6) What is next
@@ -64,7 +63,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 15:44 (Asia/Jakarta)  
+**Report Timestamp:** 2026-04-15 17:13 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
-**Task:** open wallet lifecycle foundation lane after Phase 6.4 closeout with one narrow executable slice  
-**Branch:** `feature/wallet-lifecycle-foundation-phase6-next-20260415`
+**Task:** harden Phase 6.5.1 wallet secret-loading contract to remove plaintext secret exposure  
+**Branch:** `fix/core-pr517-secret-surface-hardening-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md
@@ -1,0 +1,70 @@
+# FORGE-X Report — Wallet Lifecycle Foundation Lane Opening (Phase 6.5.1)
+
+**Validation Tier:** MAJOR  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletSecretLoader.load_secret` contract in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` only.  
+**Not in Scope:** full wallet lifecycle rollout, secret rotation automation, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, broad refactor, or reopening Phase 6.4 monitoring expansion scope.  
+**Suggested Next Step:** SENTINEL validation required before merge. Source: `projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md`. Tier: MAJOR.
+
+---
+
+## 1) What was built
+- Opened a new execution-adjacent and non-monitoring lane under Phase 6 by selecting exactly one narrow wallet lifecycle foundation slice: **wallet secret loading contract with ownership + activation constraints**.
+- Implemented `WalletSecretLoader` with deterministic block reasons and explicit contract validation:
+  - input contract validation
+  - owner/requester identity match requirement
+  - wallet activation requirement
+  - env-secret presence requirement
+  - deterministic secret fingerprinting on success
+- Added focused tests covering success and the three narrow block paths (ownership mismatch, inactive wallet, and missing secret).
+
+## 2) Current system architecture
+- The new lane is isolated in `platform/wallet_auth` and does not alter execution orchestration, settlement, or portfolio flow.
+- Integration scope is narrow and local:
+  - `WalletSecretLoadPolicy` defines the minimal policy contract for secret loading.
+  - `WalletSecretLoader.load_secret` enforces ownership and activation before reading env-bound secret data.
+  - `WalletSecretLoadResult` returns deterministic status + reason and avoids silent failures.
+- No lifecycle scheduler, rotation workflow, multi-wallet registry, or runtime-wide activation orchestration was introduced.
+
+## 3) Files created / modified (full paths)
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- Secret loading succeeds only when the policy contract is valid, requester owns the wallet, wallet is active, and the configured env secret exists.
+- Secret loading deterministically blocks with explicit reason codes when ownership mismatches, wallet is inactive, or secret is missing.
+- The selected slice is implemented as one named runtime surface only (`WalletSecretLoader.load_secret`) and remains separated from Phase 6.4 monitoring boundaries.
+
+## 5) Known issues
+- This slice intentionally returns secret value directly in result for narrow contract testing; downstream secure handling/redaction policies are not implemented in this lane.
+- Secret rotation, persistent wallet state transitions, and multi-wallet lifecycle orchestration remain intentionally out of scope.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- Validation Tier: **MAJOR**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletSecretLoader.load_secret` ownership/activation-constrained secret loading contract only**
+- Not in Scope: **full lifecycle orchestration or automation expansion**
+- Suggested Next Step: **SENTINEL validation required before merge**
+
+---
+
+## Validation declaration
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletSecretLoader.load_secret` only
+- Not in Scope: full wallet lifecycle rollout and automation surfaces
+- Suggested Next Step: SENTINEL validation
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-15 15:44 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** open wallet lifecycle foundation lane after Phase 6.4 closeout with one narrow executable slice  
+**Branch:** `feature/wallet-lifecycle-foundation-phase6-next-20260415`

--- a/projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md
@@ -1,0 +1,137 @@
+# SENTINEL Report — Phase 6.5.1 Wallet Secret-Loading Contract Validation
+
+## Environment
+- Timestamp (Asia/Jakarta): 2026-04-15 17:19
+- Role: SENTINEL (NEXUS)
+- Repo: `/workspace/walker-ai-team`
+- Branch context: `feature/wallet-lifecycle-foundation-phase6-next-20260415` (Codex HEAD observed as `work`; allowed by AGENTS Codex/worktree rule)
+- Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py::WalletSecretLoader.load_secret`
+- Source Forge Report: `projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md`
+
+## Validation Context
+- Objective: verify the narrow contract behavior and safety surface for secret loading.
+- In-scope checks:
+  - deterministic allow path and deterministic block reasons
+  - safe result surface with no plaintext secret leakage
+  - scope remains narrow (no rotation/vault/multi-wallet/portfolio/scheduler/settlement expansion)
+- Not in scope enforced per task: full wallet lifecycle rollout, secret rotation automation, secure vault integration, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, broad lifecycle rollout.
+
+## Phase 0 Checks
+1. Forge report exists at exact path: PASS.
+2. Forge report naming format `[phase]_[increment]_[name].md`: PASS (`25_41_wallet_lifecycle_foundation_opening.md`).
+3. Six required forge sections present: PASS (`What was built`, `Current system architecture`, `Files created / modified`, `What is working`, `Known issues`, `What is next`).
+4. Forge metadata present (Tier/Claim/Target/Not in Scope): PASS.
+5. `PROJECT_STATE.md` full timestamp and truthful 6.5.1 in-progress state before validation: PASS (`2026-04-15 17:13`; includes pending MAJOR SENTINEL validation and 6.5.1 in progress).
+6. FORGE-X output consistency with MAJOR gate: PASS based on source forge report declaration and NEXT PRIORITY in `PROJECT_STATE.md`.
+7. `py_compile` evidence exists: PASS (declared in forge report and re-run by SENTINEL).
+8. `pytest` evidence exists/matches successful invocation: PASS (declared in forge report and re-run by SENTINEL: 4 passed).
+
+## Findings
+### F1 — Contract input validation is deterministic
+- Evidence:
+  - `_validate_policy` enforces required non-empty string fields, strict bool for `wallet_active`, and non-empty env var key.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:87-98`
+  - Contract failures are mapped to deterministic `invalid_contract` block reason with explicit `contract_error` note.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:39-45`
+- Runtime proof: SENTINEL ad-hoc invocation with `wallet_binding_id=''` returned `success=False`, `blocked_reason='invalid_contract'`.
+- Result: PASS.
+
+### F2 — Ownership mismatch deterministically blocks
+- Evidence:
+  - Ownership guard compares requester vs owner and returns `ownership_mismatch`.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:47-52`
+  - Test verifies deterministic block behavior.  
+    File: `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py:35-51`
+- Runtime proof: SENTINEL ad-hoc invocation returned `success=False`, `blocked_reason='ownership_mismatch'`.
+- Result: PASS.
+
+### F3 — Inactive wallet deterministically blocks
+- Evidence:
+  - Active-state guard returns `wallet_not_active`.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:54-59`
+  - Test asserts this block reason.  
+    File: `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py:54-69`
+- Runtime proof: SENTINEL ad-hoc invocation returned `success=False`, `blocked_reason='wallet_not_active'`.
+- Result: PASS.
+
+### F4 — Missing env secret deterministically blocks
+- Evidence:
+  - Missing/empty env value maps to `secret_missing`.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:61-68`
+  - Test asserts missing secret behavior and no fingerprint.  
+    File: `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py:72-81`
+- Runtime proof: SENTINEL ad-hoc invocation with missing env key returned `success=False`, `blocked_reason='secret_missing'`.
+- Result: PASS.
+
+### F5 — Success path requires all claimed preconditions
+- Evidence:
+  - Success returned only after contract validation, ownership match, active wallet, and present secret.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:39-78`
+  - Success test validates expected fingerprint and safe status fields.  
+    File: `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py:22-33`
+- Runtime proof: SENTINEL ad-hoc invocation returned `success=True`, `blocked_reason=None`, `secret_loaded=True`.
+- Result: PASS.
+
+### F6 — Public result surface does not expose plaintext secret material
+- Evidence:
+  - `WalletSecretLoadResult` fields exclude any plaintext secret field; only `secret_loaded` + `secret_fingerprint` and safe metadata (`notes`) are exposed.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:24-33`
+  - Success path returns fingerprint only, not secret bytes/string.  
+    File: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py:70-78`
+  - Tests assert `secret_value` attribute is absent on success and blocked responses.  
+    File: `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py:32,51`
+  - Runtime inspection of result dict keys confirms only safe fields are present.
+- Result: PASS.
+
+### F7 — Narrow integration boundary preserved (no silent widening)
+- Evidence:
+  - New lane implementation is isolated to one module and one test file under wallet_auth + targeted phase test.
+  - No code path for secret rotation, vault adapters, multi-wallet orchestration, portfolio management, scheduler generalization, or settlement automation appears in target module.
+- Result: PASS (narrow claim consistent with code).
+
+## Score Breakdown
+- Phase 0 handoff integrity: 20/20
+- Contract behavior correctness (success + negative paths): 30/30
+- Safe secret-surface controls: 25/25
+- Scope/claim alignment (NARROW INTEGRATION): 15/15
+- Evidence quality and reproducibility: 8/10
+
+**Total Score: 98/100**
+
+## Critical Issues
+- Critical count: 0
+- No blocker-level contradictions found against declared claim level or validation target.
+
+## Status
+- Verdict: **APPROVED**
+- Tier gate result: MAJOR validation requirements satisfied for the declared narrow target.
+
+## PR Gate Result
+- Gate decision: **PASS — eligible to proceed to COMMANDER final decision**.
+- PR target policy: source branch only (`feature/wallet-lifecycle-foundation-phase6-next-20260415`), never `main`.
+
+## Broader Audit Finding
+- Non-critical hygiene warning persists from pytest configuration: `Unknown config option: asyncio_mode`.
+- This warning does not alter runtime behavior for the validated target and remains suitable for deferred backlog handling.
+
+## Reasoning
+The validated function enforces deterministic policy gating before secret access, returns deterministic reasons for all required blocked paths, and avoids exposing plaintext secret material. The observable result contract is constrained to safe status/fingerprint metadata and matches the declared NARROW INTEGRATION claim. No evidence indicates a widened lifecycle rollout in this change set.
+
+## Fix Recommendations
+- No blocker fix required for this gate.
+- Optional hardening follow-up (non-blocking): add one explicit pytest case for invalid contract input to mirror current ad-hoc runtime proof.
+- Optional hygiene follow-up (non-blocking): clean pytest config option warning in a dedicated maintenance pass.
+
+## Out-of-scope Advisory
+- Full lifecycle orchestration, rotation, vault integration, and scheduler/portfolio/settlement automation remain correctly out of scope for this validation target.
+
+## Deferred Minor Backlog
+- [DEFERRED] Pytest config warning `Unknown config option: asyncio_mode` — retain in `PROJECT_STATE.md` known issues for later hygiene pass.
+
+## Telegram Visual Preview
+- Verdict: APPROVED (98/100)
+- Target: `WalletSecretLoader.load_secret`
+- Critical: 0
+- Summary: deterministic ownership/activation/env-secret contract verified; plaintext secret not exposed on result surface; narrow scope preserved.

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py
@@ -28,8 +28,8 @@ def test_phase6_5_1_secret_loading_success(monkeypatch) -> None:
     assert result.success is True
     assert result.blocked_reason is None
     assert result.secret_loaded is True
-    assert result.secret_value == "secret-value-123"
     assert result.secret_fingerprint == "282768175c21798f"
+    assert hasattr(result, "secret_value") is False
 
 
 def test_phase6_5_1_blocks_ownership_mismatch(monkeypatch) -> None:
@@ -48,7 +48,7 @@ def test_phase6_5_1_blocks_ownership_mismatch(monkeypatch) -> None:
     assert result.success is False
     assert result.blocked_reason == WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH
     assert result.secret_loaded is False
-    assert result.secret_value is None
+    assert hasattr(result, "secret_value") is False
 
 
 def test_phase6_5_1_blocks_inactive_wallet(monkeypatch) -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_SECRET_LOAD_BLOCK_SECRET_MISSING,
+    WALLET_SECRET_LOAD_BLOCK_WALLET_NOT_ACTIVE,
+    WalletSecretLoadPolicy,
+    WalletSecretLoader,
+)
+
+
+def _base_policy() -> WalletSecretLoadPolicy:
+    return WalletSecretLoadPolicy(
+        wallet_binding_id="wb-phase6-5-1",
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+        secret_env_var="PHASE6_WALLET_SECRET",
+    )
+
+
+def test_phase6_5_1_secret_loading_success(monkeypatch) -> None:
+    monkeypatch.setenv("PHASE6_WALLET_SECRET", "secret-value-123")
+    loader = WalletSecretLoader()
+
+    result = loader.load_secret(_base_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.secret_loaded is True
+    assert result.secret_value == "secret-value-123"
+    assert result.secret_fingerprint == "282768175c21798f"
+
+
+def test_phase6_5_1_blocks_ownership_mismatch(monkeypatch) -> None:
+    monkeypatch.setenv("PHASE6_WALLET_SECRET", "secret-value-123")
+    loader = WalletSecretLoader()
+    policy = WalletSecretLoadPolicy(
+        wallet_binding_id="wb-phase6-5-1",
+        owner_user_id="user-owner",
+        requested_by_user_id="user-requester",
+        wallet_active=True,
+        secret_env_var="PHASE6_WALLET_SECRET",
+    )
+
+    result = loader.load_secret(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH
+    assert result.secret_loaded is False
+    assert result.secret_value is None
+
+
+def test_phase6_5_1_blocks_inactive_wallet(monkeypatch) -> None:
+    monkeypatch.setenv("PHASE6_WALLET_SECRET", "secret-value-123")
+    loader = WalletSecretLoader()
+    policy = WalletSecretLoadPolicy(
+        wallet_binding_id="wb-phase6-5-1",
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=False,
+        secret_env_var="PHASE6_WALLET_SECRET",
+    )
+
+    result = loader.load_secret(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_SECRET_LOAD_BLOCK_WALLET_NOT_ACTIVE
+    assert result.secret_loaded is False
+
+
+def test_phase6_5_1_blocks_when_secret_missing(monkeypatch) -> None:
+    monkeypatch.delenv("PHASE6_WALLET_SECRET", raising=False)
+    loader = WalletSecretLoader()
+
+    result = loader.load_secret(_base_policy())
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_SECRET_LOAD_BLOCK_SECRET_MISSING
+    assert result.secret_loaded is False
+    assert result.secret_fingerprint is None


### PR DESCRIPTION
### Motivation
- Start a new execution-adjacent, non-monitoring lane after Phase 6.4 closeout by establishing a minimal, safe wallet lifecycle foundation slice.  
- Select a single narrow, implementable surface that does not expand orchestration or production automation, specifically a deterministic secret-loading contract with ownership and activation constraints.

### Description
- Implemented a narrow wallet secret-loading contract at `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` providing `WalletSecretLoader.load_secret`, deterministic block reasons, input contract validation, owner-match and wallet-active checks, env-secret boundary, and fingerprinting.  
- Added focused unit tests at `projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py` covering success, ownership mismatch, inactive-wallet block, and missing-secret block.  
- Updated project metadata: `PROJECT_STATE.md` and `ROADMAP.md` to open Phase 6.5.1 (Wallet Lifecycle Foundation — Secret Loading Contract) and set the NEXT PRIORITY to SENTINEL validation.  
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/25_41_wallet_lifecycle_foundation_opening.md` that declares Validation Tier: MAJOR and Claim Level: NARROW INTEGRATION and lists the exact Validation Target and Not-in-Scope items.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py` and it passed.  
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py` once and collection failed due to module import path resolution (`ModuleNotFoundError: No module named 'projects'`).  
- Re-ran tests with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py` and all tests passed (`4 passed`) with one non-fatal pytest config warning `Unknown config option: asyncio_mode` that is recorded as a deferred hygiene item.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4f9365108325b5760a0e849ec863)