### PR TITLE
Recreate Phase 6.5.3 wallet state read boundary on compliant branch

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,21 +1,18 @@
-📅 Last Updated : 2026-04-16 00:00
-🔄 Status       : AGENTS.md patched with 4 insertions: extended area list, area/date rules, repo-root path format check, and Codex worktree branch name fallback rule (Validation Tier: MINOR, Claim Level: FOUNDATION).
+📅 Last Updated : 2026-04-16 08:32
+🔄 Status       : Phase 6.5.3 wallet state read boundary has been recreated on compliant branch `feature/core-wallet-state-read-boundary-20260416` with replacement PR pending COMMANDER review after prior PR #528 closure.
 
 ✅ COMPLETED
-- AGENTS.md patched with PATCH 1 (extended areas + area/date rules after briefer), PATCH 2A (repo-root path format check in pre-flight checklist), PATCH 2B (repo-root path definition in GLOBAL HARD RULES), PATCH 3 (Codex worktree branch fallback rule) — Validation Tier: MINOR, Claim Level: FOUNDATION.
-- AGENTS.md FORGE-X pre-flight checklist patched with 4 branch-drift guard checks inserted immediately after forge report path check line (Validation Tier: MINOR, Claim Level: FOUNDATION).
-- docs/commander_knowledge.md PRE-REVIEW DRIFT CHECK patched with 3 branch-drift guard checks inserted immediately after report-claims line (Validation Tier: MINOR, Claim Level: FOUNDATION).
-- Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
+- AGENTS.md branch/path drift guard updates from PR #529 remain merged truth.
+- Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and validated.
 - Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory records.
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
-- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.4.4 gateway-path monitoring narrow integration expansion merged via PR #493 with SENTINEL validation path recorded in PR #495 (97/100).
-- Phase 6.4.5 exchange-path monitoring narrow integration merged after PR #497 and PR #498 with accepted four-path runtime baseline.
-- Phase 6.4.8 settlement-boundary monitoring narrow integration merged with accepted seven-path runtime baseline by adding FundSettlementEngine.settle_with_trace.
-- Phase 6.5.2 wallet lifecycle state/storage boundary contract is merged-main accepted truth (done) via PR #524 at WalletStateStorageBoundary.store_state, preserving narrow-scope exclusions (no rotation, vault integration, multi-wallet orchestration, portfolio rollout, scheduler generalization, or settlement automation).
+- Phase 6.4.3 through 6.4.10 narrow monitoring boundary integrations merged in accepted scoped slices.
+- Phase 6.5.1 wallet secret-loading contract merged as narrow integration.
+- Phase 6.5.2 wallet lifecycle state/storage boundary contract merged via PR #524 and remains accepted truth.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.3 wallet state read boundary replacement PR is open on `feature/core-wallet-state-read-boundary-20260416`; merge pending COMMANDER review.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,7 +22,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review of AGENTS.md diff — confirm all 4 patches landed at correct positions with no existing content altered; merge after confirmation (Validation Tier: MINOR, SENTINEL not required).
+- COMMANDER review required before merge on replacement PR for Phase 6.5.3 from `feature/core-wallet-state-read-boundary-20260416`. Source: reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
@@ -35,6 +32,5 @@
 - Phase 5.6 introduces first real settlement boundary only; still single-shot with no retry, batching, async automation, or portfolio lifecycle management.
 - Phase 6.1 introduces in-memory execution ledger and read-only reconciliation only; no external persistence, correction logic, or background automation are implemented.
 - Phase 6.2 introduces append-only local-file persistent ledger and audit trail query only; no mutation or correction logic, background automation, or external DB are implemented.
