### PR TITLE
feat(wallet): add phase 6.5.4 WalletStateStorageBoundary.clear_state with contracts and tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 15:00
-🔄 Status       : Phase 6.5.3 wallet state read boundary narrow slice merged via PR #536 — WalletStateStorageBoundary.read_state is now merged-main accepted truth, post-merge sync complete.
+📅 Last Updated : 2026-04-16 13:12
+🔄 Status       : Phase 6.5.4 wallet state clear boundary implemented on feature branch with deterministic clear contract for one wallet binding only; pending COMMANDER review.
 
 ✅ COMPLETED
 - AGENTS.md and docs/commander_knowledge.md patched with branch verification gate: FORGE-X task process step 8 (branch verify before report/state write), pre-flight checklist +2 checks (PROJECT_STATE branch ref + drift report gate), PRE-REVIEW DRIFT CHECK +2 checks (PROJECT_STATE branch ref + NEEDS-FIX on mismatch) — Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -11,7 +11,7 @@
 - Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory records.
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.5.3 wallet state read boundary narrow slice is merged-main accepted truth via PR #536 at WalletStateStorageBoundary.read_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
+- Phase 6.5.4 wallet state clear boundary implemented at WalletStateStorageBoundary.clear_state with deterministic clear contracts for invalid contract, ownership mismatch, wallet not active, and not found, plus one-wallet-binding-only clear success behavior.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
@@ -24,7 +24,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- Confirm with Mr. Walker whether to open Phase 6.5.4 or the next narrow wallet lifecycle slice after PR #536 post-merge sync.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 13:12
-🔄 Status       : Phase 6.5.4 wallet state clear boundary implemented on feature branch with deterministic clear contract for one wallet binding only; pending COMMANDER review.
+📅 Last Updated : 2026-04-16 15:10
+🔄 Status       : PR #537 project-state drift corrected for pre-merge truth on feature branch; Phase 6.5.3 merged-main accepted truth preserved and Phase 6.5.4 remains pending COMMANDER review.
 
 ✅ COMPLETED
 - AGENTS.md and docs/commander_knowledge.md patched with branch verification gate: FORGE-X task process step 8 (branch verify before report/state write), pre-flight checklist +2 checks (PROJECT_STATE branch ref + drift report gate), PRE-REVIEW DRIFT CHECK +2 checks (PROJECT_STATE branch ref + NEEDS-FIX on mismatch) — Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -11,10 +11,11 @@
 - Phase 6.1 execution ledger and read-only reconciliation implemented with deterministic append-only in-memory records.
 - Phase 6.2 persistent ledger and audit trail implemented with append-only local-file persistence and deterministic reload.
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.5.4 wallet state clear boundary implemented at WalletStateStorageBoundary.clear_state with deterministic clear contracts for invalid contract, ownership mismatch, wallet not active, and not found, plus one-wallet-binding-only clear success behavior.
+- Phase 6.5.3 wallet state read boundary narrow slice is merged-main accepted truth via PR #536 at WalletStateStorageBoundary.read_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.4 wallet state clear boundary implementation exists on feature branch for PR #537 and remains pending COMMANDER review; merged-main acceptance is not yet claimed.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -24,7 +25,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md. Tier: STANDARD.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/27_44_phase6_5_4_project_state_drift_fix.md. Tier: MINOR.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -18,6 +18,10 @@ WALLET_STATE_READ_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_READ_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_STATE_READ_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_READ_BLOCK_NOT_FOUND = "not_found"
+WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_CLEAR_BLOCK_NOT_FOUND = "not_found"
 
 
 @dataclass(frozen=True)
@@ -148,6 +152,25 @@ class WalletStateReadResult:
 
 
 @dataclass(frozen=True)
+class WalletStateClearPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateClearResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_cleared: bool
+    cleared_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
 class WalletStateStoragePolicy:
     wallet_binding_id: str
     owner_user_id: str
@@ -256,6 +279,50 @@ class WalletStateStorageBoundary:
             notes={"stored_keys": sorted(record["state_snapshot"].keys())},
         )
 
