### PR TITLE
Phase 6.5.2: add WalletStateStorageBoundary.store_state and focused tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 21:09
-🔄 Status       : FORGE-X follow-up for PR #524 completed on branch fix/core-pr524-wallet-state-storage-followup-20260415 with roadmap truth sync (6.5.1 done, 6.5.2 active) and hardened wallet state/storage validation in WalletStateStorageBoundary.store_state; awaiting COMMANDER review.
+📅 Last Updated : 2026-04-15 21:16
+🔄 Status       : FORGE-X traceability cleanup for PR #524 completed: PROJECT_STATE/report branch references now align to the actual open PR #524 source branch feature/core-wallet-state-storage-boundary-20260415; PR #524 remains the active STANDARD review item for Phase 6.5.2 WalletStateStorageBoundary.store_state.
 
 ✅ COMPLETED
 - AGENTS.md patched with POST-MERGE SYNC RULE section after ## PROJECT_STATE RULE (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -15,7 +15,7 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5.2 wallet lifecycle state/storage boundary remains the active narrow slice pending COMMANDER review for PR #524 follow-up.
+- Phase 6.5.2 wallet lifecycle state/storage boundary remains the active narrow slice pending COMMANDER review on PR #524 source branch feature/core-wallet-state-storage-boundary-20260415.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,7 +25,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD. Branch: fix/core-pr524-wallet-state-storage-followup-20260415.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD. Branch: feature/core-wallet-state-storage-boundary-20260415 (PR #524).
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 20:52
-🔄 Status       : FORGE-X completed Phase 6.5.2 wallet state/storage boundary narrow integration (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION, target: WalletStateStorageBoundary.store_state); awaiting COMMANDER review on branch feature/core-wallet-state-storage-boundary-20260415.
+📅 Last Updated : 2026-04-15 21:09
+🔄 Status       : FORGE-X follow-up for PR #524 completed on branch fix/core-pr524-wallet-state-storage-followup-20260415 with roadmap truth sync (6.5.1 done, 6.5.2 active) and hardened wallet state/storage validation in WalletStateStorageBoundary.store_state; awaiting COMMANDER review.
 
 ✅ COMPLETED
 - AGENTS.md patched with POST-MERGE SYNC RULE section after ## PROJECT_STATE RULE (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -11,11 +11,11 @@
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
 - Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.5.2 wallet state/storage boundary narrow integration implemented with deterministic contract blocks/success behavior at WalletStateStorageBoundary.store_state (pending COMMANDER review).
+- Phase 6.5.1 wallet lifecycle secret-loading contract is merged-main accepted truth (done) and PR #524 follow-up now hardens bool/NaN invalid-state rejection for the 6.5.2 state/storage boundary.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5 wallet lifecycle foundation remains in staged narrow delivery mode; secret-loading slice previously validated and state/storage boundary slice now added pending COMMANDER review.
+- Phase 6.5.2 wallet lifecycle state/storage boundary remains the active narrow slice pending COMMANDER review for PR #524 follow-up.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,7 +25,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD. Branch: fix/core-pr524-wallet-state-storage-followup-20260415.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 18:10
-🔄 Status       : SENTINEL validation completed for Phase 6.5.1 wallet secret-loading contract (NARROW INTEGRATION target: WalletSecretLoader.load_secret) with APPROVED verdict (98/100, 0 critical); awaiting COMMANDER final decision. AGENTS.md updated with POST-MERGE SYNC RULE section (MINOR doc patch, branch: update/core-agents-post-merge-sync-20260415).
+📅 Last Updated : 2026-04-15 20:52
+🔄 Status       : FORGE-X completed Phase 6.5.2 wallet state/storage boundary narrow integration (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION, target: WalletStateStorageBoundary.store_state); awaiting COMMANDER review on branch feature/core-wallet-state-storage-boundary-20260415.
 
 ✅ COMPLETED
 - AGENTS.md patched with POST-MERGE SYNC RULE section after ## PROJECT_STATE RULE (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -10,24 +10,22 @@
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
-- Phase 6.4.6 signing-boundary monitoring narrow integration merged after PR #501 and PR #502 with accepted five-path runtime baseline.
-- Phase 6.4.7 capital-boundary monitoring narrow integration merged after PR #504 and PR #505 with accepted six-path runtime baseline.
 - Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.5.1 wallet lifecycle foundation secret-loading contract narrow validation completed with SENTINEL APPROVED verdict (source: projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md).
