### PR TITLE
Phase 6.5.3: add owner-aware WalletStateReadBoundary and regression tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 12:00
-🔄 Status       : docs/commander_knowledge.md patched — ## BRANCH FORMAT (FINAL) replaced with ## BRANCH FORMAT (standard + Codex formats, traceability rule, COMMANDER task generation rule) (Validation Tier: MINOR, Claim Level: FOUNDATION).
+📅 Last Updated : 2026-04-16 19:37
+🔄 Status       : Phase 6.5.3 wallet state read boundary recreated on branch feature/core-wallet-state-read-boundary-20260416 with owner-aware storage/read contract and deterministic gates/results (Validation Tier: STANDARD, Claim Level: NARROW INTEGRATION).
 
 ✅ COMPLETED
 - AGENTS.md patched with PATCH 1 (extended areas + area/date rules after briefer), PATCH 2A (repo-root path format check in pre-flight checklist), PATCH 2B (repo-root path definition in GLOBAL HARD RULES), PATCH 3 (Codex worktree branch fallback rule) — Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -26,7 +26,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review of docs/commander_knowledge.md diff — confirm ## BRANCH FORMAT (FINAL) replaced cleanly with ## BRANCH FORMAT (standard + Codex formats) and no other content altered; merge after confirmation (Validation Tier: MINOR, SENTINEL not required).
+- COMMANDER review required before merge. Auto PR review support optional if used. Source: reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -14,7 +14,11 @@ WALLET_SECRET_LOAD_BLOCK_RUNTIME_ERROR = "runtime_error"
 WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_STORAGE_BLOCK_INVALID_STATE = "invalid_state"
-
+WALLET_STATE_STORAGE_BLOCK_OWNERSHIP_CONFLICT = "ownership_conflict"
+WALLET_STATE_READ_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_READ_BLOCK_NOT_FOUND = "not_found"
 
 @dataclass(frozen=True)
 class WalletSecretLoadPolicy:
