### PR TITLE
feat(wallet): add Phase 6.5.3 wallet state read boundary (WalletStateReadBoundary)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 08:10
-🔄 Status       : Phase 6.5.3 wallet state retrieval/read boundary is implemented at narrow scope on the wallet auth lifecycle foundation surface and is now ready for COMMANDER STANDARD review.
+📅 Last Updated : 2026-04-16 08:22
+🔄 Status       : Phase 6.5.3 wallet state retrieval/read boundary implementation remains open on replacement branch feature/core-wallet-state-read-boundary-20260416 and is pending COMMANDER STANDARD review.
 
 ✅ COMPLETED
 - AGENTS.md FORGE-X pre-flight checklist patched with 4 branch-drift guard checks inserted immediately after forge report path check line (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -11,10 +11,11 @@
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
 - Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.5.3 wallet lifecycle state retrieval/read boundary is now implemented at narrow integration scope via WalletStateReadBoundary.read_state complementing WalletStateStorageBoundary.store_state (COMMANDER review pending).
+- Phase 6.5.2 wallet lifecycle state/storage boundary contract is merged-main accepted truth (done) via PR #524 at WalletStateStorageBoundary.store_state, preserving narrow-scope exclusions.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.3 wallet lifecycle state retrieval/read boundary implementation is complete in code on branch feature/core-wallet-state-read-boundary-20260416, but remains in-progress until replacement PR review and merge.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-15 23:36
-🔄 Status       : Post-merge PROJECT_STATE sync completed for the merged branch-drift guard doc patch; next-task gate is now clean for forward execution.
+📅 Last Updated : 2026-04-16 08:10
+🔄 Status       : Phase 6.5.3 wallet state retrieval/read boundary is implemented at narrow scope on the wallet auth lifecycle foundation surface and is now ready for COMMANDER STANDARD review.
 
 ✅ COMPLETED
 - AGENTS.md FORGE-X pre-flight checklist patched with 4 branch-drift guard checks inserted immediately after forge report path check line (Validation Tier: MINOR, Claim Level: FOUNDATION).
@@ -11,7 +11,7 @@
 - Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
 - Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
 - Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.5.2 wallet lifecycle state/storage boundary contract is merged-main accepted truth (done) via PR #524 at WalletStateStorageBoundary.store_state, preserving narrow-scope exclusions (no rotation, vault integration, multi-wallet orchestration, portfolio rollout, scheduler generalization, or settlement automation).
+- Phase 6.5.3 wallet lifecycle state retrieval/read boundary is now implemented at narrow integration scope via WalletStateReadBoundary.read_state complementing WalletStateStorageBoundary.store_state (COMMANDER review pending).
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
@@ -24,7 +24,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- Phase 6.5.3 wallet state retrieval / read boundary implementation and integration handoff prep (Validation Tier: STANDARD) as the next valid work item after this sync.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -14,6 +14,10 @@ WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
 WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_STORAGE_BLOCK_INVALID_STATE = "invalid_state"
+WALLET_STATE_READ_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND = "state_not_found"
+WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 
 
 @dataclass(frozen=True)
@@ -176,6 +180,7 @@ class WalletStateStorageBoundary:
         next_revision = 1 if prior_record is None else int(prior_record["revision"]) + 1
         self._store[policy.wallet_binding_id] = {
             "revision": next_revision,
+            "owner_user_id": policy.owner_user_id,
             "state_snapshot": dict(policy.state_snapshot),
         }
 
@@ -189,6 +194,92 @@ class WalletStateStorageBoundary:
             notes={"stored_keys": sorted(policy.state_snapshot.keys())},
         )
 
