### PR TITLE
chore/core-commander-knowledge-branch-format-20260416: replace BRANCH FORMAT (FINAL) section with dual-format BRANCH FORMAT section (standard + Codex)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 11:00
-🔄 Status       : AGENTS.md patched with PATCH 1 (branch naming — purpose segment rules, wrong examples, hard no-dots/underscores rule) and PATCH 2 (PROJECT_STATE RULE — scope-bound update rule) (Validation Tier: MINOR, Claim Level: FOUNDATION).
+📅 Last Updated : 2026-04-16 12:00
+🔄 Status       : docs/commander_knowledge.md patched — ## BRANCH FORMAT (FINAL) replaced with ## BRANCH FORMAT (standard + Codex formats, traceability rule, COMMANDER task generation rule) (Validation Tier: MINOR, Claim Level: FOUNDATION).
 
 ✅ COMPLETED
 - AGENTS.md patched with PATCH 1 (extended areas + area/date rules after briefer), PATCH 2A (repo-root path format check in pre-flight checklist), PATCH 2B (repo-root path definition in GLOBAL HARD RULES), PATCH 3 (Codex worktree branch fallback rule) — Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -26,7 +26,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review of AGENTS.md diff — confirm PATCH 1 (branch naming purpose segment rules + wrong examples + hard no-dots/underscores rule) and PATCH 2 (scope-bound PROJECT_STATE update rule) landed at correct positions with no existing content altered; merge after confirmation (Validation Tier: MINOR, SENTINEL not required).
+- COMMANDER review of docs/commander_knowledge.md diff — confirm ## BRANCH FORMAT (FINAL) replaced cleanly with ## BRANCH FORMAT (standard + Codex formats) and no other content altered; merge after confirmation (Validation Tier: MINOR, SENTINEL not required).
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/docs/commander_knowledge.md
+++ b/docs/commander_knowledge.md
@@ -430,37 +430,50 @@ If SENTINEL reports broader findings outside declared task scope:
 
 ---
 
-## BRANCH FORMAT (FINAL)
+## BRANCH FORMAT
 
-{prefix}/{area}-{purpose}-{date}
+Two valid formats depending on execution environment:
 
-Prefixes:
-- feature/
-- fix/
-- update/
-- hotfix/
-- refactor/
-- chore/
+### Standard format (manual / non-Codex execution)
+{prefix}/{area}-{purpose}-{YYYYMMDD}
 
-Areas:
-- ui
-- ux
-- execution
-- risk
-- monitoring
-- data
-- infra
-- core
-- strategy
-- sentinel
-- briefer
+Prefixes: feature/ fix/ update/ hotfix/ refactor/ chore/
+Areas: ui, ux, execution, risk, monitoring, data, infra, core,
+       strategy, sentinel, briefer, wallet, lifecycle, signal,
+       pipeline, backtest, report
+Date: YYYYMMDD — no dashes, no dots
 
 Examples:
-- feature/execution-order-engine-20260406
-- fix/risk-drawdown-circuit-20260406
-- update/infra-redis-config-20260406
-- hotfix/execution-kill-switch-20260406
-- chore/briefer-investor-report-20260406
+- feature/wallet-state-read-boundary-20260416
+- fix/risk-drawdown-circuit-20260416
+- update/core-agents-naming-20260416
+
+### Codex format (tasks executed via Codex platform)
+feature/{area}-{purpose}-{YYYY-MM-DD}
+
+Rules for Codex tasks:
+- prefix is always feature/ — Codex does not support other prefixes
+- date uses YYYY-MM-DD with dashes — this is Codex platform default
+- area must still be a valid noun from the areas list above
+- purpose must still be short — max 4 words hyphen-separated
+- no dots anywhere — phase tokens use hyphens (phase-6-5-3 not 6.5.3)
+
+Examples:
+- feature/wallet-state-read-boundary-2026-04-16
+- feature/core-agents-branch-patch-2026-04-16
+- feature/risk-drawdown-circuit-2026-04-16
+
+### COMMANDER task generation rule
+When generating a task for Codex execution:
+- declare branch using Codex format in the Branch: field
+- do not use update/ fix/ chore/ prefixes — Codex will override to feature/
+- FORGE-X report and PROJECT_STATE must record the actual Codex branch,
+  not the declared standard format
+
+### Traceability rule
+Branch name in forge report must match actual PR head branch exactly.
+If Codex generates a different branch than declared → FORGE-X must
+update the report to reflect the actual branch, not the task declaration.
 
 ---
 


### PR DESCRIPTION
docs/commander_knowledge.md — ## BRANCH FORMAT (FINAL) replaced with
## BRANCH FORMAT covering standard (YYYYMMDD) and Codex (YYYY-MM-DD)
formats, COMMANDER task generation rule, and traceability rule.
PROJECT_STATE.md updated with scope-bound patch entry.

Validation Tier: MINOR
Claim Level: FOUNDATION

https://claude.ai/code/session_016MkDqn4cJA19rkgBuVsZvS