### PR TITLE
feat(wallet): add phase 6.5.5 WalletStateStorageBoundary.has_state

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 15:20
-🔄 Status       : Phase 6.5.4 wallet state clear boundary merged via PR #537 — WalletStateStorageBoundary.clear_state is now merged-main accepted truth, post-merge sync complete.
+📅 Last Updated : 2026-04-16 15:56
+🔄 Status       : Phase 6.5.5 wallet state exists boundary implemented on feature/wallet-state-exists-boundary-20260416 — WalletStateStorageBoundary.has_state is ready for COMMANDER review (STANDARD, narrow scope).
 
 ✅ COMPLETED
 - AGENTS.md patched with Asia/Jakarta timezone enforcement: PATCH 1 (Timestamps section — Enforcement block after Format/Example lines), PATCH 2 (FORGE-X pre-flight checklist — 3 new timestamp/non-regression checks after forge report path check) - Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -14,6 +14,7 @@
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.5.3 wallet state read boundary narrow slice is merged-main accepted truth via PR #536 at WalletStateStorageBoundary.read_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
 - Phase 6.5.4 wallet state clear boundary is merged-main accepted truth via PR #537 at WalletStateStorageBoundary.clear_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
+- Phase 6.5.5 wallet state exists boundary implemented at WalletStateStorageBoundary.has_state with deterministic success true/false and block contracts for invalid contract, ownership mismatch, and wallet not active (pending COMMANDER review).
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
@@ -26,7 +27,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
-- Confirm with Mr. Walker whether to open Phase 6.5.5 or the next narrow wallet lifecycle slice after PR #537 post-merge sync.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-16 15:20
+**Last Updated:** 2026-04-16 15:56
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.
 **Status:** 🚧 In Progress
-**Last Updated:** 2026-04-16 15:20
+**Last Updated:** 2026-04-16 15:56
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -64,6 +64,7 @@
 | 6.5.2 | Wallet Lifecycle Foundation — State/Storage Boundary Contract | ✅ Done | Merged-main accepted truth after PR #524 at `WalletStateStorageBoundary.store_state` with deterministic success and block contracts for active/inactive and valid/invalid wallet state snapshots (including bool/NaN invalid-state rejection). Explicit exclusions preserved: no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration. |
 | 6.5.3 | Wallet Lifecycle Foundation — State Read Boundary Narrow Slice | ✅ Done | Merged-main accepted truth after PR #536 at `WalletStateStorageBoundary.read_state` with deterministic success and block contracts for invalid contract, ownership mismatch, inactive wallet, and not-found reads, returning snapshot copy and stored revision. Explicit exclusions preserved: no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration. |
 | 6.5.4 | Wallet Lifecycle Foundation — State Clear Boundary Narrow Slice | ✅ Done | Merged-main accepted truth after PR #537 at `WalletStateStorageBoundary.clear_state` with deterministic success and block contracts for invalid contract, ownership mismatch, inactive wallet, and not-found clears, removing exactly one named wallet binding only. Explicit exclusions preserved: no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration. |
+| 6.5.5 | Wallet Lifecycle Foundation — State Exists Boundary Narrow Slice | 🚧 In Progress | Feature-branch implementation complete at `WalletStateStorageBoundary.has_state` with deterministic success true/false and block contracts for invalid contract, ownership mismatch, and inactive wallet. Pending COMMANDER review before merge; explicit exclusions unchanged (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, or broader runtime integration). |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -22,6 +22,9 @@ WALLET_STATE_CLEAR_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_CLEAR_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_STATE_CLEAR_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_CLEAR_BLOCK_NOT_FOUND = "not_found"
+WALLET_STATE_EXISTS_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_EXISTS_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 
 
 @dataclass(frozen=True)
@@ -167,6 +170,24 @@ class WalletStateClearResult:
     owner_user_id: str
     state_cleared: bool
     cleared_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class WalletStateExistsPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateExistsResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    state_exists: bool
     notes: dict[str, Any] | None = None
 
 
@@ -323,6 +344,39 @@ class WalletStateStorageBoundary:
             notes={"cleared": True},
         )
 