+    def read_stored_record(self, wallet_binding_id: str) -> dict[str, Any] | None:
+        stored_record = self._store.get(wallet_binding_id)
+        if stored_record is None:
+            return None
+        return {
+            "revision": int(stored_record["revision"]),
+            "owner_user_id": str(stored_record["owner_user_id"]),
+            "state_snapshot": dict(stored_record["state_snapshot"]),
+        }
+
+
+@dataclass(frozen=True)
+class WalletStateReadPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateReadResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_found: bool
+    stored_revision: int | None
+    state_snapshot: dict[str, Any] | None
+    notes: dict[str, Any] | None = None
+
+
+class WalletStateReadBoundary:
+    """Phase 6.5.3 narrow wallet lifecycle boundary: wallet state retrieval contract only."""
+
+    def __init__(self, state_storage_boundary: WalletStateStorageBoundary) -> None:
+        self._state_storage_boundary = state_storage_boundary
+
+    def read_state(self, policy: WalletStateReadPolicy) -> WalletStateReadResult:
+        contract_error = _validate_state_read_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        state_record = self._state_storage_boundary.read_stored_record(policy.wallet_binding_id)
+        if state_record is None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+                notes={"wallet_binding_id": policy.wallet_binding_id},
+            )
+
+        if state_record.get("owner_user_id") != policy.owner_user_id:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        return WalletStateReadResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_found=True,
+            stored_revision=int(state_record["revision"]),
+            state_snapshot=dict(state_record["state_snapshot"]),
+            notes={"stored_keys": sorted(state_record["state_snapshot"].keys())},
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -199,6 +290,18 @@ def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | No
         return "wallet_active_must_be_bool"
     if not isinstance(policy.state_snapshot, dict):
         return "state_snapshot_must_be_dict"