-- Phase 6.3 introduces deterministic kill-switch halt state control only; runtime orchestration wiring and selective scope routing remain intentionally out of scope.
 - Phase 6.4 narrow monitoring remains intentionally scoped to execution-adjacent paths only and explicitly excludes platform-wide monitoring rollout, scheduler generalization, wallet lifecycle expansion, portfolio orchestration, and settlement automation.
 - [DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning — carried forward as non-runtime hygiene backlog.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -14,6 +14,10 @@ WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
 WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_STORAGE_BLOCK_INVALID_STATE = "invalid_state"
+WALLET_STATE_READ_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND = "state_not_found"
 
 
 @dataclass(frozen=True)
@@ -142,6 +146,26 @@ class WalletStateStorageResult:
     notes: dict[str, Any] | None = None
 
 
+@dataclass(frozen=True)
+class WalletStateReadPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateReadResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_read: bool
+    stored_revision: int | None
+    state_snapshot: dict[str, Any] | None
+    notes: dict[str, Any] | None = None
+
+
 class WalletStateStorageBoundary:
     """Phase 6.5.2 narrow wallet lifecycle boundary: wallet state/storage contract only."""
 
@@ -175,6 +199,7 @@ class WalletStateStorageBoundary:
         prior_record = self._store.get(policy.wallet_binding_id)
         next_revision = 1 if prior_record is None else int(prior_record["revision"]) + 1
         self._store[policy.wallet_binding_id] = {
+            "owner_user_id": policy.owner_user_id,
             "revision": next_revision,
             "state_snapshot": dict(policy.state_snapshot),
         }
@@ -187,6 +212,75 @@ class WalletStateStorageBoundary:
             state_stored=True,
             stored_revision=next_revision,
             notes={"stored_keys": sorted(policy.state_snapshot.keys())},
+        )
+
+    def read_state_record(
+        self,
+        *,
+        wallet_binding_id: str,
+        owner_user_id: str,
+    ) -> dict[str, Any] | None:
+        record = self._store.get(wallet_binding_id)
+        if record is None:
+            return None
+        if record.get("owner_user_id") != owner_user_id:
+            return None
+        return {
+            "owner_user_id": str(record["owner_user_id"]),
+            "revision": int(record["revision"]),
+            "state_snapshot": dict(record["state_snapshot"]),
+        }
+
+
+class WalletStateReadBoundary:
+    """Phase 6.5.3 narrow wallet lifecycle boundary: wallet state read contract only."""
+
+    def __init__(self, state_storage: WalletStateStorageBoundary) -> None:
+        self._state_storage = state_storage
+
+    def read_state(self, policy: WalletStateReadPolicy) -> WalletStateReadResult:
+        contract_error = _validate_state_read_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        state_record = self._state_storage.read_state_record(
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+        )
+        if state_record is None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+                notes={"wallet_binding_id": policy.wallet_binding_id},
+            )
+
+        return WalletStateReadResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_read=True,
+            stored_revision=state_record["revision"],
+            state_snapshot=dict(state_record["state_snapshot"]),
+            notes={"available_keys": sorted(state_record["state_snapshot"].keys())},
         )
 
 