+- Phase 6.5.2 wallet state/storage boundary narrow integration implemented with deterministic contract blocks/success behavior at WalletStateStorageBoundary.store_state (pending COMMANDER review).
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5 wallet lifecycle foundation remains in staged narrow delivery mode; only secret-loading contract slice has completed MAJOR validation.
+- Phase 6.5 wallet lifecycle foundation remains in staged narrow delivery mode; secret-loading slice previously validated and state/storage boundary slice now added pending COMMANDER review.
 
 📋 NOT STARTED
-- Full wallet lifecycle implementation including secret loading/storage expansion, secure rotation, and production orchestration.
+- Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 - Reconciliation mutation and correction workflow excluded from Phase 6.1 and Phase 6.2.
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review of AGENTS.md diff (branch: update/core-agents-post-merge-sync-20260415) — confirm POST-MERGE SYNC RULE landed at correct position, no existing content altered. Then: review and merge decision for Phase 6.5.1 SENTINEL output. Source: projects/polymarket/polyquantbot/reports/sentinel/25_29_phase6_5_1_wallet_secret_loading_validation.md. Tier: MAJOR.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 21:16
-🔄 Status       : FORGE-X traceability cleanup for PR #524 completed: PROJECT_STATE/report branch references now align to the actual open PR #524 source branch feature/core-wallet-state-storage-boundary-20260415; PR #524 remains the active STANDARD review item for Phase 6.5.2 WalletStateStorageBoundary.store_state.
+📅 Last Updated : 2026-04-15 21:29
+🔄 Status       : FORGE-X traceability cleanup for PR #524 completed: PROJECT_STATE/report branch references now align to the actual open PR #524 source branch feature/extend-wallet-lifecycle-to-state-storage-boundary-2026-04-15; PR #524 remains the active STANDARD review item for Phase 6.5.2 WalletStateStorageBoundary.store_state.
 
 ✅ COMPLETED
 - AGENTS.md patched with POST-MERGE SYNC RULE section after ## PROJECT_STATE RULE (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -15,7 +15,7 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