+    return None
+
+
+def _validate_state_read_policy(policy: WalletStateReadPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
     return None
 
 
@@ -243,5 +346,23 @@ def _blocked_state_storage_result(
         owner_user_id=policy.owner_user_id,
         state_stored=False,
         stored_revision=None,
+        notes=notes,
+    )
+
+
+def _blocked_state_read_result(
+    *,
+    policy: WalletStateReadPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateReadResult:
+    return WalletStateReadResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_found=False,
+        stored_revision=None,
+        state_snapshot=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
@@ -26,10 +26,10 @@
 - Narrow integration remains limited to the named read path on wallet auth lifecycle foundation surfaces; no broader lifecycle rollout is claimed.
 
 ## 3) Files created / modified (full paths)
-- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
-- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
-- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`
-- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+- Modified: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`
+- Modified: `PROJECT_STATE.md`
 
 ## 4) What is working
 - Explicit read boundary exists and is callable through `WalletStateReadBoundary.read_state`.
@@ -65,4 +65,4 @@
 **Report Timestamp:** 2026-04-16 08:10 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
 **Task:** phase-6-5-3-wallet-state-read-boundary  
-**Branch:** `work`
+**Branch:** `feature/core-wallet-state-read-boundary-20260416`

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
@@ -1,0 +1,68 @@
+# FORGE-X Report — Phase 6.5.3 Wallet State Retrieval/Read Boundary Narrow Integration
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateReadBoundary.read_state` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` only.  
+**Not in Scope:** secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broader wallet full-runtime lifecycle claims, unrelated refactors.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review optional if useful. Source: `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Added an explicit read-side boundary contract for wallet state retrieval that complements the existing store-side boundary foundation.
+- Introduced one new narrow runtime surface: `WalletStateReadBoundary.read_state`.
+- Added read contract policies/results for deterministic wallet state retrieval outcomes:
+  - valid active owner request + stored state exists => deterministic success with revision + snapshot,
+  - inactive wallet => deterministic block `wallet_not_active`,
+  - missing stored state => deterministic block `state_not_found`,
+  - requestor ownership mismatch or stored owner mismatch => deterministic block `ownership_mismatch`,
+  - invalid read contract => deterministic block `invalid_contract`.
+- Extended storage record payload to persist `owner_user_id` alongside revision + snapshot so read boundary ownership checks can stay explicit and deterministic.
+
+## 2) Current system architecture
+- `WalletSecretLoader.load_secret` remains unchanged as the 6.5.1 narrow secret-loading surface.
+- `WalletStateStorageBoundary.store_state` remains the 6.5.2 write/store boundary and now stores `owner_user_id` in each stored wallet record.
+- `WalletStateReadBoundary.read_state` is now the explicit 6.5.3 read boundary contract and reads through the storage boundary by calling `WalletStateStorageBoundary.read_stored_record`.
+- Narrow integration remains limited to the named read path on wallet auth lifecycle foundation surfaces; no broader lifecycle rollout is claimed.
+
+## 3) Files created / modified (full paths)
+- Modified: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+- Created: `/workspace/walker-ai-team/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`
+- Modified: `/workspace/walker-ai-team/PROJECT_STATE.md`
+
+## 4) What is working
+- Explicit read boundary exists and is callable through `WalletStateReadBoundary.read_state`.
+- Read path returns deterministic success with copied snapshot and stored revision when contract + activity + ownership + stored state constraints pass.
+- Deterministic block contracts are enforced for inactive wallet, state missing, invalid read policy, and ownership mismatch conditions.
+- Focused tests for the new read boundary behavior pass with zero failures.
+
+## 5) Known issues
+- Wallet lifecycle integration remains intentionally narrow and foundation-scoped to explicit secret-load/store/read boundaries only; rotation, vault integration, orchestration, and portfolio rollout remain excluded.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- Validation Tier: **STANDARD**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletStateReadBoundary.read_state` on wallet auth lifecycle surface only**
+- Not in Scope: **secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broader full-runtime lifecycle claims, unrelated refactors**
+- Suggested Next Step: **COMMANDER review required before merge (auto PR review optional support)**
+
+---
+
+## Validation declaration
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: Wallet state retrieval/read boundary on the named wallet auth lifecycle surface only
+- Not in Scope: secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broader full-runtime lifecycle claims, unrelated refactors
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-16 08:10 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** phase-6-5-3-wallet-state-read-boundary  
+**Branch:** `work`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+    WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateReadBoundary,
+    WalletStateReadPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _storage_policy() -> WalletStateStoragePolicy:
+    return WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": 210.75,
+            "nonce": 4,
+        },
+    )
+
+
+def _read_policy() -> WalletStateReadPolicy:
+    return WalletStateReadPolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-1",
+        requested_by_user_id="owner-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_3_reads_stored_wallet_state_through_boundary() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+    storage_boundary.store_state(_storage_policy())
+
+    result = read_boundary.read_state(_read_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.state_found is True
+    assert result.stored_revision == 1
+    assert result.state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 210.75,
+        "nonce": 4,
+    }
+
+
+def test_phase6_5_3_blocks_read_when_wallet_not_active() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+    policy = WalletStateReadPolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-1",
+        requested_by_user_id="owner-1",
+        wallet_active=False,
+    )
+
+    result = read_boundary.read_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_found is False
+    assert result.stored_revision is None
+
+
+def test_phase6_5_3_blocks_read_when_state_not_found() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+
+    result = read_boundary.read_state(_read_policy())
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND
+    assert result.state_found is False
+    assert result.state_snapshot is None
+
+
+def test_phase6_5_3_blocks_read_on_requestor_ownership_mismatch() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+    storage_boundary.store_state(_storage_policy())
+    policy = WalletStateReadPolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-1",
+        requested_by_user_id="owner-2",
+        wallet_active=True,
+    )
+
+    result = read_boundary.read_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_found is False
+    assert result.state_snapshot is None
+
+
+def test_phase6_5_3_blocks_read_when_stored_owner_differs() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+    storage_boundary.store_state(_storage_policy())
+    policy = WalletStateReadPolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-2",
+        requested_by_user_id="owner-2",
+        wallet_active=True,
+    )
+
+    result = read_boundary.read_state(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_found is False
+    assert result.state_snapshot is None


### PR DESCRIPTION
### Motivation
- Provide an explicit read-side wallet lifecycle boundary so persisted wallet auth state can be retrieved through a deterministic contract that complements the existing store-side boundary.  
- Keep the work narrowly scoped to the read retrieval surface only (STANDARD / NARROW INTEGRATION) and preserve existing exclusions (no rotation, vault, orchestration, portfolio, scheduler, or settlement changes).  
- Deliver a testable, deterministic contract so downstream validation and COMMANDER review can proceed without expanding runtime claims.

### Description
- Added read-side constants, dataclasses, and the `WalletStateReadBoundary.read_state` contract in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.  
- Extended `WalletStateStorageBoundary` to persist `owner_user_id`, exposed `read_stored_record` for explicit boundary-to-boundary reads, and added helper validation `_validate_state_read_policy`.  
- Added focused tests in `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` covering success, inactive-wallet block, missing-state block, requestor ownership mismatch, and stored-owner mismatch.  
- Created the FORGE report at `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md` and updated `PROJECT_STATE.md` to reflect the new in-progress/completed truth and next gate (COMMANDER review, STANDARD).

### Testing
- Ran compile check with `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` which succeeded.  
- Ran unit tests with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` which returned `10 passed, 1 warning` (the warning is a deferred pytest config hygiene note).  
- Ran repository check `find . -type d -name 'phase*'` as part of validation commands which completed without unexpected phase* directories.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e036906bc88325823dcbb12e3b0eac)