@@ -243,5 +337,35 @@ def _blocked_state_storage_result(
         owner_user_id=policy.owner_user_id,
         state_stored=False,
         stored_revision=None,
+        notes=notes,
+    )
+
+
+def _validate_state_read_policy(policy: WalletStateReadPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_state_read_result(
+    *,
+    policy: WalletStateReadPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateReadResult:
+    return WalletStateReadResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_read=False,
+        stored_revision=None,
+        state_snapshot=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
@@ -1,0 +1,65 @@
+# FORGE-X Report — Phase 6.5.3 Wallet State Read Boundary Replacement PR
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateReadBoundary.read_state` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` on the wallet auth lifecycle foundation surface only.  
+**Not in Scope:** secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broader wallet full-runtime lifecycle claims, unrelated refactors, or runtime behavior beyond the reviewed 6.5.3 slice.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Source: `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+- Recreated the Phase 6.5.3 wallet state read boundary implementation on a branch-compliant replacement path.
+- Added the narrow read contract for `WalletStateReadBoundary.read_state` with policy/result dataclasses and deterministic block reasons.
+- Added an ownership-aware storage read path (`WalletStateStorageBoundary.read_state_record`) so read access only returns records where wallet binding and owner match.
+- Added focused 6.5.3 tests covering success and deterministic blocks for ownership mismatch, inactive wallet, and missing/owner-mismatched state.
+
+## 2) Current system architecture
+- Wallet lifecycle foundation remains narrow and isolated in `platform/wallet_auth`.
+- Contract surfaces now include:
+  - `WalletStateStorageBoundary.store_state` for deterministic revisioned writes.
+  - `WalletStateStorageBoundary.read_state_record` for owner-bound lookup.
+  - `WalletStateReadBoundary.read_state` for policy-gated read behavior over the storage boundary.
+- No expansion into full runtime wallet orchestration, rotation flows, settlement automation, or portfolio lifecycle behavior.
+
+## 3) Files created / modified (full paths)
+- Modified: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- Created: `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4) What is working
+- `WalletStateReadBoundary.read_state` returns deterministic success for matching owner/requester on an active wallet when a stored state exists.
+- Read path blocks deterministically on ownership mismatch, inactive wallets, and missing owner-bound state records.
+- Storage path remains revisioned and now stores owner metadata required for ownership-aware reads.
+- Focused 6.5.3 tests pass for the declared boundary-only behavior.
+
+## 5) Known issues
+- Wallet lifecycle remains intentionally narrow; secret rotation, vault integration, multi-wallet orchestration, and portfolio rollout are still out of scope.
+- Existing deferred warning remains: pytest config `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+- Validation Tier: **STANDARD**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletStateReadBoundary.read_state` on wallet auth lifecycle foundation only**
+- Not in Scope: **full wallet lifecycle runtime integration and automation surfaces**
+- Suggested Next Step: **COMMANDER review on replacement PR from `feature/core-wallet-state-read-boundary-20260416`**
+
+---
+
+## Validation declaration
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateReadBoundary.read_state` on wallet auth lifecycle foundation only
+- Not in Scope: full wallet runtime lifecycle claims and unrelated refactors
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-16 08:30 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** recreate-phase-6-5-3-on-compliant-branch  
+**Branch:** `feature/core-wallet-state-read-boundary-20260416`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+    WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateReadBoundary,
+    WalletStateReadPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _seed_state(storage: WalletStateStorageBoundary) -> None:
+    result = storage.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 101.25,
+                "nonce": 8,
+            },
+        )
+    )
+    assert result.success is True
+
+
+def test_phase6_5_3_wallet_state_read_success_for_owner() -> None:
+    storage = WalletStateStorageBoundary()
+    _seed_state(storage)
+    boundary = WalletStateReadBoundary(storage)
+
+    result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.state_read is True
+    assert result.stored_revision == 1
+    assert result.state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 101.25,
+        "nonce": 8,
+    }
+
+
+def test_phase6_5_3_wallet_state_read_blocks_non_owner() -> None:
+    storage = WalletStateStorageBoundary()
+    _seed_state(storage)
+    boundary = WalletStateReadBoundary(storage)
+
+    result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_read is False
+    assert result.stored_revision is None
+
+
+def test_phase6_5_3_wallet_state_read_blocks_inactive_wallet() -> None:
+    storage = WalletStateStorageBoundary()
+    _seed_state(storage)
+    boundary = WalletStateReadBoundary(storage)
+
+    result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_read is False
+
+
+def test_phase6_5_3_wallet_state_read_blocks_unknown_wallet_or_owner() -> None:
+    storage = WalletStateStorageBoundary()
+    _seed_state(storage)
+    boundary = WalletStateReadBoundary(storage)
+
+    unknown_wallet_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-missing",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    wrong_owner_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-2",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        )
+    )
+
+    assert unknown_wallet_result.success is False
+    assert unknown_wallet_result.blocked_reason == WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND
+    assert wrong_owner_result.success is False
+    assert wrong_owner_result.blocked_reason == WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND


### PR DESCRIPTION
### Motivation
- Reapply the Phase 6.5.3 wallet state read boundary on a branch-compliant replacement to remove branch and traceability drift while preserving the existing narrow runtime implementation.

### Description
- Added `WalletStateReadPolicy` and `WalletStateReadResult` dataclasses and implemented `WalletStateReadBoundary.read_state` with deterministic block reasons and ownership/activation guards in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.
- Extended `WalletStateStorageBoundary` to persist `owner_user_id` and added `read_state_record` owner-aware lookup to support authorization-aware reads.
- Created focused tests at `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`, added the forge report `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md`, and updated `PROJECT_STATE.md` to reflect the replacement-PR state.
- Changes were committed on branch `feature/core-wallet-state-read-boundary-20260416` and a replacement PR was opened from that branch (PR numeric ID could not be retrieved from this environment).

### Testing
- Ran `python -m py_compile` for the changed files and it passed with no compile errors.
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py`, which returned `4 passed` and one non-blocking pytest config warning about `asyncio_mode`.
- Verified presence of phase directories with `find . -type d -name 'phase*'` as requested.
- Attempted to query GitHub CLI for the PR ID but the environment is unauthenticated so the numeric PR ID could not be retrieved here; please confirm the PR number remotely.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03bcb02088325b6b38f834acdc01b)