+    def clear_state(self, policy: WalletStateClearPolicy) -> WalletStateClearResult:
+        """Phase 6.5.4 narrow wallet lifecycle boundary: clear one stored wallet state only."""
+        contract_error = _validate_state_clear_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_clear_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_clear_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_clear_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        record = self._store.get(policy.wallet_binding_id)
+        if record is None:
+            return _blocked_state_clear_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_CLEAR_BLOCK_NOT_FOUND,
+                notes={"wallet_binding_id": policy.wallet_binding_id},
+            )
+
+        cleared_revision = int(record["revision"])
+        del self._store[policy.wallet_binding_id]
+        return WalletStateClearResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_cleared=True,
+            cleared_revision=cleared_revision,
+            notes={"cleared": True},
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -310,6 +377,35 @@ def _blocked_state_storage_result(
         owner_user_id=policy.owner_user_id,
         state_stored=False,
         stored_revision=None,
+        notes=notes,
+    )
+
+
+def _validate_state_clear_policy(policy: WalletStateClearPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_state_clear_result(
+    *,
+    policy: WalletStateClearPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateClearResult:
+    return WalletStateClearResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_cleared=False,
+        cleared_revision=None,
         notes=notes,
     )
 

--- a/projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md
@@ -1,0 +1,93 @@
+# FORGE-X Report — Phase 6.5.4 Wallet State Clear Boundary Narrow Integration
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** `WalletStateStorageBoundary.clear_state` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` only.
+**Not in Scope:** secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Source: `projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+- Added one explicit runtime surface: `WalletStateStorageBoundary.clear_state`.
+- Added clear request contract `WalletStateClearPolicy`.
+- Added clear result contract `WalletStateClearResult`.
+- Added deterministic clear block reason constants:
+  - `WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT`
+  - `WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH`
+  - `WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE`
+  - `WALLET_STATE_CLEAR_BLOCK_NOT_FOUND`
+- Implemented deterministic clear behavior:
+  - invalid contract → block `invalid_contract`
+  - ownership mismatch → block `ownership_mismatch`
+  - wallet not active → block `wallet_not_active`
+  - wallet binding not found → block `not_found`
+  - valid request with active owner match and existing binding → remove stored state for that named wallet binding only
+- Added `_validate_state_clear_policy` and `_blocked_state_clear_result` helpers to keep boundary logic deterministic and local.
+
+## 2) Current system architecture
+
+- `WalletSecretLoader.load_secret` remains the Phase 6.5.1 secret-loading boundary.
+- `WalletStateStorageBoundary.store_state` remains the Phase 6.5.2 write boundary.
+- `WalletStateStorageBoundary.read_state` remains the Phase 6.5.3 read boundary.
+- `WalletStateStorageBoundary.clear_state` is now the Phase 6.5.4 narrow clear boundary in the same in-memory storage class.
+- Storage remains local to the in-memory `_store` dictionary; no persistence, scheduler, vault, orchestration, or portfolio runtime expansion was added.
+
+## 3) Files created / modified (full paths)
+
+- Modified: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+  - Added clear block constants
+  - Added `WalletStateClearPolicy`
+  - Added `WalletStateClearResult`
+  - Added `WalletStateStorageBoundary.clear_state`
+  - Added `_validate_state_clear_policy`
+  - Added `_blocked_state_clear_result`
+- Created: `projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md`
+- Modified: `PROJECT_STATE.md`
+
+## 4) What is working
+
+- Clear succeeds only when clear contract is valid, ownership matches, wallet is active, and the wallet binding exists.
+- On success, clear removes exactly one named wallet binding from boundary storage.
+- Clear does not remove other wallet binding state entries.
+- Deterministic block behavior is enforced for invalid contract, ownership mismatch, inactive wallet, and not found.
+- Focused pytest coverage passes for success and all deterministic block paths.
+- `py_compile` passes on touched files.
+
+## 5) Known issues
+
+- Wallet lifecycle boundaries remain intentionally narrow and in-memory only; no vault integration, rotation workflow, or multi-wallet orchestration in this slice.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: **STANDARD**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletStateStorageBoundary.clear_state` only**
+- Not in Scope: **secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration**
+- Suggested Next Step: **COMMANDER review required before merge (auto PR review optional support)**
+
+---
+
+## Validation declaration
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateStorageBoundary.clear_state` only
+- Not in Scope: secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py`
+   Result: 5 passed, 1 warning (pre-existing asyncio_mode warning), 0 failures
+3. `find . -type d -name 'phase*'`
+   Result: no forbidden `phase*/` folders found
+
+**Report Timestamp:** 2026-04-16 13:12 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.5.4 wallet state clear boundary
+**Branch:** `feature/wallet-state-clear-boundary-20260416`

--- a/projects/polymarket/polyquantbot/reports/forge/27_44_phase6_5_4_project_state_drift_fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/27_44_phase6_5_4_project_state_drift_fix.md
@@ -1,0 +1,69 @@
+# FORGE-X Report — PR #537 PROJECT_STATE Drift Fix (Phase 6.5.4 Context)
+
+**Validation Tier:** MINOR
+**Claim Level:** FOUNDATION
+**Validation Target:** `PROJECT_STATE.md` repo-truth preservation and timestamp correctness for PR #537 only.
+**Not in Scope:** wallet clear boundary runtime logic, broader wallet lifecycle integration, ROADMAP milestone advancement, secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Source: `projects/polymarket/polyquantbot/reports/forge/27_44_phase6_5_4_project_state_drift_fix.md`. Tier: MINOR.
+
+---
+
+## 1) What was built
+
+- Corrected `PROJECT_STATE.md` only to remove PR #537 state drift.
+- Preserved Phase 6.5.3 completed wording as merged-main accepted truth.
+- Moved 6.5.4 representation to pre-merge feature-branch truth (pending COMMANDER review) instead of merged-main accepted truth.
+- Updated `Last Updated` with Asia/Jakarta timestamp that does not move backward relative to current main truth.
+
+## 2) Current system architecture
+
+- No runtime architecture changes were made.
+- `WalletStateStorageBoundary.clear_state` code path and tests were intentionally left unchanged.
+- This fix is documentation/state integrity only (FOUNDATION claim level).
+
+## 3) Files created / modified (full paths)
+
+- Modified: `PROJECT_STATE.md`
+- Created: `projects/polymarket/polyquantbot/reports/forge/27_44_phase6_5_4_project_state_drift_fix.md`
+
+## 4) What is working
+
+- `PROJECT_STATE.md` now reflects pre-merge truth for Phase 6.5.4 on the feature branch.
+- Phase 6.5.3 merged-main completed truth is preserved.
+- Unrelated items and known issues remain unchanged.
+- `NEXT PRIORITY` now points to this MINOR drift-fix report for COMMANDER review.
+
+## 5) Known issues
+
+- Git remote `origin` is unavailable in this Codex worktree environment, so fetch/rebase against `origin/main` cannot be executed directly in this task context.
+- No runtime issue introduced by this state-file-only correction.
+
+## 6) What is next
+
+- Validation Tier: **MINOR**
+- Claim Level: **FOUNDATION**
+- Validation Target: **`PROJECT_STATE.md` drift correction only**
+- Not in Scope: **wallet runtime logic and roadmap advancement**
+- Suggested Next Step: **COMMANDER review required before merge (auto PR review optional support)**
+
+---
+
+## Validation declaration
+
+- Validation Tier: MINOR
+- Claim Level: FOUNDATION
+- Validation Target: `PROJECT_STATE.md` repo-truth preservation and timestamp correctness in PR #537 only
+- Not in Scope: wallet clear boundary runtime logic, broader wallet lifecycle integration, ROADMAP milestone advancement, secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+
+1. `git fetch origin main && git rebase origin/main`
+   Result: failed in environment (`origin` remote unavailable)
+2. `git diff -- PROJECT_STATE.md`
+   Result: state-only drift correction verified
+
+**Report Timestamp:** 2026-04-16 15:10 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Fix PR #537 project state drift
+**Branch:** `feature/wallet-state-clear-boundary-20260416`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_CLEAR_BLOCK_NOT_FOUND,
+    WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateClearPolicy,
+    WalletStateReadPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _base_clear_policy() -> WalletStateClearPolicy:
+    return WalletStateClearPolicy(
+        wallet_binding_id="wb-phase6-5-4-a",
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_4_clear_state_removes_named_wallet_binding_only() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-4-b",
+            owner_user_id="user-2",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 50.0, "nonce": 9},
+        )
+    )
+
+    clear_result = boundary.clear_state(_base_clear_policy())
+
+    assert clear_result.success is True
+    assert clear_result.blocked_reason is None
+    assert clear_result.state_cleared is True
+    assert clear_result.cleared_revision == 1
+
+    cleared_read = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert cleared_read.success is False
+    assert cleared_read.blocked_reason == WALLET_STATE_CLEAR_BLOCK_NOT_FOUND
+
+    surviving_read = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-4-b",
+            owner_user_id="user-2",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        )
+    )
+    assert surviving_read.success is True
+    assert surviving_read.state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 50.0,
+        "nonce": 9,
+    }
+
+
+def test_phase6_5_4_clear_state_blocks_invalid_contract() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.clear_state(
+        WalletStateClearPolicy(
+            wallet_binding_id="",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT
+    assert result.state_cleared is False
+    assert result.cleared_revision is None
+    assert result.notes == {"contract_error": "wallet_binding_id_required"}
+
+
+def test_phase6_5_4_clear_state_blocks_ownership_mismatch() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+
+    result = boundary.clear_state(
+        WalletStateClearPolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-99",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_cleared is False
+    assert result.cleared_revision is None
+
+
+def test_phase6_5_4_clear_state_blocks_wallet_not_active() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+
+    result = boundary.clear_state(
+        WalletStateClearPolicy(
+            wallet_binding_id="wb-phase6-5-4-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_cleared is False
+    assert result.cleared_revision is None
+
+
+def test_phase6_5_4_clear_state_blocks_not_found() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.clear_state(_base_clear_policy())
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_CLEAR_BLOCK_NOT_FOUND
+    assert result.state_cleared is False
+    assert result.cleared_revision is None


### PR DESCRIPTION
### Motivation
- Provide the next narrow wallet lifecycle boundary to deterministically remove stored state for a single wallet binding while enforcing explicit block contracts for invalid request, ownership mismatch, inactive wallet, and not found.
- Keep the change tightly scoped to the in-memory wallet state boundary without adding vault integration, multi-wallet orchestration, or broader runtime expansion.

### Description
- Added deterministic clear block constants and dataclasses `WalletStateClearPolicy` and `WalletStateClearResult` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` and implemented `WalletStateStorageBoundary.clear_state` with local helpers `_validate_state_clear_policy` and `_blocked_state_clear_result` to enforce contract behavior and remove only the named binding.
- Kept storage in the existing in-memory `_store` dict shared with `store_state`/`read_state` and returned the cleared revision on success while preserving narrow-scope exclusions.
- Added focused pytest coverage `projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py` covering success and all deterministic block paths, and created the FORGE report `projects/polymarket/polyquantbot/reports/forge/26_43_phase6_5_4_wallet_state_clear_boundary.md` describing the change.
- Updated `PROJECT_STATE.md` to reflect Phase 6.5.4 implementation status and next gate (COMMANDER review); `ROADMAP.md` unchanged as roadmap-level truth did not change.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py` with no compile errors.
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py` resulting in `5 passed, 1 warning` (pre-existing pytest config warning) and then combined read+clear tests with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_4_wallet_state_clear_boundary_20260416.py` resulting in `12 passed, 1 warning`.
- Verified there are no forbidden `phase*/` folders with `find . -type d -name 'phase*'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07dbf85148325902a2c70c18c0376)