### PR TITLE
Recreate Phase 6.5.3 wallet state read boundary on compliant branch

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 00:00
-🔄 Status       : AGENTS.md patched with 4 insertions: extended area list, area/date rules, repo-root path format check, and Codex worktree branch name fallback rule (Validation Tier: MINOR, Claim Level: FOUNDATION).
+📅 Last Updated : 2026-04-16 08:43
+🔄 Status       : Phase 6.5.3 wallet state read boundary replacement PR is open from feature/core-wallet-state-read-boundary-20260416 after PR #530 was closed; pending COMMANDER review (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION).
 
 ✅ COMPLETED
 - AGENTS.md patched with PATCH 1 (extended areas + area/date rules after briefer), PATCH 2A (repo-root path format check in pre-flight checklist), PATCH 2B (repo-root path definition in GLOBAL HARD RULES), PATCH 3 (Codex worktree branch fallback rule) — Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -16,6 +16,7 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.3 wallet state read boundary replacement PR is open from feature/core-wallet-state-read-boundary-20260416; PR #530 is closed and superseded, pending COMMANDER review.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,7 +26,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review of AGENTS.md diff — confirm all 4 patches landed at correct positions with no existing content altered; merge after confirmation (Validation Tier: MINOR, SENTINEL not required).
+- COMMANDER review of replacement PR from feature/core-wallet-state-read-boundary-20260416 for Phase 6.5.3 wallet state read boundary narrow integration (Validation Tier: STANDARD, SENTINEL not required unless reclassified MAJOR).
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -14,6 +14,10 @@ WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
 WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_STORAGE_BLOCK_INVALID_STATE = "invalid_state"
+WALLET_STATE_READ_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND = "state_not_found"
 
 
 @dataclass(frozen=True)
@@ -175,6 +179,7 @@ class WalletStateStorageBoundary:
         prior_record = self._store.get(policy.wallet_binding_id)
         next_revision = 1 if prior_record is None else int(prior_record["revision"]) + 1
         self._store[policy.wallet_binding_id] = {
+            "owner_user_id": policy.owner_user_id,
             "revision": next_revision,
             "state_snapshot": dict(policy.state_snapshot),
         }
@@ -188,6 +193,22 @@ class WalletStateStorageBoundary:
             stored_revision=next_revision,
             notes={"stored_keys": sorted(policy.state_snapshot.keys())},
         )
