### PR TITLE
Phase 6.5.8: add wallet state metadata exact lookup boundary

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-17 03:53
-🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.7 metadata query expansion is now implemented on the active FORGE-X branch and awaiting COMMANDER review.
+📅 Last Updated : 2026-04-17 04:05
+🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.8 metadata exact lookup is now implemented on the active FORGE-X branch and awaiting COMMANDER review.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -16,6 +16,7 @@
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
 - Phase 6.5.7 wallet state metadata query expansion is implemented at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters (prefix, min revision, max entries) while preserving owner scope and metadata-only output.
+- Phase 6.5.8 wallet state metadata exact lookup is implemented at WalletStateStorageBoundary.get_state_metadata with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision) and deterministic blocks for invalid contract, ownership mismatch, wallet not active, and metadata not found.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -24,7 +25,7 @@
 - Reconciliation mutation and correction workflow beyond the delivered read-only / append-only boundaries.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/28_49_phase6_5_7_wallet_state_metadata_query_expansion.md. Tier: STANDARD.
+- COMMANDER review required before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md. Tier: STANDARD.
 - After merge, perform post-merge sync to move 6.5.7 truth from IN PROGRESS to COMPLETED on main.
 - Keep next wallet lifecycle slice narrow and metadata/state-boundary scoped only.
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -28,6 +28,10 @@ WALLET_STATE_EXISTS_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_LIST_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_LIST_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_STATE_LIST_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_METADATA_EXACT_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_METADATA_EXACT_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_METADATA_EXACT_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND = "not_found"
 
 
 @dataclass(frozen=True)
@@ -216,6 +220,24 @@ class WalletStateListMetadataResult:
     blocked_reason: str | None
     owner_user_id: str
     entries: list[WalletStateMetadataEntry] | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class WalletStateExactMetadataPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateExactMetadataResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    entry: WalletStateMetadataEntry | None
     notes: dict[str, Any] | None = None
 
 
@@ -478,6 +500,50 @@ class WalletStateStorageBoundary:
             notes=notes,
         )
 
+    def get_state_metadata(self, policy: WalletStateExactMetadataPolicy) -> WalletStateExactMetadataResult:
+        """Phase 6.5.8 narrow wallet lifecycle boundary: fetch one wallet metadata entry only."""
+        contract_error = _validate_state_exact_metadata_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_exact_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_exact_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_exact_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        record = self._store.get(policy.wallet_binding_id)
+        if record is None or record.get("owner_user_id") != policy.owner_user_id:
+            return _blocked_state_exact_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND,
+                notes={"wallet_binding_id": policy.wallet_binding_id},
+            )
+
+        return WalletStateExactMetadataResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            entry=WalletStateMetadataEntry(
+                wallet_binding_id=policy.wallet_binding_id,
+                stored_revision=int(record["revision"]),
+            ),
+            notes={"wallet_binding_id": policy.wallet_binding_id},
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -648,6 +714,18 @@ def _validate_state_list_metadata_policy(policy: WalletStateListMetadataPolicy) 
     return None
 
 