+    def has_state(self, policy: WalletStateExistsPolicy) -> WalletStateExistsResult:
+        """Phase 6.5.5 narrow wallet lifecycle boundary: check if one wallet state exists."""
+        contract_error = _validate_state_exists_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_exists_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_EXISTS_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_exists_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_EXISTS_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_exists_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        return WalletStateExistsResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            state_exists=policy.wallet_binding_id in self._store,
+            notes={"wallet_binding_id": policy.wallet_binding_id},
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -422,6 +476,18 @@ def _validate_state_read_policy(policy: WalletStateReadPolicy) -> str | None:
     return None
 
 
+def _validate_state_exists_policy(policy: WalletStateExistsPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
 def _blocked_state_read_result(
     *,
     policy: WalletStateReadPolicy,
@@ -436,5 +502,21 @@ def _blocked_state_read_result(
         state_found=False,
         state_snapshot=None,
         stored_revision=None,
+        notes=notes,
+    )
+
+
+def _blocked_state_exists_result(
+    *,
+    policy: WalletStateExistsPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateExistsResult:
+    return WalletStateExistsResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        state_exists=False,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md
+++ b/projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md
@@ -1,0 +1,91 @@
+# FORGE-X Report — Phase 6.5.5 Wallet State Exists Boundary Narrow Integration
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** `WalletStateStorageBoundary.has_state` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` only.
+**Not in Scope:** secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Source: `projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md`. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+- Added one explicit runtime surface: `WalletStateStorageBoundary.has_state`.
+- Added one narrow request contract: `WalletStateExistsPolicy`.
+- Added one narrow result contract: `WalletStateExistsResult`.
+- Added deterministic exists block reason constants:
+  - `WALLET_STATE_EXISTS_BLOCK_INVALID_CONTRACT`
+  - `WALLET_STATE_EXISTS_BLOCK_OWNERSHIP_MISMATCH`
+  - `WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE`
+- Implemented deterministic exists behavior:
+  - invalid contract → block `invalid_contract`
+  - ownership mismatch → block `ownership_mismatch`
+  - wallet not active → block `wallet_not_active`
+  - valid contract + owner match + active wallet → success with `state_exists=True` only when the named wallet binding has stored state in boundary memory, else `state_exists=False`
+- Added `_validate_state_exists_policy` and `_blocked_state_exists_result` helpers to keep exists-check behavior deterministic and local.
+
+## 2) Current system architecture
+
+- `WalletSecretLoader.load_secret` remains the Phase 6.5.1 secret-loading boundary.
+- `WalletStateStorageBoundary.store_state` remains the Phase 6.5.2 write boundary.
+- `WalletStateStorageBoundary.read_state` remains the Phase 6.5.3 read boundary.
+- `WalletStateStorageBoundary.clear_state` remains the Phase 6.5.4 clear boundary.
+- `WalletStateStorageBoundary.has_state` is now the Phase 6.5.5 narrow exists boundary in the same in-memory storage class.
+- Storage remains local to in-memory `_store`; no persistence, vault, orchestration, portfolio, scheduler, or settlement runtime expansion was added.
+
+## 3) Files created / modified (full paths)
+
+- Modified: `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+  - Added exists block constants
+  - Added `WalletStateExistsPolicy`
+  - Added `WalletStateExistsResult`
+  - Added `WalletStateStorageBoundary.has_state`
+  - Added `_validate_state_exists_policy`
+  - Added `_blocked_state_exists_result`
+- Created: `projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py`
+- Created: `projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md`
+- Modified: `PROJECT_STATE.md`
+- Modified: `ROADMAP.md`
+
+## 4) What is working
+
+- Exists check succeeds when contract is valid, request ownership matches, and wallet is active.
+- On success, returns deterministic existence for one named wallet binding only (`state_exists=True/False`).
+- Existence check remains isolated to in-memory boundary store and does not mutate stored data.
+- Deterministic block behavior is enforced for invalid contract, ownership mismatch, and inactive wallet.
+- Focused pytest coverage passes for success true, success false, and all deterministic block paths.
+- `py_compile` passes on touched files.
+
+## 5) Known issues
+
+- Wallet lifecycle boundaries remain intentionally narrow and in-memory only; no vault integration, rotation workflow, or multi-wallet orchestration in this slice.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: **STANDARD**
+- Claim Level: **NARROW INTEGRATION**
+- Validation Target: **`WalletStateStorageBoundary.has_state` only**
+- Not in Scope: **secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration**
+- Suggested Next Step: **COMMANDER review required before merge (auto PR review optional support)**
+
+---
+
+## Validation declaration
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateStorageBoundary.has_state` only
+- Not in Scope: secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, settlement automation, broader wallet runtime integration
+- Suggested Next Step: COMMANDER review
+
+## Validation commands run
+
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py`
+3. `find . -type d -name 'phase*'`
+
+**Report Timestamp:** 2026-04-16 15:56 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.5.5 wallet state exists boundary
+**Branch:** `feature/wallet-state-exists-boundary-20260416`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_EXISTS_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_EXISTS_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateExistsPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _base_exists_policy() -> WalletStateExistsPolicy:
+    return WalletStateExistsPolicy(
+        wallet_binding_id="wb-phase6-5-5-a",
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_5_has_state_returns_true_for_existing_named_wallet_binding() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-5-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-5-b",
+            owner_user_id="user-2",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 50.0, "nonce": 9},
+        )
+    )
+
+    result = boundary.has_state(_base_exists_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.state_exists is True
+
+
+def test_phase6_5_5_has_state_returns_false_when_named_wallet_binding_missing() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-5-other",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+
+    result = boundary.has_state(_base_exists_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.state_exists is False
+
+
+def test_phase6_5_5_has_state_blocks_invalid_contract() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.has_state(
+        WalletStateExistsPolicy(
+            wallet_binding_id="",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_EXISTS_BLOCK_INVALID_CONTRACT
+    assert result.state_exists is False
+    assert result.notes == {"contract_error": "wallet_binding_id_required"}
+
+
+def test_phase6_5_5_has_state_blocks_ownership_mismatch() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-5-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+
+    result = boundary.has_state(
+        WalletStateExistsPolicy(
+            wallet_binding_id="wb-phase6-5-5-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-99",
+            wallet_active=True,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_EXISTS_BLOCK_OWNERSHIP_MISMATCH
+    assert result.state_exists is False
+
+
+def test_phase6_5_5_has_state_blocks_wallet_not_active() -> None:
+    boundary = WalletStateStorageBoundary()
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-5-a",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        )
+    )
+
+    result = boundary.has_state(
+        WalletStateExistsPolicy(
+            wallet_binding_id="wb-phase6-5-5-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        )
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE
+    assert result.state_exists is False


### PR DESCRIPTION
### Motivation
- Provide a deterministic, narrow-scope runtime surface to check whether a single named wallet binding has stored state in the in-memory wallet boundary. 
- Preserve the wallet lifecycle contract pattern (validate contract, ownership, and active status) used by prior boundaries while avoiding any persistence, vault, or orchestration scope expansion.

### Description
- Added `WalletStateExistsPolicy` and `WalletStateExistsResult` dataclasses and new block constants `WALLET_STATE_EXISTS_BLOCK_*` to the wallet lifecycle foundation module. 
- Implemented `WalletStateStorageBoundary.has_state` with deterministic contract validation and blocking for invalid contract, ownership mismatch, and inactive wallet, plus helpers `_validate_state_exists_policy` and `_blocked_state_exists_result`. 
- Added focused pytest coverage in `projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py` covering success true, success false, invalid contract, ownership mismatch, and inactive wallet paths. 
- Produced FORGE report at `projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md` and updated `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 6.5.5 feature-branch implementation.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py` which completed without syntax errors. 
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_5_wallet_state_exists_boundary_20260416.py` which passed `5` tests with `1` pre-existing pytest config warning and `0` failures. 
- Confirmed no forbidden `phase*/` folders via `find . -type d -name 'phase*'` and committed the changes on branch `feature/wallet-state-exists-boundary-20260416` for COMMANDER review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e087934aec8325bb465af8ce06db5f)