### PR TITLE
Phase 6.5.9: add owner-scoped exact wallet metadata batch lookup

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-17 04:24
-🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.8 metadata exact lookup awaits COMMANDER review; docs/commander_knowledge.md sync (13 patches + VELOCITY MODE) is implemented on branch claude/sync-commander-knowledge-1n14o awaiting COMMANDER review.
+📅 Last Updated : 2026-04-17 04:35
+🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.8 metadata exact lookup and Phase 6.5.9 metadata exact batch lookup await COMMANDER review; docs/commander_knowledge.md sync (13 patches + VELOCITY MODE) is implemented on branch claude/sync-commander-knowledge-1n14o awaiting COMMANDER review.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -17,6 +17,7 @@
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
 - Phase 6.5.7 wallet state metadata query expansion is implemented at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters (prefix, min revision, max entries) while preserving owner scope and metadata-only output.
 - Phase 6.5.8 wallet state metadata exact lookup is implemented at WalletStateStorageBoundary.get_state_metadata with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision) and deterministic blocks for invalid contract, ownership mismatch, wallet not active, and metadata not found.
+- Phase 6.5.9 wallet state metadata exact batch lookup is implemented at WalletStateStorageBoundary.get_state_metadata_batch with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision), input-order deterministic responses, and deterministic handling for invalid contract, ownership mismatch, wallet not active, and missing wallet_binding_id entries.
 - docs/commander_knowledge.md sync — 13 patches applied (branch mismatch, path resolve, timestamp, domain structure, SENTINEL never-list, report naming, VELOCITY MODE) on branch claude/sync-commander-knowledge-1n14o; awaiting COMMANDER review.
 
 📋 NOT STARTED
@@ -28,7 +29,7 @@
 🎯 NEXT PRIORITY
 - COMMANDER review required for commander_knowledge.md sync (Tier: MINOR). Source: projects/polymarket/polyquantbot/reports/forge/30_1_commander-sync.md. Branch: claude/sync-commander-knowledge-1n14o.
 - COMMANDER review required for Phase 6.5.8 before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md. Tier: STANDARD.
-- After merge of 6.5.8, perform post-merge sync to move 6.5.7 truth from IN PROGRESS to COMPLETED on main.
+- COMMANDER review required for Phase 6.5.9 before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-17 04:35
-🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.8 metadata exact lookup and Phase 6.5.9 metadata exact batch lookup await COMMANDER review; docs/commander_knowledge.md sync (13 patches + VELOCITY MODE) is implemented on branch claude/sync-commander-knowledge-1n14o awaiting COMMANDER review.
+📅 Last Updated : 2026-04-17 04:49
+🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6; Phase 6.5.8 metadata exact lookup and Phase 6.5.9 metadata exact batch lookup (with deferred cleanup guard + report correction) await COMMANDER review; docs/commander_knowledge.md sync (13 patches + VELOCITY MODE) is implemented on branch claude/sync-commander-knowledge-1n14o awaiting COMMANDER review.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -18,6 +18,7 @@
 - Phase 6.5.7 wallet state metadata query expansion is implemented at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters (prefix, min revision, max entries) while preserving owner scope and metadata-only output.
 - Phase 6.5.8 wallet state metadata exact lookup is implemented at WalletStateStorageBoundary.get_state_metadata with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision) and deterministic blocks for invalid contract, ownership mismatch, wallet not active, and metadata not found.
 - Phase 6.5.9 wallet state metadata exact batch lookup is implemented at WalletStateStorageBoundary.get_state_metadata_batch with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision), input-order deterministic responses, and deterministic handling for invalid contract, ownership mismatch, wallet not active, and missing wallet_binding_id entries.
+- Phase 6.5.9 cleanup adds a defensive max-size guard for exact batch metadata lookup input validation (`wallet_binding_ids_too_many`) and aligns forge report 29_51 branch traceability metadata.
 - docs/commander_knowledge.md sync — 13 patches applied (branch mismatch, path resolve, timestamp, domain structure, SENTINEL never-list, report naming, VELOCITY MODE) on branch claude/sync-commander-knowledge-1n14o; awaiting COMMANDER review.
 
 📋 NOT STARTED