+def _validate_state_exact_metadata_policy(policy: WalletStateExactMetadataPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
 def _blocked_state_list_metadata_result(
     *,
     policy: WalletStateListMetadataPolicy,
@@ -659,5 +737,21 @@ def _blocked_state_list_metadata_result(
         blocked_reason=blocked_reason,
         owner_user_id=policy.owner_user_id,
         entries=None,
+        notes=notes,
+    )
+
+
+def _blocked_state_exact_metadata_result(
+    *,
+    policy: WalletStateExactMetadataPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateExactMetadataResult:
+    return WalletStateExactMetadataResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        entry=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md
+++ b/projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md
@@ -1,0 +1,78 @@
+# FORGE-X Report — Phase 6.5.8 wallet state metadata exact lookup
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateStorageBoundary.get_state_metadata` exact metadata lookup only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py`.  
+**Not in Scope:** full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad wallet lifecycle redesign.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Implemented a new narrow wallet metadata exact lookup boundary on `WalletStateStorageBoundary`:
+- Added `get_state_metadata(policy: WalletStateExactMetadataPolicy) -> WalletStateExactMetadataResult`.
+- Added deterministic block contracts for:
+  - invalid contract (`invalid_contract`)
+  - ownership mismatch (`ownership_mismatch`)
+  - wallet not active (`wallet_not_active`)
+  - metadata not found (`not_found`)
+- Added exact metadata-only success output through `WalletStateMetadataEntry` with only:
+  - `wallet_binding_id`
+  - `stored_revision`
+
+No state snapshot fields are exposed by this method.
+
+## 2) Current system architecture
+
+Wallet lifecycle storage boundaries now include:
+- `store_state` (6.5.2)
+- `read_state` (6.5.3)
+- `clear_state` (6.5.4)
+- `has_state` (6.5.5)
+- `list_state_metadata` (6.5.6 + 6.5.7)
+- `get_state_metadata` (6.5.8 exact single-wallet metadata lookup)
+
+Phase 6.5.8 is narrow integration limited to one wallet-binding exact metadata retrieval path only.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py`
+- `projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md`
+
+## 4) What is working
+
+- Exact metadata lookup works for one `wallet_binding_id` in owner scope only.
+- Success response returns metadata-only entry (`wallet_binding_id`, `stored_revision`) with no snapshot exposure.
+- Deterministic block behavior works for invalid contract, ownership mismatch, wallet not active, and metadata not found.
+- Existing list metadata behavior remains passing for 6.5.6 and 6.5.7 focused tests.
+
+Validation commands run:
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py`
+3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py`
+
+## 5) Known issues
+
+- Wallet lifecycle remains intentionally narrow and in-memory; no vault, orchestration, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: wallet state metadata exact lookup only (`get_state_metadata`)
+- Not in Scope: full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad wallet lifecycle redesign
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-17 04:05 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.5.8 wallet state metadata exact lookup  
+**Branch:** `feature/wallet-metadata-exact-lookup-2026-04-17`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_METADATA_EXACT_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND,
+    WALLET_STATE_METADATA_EXACT_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_METADATA_EXACT_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateExactMetadataPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _store_state(
+    *,
+    boundary: WalletStateStorageBoundary,
+    wallet_binding_id: str,
+    owner_user_id: str = "user-1",
+    nonce: int = 1,
+) -> None:
+    result = boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id=wallet_binding_id,
+            owner_user_id=owner_user_id,
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 100.0,
+                "nonce": nonce,
+            },
+        ),
+    )
+    assert result.success is True
+
+
+def _base_exact_policy(wallet_binding_id: str = "wb-phase6-5-8-a") -> WalletStateExactMetadataPolicy:
+    return WalletStateExactMetadataPolicy(
+        wallet_binding_id=wallet_binding_id,
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_8_exact_metadata_lookup_success_metadata_only() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-8-a")
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-8-a", nonce=2)
+
+    result = boundary.get_state_metadata(_base_exact_policy())
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.entry is not None
+    assert result.entry.wallet_binding_id == "wb-phase6-5-8-a"
+    assert result.entry.stored_revision == 2
+    assert not hasattr(result.entry, "state_snapshot")
+
+
+def test_phase6_5_8_exact_metadata_lookup_blocks_not_found() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.get_state_metadata(_base_exact_policy("missing-binding"))
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND
+    assert result.entry is None
+
+
+def test_phase6_5_8_exact_metadata_lookup_blocks_invalid_contract() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.get_state_metadata(
+        WalletStateExactMetadataPolicy(
+            wallet_binding_id="",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BLOCK_INVALID_CONTRACT
+    assert result.entry is None
+    assert result.notes == {"contract_error": "wallet_binding_id_required"}
+
+
+def test_phase6_5_8_exact_metadata_lookup_blocks_ownership_mismatch() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-8-a")
+
+    result = boundary.get_state_metadata(
+        WalletStateExactMetadataPolicy(
+            wallet_binding_id="wb-phase6-5-8-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BLOCK_OWNERSHIP_MISMATCH
+    assert result.entry is None
+
+
+def test_phase6_5_8_exact_metadata_lookup_blocks_wallet_not_active() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-8-a")
+
+    result = boundary.get_state_metadata(
+        WalletStateExactMetadataPolicy(
+            wallet_binding_id="wb-phase6-5-8-a",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BLOCK_WALLET_NOT_ACTIVE
+    assert result.entry is None


### PR DESCRIPTION
### Motivation
- Provide a narrow wallet lifecycle surface to fetch exact metadata for a single `wallet_binding_id` without exposing full state snapshots. 
- Preserve deterministic owner-scoped success/block semantics and add an explicit not-found result for missing metadata.

### Description
- Add `WalletStateExactMetadataPolicy` / `WalletStateExactMetadataResult` dataclasses and new block constants (`WALLET_STATE_METADATA_EXACT_*`) in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.
- Implement `WalletStateStorageBoundary.get_state_metadata(policy: WalletStateExactMetadataPolicy) -> WalletStateExactMetadataResult` which returns metadata-only `WalletStateMetadataEntry` (`wallet_binding_id`, `stored_revision`) and blocks deterministically for invalid contract, ownership mismatch, wallet not active, and metadata not found.
- Add focused unit tests `projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py` covering success (metadata-only), not-found, invalid-contract, ownership-mismatch, and inactive-wallet cases.
- Add FORGE report `projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md` and update `PROJECT_STATE.md` to reflect Phase 6.5.8 in-progress status.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py` and compilation succeeded.
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py` and the new tests passed (`5 passed`).
- Ran `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py` and existing metadata-listing tests passed; combined run shows `20 passed, 1 warning` (warning: pytest config `asyncio_mode`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14ecffa288325a8522fb9beb29f70)