-- Phase 6.5.2 wallet lifecycle state/storage boundary remains the active narrow slice pending COMMANDER review on PR #524 source branch feature/core-wallet-state-storage-boundary-20260415.
+- Phase 6.5.2 wallet lifecycle state/storage boundary remains the active narrow slice pending COMMANDER review on PR #524 source branch feature/extend-wallet-lifecycle-to-state-storage-boundary-2026-04-15.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,7 +25,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD. Branch: feature/core-wallet-state-storage-boundary-20260415 (PR #524).
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md. Tier: STANDARD. Branch: feature/extend-wallet-lifecycle-to-state-storage-boundary-2026-04-15 (PR #524).
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 15:44
+**Last Updated:** 2026-04-15 20:52
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 15:44
+**Last Updated:** 2026-04-15 20:52
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -61,6 +61,7 @@
 | 6.4.9 | Orchestration-Entry Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow orchestration-entry boundary at ExecutionActivationGate.evaluate_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Accepted eight-path baseline now includes transport, authorizer, gateway, exchange, signing, capital, settlement, and orchestration-entry boundaries. No platform-wide monitoring rollout claimed. |
 | 6.4.10 | Adapter-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted after PR #513 and PR #514 at declared narrow scope. Accepted nine execution-related runtime paths: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, WalletCapitalController.authorize_capital_with_trace, FundSettlementEngine.settle_with_trace, ExecutionActivationGate.evaluate_with_trace, ExecutionAdapter.build_order_with_trace. Explicit exclusions preserved: no platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, and no settlement automation beyond exact named boundary methods. |
 | 6.5.1 | Wallet Lifecycle Foundation — Secret Loading Contract | 🚧 In Progress | New execution-adjacent non-monitoring lane opened at narrow scope: deterministic wallet secret loading contract with ownership + activation constraints only. Explicit exclusions preserved: no secret rotation automation, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, or broad lifecycle rollout. |
+| 6.5.2 | Wallet Lifecycle Foundation — State/Storage Boundary Contract | 🚧 In Progress | FORGE-X scope expanded to next narrow wallet lifecycle slice at `WalletStateStorageBoundary.store_state` only, with deterministic success and block contracts for active/inactive and valid/invalid wallet state snapshots. Explicit exclusions preserved: no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 20:52
+**Last Updated:** 2026-04-15 21:09
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-15 20:52
+**Last Updated:** 2026-04-15 21:09
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -60,7 +60,7 @@
 | 6.4.8 | Settlement-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow settlement boundary at FundSettlementEngine.settle_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Seven-path baseline preserved through settlement boundary; no platform-wide monitoring rollout claimed. |
 | 6.4.9 | Orchestration-Entry Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted for narrow orchestration-entry boundary at ExecutionActivationGate.evaluate_with_trace with deterministic ALLOW/BLOCK/HALT monitoring decisions. Accepted eight-path baseline now includes transport, authorizer, gateway, exchange, signing, capital, settlement, and orchestration-entry boundaries. No platform-wide monitoring rollout claimed. |
 | 6.4.10 | Adapter-Boundary Monitoring Narrow Integration Expansion | ✅ Done | Merged-main truth accepted after PR #513 and PR #514 at declared narrow scope. Accepted nine execution-related runtime paths: ExecutionTransport.submit_with_trace, LiveExecutionAuthorizer.authorize_with_trace, ExecutionGateway.simulate_execution_with_trace, ExchangeIntegration.execute_with_trace, SecureSigningEngine.sign_with_trace, WalletCapitalController.authorize_capital_with_trace, FundSettlementEngine.settle_with_trace, ExecutionActivationGate.evaluate_with_trace, ExecutionAdapter.build_order_with_trace. Explicit exclusions preserved: no platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, and no settlement automation beyond exact named boundary methods. |
-| 6.5.1 | Wallet Lifecycle Foundation — Secret Loading Contract | 🚧 In Progress | New execution-adjacent non-monitoring lane opened at narrow scope: deterministic wallet secret loading contract with ownership + activation constraints only. Explicit exclusions preserved: no secret rotation automation, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, or broad lifecycle rollout. |
+| 6.5.1 | Wallet Lifecycle Foundation — Secret Loading Contract | ✅ Done | Merged-main accepted truth: deterministic wallet secret loading contract at `WalletSecretLoader.load_secret` with ownership + activation constraints and no plaintext secret output. Explicit exclusions preserved: no secret rotation automation, multi-wallet orchestration, portfolio management, scheduler generalization, settlement automation, or broad lifecycle rollout. |
 | 6.5.2 | Wallet Lifecycle Foundation — State/Storage Boundary Contract | 🚧 In Progress | FORGE-X scope expanded to next narrow wallet lifecycle slice at `WalletStateStorageBoundary.store_state` only, with deterministic success and block contracts for active/inactive and valid/invalid wallet state snapshots. Explicit exclusions preserved: no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration. |
 
 ---

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -10,6 +10,9 @@ WALLET_SECRET_LOAD_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_SECRET_LOAD_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_SECRET_LOAD_BLOCK_SECRET_MISSING = "secret_missing"
 WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
+WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_STORAGE_BLOCK_INVALID_STATE = "invalid_state"
 
 
 @dataclass(frozen=True)
@@ -117,3 +120,121 @@ def _blocked_result(
 
 def _secret_fingerprint(secret_value: str) -> str:
     return hashlib.sha256(secret_value.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class WalletStateStoragePolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    wallet_active: bool
+    state_snapshot: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WalletStateStorageResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_stored: bool
+    stored_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+class WalletStateStorageBoundary:
+    """Phase 6.5.2 narrow wallet lifecycle boundary: wallet state/storage contract only."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict[str, Any]] = {}
+
+    def store_state(self, policy: WalletStateStoragePolicy) -> WalletStateStorageResult:
+        contract_error = _validate_state_storage_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        state_error = _validate_state_snapshot(policy.state_snapshot)
+        if state_error is not None:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_INVALID_STATE,
+                notes={"state_error": state_error},
+            )
+
+        prior_record = self._store.get(policy.wallet_binding_id)
+        next_revision = 1 if prior_record is None else int(prior_record["revision"]) + 1
+        self._store[policy.wallet_binding_id] = {
+            "revision": next_revision,
+            "state_snapshot": dict(policy.state_snapshot),
+        }
+
+        return WalletStateStorageResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_stored=True,
+            stored_revision=next_revision,
+            notes={"stored_keys": sorted(policy.state_snapshot.keys())},
+        )
+
+
+def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if not isinstance(policy.state_snapshot, dict):
+        return "state_snapshot_must_be_dict"
+    return None
+
+
+def _validate_state_snapshot(state_snapshot: dict[str, Any]) -> str | None:
+    required_fields = ("wallet_status", "available_balance", "nonce")
+    for field in required_fields:
+        if field not in state_snapshot:
+            return f"{field}_required"
+
+    wallet_status = state_snapshot["wallet_status"]
+    if wallet_status not in {"ready", "suspended"}:
+        return "wallet_status_invalid"
+
+    available_balance = state_snapshot["available_balance"]
+    if not isinstance(available_balance, (int, float)):
+        return "available_balance_invalid_type"
+    if available_balance < 0:
+        return "available_balance_negative"
+
+    nonce = state_snapshot["nonce"]
+    if not isinstance(nonce, int) or nonce < 0:
+        return "nonce_invalid"
+    return None
+
+
+def _blocked_state_storage_result(
+    *,
+    policy: WalletStateStoragePolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateStorageResult:
+    return WalletStateStorageResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_stored=False,
+        stored_revision=None,
+        notes=notes,
+    )

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -212,12 +213,18 @@ def _validate_state_snapshot(state_snapshot: dict[str, Any]) -> str | None:
         return "wallet_status_invalid"
 
     available_balance = state_snapshot["available_balance"]
+    if isinstance(available_balance, bool):
+        return "available_balance_invalid_type"
     if not isinstance(available_balance, (int, float)):
         return "available_balance_invalid_type"
+    if math.isnan(float(available_balance)):
+        return "available_balance_nan"
     if available_balance < 0:
         return "available_balance_negative"
 
     nonce = state_snapshot["nonce"]
+    if isinstance(nonce, bool):
+        return "nonce_invalid"
     if not isinstance(nonce, int) or nonce < 0:
         return "nonce_invalid"
     return None

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
@@ -63,7 +63,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 21:09 (Asia/Jakarta)  
+**Report Timestamp:** 2026-04-15 21:16 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
-**Task:** correct PR 524 traceability, roadmap truth, and numeric state validation follow-up for wallet state/storage boundary  
-**Branch:** `fix/core-pr524-wallet-state-storage-followup-20260415`
+**Task:** final PR #524 branch traceability sync for PROJECT_STATE/report surfaces (no runtime logic expansion)  
+**Branch:** `feature/core-wallet-state-storage-boundary-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
@@ -14,7 +14,7 @@
 - Defined deterministic wallet state/storage contract behavior:
   - valid contract + active wallet + valid state snapshot => success and deterministic revision increment,
   - inactive wallet => deterministic block `wallet_not_active`,
-  - invalid state snapshot => deterministic block `invalid_state` with explicit `state_error` detail.
+  - invalid state snapshot => deterministic block `invalid_state` with explicit `state_error` detail, including explicit bool rejection for numeric fields and NaN rejection for `available_balance`.
 - Kept state handling local to this boundary with no orchestration or vault expansion.
 
 ## 2) Current system architecture
@@ -34,7 +34,7 @@
 
 ## 4) What is working
 - `WalletStateStorageBoundary.store_state` stores valid wallet state and increments deterministic per-wallet revision numbers.
-- Deterministic failure contracts are implemented for inactive wallet and invalid state conditions.
+- Deterministic failure contracts are implemented for inactive wallet and invalid state conditions, including bool/NaN invalid numeric state handling.
 - Focused tests prove deterministic success and failure behavior for the single named runtime surface.
 - No plaintext secret output or wallet lifecycle claim inflation was introduced.
 
@@ -63,7 +63,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 20:52 (Asia/Jakarta)  
+**Report Timestamp:** 2026-04-15 21:09 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
-**Task:** expand wallet lifecycle foundation to wallet state/storage boundary on one named runtime surface  
-**Branch:** `feature/core-wallet-state-storage-boundary-20260415`
+**Task:** correct PR 524 traceability, roadmap truth, and numeric state validation follow-up for wallet state/storage boundary  
+**Branch:** `fix/core-pr524-wallet-state-storage-followup-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
@@ -1,0 +1,69 @@
+# FORGE-X Report — Phase 6.5.2 Wallet State/Storage Boundary Narrow Integration
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateStorageBoundary.store_state` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` only.  
+**Not in Scope:** secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader wallet runtime integration.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Source: `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Added the next narrow wallet lifecycle boundary at wallet state/storage handling only.
+- Introduced one explicit runtime surface: `WalletStateStorageBoundary.store_state`.
+- Defined deterministic wallet state/storage contract behavior:
+  - valid contract + active wallet + valid state snapshot => success and deterministic revision increment,
+  - inactive wallet => deterministic block `wallet_not_active`,
+  - invalid state snapshot => deterministic block `invalid_state` with explicit `state_error` detail.
+- Kept state handling local to this boundary with no orchestration or vault expansion.
+
+## 2) Current system architecture
+- `WalletSecretLoader.load_secret` remains unchanged as the prior narrow secret-loading surface.
+- New boundary is isolated in the same wallet lifecycle foundation module:
+  - `WalletStateStoragePolicy` defines contract fields for state storage.
+  - `WalletStateStorageBoundary.store_state` validates contract/state and writes deterministic in-memory storage revision per wallet binding.
+  - `WalletStateStorageResult` returns deterministic success/failure shape without introducing broader runtime integration claims.
+- No scheduler lifecycle, rotation workflow, multi-wallet registry, or portfolio orchestration path was introduced.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `/workspace/walker-ai-team/ROADMAP.md`
+
+## 4) What is working
+- `WalletStateStorageBoundary.store_state` stores valid wallet state and increments deterministic per-wallet revision numbers.
+- Deterministic failure contracts are implemented for inactive wallet and invalid state conditions.
+- Focused tests prove deterministic success and failure behavior for the single named runtime surface.
+- No plaintext secret output or wallet lifecycle claim inflation was introduced.
+
+## 5) Known issues
+- State storage is intentionally narrow and in-memory only; persistence, orchestration, and rotation flows remain excluded.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- Validation Tier: **STANDARD**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletStateStorageBoundary.store_state` only**
+- Not in Scope: **rotation/vault/orchestration/portfolio/scheduler/settlement automation and broader runtime lifecycle integration**
+- Suggested Next Step: **COMMANDER review required before merge (auto PR review optional support)**
+
+---
+
+## Validation declaration
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateStorageBoundary.store_state` only
+- Not in Scope: secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-15 20:52 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** expand wallet lifecycle foundation to wallet state/storage boundary on one named runtime surface  
+**Branch:** `feature/core-wallet-state-storage-boundary-20260415`

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md
@@ -63,7 +63,7 @@
 2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`
 3. `find . -type d -name 'phase*'`
 
-**Report Timestamp:** 2026-04-15 21:16 (Asia/Jakarta)  
+**Report Timestamp:** 2026-04-15 21:29 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
 **Task:** final PR #524 branch traceability sync for PROJECT_STATE/report surfaces (no runtime logic expansion)  
-**Branch:** `feature/core-wallet-state-storage-boundary-20260415`
+**Branch:** `feature/extend-wallet-lifecycle-to-state-storage-boundary-2026-04-15`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py
@@ -77,3 +77,59 @@ def test_phase6_5_2_blocks_invalid_wallet_state_snapshot() -> None:
     assert result.state_stored is False
     assert result.stored_revision is None
     assert result.notes == {"state_error": "available_balance_negative"}
+
+
+def test_phase6_5_2_blocks_bool_numeric_fields_in_state_snapshot() -> None:
+    boundary = WalletStateStorageBoundary()
+    bool_balance_policy = WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": True,
+            "nonce": 1,
+        },
+    )
+    bool_nonce_policy = WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": 25.0,
+            "nonce": False,
+        },
+    )
+
+    balance_result = boundary.store_state(bool_balance_policy)
+    nonce_result = boundary.store_state(bool_nonce_policy)
+
+    assert balance_result.success is False
+    assert balance_result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_INVALID_STATE
+    assert balance_result.notes == {"state_error": "available_balance_invalid_type"}
+    assert nonce_result.success is False
+    assert nonce_result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_INVALID_STATE
+    assert nonce_result.notes == {"state_error": "nonce_invalid"}
+
+
+def test_phase6_5_2_blocks_nan_available_balance() -> None:
+    boundary = WalletStateStorageBoundary()
+    policy = WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": float("nan"),
+            "nonce": 2,
+        },
+    )
+
+    result = boundary.store_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_INVALID_STATE
+    assert result.state_stored is False
+    assert result.stored_revision is None
+    assert result.notes == {"state_error": "available_balance_nan"}

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_STORAGE_BLOCK_INVALID_STATE,
+    WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _base_policy() -> WalletStateStoragePolicy:
+    return WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": 125.50,
+            "nonce": 3,
+        },
+    )
+
+
+def test_phase6_5_2_wallet_state_storage_success_is_deterministic() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result_first = boundary.store_state(_base_policy())
+    result_second = boundary.store_state(_base_policy())
+
+    assert result_first.success is True
+    assert result_first.blocked_reason is None
+    assert result_first.state_stored is True
+    assert result_first.stored_revision == 1
+    assert result_second.success is True
+    assert result_second.state_stored is True
+    assert result_second.stored_revision == 2
+
+
+def test_phase6_5_2_blocks_inactive_wallet_state_storage() -> None:
+    boundary = WalletStateStorageBoundary()
+    policy = WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=False,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": 20.0,
+            "nonce": 1,
+        },
+    )
+
+    result = boundary.store_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_stored is False
+    assert result.stored_revision is None
+
+
+def test_phase6_5_2_blocks_invalid_wallet_state_snapshot() -> None:
+    boundary = WalletStateStorageBoundary()
+    policy = WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-2",
+        owner_user_id="user-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": -1.0,
+            "nonce": 1,
+        },
+    )
+
+    result = boundary.store_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_INVALID_STATE
+    assert result.state_stored is False
+    assert result.stored_revision is None
+    assert result.notes == {"state_error": "available_balance_negative"}


### PR DESCRIPTION
### Motivation
- Extend the wallet lifecycle foundation by adding the next narrow boundary focused solely on deterministic wallet state/storage handling without introducing rotation, vaults, orchestration, or multi-wallet concerns. 
- Define a precise, testable contract for valid and invalid wallet state conditions and ensure no plaintext secret exposure or claim inflation is introduced.

### Description
- Added `WalletStateStoragePolicy` and `WalletStateStorageResult` dataclasses and implemented `WalletStateStorageBoundary.store_state` that validates contract input, enforces `wallet_active`, validates `state_snapshot`, and stores an in-memory per-wallet revision deterministically. 
- Implemented deterministic block reasons: `invalid_contract`, `wallet_not_active`, and `invalid_state`, and deterministic success behavior that returns `stored_revision` and safe metadata only. 
- Updated `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, added tests at `projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py`, created the FORGE-X report `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_2_wallet_state_storage_boundary.md`, and updated `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 6.5.2 scope. 
- Declared `Validation Tier: STANDARD` and `Claim Level: NARROW INTEGRATION` for the single named runtime surface `WalletStateStorageBoundary.store_state` (COMMANDER review required before merge).

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py` and it completed without errors. 
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_1_wallet_lifecycle_secret_loading_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py` and all tests passed (`7 passed`) with a single non-runtime `pytest` config warning about `asyncio_mode`. 
- Additional validation commands (`find . -type d -name 'phase*'`) were executed as recorded in the FORGE-X report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df97be15648325b1ce98600ba83f9f)