### PR TITLE
fix: add mandatory confirmation gate to commander direct-fix mode

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-16 15:56
-🔄 Status       : Phase 6.5.5 wallet state exists boundary implemented on feature/wallet-state-exists-boundary-20260416 — WalletStateStorageBoundary.has_state is ready for COMMANDER review (STANDARD, narrow scope).
+📅 Last Updated : 2026-04-16 17:43
+🔄 Status       : docs/commander_knowledge.md patched with mandatory confirmation gate for direct-fix mode (MINOR) — Phase 6.5.5 wallet state exists boundary still pending COMMANDER review (STANDARD, narrow scope).
 
 ✅ COMPLETED
 - AGENTS.md patched with Asia/Jakarta timezone enforcement: PATCH 1 (Timestamps section — Enforcement block after Format/Example lines), PATCH 2 (FORGE-X pre-flight checklist — 3 new timestamp/non-regression checks after forge report path check) - Validation Tier: MINOR, Claim Level: FOUNDATION.
@@ -15,6 +15,7 @@
 - Phase 6.5.3 wallet state read boundary narrow slice is merged-main accepted truth via PR #536 at WalletStateStorageBoundary.read_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
 - Phase 6.5.4 wallet state clear boundary is merged-main accepted truth via PR #537 at WalletStateStorageBoundary.clear_state, preserving narrow-scope exclusions (no secret rotation, vault integration, multi-wallet orchestration, portfolio management rollout, scheduler generalization, or settlement automation).
 - Phase 6.5.5 wallet state exists boundary implemented at WalletStateStorageBoundary.has_state with deterministic success true/false and block contracts for invalid contract, ownership mismatch, and wallet not active (pending COMMANDER review).
+- docs/commander_knowledge.md patched with PATCH 1 (COMMANDER DIRECT-FIX MODE — mandatory confirmation gate block before condition list) and PATCH 2 (CORE RULES — no direct fix before confirmation line after no-task-before-confirmation) — Validation Tier: MINOR, Claim Level: FOUNDATION.
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
@@ -27,6 +28,7 @@
 - Platform-wide monitoring rollout remains out of scope; no scheduler generalization, no portfolio orchestration, and no settlement automation beyond exact named boundary methods.
 
 🎯 NEXT PRIORITY
+- COMMANDER review required for confirmation gate patch (docs/commander_knowledge.md). Branch: feature/commander-direct-fix-confirmation-gate-2026-04-16. Tier: MINOR
 - COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/26_44_phase6_5_5_wallet_state_exists_boundary.md. Tier: STANDARD
 
 ⚠️ KNOWN ISSUES

--- a/docs/commander_knowledge.md
+++ b/docs/commander_knowledge.md
@@ -212,6 +212,8 @@ Current PROJECT_ROOT = projects/polymarket/polyquantbot
 ## CORE RULES
 
 - No task before confirmation
+* No direct fix before confirmation — always ask Mr. Walker first:
+  direct fix or FORGE-X task — never self-initiate either path
 - No assumption unless grounded
 - No silent scope expansion
 - No approval based on wording alone
@@ -284,6 +286,22 @@ Auto PR review is conditional support, not a mandatory gate.
 ## COMMANDER DIRECT-FIX MODE
 
 COMMANDER may fix a minor issue or bug/error directly — no FORGE-X task needed — when ALL are true:
+
+Confirmation gate (mandatory — always before execution):
+- COMMANDER must always inform Mr. Walker what will be fixed and why
+  BEFORE executing any direct fix
+- State clearly:
+  - what file(s) will be changed
+  - what the change is
+  - why it qualifies as direct fix (within threshold)
+- Always ask Mr. Walker to choose:
+  "Direct fix sekarang, atau gw buatkan FORGE-X task?"
+- Wait for explicit approval signal before proceeding
+- Approval signals: ok / go / lanjut / gas / yes / do it / execute /
+  direct fix / langsung
+- If Mr. Walker says task or forge → generate FORGE-X task instead
+- Never assume silence or prior context as approval
+- Never self-initiate direct fix without this confirmation step
 
 - Validation Tier = MINOR
 - No capital / risk / execution / strategy / async-core impact


### PR DESCRIPTION
PATCH 1 — docs/commander_knowledge.md: Insert confirmation gate block
(mandatory before execution) in COMMANDER DIRECT-FIX MODE section,
immediately after opening line and before existing condition list.

PATCH 2 — docs/commander_knowledge.md: Insert one new rule in CORE
RULES section after "No task before confirmation" line — direct fix
also requires explicit Mr. Walker approval before proceeding.

PROJECT_STATE.md updated with scope-bound edit only.

Validation Tier: MINOR
Claim Level: FOUNDATION

https://claude.ai/code/session_01QuNSC1RPVQETxbzQiYAHQL