+
+    def read_state_record(
+        self,
+        *,
+        wallet_binding_id: str,
+        owner_user_id: str,
+    ) -> dict[str, Any] | None:
+        record = self._store.get(wallet_binding_id)
+        if record is None:
+            return None
+        if record.get("owner_user_id") != owner_user_id:
+            return None
+        return {
+            "revision": int(record["revision"]),
+            "state_snapshot": dict(record["state_snapshot"]),
+        }
 
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
@@ -242,6 +263,108 @@ def _blocked_state_storage_result(
         wallet_binding_id=policy.wallet_binding_id,
         owner_user_id=policy.owner_user_id,
         state_stored=False,
+        stored_revision=None,
+        notes=notes,
+    )
+
+
+@dataclass(frozen=True)
+class WalletStateReadPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateReadResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_read: bool
+    state_snapshot: dict[str, Any] | None
+    stored_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+class WalletStateReadBoundary:
+    """Phase 6.5.3 narrow wallet lifecycle boundary: wallet state read contract only."""
+
+    def __init__(self, storage_boundary: WalletStateStorageBoundary) -> None:
+        self._storage_boundary = storage_boundary
+
+    def read_state(self, policy: WalletStateReadPolicy) -> WalletStateReadResult:
+        contract_error = _validate_state_read_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        record = self._storage_boundary.read_state_record(
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+        )
+        if record is None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+                notes={"wallet_binding_id": policy.wallet_binding_id},
+            )
+
+        return WalletStateReadResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_read=True,
+            state_snapshot=dict(record["state_snapshot"]),
+            stored_revision=int(record["revision"]),
+            notes={"source": "wallet_state_storage_boundary"},
+        )
+
+
+def _validate_state_read_policy(policy: WalletStateReadPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_state_read_result(
+    *,
+    policy: WalletStateReadPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateReadResult:
+    return WalletStateReadResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_read=False,
+        state_snapshot=None,
         stored_revision=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
@@ -1,0 +1,41 @@
+# FORGE-X Report — Phase 6.5.3 Wallet State Read Boundary (Replacement PR)
+
+- Timestamp (Asia/Jakarta): 2026-04-16 08:43
+- Branch: feature/core-wallet-state-read-boundary-20260416
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateReadBoundary.read_state` on the wallet auth lifecycle foundation surface only
+- Not in Scope: Secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broader wallet full-runtime lifecycle claims, unrelated refactors, historical PROJECT_STATE cleanup, monitoring milestone rewrites, known-issue pruning outside direct 6.5.3 truth
+- Suggested Next Step: COMMANDER review for replacement PR approval/merge (auto PR review support optional baseline)
+
+## 1) What was built
+- Recreated the Phase 6.5.3 narrow runtime wallet state read boundary by adding `WalletStateReadBoundary.read_state` with strict contract validation, owner/requestor gate, active-wallet gate, and deterministic blocked-result paths.
+- Added supporting read policy/result contracts and read blocked-reason constants for stable behavior checks.
+- Added owner-aware storage read support in the existing state storage boundary so read access is constrained by `(wallet_binding_id, owner_user_id)`.
+- Added focused Phase 6.5.3 tests that cover success path and key blocked paths for ownership, inactive wallet state, and missing/wrong-owner state.
+
+## 2) Current system architecture
+- `WalletStateStorageBoundary` remains the write/read backing boundary for wallet lifecycle state snapshots in this narrow phase.
+- `WalletStateReadBoundary` is a narrow integration on top of storage that enforces access gates before returning stored snapshot + revision.
+- Read integration scope is limited to wallet auth lifecycle foundation surface only; no broader runtime wallet lifecycle orchestration is claimed.
+
+## 3) Files created / modified (full paths)
+- projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+- projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+- projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+- PROJECT_STATE.md
+
+## 4) What is working
+- `WalletStateReadBoundary.read_state` returns deterministic success result for valid owner request with active wallet and existing state record.
+- Reads are blocked on ownership mismatch between `requested_by_user_id` and `owner_user_id`.
+- Reads are blocked when wallet is inactive.
+- Reads return deterministic not-found block when no matching `(wallet_binding_id, owner_user_id)` state exists.
+- Focused Phase 6.5.3 test suite passes for the new read boundary slice.
+
+## 5) Known issues
+- This phase remains intentionally narrow integration only; no secret rotation, vault integration, multi-wallet orchestration, portfolio rollout, scheduler generalization, or settlement automation expansion is provided here.
+- Existing unrelated deferred/historical known issues remain unchanged and are not part of this replacement scope.
+
+## 6) What is next
+- Open replacement PR from `feature/core-wallet-state-read-boundary-20260416` to supersede closed PR #530 traceability-wise.
+- COMMANDER review gate for STANDARD tier remains required before merge.

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND,
+    WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateReadBoundary,
+    WalletStateReadPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _seed_wallet_state(boundary: WalletStateStorageBoundary) -> None:
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-owner",
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 100.0,
+                "nonce": 11,
+            },
+        )
+    )
+
+
+def _base_read_policy() -> WalletStateReadPolicy:
+    return WalletStateReadPolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="user-owner",
+        requested_by_user_id="user-owner",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_3_wallet_state_read_success_returns_stored_snapshot() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    _seed_wallet_state(storage_boundary)
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+
+    result = read_boundary.read_state(_base_read_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.state_read is True
+    assert result.stored_revision == 1
+    assert result.state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 100.0,
+        "nonce": 11,
+    }
+
+
+def test_phase6_5_3_wallet_state_read_blocks_owner_mismatch() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    _seed_wallet_state(storage_boundary)
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+
+    result = read_boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-owner",
+            requested_by_user_id="user-other",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_read is False
+    assert result.state_snapshot is None
+
+
+def test_phase6_5_3_wallet_state_read_blocks_inactive_wallet() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    _seed_wallet_state(storage_boundary)
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+
+    result = read_boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-owner",
+            requested_by_user_id="user-owner",
+            wallet_active=False,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_read is False
+    assert result.state_snapshot is None
+
+
+def test_phase6_5_3_wallet_state_read_blocks_missing_or_wrong_owner_state() -> None:
+    storage_boundary = WalletStateStorageBoundary()
+    _seed_wallet_state(storage_boundary)
+    read_boundary = WalletStateReadBoundary(storage_boundary)
+
+    wrong_owner_result = read_boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="user-other",
+            requested_by_user_id="user-other",
+            wallet_active=True,
+        )
+    )
+    missing_wallet_result = read_boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-missing",
+            owner_user_id="user-owner",
+            requested_by_user_id="user-owner",
+            wallet_active=True,
+        )
+    )
+
+    assert wrong_owner_result.success is False
+    assert wrong_owner_result.blocked_reason == WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND
+    assert missing_wallet_result.success is False
+    assert missing_wallet_result.blocked_reason == WALLET_STATE_READ_BLOCK_STATE_NOT_FOUND


### PR DESCRIPTION
### Motivation
- Restore the Phase 6.5.3 narrow runtime slice that provides an owner-aware, gate-enforced wallet state read surface on the exact branch `feature/core-wallet-state-read-boundary-20260416` while avoiding unrelated history or PROJECT_STATE rewrites.
- Preserve narrow-scope claims (read-only boundary, no rotation/vault/multi-wallet/portfolio orchestration) and provide focused tests and a matching FORGE report for traceable validation.

### Description
- Added read-blocking constants and owner-aware storage support by storing `owner_user_id` in `WalletStateStorageBoundary` and a `read_state_record(...)` accessor in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.
- Implemented `WalletStateReadPolicy`, `WalletStateReadResult`, and `WalletStateReadBoundary.read_state` with strict contract validation, ownership/requestor gate, active-wallet gate, deterministic blocked results, and not-found handling in `wallet_lifecycle_foundation.py`.
- Added focused tests `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` that exercise success, ownership mismatch, inactive wallet, and missing/wrong-owner scenarios.
- Created FORGE report at `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md` and applied the minimal-truth `PROJECT_STATE.md` update reflecting that PR #530 was closed and the replacement PR is open and pending COMMANDER review; all scoped changes were committed on branch `feature/core-wallet-state-read-boundary-20260416`.
- A replacement PR creation was executed, but the PR tool output did not return a numeric PR ID in this environment; the branch and report are present as required.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` and it completed with no syntax errors (passed).
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py` once and collection failed due to `ModuleNotFoundError: No module named 'projects'` (resolved by setting `PYTHONPATH=`.).
- Re-ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py` and all tests passed (`9 passed`) with one non-critical pytest config warning about `asyncio_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03e8757548325b4ecd913455416b7)