### PR TITLE
Phase 6.5.7: expand wallet state metadata query filters

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-17 03:41
-🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; next work should open only after this clean post-merge state is written on main.
+📅 Last Updated : 2026-04-17 03:53
+🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.7 metadata query expansion is now implemented on the active FORGE-X branch and awaiting COMMANDER review.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -15,6 +15,7 @@
 
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
+- Phase 6.5.7 wallet state metadata query expansion is implemented at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters (prefix, min revision, max entries) while preserving owner scope and metadata-only output.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -23,9 +24,9 @@
 - Reconciliation mutation and correction workflow beyond the delivered read-only / append-only boundaries.
 
 🎯 NEXT PRIORITY
-- Confirm the next narrow wallet lifecycle slice after 6.5.6 and open one scoped FORGE-X task only after repo-root truth is clean on main.
-- Recommended next slice: wallet state metadata query expansion only if it stays narrow and does not expand into orchestration, vault, or portfolio rollout.
-- Source: projects/polymarket/polyquantbot/reports/forge/27_48_phase6_5_6_final_truth_alignment.md. Tier: STANDARD.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md. Tier: STANDARD.
+- After merge, perform post-merge sync to move 6.5.7 truth from IN PROGRESS to COMPLETED on main.
+- Keep next wallet lifecycle slice narrow and metadata/state-boundary scoped only.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -205,6 +205,9 @@ class WalletStateListMetadataPolicy:
     owner_user_id: str
     requested_by_user_id: str
     wallet_active: bool
+    wallet_binding_prefix: str | None = None
+    min_stored_revision: int | None = None
+    max_entries: int | None = None
 
 
 @dataclass(frozen=True)
@@ -430,20 +433,49 @@ class WalletStateStorageBoundary:
                 notes={"wallet_active": False},
             )
 