@@ -29,7 +30,7 @@
 🎯 NEXT PRIORITY
 - COMMANDER review required for commander_knowledge.md sync (Tier: MINOR). Source: projects/polymarket/polyquantbot/reports/forge/30_1_commander-sync.md. Branch: claude/sync-commander-knowledge-1n14o.
 - COMMANDER review required for Phase 6.5.8 before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md. Tier: STANDARD.
-- COMMANDER review required for Phase 6.5.9 before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md. Tier: STANDARD.
+- COMMANDER review required for Phase 6.5.9 cleanup before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_52_phase6_5_9_wallet_metadata_cleanup.md. Tier: STANDARD.
 
 ⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -35,6 +35,8 @@ WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND = "not_found"
 WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY = "wallet_binding_ids_too_many"
+WALLET_STATE_METADATA_EXACT_BATCH_MAX_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -579,9 +581,12 @@ class WalletStateStorageBoundary:
         Output remains metadata-only (wallet_binding_id + stored_revision) and never exposes snapshots."""
         contract_error = _validate_state_exact_batch_metadata_policy(policy)
         if contract_error is not None:
+            blocked_reason = WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT
+            if contract_error == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY:
+                blocked_reason = WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY
             return _blocked_state_exact_batch_metadata_result(
                 policy=policy,
-                blocked_reason=WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT,
+                blocked_reason=blocked_reason,
                 notes={"contract_error": contract_error},
             )
 
@@ -818,6 +823,8 @@ def _validate_state_exact_batch_metadata_policy(policy: WalletStateExactBatchMet
         return "wallet_binding_ids_must_be_list"
     if len(policy.wallet_binding_ids) == 0:
         return "wallet_binding_ids_required"
+    if len(policy.wallet_binding_ids) > WALLET_STATE_METADATA_EXACT_BATCH_MAX_SIZE:
+        return "wallet_binding_ids_too_many"
     for wallet_binding_id in policy.wallet_binding_ids:
         if not isinstance(wallet_binding_id, str) or not wallet_binding_id.strip():
             return "wallet_binding_id_required"
@@ -867,10 +874,13 @@ def _blocked_state_exact_batch_metadata_result(
     blocked_reason: str,
     notes: dict[str, Any] | None,
 ) -> WalletStateExactBatchMetadataResult:
+    entries: list[WalletStateExactBatchMetadataEntry] | None = None
+    if blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY:
+        entries = []
     return WalletStateExactBatchMetadataResult(
         success=False,
         blocked_reason=blocked_reason,
         owner_user_id=policy.owner_user_id,
-        entries=None,
+        entries=entries,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -32,6 +32,9 @@ WALLET_STATE_METADATA_EXACT_BLOCK_INVALID_CONTRACT = "invalid_contract"
 WALLET_STATE_METADATA_EXACT_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
 WALLET_STATE_METADATA_EXACT_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_METADATA_EXACT_BLOCK_NOT_FOUND = "not_found"
+WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 
 
 @dataclass(frozen=True)
@@ -238,6 +241,29 @@ class WalletStateExactMetadataResult:
     wallet_binding_id: str
     owner_user_id: str
     entry: WalletStateMetadataEntry | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class WalletStateExactBatchMetadataPolicy:
+    wallet_binding_ids: list[str]
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateExactBatchMetadataEntry:
+    wallet_binding_id: str
+    stored_revision: int | None
+
+
+@dataclass(frozen=True)
+class WalletStateExactBatchMetadataResult:
+    success: bool
+    blocked_reason: str | None
+    owner_user_id: str
+    entries: list[WalletStateExactBatchMetadataEntry] | None
     notes: dict[str, Any] | None = None
 
 
@@ -544,6 +570,67 @@ class WalletStateStorageBoundary:
             notes={"wallet_binding_id": policy.wallet_binding_id},
         )
 
+    def get_state_metadata_batch(
+        self,
+        policy: WalletStateExactBatchMetadataPolicy,
+    ) -> WalletStateExactBatchMetadataResult:
+        """Phase 6.5.9 narrow wallet lifecycle boundary: fetch metadata for explicit wallet_binding_ids.
+        Deterministic ordering is preserved by iterating wallet_binding_ids in the exact input order.
+        Output remains metadata-only (wallet_binding_id + stored_revision) and never exposes snapshots."""
+        contract_error = _validate_state_exact_batch_metadata_policy(policy)
+        if contract_error is not None:
+            return _blocked_state_exact_batch_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_exact_batch_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_exact_batch_metadata_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        entries: list[WalletStateExactBatchMetadataEntry] = []
+        missing_wallet_binding_ids: list[str] = []
+        for wallet_binding_id in policy.wallet_binding_ids:
+            record = self._store.get(wallet_binding_id)
+            if record is None or record.get("owner_user_id") != policy.owner_user_id:
+                entries.append(
+                    WalletStateExactBatchMetadataEntry(
+                        wallet_binding_id=wallet_binding_id,
+                        stored_revision=None,
+                    ),
+                )
+                missing_wallet_binding_ids.append(wallet_binding_id)
+                continue
+
+            entries.append(
+                WalletStateExactBatchMetadataEntry(
+                    wallet_binding_id=wallet_binding_id,
+                    stored_revision=int(record["revision"]),
+                ),
+            )
+
+        return WalletStateExactBatchMetadataResult(
+            success=True,
+            blocked_reason=None,
+            owner_user_id=policy.owner_user_id,
+            entries=entries,
+            notes={
+                "entry_count": len(entries),
+                "missing_wallet_binding_ids": missing_wallet_binding_ids,
+            },
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -726,6 +813,23 @@ def _validate_state_exact_metadata_policy(policy: WalletStateExactMetadataPolicy
     return None
 
 
+def _validate_state_exact_batch_metadata_policy(policy: WalletStateExactBatchMetadataPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_ids, list):
+        return "wallet_binding_ids_must_be_list"
+    if len(policy.wallet_binding_ids) == 0:
+        return "wallet_binding_ids_required"
+    for wallet_binding_id in policy.wallet_binding_ids:
+        if not isinstance(wallet_binding_id, str) or not wallet_binding_id.strip():
+            return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
 def _blocked_state_list_metadata_result(
     *,
     policy: WalletStateListMetadataPolicy,
@@ -753,5 +857,20 @@ def _blocked_state_exact_metadata_result(
         wallet_binding_id=policy.wallet_binding_id,
         owner_user_id=policy.owner_user_id,
         entry=None,
+        notes=notes,
+    )
+
+
+def _blocked_state_exact_batch_metadata_result(
+    *,
+    policy: WalletStateExactBatchMetadataPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateExactBatchMetadataResult:
+    return WalletStateExactBatchMetadataResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        owner_user_id=policy.owner_user_id,
+        entries=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md
+++ b/projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md
@@ -78,4 +78,6 @@ Validation commands run:
 **Report Timestamp:** 2026-04-17 04:35 (Asia/Jakarta)  
 **Role:** FORGE-X (NEXUS)  
 **Task:** Phase 6.5.9 wallet state metadata exact lookup batch  
-**Branch:** `feature/wallet-metadata-exact-batch-2026-04-17`
+**Branch:** `feature/add-batch-exact-metadata-lookup-for-wallets-2026-04-16`
+
+Known Deferred: Branch naming note: current PR head uses "add" as area segment (verb) instead of a noun area per AGENTS.md branch rule. Kept for 6.5.9 to avoid re-submit churn. Future wallet-metadata slices must use a noun area (e.g., data, core).

--- a/projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md
+++ b/projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md
@@ -1,0 +1,81 @@
+# FORGE-X Report — Phase 6.5.9 wallet state metadata exact lookup batch
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateStorageBoundary.get_state_metadata_batch` exact batch metadata lookup only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`.  
+**Not in Scope:** full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad wallet lifecycle redesign.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Implemented a new narrow wallet metadata exact batch lookup boundary on `WalletStateStorageBoundary`:
+- Added `get_state_metadata_batch(policy: WalletStateExactBatchMetadataPolicy) -> WalletStateExactBatchMetadataResult`.
+- Added deterministic block contracts for:
+  - invalid contract (`invalid_contract`)
+  - ownership mismatch (`ownership_mismatch`)
+  - wallet not active (`wallet_not_active`)
+- Added deterministic missing-entry handling in successful responses:
+  - each requested `wallet_binding_id` is returned in output
+  - missing or non-owner entries return `stored_revision=None`
+  - notes include `missing_wallet_binding_ids`
+- Added deterministic ordering guarantee based on exact input order of `wallet_binding_ids`.
+- Added metadata-only batch output (`wallet_binding_id`, `stored_revision`) with no full snapshot exposure.
+
+## 2) Current system architecture
+
+Wallet lifecycle storage boundaries now include:
+- `store_state` (6.5.2)
+- `read_state` (6.5.3)
+- `clear_state` (6.5.4)
+- `has_state` (6.5.5)
+- `list_state_metadata` (6.5.6 + 6.5.7)
+- `get_state_metadata` (6.5.8)
+- `get_state_metadata_batch` (6.5.9 exact multi-wallet metadata lookup)
+
+Phase 6.5.9 is narrow integration limited to one owner-scoped exact metadata batch retrieval path only.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+- `projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md`
+
+## 4) What is working
+
+- Exact batch metadata lookup works for explicit `wallet_binding_id` lists in owner scope only.
+- Success response returns metadata-only entries (`wallet_binding_id`, `stored_revision`) with no snapshot exposure.
+- Deterministic output order is preserved using exact input order.
+- Deterministic block behavior works for invalid contract, ownership mismatch, and wallet-not-active paths.
+- Deterministic missing handling works with `stored_revision=None` plus `missing_wallet_binding_ids` notes.
+- Existing single exact lookup behavior remains passing for 6.5.8 focused tests.
+
+Validation commands run:
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py`
+
+## 5) Known issues
+
+- Wallet lifecycle remains intentionally narrow and in-memory; no vault, orchestration, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: wallet state metadata exact batch lookup only (`get_state_metadata_batch`)
+- Not in Scope: full snapshot reads, secret rotation, vault integration, portfolio rollout, multi-wallet orchestration, scheduler expansion, settlement automation, broad wallet lifecycle redesign
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-17 04:35 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.5.9 wallet state metadata exact lookup batch  
+**Branch:** `feature/wallet-metadata-exact-batch-2026-04-17`

--- a/projects/polymarket/polyquantbot/reports/forge/29_52_phase6_5_9_wallet_metadata_cleanup.md
+++ b/projects/polymarket/polyquantbot/reports/forge/29_52_phase6_5_9_wallet_metadata_cleanup.md
@@ -1,0 +1,72 @@
+# FORGE-X Report — Phase 6.5.9 wallet metadata cleanup + convention sync
+
+**Validation Tier:** STANDARD  
+**Claim Level:** NARROW INTEGRATION  
+**Validation Target:** `WalletStateStorageBoundary.get_state_metadata_batch` input validation path only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, plus metadata correction in `projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md`.  
+**Not in Scope:** any happy-path batch lookup behavior change, ordering change, missing-entry handling change, owner scope logic change, other wallet lifecycle boundaries, other reports, branch rename, or PR #546 re-submit.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered a post-merge cleanup bundle for deferred PR #546 items only:
+- Added a defensive batch size guard for exact metadata batch lookup with max size constant `WALLET_STATE_METADATA_EXACT_BATCH_MAX_SIZE = 100`.
+- Added deterministic blocked handling for oversized input using blocked reason `wallet_binding_ids_too_many`.
+- Added one focused negative test for oversized input validation and blocked response behavior.
+- Corrected the Branch field in forge report `29_51` to the actual merged PR head branch.
+- Appended a single "Known Deferred" branch naming note in `29_51` for convention traceability.
+
+## 2) Current system architecture
+
+Phase 6.5.9 narrow batch metadata lookup remains unchanged on the happy path:
+- owner-scoped access behavior remains intact
+- input-order deterministic output remains intact
+- metadata-only output contract remains intact
+- missing-entry handling behavior remains intact
+
+Only the input validation path now adds deterministic protective size limits before normal processing.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+- `projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md`
+- `PROJECT_STATE.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/reports/forge/29_52_phase6_5_9_wallet_metadata_cleanup.md`
+
+## 4) What is working
+
+- Oversized `wallet_binding_ids` input (`>100`) is deterministically blocked with `wallet_binding_ids_too_many`.
+- Oversized input returns a blocked result with preserved owner scope and deterministic empty entries list.
+- Existing 6.5.9 tests continue to pass with the new guard test added (6 total in file).
+- Full regression for 6.5.6 through 6.5.9 remains passing.
+- Forge report `29_51` branch field now matches the actual merged PR head branch and includes a deferred branch naming note.
+
+Validation commands run:
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+2. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`
+
+## 5) Known issues
+
+- Wallet lifecycle remains intentionally narrow and in-memory; no vault, orchestration, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `get_state_metadata_batch` input validation path + forge report 29_51 metadata correction only
+- Not in Scope: any happy-path behavior change or scope expansion beyond deferred cleanup items
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-17 04:49 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** wallet metadata cleanup + convention sync  
+**Branch:** `chore/core-wallet-metadata-cleanup-20260417`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
     WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT,
     WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY,
     WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE,
     WalletStateExactBatchMetadataPolicy,
     WalletStateStorageBoundary,
     WalletStateStoragePolicy,
+    _validate_state_exact_batch_metadata_policy,
 )
 
 
@@ -143,3 +145,23 @@ def test_phase6_5_9_exact_metadata_batch_blocks_wallet_not_active() -> None:
     assert result.success is False
     assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE
     assert result.entries is None
+
+
+def test_phase6_5_9_exact_metadata_batch_blocks_too_many_wallet_binding_ids() -> None:
+    boundary = WalletStateStorageBoundary()
+    wallet_binding_ids = [f"wb-phase6-5-9-{index}" for index in range(101)]
+    policy = WalletStateExactBatchMetadataPolicy(
+        wallet_binding_ids=wallet_binding_ids,
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+    assert _validate_state_exact_batch_metadata_policy(policy) == "wallet_binding_ids_too_many"
+
+    result = boundary.get_state_metadata_batch(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY
+    assert result.entries == []
+    assert result.owner_user_id == "user-1"

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateExactBatchMetadataPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+)
+
+
+def _store_state(
+    *,
+    boundary: WalletStateStorageBoundary,
+    wallet_binding_id: str,
+    owner_user_id: str = "user-1",
+    nonce: int = 1,
+) -> None:
+    result = boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id=wallet_binding_id,
+            owner_user_id=owner_user_id,
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": 100.0,
+                "nonce": nonce,
+            },
+        ),
+    )
+    assert result.success is True
+
+
+def _base_batch_policy(
+    wallet_binding_ids: list[str] | None = None,
+) -> WalletStateExactBatchMetadataPolicy:
+    return WalletStateExactBatchMetadataPolicy(
+        wallet_binding_ids=wallet_binding_ids or ["wb-phase6-5-9-a", "wb-phase6-5-9-b"],
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_9_exact_metadata_batch_success_preserves_input_order_and_metadata_only() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-a")
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-a", nonce=2)
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-b")
+
+    result = boundary.get_state_metadata_batch(_base_batch_policy(["wb-phase6-5-9-b", "wb-phase6-5-9-a"]))
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.entries is not None
+    assert [entry.wallet_binding_id for entry in result.entries] == ["wb-phase6-5-9-b", "wb-phase6-5-9-a"]
+    assert [entry.stored_revision for entry in result.entries] == [1, 2]
+    assert not hasattr(result.entries[0], "state_snapshot")
+
+
+def test_phase6_5_9_exact_metadata_batch_missing_entries_are_deterministic() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-a")
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-other-owner", owner_user_id="user-2")
+
+    result = boundary.get_state_metadata_batch(
+        _base_batch_policy(
+            [
+                "wb-phase6-5-9-a",
+                "wb-phase6-5-9-missing",
+                "wb-phase6-5-9-other-owner",
+            ],
+        ),
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert [entry.wallet_binding_id for entry in result.entries] == [
+        "wb-phase6-5-9-a",
+        "wb-phase6-5-9-missing",
+        "wb-phase6-5-9-other-owner",
+    ]
+    assert [entry.stored_revision for entry in result.entries] == [1, None, None]
+    assert result.notes == {
+        "entry_count": 3,
+        "missing_wallet_binding_ids": [
+            "wb-phase6-5-9-missing",
+            "wb-phase6-5-9-other-owner",
+        ],
+    }
+
+
+def test_phase6_5_9_exact_metadata_batch_blocks_invalid_contract() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.get_state_metadata_batch(
+        WalletStateExactBatchMetadataPolicy(
+            wallet_binding_ids=[],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.entries is None
+    assert result.notes == {"contract_error": "wallet_binding_ids_required"}
+
+
+def test_phase6_5_9_exact_metadata_batch_blocks_ownership_mismatch() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-a")
+
+    result = boundary.get_state_metadata_batch(
+        WalletStateExactBatchMetadataPolicy(
+            wallet_binding_ids=["wb-phase6-5-9-a"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH
+    assert result.entries is None
+
+
+def test_phase6_5_9_exact_metadata_batch_blocks_wallet_not_active() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-9-a")
+
+    result = boundary.get_state_metadata_batch(
+        WalletStateExactBatchMetadataPolicy(
+            wallet_binding_ids=["wb-phase6-5-9-a"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE
+    assert result.entries is None


### PR DESCRIPTION
### Motivation
- Provide a narrow read-only boundary to fetch metadata for multiple `wallet_binding_id` values in a single request without exposing full state snapshots.
- Keep owner-scoped access and metadata-only output (`wallet_binding_id`, `stored_revision`) while avoiding extra lifecycle or vault scope changes.
- Ensure deterministic behavior for ordering, missing entries, and blocking conditions (invalid contract, ownership mismatch, wallet not active).

### Description
- Added new batch block constants and dataclasses: `WALLET_STATE_METADATA_EXACT_BATCH_*`, `WalletStateExactBatchMetadataPolicy`, `WalletStateExactBatchMetadataEntry`, and `WalletStateExactBatchMetadataResult` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.
- Implemented `WalletStateStorageBoundary.get_state_metadata_batch(policy: WalletStateExactBatchMetadataPolicy)` which iterates `wallet_binding_ids` in exact input order, returns metadata-only entries with `stored_revision` or `None` for missing/non-owner entries, and records `missing_wallet_binding_ids` in `notes`.
- Added deterministic policy validator `_validate_state_exact_batch_metadata_policy` and blocked-result helper `_blocked_state_exact_batch_metadata_result`, and new batch block handling for `invalid_contract`, `ownership_mismatch`, and `wallet_not_active`.
- Added focused tests `projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py`, a FORGE report `projects/polymarket/polyquantbot/reports/forge/29_51_phase6_5_9_wallet_state_metadata_exact_lookup_batch.md`, and updated `PROJECT_STATE.md` to mark Phase 6.5.9 in progress.

### Testing
- Ran static compile check: `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py` which succeeded.
- Ran focused pytest for the new batch tests: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py` and observed the new tests pass (5 passed).
- Ran the full wallet metadata test set: `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_6_wallet_state_list_metadata_boundary_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_7_wallet_state_metadata_query_expansion_20260416.py projects/polymarket/polyquantbot/tests/test_phase6_5_8_wallet_state_metadata_exact_lookup_20260417.py projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py` and observed all tests passed (`25 passed`) with one non-blocking pytest config warning about `asyncio_mode`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e155b429248325b69d39b4c8e11740)