@@ -242,6 +246,158 @@ def _blocked_state_storage_result(
         wallet_binding_id=policy.wallet_binding_id,
         owner_user_id=policy.owner_user_id,
         state_stored=False,
+        stored_revision=None,
+        notes=notes,
+    )
+
+
+@dataclass(frozen=True)
+class WalletStateReadPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateReadResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_found: bool
+    state_snapshot: dict[str, Any] | None
+    stored_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+class WalletStateReadBoundary:
+    """Phase 6.5.3 narrow wallet lifecycle boundary: owner-aware read contract only."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, Any]] = {}
+        self._wallet_owner_index: dict[str, str] = {}
+
+    def store_state(self, policy: WalletStateStoragePolicy) -> WalletStateStorageResult:
+        contract_error = _validate_state_storage_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        state_error = _validate_state_snapshot(policy.state_snapshot)
+        if state_error is not None:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_INVALID_STATE,
+                notes={"state_error": state_error},
+            )
+
+        existing_owner = self._wallet_owner_index.get(policy.wallet_binding_id)
+        if existing_owner is not None and existing_owner != policy.owner_user_id:
+            return _blocked_state_storage_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_STORAGE_BLOCK_OWNERSHIP_CONFLICT,
+                notes={"existing_owner_user_id": existing_owner},
+            )
+
+        scoped_key = (policy.wallet_binding_id, policy.owner_user_id)
+        prior_record = self._store.get(scoped_key)
+        next_revision = 1 if prior_record is None else int(prior_record["revision"]) + 1
+        self._wallet_owner_index[policy.wallet_binding_id] = policy.owner_user_id
+        self._store[scoped_key] = {
+            "revision": next_revision,
+            "state_snapshot": dict(policy.state_snapshot),
+        }
+
+        return WalletStateStorageResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_stored=True,
+            stored_revision=next_revision,
+            notes={"stored_keys": sorted(policy.state_snapshot.keys())},
+        )
+
+    def read_state(self, policy: WalletStateReadPolicy) -> WalletStateReadResult:
+        contract_error = _validate_state_read_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        scoped_key = (policy.wallet_binding_id, policy.owner_user_id)
+        stored_record = self._store.get(scoped_key)
+        if stored_record is None:
+            return _blocked_state_read_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BLOCK_NOT_FOUND,
+                notes={"lookup_key": policy.wallet_binding_id},
+            )
+
+        return WalletStateReadResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_found=True,
+            state_snapshot=dict(stored_record["state_snapshot"]),
+            stored_revision=int(stored_record["revision"]),
+            notes={"stored_keys": sorted(stored_record["state_snapshot"].keys())},
+        )
+
+
+def _validate_state_read_policy(policy: WalletStateReadPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_state_read_result(
+    *,
+    policy: WalletStateReadPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateReadResult:
+    return WalletStateReadResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_found=False,
+        state_snapshot=None,
         stored_revision=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
@@ -1,0 +1,46 @@
+# 25_42_phase6_5_3_wallet_state_read_boundary
+
+- Timestamp (Asia/Jakarta, UTC+7): 2026-04-16 19:35
+- Branch: feature/core-wallet-state-read-boundary-20260416
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py::WalletStateReadBoundary.read_state and its owner-aware storage/read contract
+- Not in Scope: secret rotation automation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation expansion, broad wallet lifecycle rollout
+- Suggested Next Step: COMMANDER review required before merge. Auto PR review support optional. Source: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md. Tier: STANDARD.
+
+## 1) What was built
+- Implemented a new owner-aware wallet state read boundary at `WalletStateReadBoundary` with deterministic contract validation, ownership/requestor gate, active-wallet gate, and not-found behavior.
+- Added owner-aware state write behavior inside `WalletStateReadBoundary.store_state` to prevent cross-owner overwrite when `wallet_binding_id` is already bound to a different owner.
+- Preserved merged-main accepted truth for Phase 6.5.2 storage boundary by leaving `WalletStateStorageBoundary.store_state` behavior unchanged.
+- Added focused regression tests for Phase 6.5.3 plus compatibility verification against Phase 6.5.2 tests.
+
+## 2) Current system architecture
+- `WalletStateStorageBoundary` remains the accepted Phase 6.5.2 storage contract (unchanged behavior).
+- `WalletStateReadBoundary` now provides the Phase 6.5.3 narrow read surface:
+  - Owner-scoped storage key: `(wallet_binding_id, owner_user_id)`.
+  - Owner index enforces one owner per wallet binding ID and rejects conflicting writes.
+  - `read_state` validates policy, requestor ownership, active-wallet status, and returns deterministic `not_found` when owner-scoped state does not exist.
+
+## 3) Files created / modified (full paths)
+- Modified: projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+- Created: projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+- Created: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+- Modified: PROJECT_STATE.md
+
+## 4) What is working
+- Owner-aware state storage/read contract works for same-owner write/read.
+- Cross-owner overwrite attempt for same `wallet_binding_id` is deterministically blocked with `ownership_conflict`.
+- Read boundary contract validation, ownership gate, active-wallet gate, and deterministic `not_found` behavior are covered by focused tests.
+- Existing 6.5.2 storage boundary tests continue to pass unchanged.
+
+## 5) Known issues
+- GitHub live PR head verification could not be performed from this environment (no `gh` CLI and outbound API tunnel blocked), so replacement-PR branch-head traceability cannot be independently confirmed here.
+
+## 6) What is next
+- COMMANDER review of scope-limited implementation/tests/report/state update.
+- If COMMANDER environment has GitHub access, verify live PR head branch equals `feature/core-wallet-state-read-boundary-20260416` before approving replacement PR runtime review.
+
+Report: projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md
+State: PROJECT_STATE.md updated
+Validation Tier: STANDARD
+Claim Level: NARROW INTEGRATION

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_READ_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_READ_BLOCK_NOT_FOUND,
+    WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE,
+    WALLET_STATE_STORAGE_BLOCK_OWNERSHIP_CONFLICT,
+    WalletStateReadBoundary,
+    WalletStateReadPolicy,
+    WalletStateStoragePolicy,
+)
+
+
+def _base_storage_policy() -> WalletStateStoragePolicy:
+    return WalletStateStoragePolicy(
+        wallet_binding_id="wb-phase6-5-3",
+        owner_user_id="owner-1",
+        wallet_active=True,
+        state_snapshot={
+            "wallet_status": "ready",
+            "available_balance": 100.0,
+            "nonce": 9,
+        },
+    )
+
+
+def test_phase6_5_3_owner_aware_store_and_read_success() -> None:
+    boundary = WalletStateReadBoundary()
+    store_result = boundary.store_state(_base_storage_policy())
+
+    read_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="owner-1",
+            requested_by_user_id="owner-1",
+            wallet_active=True,
+        )
+    )
+
+    assert store_result.success is True
+    assert store_result.stored_revision == 1
+    assert read_result.success is True
+    assert read_result.blocked_reason is None
+    assert read_result.state_found is True
+    assert read_result.stored_revision == 1
+    assert read_result.state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 100.0,
+        "nonce": 9,
+    }
+
+
+def test_phase6_5_3_blocks_cross_owner_overwrite_for_same_wallet_binding_id() -> None:
+    boundary = WalletStateReadBoundary()
+    owner_1_result = boundary.store_state(_base_storage_policy())
+
+    owner_2_result = boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="owner-2",
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 55.0,
+                "nonce": 1,
+            },
+        )
+    )
+
+    assert owner_1_result.success is True
+    assert owner_2_result.success is False
+    assert owner_2_result.blocked_reason == WALLET_STATE_STORAGE_BLOCK_OWNERSHIP_CONFLICT
+    assert owner_2_result.notes == {"existing_owner_user_id": "owner-1"}
+
+
+def test_phase6_5_3_blocks_contract_ownership_and_activity_failures() -> None:
+    boundary = WalletStateReadBoundary()
+
+    invalid_contract_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="",
+            owner_user_id="owner-1",
+            requested_by_user_id="owner-1",
+            wallet_active=True,
+        )
+    )
+    ownership_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="owner-1",
+            requested_by_user_id="owner-2",
+            wallet_active=True,
+        )
+    )
+    inactive_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3",
+            owner_user_id="owner-1",
+            requested_by_user_id="owner-1",
+            wallet_active=False,
+        )
+    )
+
+    assert invalid_contract_result.success is False
+    assert invalid_contract_result.blocked_reason == WALLET_STATE_READ_BLOCK_INVALID_CONTRACT
+    assert ownership_result.success is False
+    assert ownership_result.blocked_reason == WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH
+    assert inactive_result.success is False
+    assert inactive_result.blocked_reason == WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE
+
+
+def test_phase6_5_3_returns_deterministic_not_found_for_missing_owner_scoped_state() -> None:
+    boundary = WalletStateReadBoundary()
+
+    missing_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3-missing",
+            owner_user_id="owner-1",
+            requested_by_user_id="owner-1",
+            wallet_active=True,
+        )
+    )
+
+    assert missing_result.success is False
+    assert missing_result.blocked_reason == WALLET_STATE_READ_BLOCK_NOT_FOUND
+    assert missing_result.state_found is False
+    assert missing_result.state_snapshot is None
+    assert missing_result.stored_revision is None
+    assert missing_result.notes == {"lookup_key": "wb-phase6-5-3-missing"}


### PR DESCRIPTION
### Motivation
- Recreate the Phase 6.5.3 wallet state read boundary as a narrow, owner-aware read surface and fix the prior ownership-isolation issue that allowed cross-owner overwrites. 
- Preserve the merged-main Phase 6.5.2 storage contract behavior and keep the change scoped to owner-aware storage/read isolation only. 
- Provide a testable, deterministic contract (validation, ownership/requestor gate, active-wallet gate, and deterministic not-found) and surface it for COMMANDER review.

### Description
- Added `WalletStateReadBoundary`, `WalletStateReadPolicy`, `WalletStateReadResult`, owner-indexing, and new block constants to `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, and enforced owner-aware storage keys and ownership-conflict rejection. 
- Implemented `read_state` with contract validation, ownership/requestor gate, active-wallet gate, deterministic `not_found` behavior, and a `store_state` path that now rejects conflicting writes when a `wallet_binding_id` is already bound to a different owner. 
- Added focused regression tests at `projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` that cover same-owner store/read success, cross-owner overwrite blocking, contract/ownership/activity failures, and deterministic not-found results, while keeping existing Phase 6.5.2 tests unchanged. 
- Created the required forge report `projects/polymarket/polyquantbot/reports/forge/25_42_phase6_5_3_wallet_state_read_boundary.md` and performed a minimal `PROJECT_STATE.md` update (timestamp, status, next priority) consistent with the FORGE-X scope rules.

### Testing
- Ran `python -m py_compile` against the touched files and it completed with no errors. 
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_2_wallet_state_storage_boundary_20260415.py` and the suite passed with `9 passed, 1 warning` and zero failures. 
- Checked working branch with `git rev-parse --abbrev-ref HEAD` and confirmed local branch `feature/core-wallet-state-read-boundary-20260416` for traceability reported in the forge report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e045ad67808325afa59fae47be10ec)