-        entries = [
-            WalletStateMetadataEntry(
-                wallet_binding_id=wbid,
-                stored_revision=int(record["revision"]),
+        entries: list[WalletStateMetadataEntry] = []
+        for wallet_binding_id, record in sorted(self._store.items()):
+            if record.get("owner_user_id") != policy.owner_user_id:
+                continue
+            if (
+                policy.wallet_binding_prefix is not None
+                and not wallet_binding_id.startswith(policy.wallet_binding_prefix)
+            ):
+                continue
+            stored_revision = int(record["revision"])
+            if (
+                policy.min_stored_revision is not None
+                and stored_revision < policy.min_stored_revision
+            ):
+                continue
+            entries.append(
+                WalletStateMetadataEntry(
+                    wallet_binding_id=wallet_binding_id,
+                    stored_revision=stored_revision,
+                ),
             )
-            for wbid, record in sorted(self._store.items())
-            if record.get("owner_user_id") == policy.owner_user_id
-        ]
+
+        if policy.max_entries is not None:
+            entries = entries[: policy.max_entries]
+
+        applied_filters: dict[str, Any] = {}
+        if policy.wallet_binding_prefix is not None:
+            applied_filters["wallet_binding_prefix"] = policy.wallet_binding_prefix
+        if policy.min_stored_revision is not None:
+            applied_filters["min_stored_revision"] = policy.min_stored_revision
+        if policy.max_entries is not None:
+            applied_filters["max_entries"] = policy.max_entries
+
+        notes: dict[str, Any] = {"entry_count": len(entries)}
+        if applied_filters:
+            notes["applied_filters"] = applied_filters
+
         return WalletStateListMetadataResult(
             success=True,
             blocked_reason=None,
             owner_user_id=policy.owner_user_id,
             entries=entries,
-            notes={"entry_count": len(entries)},
+            notes=notes,
         )
 
 
@@ -598,6 +630,21 @@ def _validate_state_list_metadata_policy(policy: WalletStateListMetadataPolicy) 
         return "requested_by_user_id_required"
     if not isinstance(policy.wallet_active, bool):
         return "wallet_active_must_be_bool"
+    if policy.wallet_binding_prefix is not None:
+        if not isinstance(policy.wallet_binding_prefix, str):
+            return "wallet_binding_prefix_must_be_str_or_none"
+        if not policy.wallet_binding_prefix.strip():
+            return "wallet_binding_prefix_required_when_provided"
+    if policy.min_stored_revision is not None:
+        if isinstance(policy.min_stored_revision, bool) or not isinstance(policy.min_stored_revision, int):
+            return "min_stored_revision_must_be_int_or_none"
+        if policy.min_stored_revision < 1:
+            return "min_stored_revision_must_be_positive"
+    if policy.max_entries is not None:
+        if isinstance(policy.max_entries, bool) or not isinstance(policy.max_entries, int):
+            return "max_entries_must_be_int_or_none"
+        if policy.max_entries < 1:
+            return "max_entries_must_be_positive"
     return None
 
 

--- a/projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md
+++ b/projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md
@@ -1,0 +1,81 @@
+# FORGE-X Report — Phase 6.5.7 Wallet State Metadata Query Expansion
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateStorageBoundary.list_state_metadata` metadata query/filter expansion only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused query behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py`.  
+**Not in Scope:** full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad lifecycle redesign.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Implemented a narrow metadata-query expansion on `WalletStateStorageBoundary.list_state_metadata`.
+
+Added deterministic optional query filters on `WalletStateListMetadataPolicy`:
+- `wallet_binding_prefix: str | None`
+- `min_stored_revision: int | None`
+- `max_entries: int | None`
+
+Behavior added:
+- Continue blocking deterministically for invalid contract, ownership mismatch, and inactive wallet.
+- Apply owner-scope filter first, then optional prefix filter, then optional minimum revision filter.
+- Preserve deterministic ordering by iterating sorted wallet binding IDs.
+- Apply optional deterministic truncation with `max_entries` after deterministic ordering.
+- Keep result metadata-only (`wallet_binding_id`, `stored_revision`) with no snapshot exposure.
+
+## 2) Current system architecture
+
+Wallet lifecycle narrow boundaries remain:
+- `store_state` (6.5.2)
+- `read_state` (6.5.3)
+- `clear_state` (6.5.4)
+- `has_state` (6.5.5)
+- `list_state_metadata` (6.5.6 + 6.5.7 query expansion)
+
+Phase 6.5.7 expands only metadata query behavior inside `list_state_metadata`; no new lifecycle surface beyond this method was added.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py`
+- `projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md`
+
+## 4) What is working
+
+- Deterministic metadata query/filter behavior for `wallet_binding_prefix`, `min_stored_revision`, and `max_entries`.
+- Deterministic owner-scope filtering is preserved.
+- Deterministic ordering is preserved (`wallet_binding_id` ascending).
+- Deterministic block behavior is preserved:
+  - invalid contract → `WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT`
+  - ownership mismatch → `WALLET_STATE_LIST_BLOCK_OWNERSHIP_MISMATCH`
+  - inactive wallet → `WALLET_STATE_LIST_BLOCK_WALLET_NOT_ACTIVE`
+- Metadata-only output is preserved; no full snapshot field is exposed in metadata entries.
+
+Validation commands run:
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py`
+
+## 5) Known issues
+
+- Wallet lifecycle remains intentionally narrow and in-memory; no vault, orchestration, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: wallet state metadata query expansion only (`list_state_metadata`)
+- Not in Scope: full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad lifecycle redesign
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-17 03:53 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.5.7 wallet state metadata query expansion  
+**Branch:** `feature/wallet-metadata-query-expansion-2026-04-17`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_LIST_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_LIST_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateListMetadataPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _store_state(
+    *,
+    boundary: WalletStateStorageBoundary,
+    wallet_binding_id: str,
+    owner_user_id: str = "user-1",
+    nonce: int = 1,
+) -> None:
+    result = boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id=wallet_binding_id,
+            owner_user_id=owner_user_id,
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 100.0,
+                "nonce": nonce,
+            },
+        ),
+    )
+    assert result.success is True
+
+
+def test_phase6_5_7_metadata_query_applies_prefix_revision_and_limit_deterministically() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="alpha-1")
+    _store_state(boundary=boundary, wallet_binding_id="alpha-2")
+    _store_state(boundary=boundary, wallet_binding_id="alpha-2", nonce=2)
+    _store_state(boundary=boundary, wallet_binding_id="alpha-3")
+    _store_state(boundary=boundary, wallet_binding_id="beta-1")
+
+    result = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            wallet_binding_prefix="alpha-",
+            min_stored_revision=2,
+            max_entries=2,
+        ),
+    )
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.entries is not None
+    assert [entry.wallet_binding_id for entry in result.entries] == ["alpha-2"]
+    assert [entry.stored_revision for entry in result.entries] == [2]
+    assert result.notes == {
+        "entry_count": 1,
+        "applied_filters": {
+            "wallet_binding_prefix": "alpha-",
+            "min_stored_revision": 2,
+            "max_entries": 2,
+        },
+    }
+    assert not hasattr(result.entries[0], "state_snapshot")
+
+
+def test_phase6_5_7_metadata_query_limit_respects_sorted_order() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="z-wallet")
+    _store_state(boundary=boundary, wallet_binding_id="a-wallet")
+    _store_state(boundary=boundary, wallet_binding_id="m-wallet")
+
+    result = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            max_entries=2,
+        ),
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert [entry.wallet_binding_id for entry in result.entries] == [
+        "a-wallet",
+        "m-wallet",
+    ]
+
+
+def test_phase6_5_7_metadata_query_blocks_invalid_contract_for_filter_types() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    invalid_prefix = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            wallet_binding_prefix="",
+        ),
+    )
+    assert invalid_prefix.success is False
+    assert invalid_prefix.blocked_reason == WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT
+    assert invalid_prefix.notes == {"contract_error": "wallet_binding_prefix_required_when_provided"}
+
+    invalid_min_revision = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            min_stored_revision=0,
+        ),
+    )
+    assert invalid_min_revision.success is False
+    assert invalid_min_revision.blocked_reason == WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT
+    assert invalid_min_revision.notes == {"contract_error": "min_stored_revision_must_be_positive"}
+
+    invalid_max_entries = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            max_entries=False,
+        ),
+    )
+    assert invalid_max_entries.success is False
+    assert invalid_max_entries.blocked_reason == WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT
+    assert invalid_max_entries.notes == {"contract_error": "max_entries_must_be_int_or_none"}
+
+
+def test_phase6_5_7_metadata_query_blocks_ownership_mismatch_and_inactive_wallet() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="alpha-1")
+
+    ownership_result = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+            wallet_binding_prefix="alpha-",
+        ),
+    )
+    assert ownership_result.success is False
+    assert ownership_result.blocked_reason == WALLET_STATE_LIST_BLOCK_OWNERSHIP_MISMATCH
+
+    inactive_result = boundary.list_state_metadata(
+        WalletStateListMetadataPolicy(
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+            wallet_binding_prefix="alpha-",
+        ),
+    )
+    assert inactive_result.success is False
+    assert inactive_result.blocked_reason == WALLET_STATE_LIST_BLOCK_WALLET_NOT_ACTIVE


### PR DESCRIPTION
### Motivation
- Provide a narrow metadata-only query expansion for wallet lifecycle listing to support deterministic owner-scoped filtering without exposing full snapshots.  
- Support lightweight, deterministic query predicates (prefix, min revision, max entries) while preserving existing ownership and active-wallet block contracts.

### Description
- Added optional query fields to `WalletStateListMetadataPolicy`: `wallet_binding_prefix`, `min_stored_revision`, and `max_entries`.  
- Implemented deterministic filtering and truncation in `WalletStateStorageBoundary.list_state_metadata` while preserving owner-only scope, sorting by `wallet_binding_id` ascending, and returning metadata-only `WalletStateMetadataEntry` (no snapshot).  
- Added contract validation for the new fields in `_validate_state_list_metadata_policy` and include `applied_filters` in `notes` only when filters are used.  
- Added focused tests `projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py`, created a FORGE report at `projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md`, and updated `PROJECT_STATE.md` to record the 6.5.7 in-progress branch truth.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py` and compilation succeeded.  
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py` and all tests passed (`15 passed`) with one non-blocking pytest config warning about `asyncio_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14bdc83c88325b3556641e2fe3ba1)