### PR TITLE
docs: sync PROJECT_STATE/ROADMAP and clarify VELOCITY MODE after Phase 6.5.x merges

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-📅 Last Updated : 2026-04-17 05:38
-🔄 Status       : Repo-root truth is aligned for merged wallet lifecycle slices through Phase 6.5.6 and Phase 6.5.9 exact batch metadata lookup on main; Phase 6.5.8 metadata exact lookup still awaits COMMANDER review; docs/commander_knowledge.md sync (13 patches + VELOCITY MODE) is implemented on branch claude/sync-commander-knowledge-1n14o awaiting COMMANDER review.
+📅 Last Updated : 2026-04-17 09:23
+🔄 Status       : Repo-root truth is aligned with merged Phase 6.5.8 exact metadata lookup (PR #544) and Phase 6.5.9 exact batch metadata lookup (PR #546) on main; docs/commander_knowledge.md sync patches are merged on main, and this branch applies the remaining VELOCITY MODE blocker wording clarification.
 
 ✅ COMPLETED
 - Phase 5.2–5.6 execution, signing, wallet-capital, and settlement boundaries implemented and major-gated SENTINEL validation completed.
@@ -12,11 +12,11 @@
 - Phase 6.5.6 wallet state list metadata boundary is merged-main accepted truth via PR #541 at WalletStateStorageBoundary.list_state_metadata with real per-entry owner-scoped filtering, deterministic sort by wallet_binding_id ascending, metadata-only output (wallet_binding_id + stored_revision), and block contracts for invalid contract, ownership mismatch, and wallet not active.
 - AGENTS.md and docs/commander_knowledge.md direct-fix confirmation gate patch is accepted truth on main.
 - Branch verification / repo-truth drift guard patches in AGENTS.md and docs/commander_knowledge.md are accepted truth on main.
+
 🔧 IN PROGRESS
 - Phase 6.4.1 Monitoring & Circuit Breaker FOUNDATION spec contract remains in progress; runtime-wide monitoring rollout is not claimed.
 - Phase 6.5.7 wallet state metadata query expansion is implemented at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters (prefix, min revision, max entries) while preserving owner scope and metadata-only output.
-- Phase 6.5.8 wallet state metadata exact lookup is implemented at WalletStateStorageBoundary.get_state_metadata with deterministic owner-scoped metadata-only output (wallet_binding_id + stored_revision) and deterministic blocks for invalid contract, ownership mismatch, wallet not active, and metadata not found.
-- docs/commander_knowledge.md sync — 13 patches applied (branch mismatch, path resolve, timestamp, domain structure, SENTINEL never-list, report naming, VELOCITY MODE) on branch claude/sync-commander-knowledge-1n14o; awaiting COMMANDER review.
+- Repo-truth sync pass: PROJECT_STATE.md and ROADMAP.md merge-truth alignment for merged Phase 6.5.8 / 6.5.9 plus VELOCITY MODE blocker wording clarification in docs/commander_knowledge.md.
 
 📋 NOT STARTED
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,10 +25,9 @@
 - Reconciliation mutation and correction workflow beyond the delivered read-only / append-only boundaries.
 
 🎯 NEXT PRIORITY
-- COMMANDER review required for commander_knowledge.md sync (Tier: MINOR). Source: projects/polymarket/polyquantbot/reports/forge/30_1_commander-sync.md. Branch: claude/sync-commander-knowledge-1n14o.
-- COMMANDER review required for Phase 6.5.8 before merge. Auto PR review optional if used. Source: projects/polymarket/polyquantbot/reports/forge/29_50_phase6_5_8_wallet_state_metadata_exact_lookup.md. Tier: STANDARD.
+- COMMANDER review required for repo-truth sync after merged Phase 6.5.x (Tier: MINOR). Source: projects/polymarket/polyquantbot/reports/forge/30_2_repo_truth_sync_after_merged_phase6_5_x.md. Branch: update/core-repo-truth-sync-20260417.
 
-蚀️ KNOWN ISSUES
+⚠️ KNOWN ISSUES
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
 - Phase 5.3 network path is intentionally narrow with no retry, batching, and async workers.
 - Phase 5.4 introduces secure signing boundary only; wallet lifecycle and capital movement remain intentionally unimplemented.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-17 03:41
+**Last Updated:** 2026-04-17 09:23
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-17 03:41
+**Last Updated:** 2026-04-17 09:23
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -66,6 +66,9 @@
 | 6.5.4 | Wallet Lifecycle Foundation — State Clear Boundary Narrow Slice | ✅ Done | Merged-main accepted truth after PR #537 at `WalletStateStorageBoundary.clear_state` with deterministic success and block contracts for invalid contract, ownership mismatch, inactive wallet, and not-found clears. |
 | 6.5.5 | Wallet Lifecycle Foundation — State Exists Boundary Narrow Slice | ✅ Done | Merged-main accepted truth after PR #539 at `WalletStateStorageBoundary.has_state` with deterministic success true/false and block contracts for invalid contract, ownership mismatch, and inactive wallet. |
 | 6.5.6 | Wallet Lifecycle Foundation — State List Metadata Boundary Narrow Slice | ✅ Done | Merged-main accepted truth after PR #541 at `WalletStateStorageBoundary.list_state_metadata` with real per-entry owner-scoped filtering, deterministic success (sorted metadata-only entries: wallet_binding_id + stored_revision), and block contracts for invalid contract, ownership mismatch, and inactive wallet. No full snapshot exposure. |
+| 6.5.7 | Wallet Lifecycle Foundation — State Metadata Query Expansion | ✅ Done | Merged-main truth accepted via PR #543 at `WalletStateStorageBoundary.list_state_metadata` with optional deterministic filters (prefix, min revision, max entries) while preserving owner-scope metadata-only output. |
+| 6.5.8 | Wallet Lifecycle Foundation — State Metadata Exact Lookup | ✅ Done | Merged-main truth accepted via PR #544 at `WalletStateStorageBoundary.get_state_metadata` with deterministic metadata-only exact lookup and deterministic block contracts for invalid contract, ownership mismatch, inactive wallet, and not found. |
+| 6.5.9 | Wallet Lifecycle Foundation — State Metadata Exact Batch Lookup | ✅ Done | Merged-main truth accepted via PR #546 at `WalletStateStorageBoundary.get_state_metadata_batch` with owner-scoped metadata-only output, deterministic input-order preservation, and explicit missing-wallet handling via `stored_revision=None`. |
 
 ---
 

--- a/docs/commander_knowledge.md
+++ b/docs/commander_knowledge.md
@@ -83,7 +83,7 @@ Hard rules:
 * if uncertainty is low and risk is low → decide, do not ask
 * if evidence is clear → merge, do not re-verify ceremonially
 
-Only block when ALL of these are true:
+Only block when ANY of these are true:
 
 * real risk to capital / execution / runtime integrity exists, OR
 * critical safety finding exists, OR

--- a/projects/polymarket/polyquantbot/reports/forge/30_2_repo_truth_sync_after_merged_phase6_5_x.md
+++ b/projects/polymarket/polyquantbot/reports/forge/30_2_repo_truth_sync_after_merged_phase6_5_x.md
@@ -1,0 +1,74 @@
+# FORGE-X Report — repo truth sync after merged phase 6.5.x
+
+**Validation Tier:** MINOR  
+**Claim Level:** FOUNDATION  
+**Validation Target:** Repo-truth sync only for `PROJECT_STATE.md`, `ROADMAP.md`, and `docs/commander_knowledge.md`.  
+**Not in Scope:** PR #543 review, runtime logic changes, wallet code changes, execution/risk behavior, report content beyond references needed for truth sync.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review optional support. Tier: MINOR.
+
+---
+
+## 1) What was built
+
+Completed a repo-truth synchronization pass after merged Phase 6.5.x work:
+- Removed stale “await COMMANDER review” references tied to already-merged 6.5.x slices in `PROJECT_STATE.md`.
+- Updated `PROJECT_STATE.md` status/next-gate wording to reflect merged truth for 6.5.8 and 6.5.9, and to point NEXT PRIORITY to this current MINOR sync task.
+- Updated `ROADMAP.md` with merged milestone rows for:
+  - 6.5.7 metadata query expansion (PR #543)
+  - 6.5.8 metadata exact lookup (PR #544)
+  - 6.5.9 metadata exact batch lookup (PR #546)
+- Corrected VELOCITY MODE blocker logic wording in `docs/commander_knowledge.md` from an internally contradictory quantifier to unambiguous logic.
+
+## 2) Current system architecture
+
+No runtime architecture change.
+This task is documentation/state synchronization only:
+- operational truth file (`PROJECT_STATE.md`)
+- roadmap planning truth (`ROADMAP.md`)
+- commander policy wording (`docs/commander_knowledge.md`)
+
+All trading runtime paths, risk/execution behavior, and wallet implementation code remain unchanged.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+- `docs/commander_knowledge.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/reports/forge/30_2_repo_truth_sync_after_merged_phase6_5_x.md`
+
+## 4) What is working
+
+- PROJECT_STATE now reflects merged truth for 6.5.8 / 6.5.9 and removes stale review-gate wording tied to already-merged work.
+- ROADMAP Phase 6.5.x table now explicitly records 6.5.7, 6.5.8, and 6.5.9 as done with merged PR references.
+- VELOCITY MODE blocker condition sentence is now logically consistent with the OR-based condition list.
+- Timestamp updates use Asia/Jakarta full format (`YYYY-MM-DD HH:MM`).
+
+Verification evidence used:
+- Local git history merge commits:
+  - `Merge PR #543: Phase 6.5.7 metadata query expansion`
+  - `Merge PR #544: Phase 6.5.8 metadata exact lookup`
+  - `Merge PR #546: Phase 6.5.9 exact wallet metadata batch lookup`
+- Attempted remote GitHub raw verification from this environment returned HTTP 403 (CONNECT tunnel failed), so merge-truth validation was completed from local repo commit history.
+
+## 5) Known issues
+
+- Environment network restriction prevented direct raw.githubusercontent.com verification during this task (HTTP 403 tunnel failure).
+- No runtime issues introduced (docs/state-only MINOR sync).
+
+## 6) What is next
+
+- Validation Tier: MINOR
+- Claim Level: FOUNDATION
+- Validation Target: repo-truth sync only (`PROJECT_STATE.md`, `ROADMAP.md`, `docs/commander_knowledge.md`)
+- Not in Scope: runtime and wallet logic changes, execution/risk behavior changes, or SENTINEL validation
+- Suggested Next Step: COMMANDER review (No SENTINEL)
+
+---
+
+**Report Timestamp:** 2026-04-17 09:23 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** repo truth sync after merged phase 6.5.x  
+**Branch:** `update/core-repo-truth-sync-20260417` (declared task branch; Codex HEAD label is `work`)


### PR DESCRIPTION
### Motivation

- Align repo-state and roadmap planning truth with recently-merged Phase 6.5.x work and remove stale “awaiting review” blockers.
- Make commander policy unambiguous by fixing the VELOCITY MODE blocker quantifier so decisions reflect intended OR-style conditions.

### Description

- Updated `PROJECT_STATE.md` to use Asia/Jakarta timestamp `2026-04-17 09:23`, remove stale "await COMMANDER review" lines for 6.5.8/6.5.9, update `NEXT PRIORITY` to this repo-truth sync task, and normalize the known-issues label.
- Updated `ROADMAP.md` Last Updated timestamps and added explicit merged/done rows for sub-phases `6.5.7`, `6.5.8`, and `6.5.9` with PR references and notes about behavior guarantees.
- Fixed VELOCITY MODE wording in `docs/commander_knowledge.md` by changing the blocker sentence from "Only block when ALL of these are true" to "Only block when ANY of these are true" to match the OR-style condition list.
- Added the FORGE report `projects/polymarket/polyquantbot/reports/forge/30_2_repo_truth_sync_after_merged_phase6_5_x.md` documenting the sync, verification evidence, and next steps.

### Testing

- Produced Jakarta timestamp using `python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('Asia/Jakarta')).strftime('%Y-%m-%d %H:%M'))"` and applied it to `PROJECT_STATE.md` (succeeded).
- Repository diff check (`git diff --check`) passed and `rg` searches confirmed the updated strings and presence of `6.5.7`, `6.5.8`, `6.5.9`, and the VELOCITY MODE text in the modified files (succeeded).
- Attempted remote raw GitHub verification with `curl` failed due to an environment network restriction (HTTP 403), so merge-truth validation used local repository merge history as evidence (network check failed).
- Running `python3 -m py_compile` on Markdown is not applicable and produced a syntax error; no runtime code or unit tests were required for this MINOR docs/state-only change (not applicable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1995df1408325800479ffbaffd9cd)