### PR TITLE
feature(wallet): phase 6.5.10 exact batch state read boundary

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 02:25
-Status       : Repo baseline is aligned with merged Phase 6.5.9 wallet state exact batch metadata lookup truth via PR #546. Phase 6.4.1 remains spec-approved only and is not the active implementation lane. Next forward slice should continue in the Phase 6.5 wallet lifecycle lane.
+Last Updated : 2026-04-18 02:47
+Status       : Phase 6.5.10 wallet state exact batch read boundary delivered via read_state_batch on WalletStateStorageBoundary. Branch claude/wallet-state-batch-read-X9ivi open, pending COMMANDER review. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -12,12 +12,12 @@ Status       : Repo baseline is aligned with merged Phase 6.5.9 wallet state exa
 - Phase 6.5.7 wallet state metadata query expansion merged via PR #543 at WalletStateStorageBoundary.list_state_metadata with optional deterministic filters while preserving owner-scope metadata-only output.
 - Phase 6.5.8 wallet state metadata exact lookup merged via PR #544 at WalletStateStorageBoundary.get_state_metadata with deterministic metadata-only exact lookup and block contracts for invalid contract, ownership mismatch, inactive wallet, and not found.
 - Phase 6.5.9 wallet state metadata exact batch lookup merged via PR #546 at WalletStateStorageBoundary.get_state_metadata_batch with owner-scoped metadata-only output, deterministic input-order preservation, and explicit missing-wallet handling via stored_revision=None.
+- Phase 6.5.10 wallet state exact batch read boundary delivered at WalletStateStorageBoundary.read_state_batch with owner-scoped full snapshot output, deterministic input-order preservation, and explicit missing-wallet handling via state_found=False and state_snapshot=None.
 
 [IN PROGRESS]
-- None.
+- Phase 6.5.10 wallet state exact batch read boundary — PR open on claude/wallet-state-batch-read-X9ivi, pending COMMANDER review.
 
 [NOT STARTED]
-- Phase 6.5.10 wallet state exact batch read boundary is the next forward wallet lifecycle slice and has not been opened yet.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
@@ -25,7 +25,7 @@ Status       : Repo baseline is aligned with merged Phase 6.5.9 wallet state exa
 - Reconciliation mutation and correction workflow beyond the delivered read-only and append-only boundaries.
 
 [NEXT PRIORITY]
-- Open Phase 6.5.10 wallet state exact batch read boundary as the next wallet lifecycle slice.
+- COMMANDER review of Phase 6.5.10 wallet state exact batch read boundary on claude/wallet-state-batch-read-X9ivi before merge.
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 02:25
+**Last Updated:** 2026-04-18 02:47
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 02:25
+**Last Updated:** 2026-04-18 02:47
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -69,7 +69,7 @@
 | 6.5.7 | Wallet Lifecycle Foundation — State Metadata Query Expansion | ✅ Done | Merged-main truth accepted via PR #543 at `WalletStateStorageBoundary.list_state_metadata` with optional deterministic filters (prefix, min revision, max entries) while preserving owner-scope metadata-only output. |
 | 6.5.8 | Wallet Lifecycle Foundation — State Metadata Exact Lookup | ✅ Done | Merged-main truth accepted via PR #544 at `WalletStateStorageBoundary.get_state_metadata` with deterministic metadata-only exact lookup and deterministic block contracts for invalid contract, ownership mismatch, inactive wallet, and not found. |
 | 6.5.9 | Wallet Lifecycle Foundation — State Metadata Exact Batch Lookup | ✅ Done | Merged-main truth accepted via PR #546 at `WalletStateStorageBoundary.get_state_metadata_batch` with owner-scoped metadata-only output, deterministic input-order preservation, and explicit missing-wallet handling via `stored_revision=None`. |
-| 6.5.10 | Wallet Lifecycle Foundation — State Exact Batch Read Boundary | ❌ Not Started | Next forward wallet lifecycle slice after 6.5.9; deliver exact batch state reads without reopening 6.4 as the active lane. |
+| 6.5.10 | Wallet Lifecycle Foundation — State Exact Batch Read Boundary | 🚧 In Progress | Delivered WalletStateStorageBoundary.read_state_batch with owner-scoped full snapshot output, deterministic input-order preservation, and explicit missing-wallet handling via state_found=False. Pending COMMANDER review on claude/wallet-state-batch-read-X9ivi. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -37,6 +37,11 @@ WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch
 WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
 WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY = "wallet_binding_ids_too_many"
 WALLET_STATE_METADATA_EXACT_BATCH_MAX_SIZE = 100
+WALLET_STATE_READ_BATCH_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_STATE_READ_BATCH_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_STATE_READ_BATCH_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY = "wallet_binding_ids_too_many"
+WALLET_STATE_READ_BATCH_MAX_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -266,6 +271,31 @@ class WalletStateExactBatchMetadataResult:
     blocked_reason: str | None
     owner_user_id: str
     entries: list[WalletStateExactBatchMetadataEntry] | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class WalletStateReadBatchPolicy:
+    wallet_binding_ids: list[str]
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletStateReadBatchEntry:
+    wallet_binding_id: str
+    state_found: bool
+    state_snapshot: dict[str, Any] | None
+    stored_revision: int | None
+
+
+@dataclass(frozen=True)
+class WalletStateReadBatchResult:
+    success: bool
+    blocked_reason: str | None
+    owner_user_id: str
+    entries: list[WalletStateReadBatchEntry] | None
     notes: dict[str, Any] | None = None
 
 
@@ -636,6 +666,74 @@ class WalletStateStorageBoundary:
             },
         )
 
+    def read_state_batch(
+        self,
+        policy: WalletStateReadBatchPolicy,
+    ) -> WalletStateReadBatchResult:
+        """Phase 6.5.10 narrow wallet lifecycle boundary: fetch full state for explicit wallet_binding_ids.
+        Deterministic ordering is preserved by iterating wallet_binding_ids in the exact input order.
+        Missing or owner-mismatch entries return state_found=False with state_snapshot=None and stored_revision=None."""
+        contract_error = _validate_state_read_batch_policy(policy)
+        if contract_error is not None:
+            blocked_reason = WALLET_STATE_READ_BATCH_BLOCK_INVALID_CONTRACT
+            if contract_error == WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY:
+                blocked_reason = WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY
+            return _blocked_state_read_batch_result(
+                policy=policy,
+                blocked_reason=blocked_reason,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_state_read_batch_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_state_read_batch_result(
+                policy=policy,
+                blocked_reason=WALLET_STATE_READ_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        entries: list[WalletStateReadBatchEntry] = []
+        missing_wallet_binding_ids: list[str] = []
+        for wallet_binding_id in policy.wallet_binding_ids:
+            record = self._store.get(wallet_binding_id)
+            if record is None or record.get("owner_user_id") != policy.owner_user_id:
+                entries.append(
+                    WalletStateReadBatchEntry(
+                        wallet_binding_id=wallet_binding_id,
+                        state_found=False,
+                        state_snapshot=None,
+                        stored_revision=None,
+                    ),
+                )
+                missing_wallet_binding_ids.append(wallet_binding_id)
+                continue
+
+            entries.append(
+                WalletStateReadBatchEntry(
+                    wallet_binding_id=wallet_binding_id,
+                    state_found=True,
+                    state_snapshot=dict(record["state_snapshot"]),
+                    stored_revision=int(record["revision"]),
+                ),
+            )
+
+        return WalletStateReadBatchResult(
+            success=True,
+            blocked_reason=None,
+            owner_user_id=policy.owner_user_id,
+            entries=entries,
+            notes={
+                "entry_count": len(entries),
+                "missing_wallet_binding_ids": missing_wallet_binding_ids,
+            },
+        )
+
 
 def _validate_state_storage_policy(policy: WalletStateStoragePolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -878,6 +976,43 @@ def _blocked_state_exact_batch_metadata_result(
     if blocked_reason == WALLET_STATE_METADATA_EXACT_BATCH_BLOCK_TOO_MANY:
         entries = []
     return WalletStateExactBatchMetadataResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        owner_user_id=policy.owner_user_id,
+        entries=entries,
+        notes=notes,
+    )
+
+
+def _validate_state_read_batch_policy(policy: WalletStateReadBatchPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_ids, list):
+        return "wallet_binding_ids_must_be_list"
+    if len(policy.wallet_binding_ids) == 0:
+        return "wallet_binding_ids_required"
+    if len(policy.wallet_binding_ids) > WALLET_STATE_READ_BATCH_MAX_SIZE:
+        return WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY
+    for wallet_binding_id in policy.wallet_binding_ids:
+        if not isinstance(wallet_binding_id, str) or not wallet_binding_id.strip():
+            return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_state_read_batch_result(
+    *,
+    policy: WalletStateReadBatchPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletStateReadBatchResult:
+    entries: list[WalletStateReadBatchEntry] | None = None
+    if blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY:
+        entries = []
+    return WalletStateReadBatchResult(
         success=False,
         blocked_reason=blocked_reason,
         owner_user_id=policy.owner_user_id,

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-5-10_01_wallet-state-exact-batch-read.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-5-10_01_wallet-state-exact-batch-read.md
@@ -1,0 +1,93 @@
+# FORGE-X Report — Phase 6.5.10 wallet state exact batch read boundary
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** `WalletStateStorageBoundary.read_state_batch` exact batch state read path only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py`.
+**Not in Scope:** wallet mutation flows, secret rotation, vault integration, portfolio orchestration, live trading, retry workers, settlement automation, multi-wallet orchestration, scheduler expansion, Phase 6.4 monitoring work, broader wallet lifecycle rollout.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Implemented a new narrow exact batch state read boundary on `WalletStateStorageBoundary`:
+
+- Added `read_state_batch(policy: WalletStateReadBatchPolicy) -> WalletStateReadBatchResult`.
+- Added deterministic block contracts for:
+  - invalid contract (`invalid_contract`)
+  - ownership mismatch (`ownership_mismatch`)
+  - wallet not active (`wallet_not_active`)
+  - too many wallet_binding_ids (`wallet_binding_ids_too_many`)
+- Added deterministic per-entry results in successful responses:
+  - each requested `wallet_binding_id` returned in input order
+  - found entries return full `state_snapshot` copy, `state_found=True`, and `stored_revision`
+  - missing or non-owner entries return `state_found=False`, `state_snapshot=None`, `stored_revision=None`
+  - notes include `entry_count` and `missing_wallet_binding_ids`
+- Added max batch size constant `WALLET_STATE_READ_BATCH_MAX_SIZE = 100`.
+- Added new dataclasses: `WalletStateReadBatchPolicy`, `WalletStateReadBatchEntry`, `WalletStateReadBatchResult`.
+- Added validator: `_validate_state_read_batch_policy`.
+- Added blocked result helper: `_blocked_state_read_batch_result`.
+- State snapshot returned as a copy — mutation of returned snapshot cannot affect stored state.
+
+## 2) Current system architecture
+
+Wallet lifecycle storage boundaries in `WalletStateStorageBoundary` now include:
+
+- `store_state` (6.5.2) — write single wallet state
+- `read_state` (6.5.3) — read single wallet state
+- `clear_state` (6.5.4) — clear single wallet state
+- `has_state` (6.5.5) — check if single wallet state exists
+- `list_state_metadata` (6.5.6 + 6.5.7) — list metadata with optional filters
+- `get_state_metadata` (6.5.8) — exact single metadata lookup
+- `get_state_metadata_batch` (6.5.9) — exact batch metadata lookup (no snapshots)
+- `read_state_batch` (6.5.10) — exact batch state read (full snapshots, owner-scoped)
+
+All boundaries remain in-memory only. No vault, scheduler, portfolio, or orchestration wiring is claimed.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-5-10_01_wallet-state-exact-batch-read.md`
+
+## 4) What is working
+
+- Exact batch state read works for explicit `wallet_binding_id` lists in owner scope only.
+- Success response returns full `state_snapshot` (copy) per found entry plus `stored_revision` and `state_found=True`.
+- Missing or owner-mismatch entries deterministically return `state_found=False`, `state_snapshot=None`, `stored_revision=None`.
+- Deterministic input-order preservation confirmed across all test cases.
+- Snapshot copy isolation confirmed — mutation of returned snapshot does not affect stored state.
+- Block contracts confirmed for invalid contract (empty list, blank entry), ownership mismatch, wallet not active, and too-many-ids.
+- All existing 6.5.3 and 6.5.9 tests remain passing (13 tests, 0 failures).
+
+Validation commands run:
+
+1. `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. `python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py`
+3. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py` — 12 passed, 0 failures
+4. `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase6_5_9_wallet_state_metadata_exact_lookup_batch_20260417.py projects/polymarket/polyquantbot/tests/test_phase6_5_3_wallet_state_read_boundary_20260416.py` — 13 passed, 0 failures
+
+## 5) Known issues
+
+- Wallet lifecycle remains intentionally narrow and in-memory; no vault, orchestration, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletStateStorageBoundary.read_state_batch` exact batch state read path only
+- Not in Scope: wallet mutation flows, secret rotation, vault integration, portfolio orchestration, live trading, retry workers, settlement automation, Phase 6.4 monitoring work, broader wallet lifecycle rollout
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 02:47 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.5.10 wallet state exact batch read boundary
+**Branch:** `claude/wallet-state-batch-read-X9ivi`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_5_10_wallet_state_exact_batch_read_20260418.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_STATE_READ_BATCH_BLOCK_INVALID_CONTRACT,
+    WALLET_STATE_READ_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY,
+    WALLET_STATE_READ_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+    WalletStateReadBatchPolicy,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+    _validate_state_read_batch_policy,
+)
+
+
+def _store_state(
+    *,
+    boundary: WalletStateStorageBoundary,
+    wallet_binding_id: str,
+    owner_user_id: str = "user-1",
+    nonce: int = 1,
+    available_balance: float = 100.0,
+) -> None:
+    result = boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id=wallet_binding_id,
+            owner_user_id=owner_user_id,
+            wallet_active=True,
+            state_snapshot={
+                "wallet_status": "ready",
+                "available_balance": available_balance,
+                "nonce": nonce,
+            },
+        ),
+    )
+    assert result.success is True
+
+
+def _base_batch_read_policy(
+    wallet_binding_ids: list[str] | None = None,
+) -> WalletStateReadBatchPolicy:
+    return WalletStateReadBatchPolicy(
+        wallet_binding_ids=wallet_binding_ids or ["wb-phase6-5-10-a", "wb-phase6-5-10-b"],
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+
+def test_phase6_5_10_read_batch_success_returns_full_snapshots_in_input_order() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a", nonce=1, available_balance=100.0)
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a", nonce=2, available_balance=200.0)
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-b", nonce=1, available_balance=50.0)
+
+    result = boundary.read_state_batch(
+        _base_batch_read_policy(["wb-phase6-5-10-b", "wb-phase6-5-10-a"])
+    )
+
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.entries is not None
+    assert [e.wallet_binding_id for e in result.entries] == ["wb-phase6-5-10-b", "wb-phase6-5-10-a"]
+    assert [e.state_found for e in result.entries] == [True, True]
+    assert [e.stored_revision for e in result.entries] == [1, 2]
+    entry_b = result.entries[0]
+    assert entry_b.state_snapshot == {"wallet_status": "ready", "available_balance": 50.0, "nonce": 1}
+    entry_a = result.entries[1]
+    assert entry_a.state_snapshot == {"wallet_status": "ready", "available_balance": 200.0, "nonce": 2}
+
+
+def test_phase6_5_10_read_batch_snapshot_is_copy_not_reference() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a")
+
+    result = boundary.read_state_batch(_base_batch_read_policy(["wb-phase6-5-10-a"]))
+
+    assert result.success is True
+    assert result.entries is not None
+    snapshot = result.entries[0].state_snapshot
+    assert snapshot is not None
+    snapshot["tampered"] = True
+    result2 = boundary.read_state_batch(_base_batch_read_policy(["wb-phase6-5-10-a"]))
+    assert result2.entries is not None
+    assert "tampered" not in result2.entries[0].state_snapshot
+
+
+def test_phase6_5_10_read_batch_missing_entries_are_deterministic() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a")
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-other-owner", owner_user_id="user-2")
+
+    result = boundary.read_state_batch(
+        _base_batch_read_policy(
+            [
+                "wb-phase6-5-10-a",
+                "wb-phase6-5-10-missing",
+                "wb-phase6-5-10-other-owner",
+            ],
+        ),
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert [e.wallet_binding_id for e in result.entries] == [
+        "wb-phase6-5-10-a",
+        "wb-phase6-5-10-missing",
+        "wb-phase6-5-10-other-owner",
+    ]
+    assert [e.state_found for e in result.entries] == [True, False, False]
+    assert [e.stored_revision for e in result.entries] == [1, None, None]
+    assert [e.state_snapshot for e in result.entries] == [
+        {"wallet_status": "ready", "available_balance": 100.0, "nonce": 1},
+        None,
+        None,
+    ]
+    assert result.notes == {
+        "entry_count": 3,
+        "missing_wallet_binding_ids": [
+            "wb-phase6-5-10-missing",
+            "wb-phase6-5-10-other-owner",
+        ],
+    }
+
+
+def test_phase6_5_10_read_batch_all_missing_returns_success_with_none_snapshots() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.read_state_batch(
+        _base_batch_read_policy(["wb-phase6-5-10-missing-1", "wb-phase6-5-10-missing-2"])
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert all(e.state_found is False for e in result.entries)
+    assert all(e.state_snapshot is None for e in result.entries)
+    assert all(e.stored_revision is None for e in result.entries)
+    assert result.notes is not None
+    assert result.notes["missing_wallet_binding_ids"] == [
+        "wb-phase6-5-10-missing-1",
+        "wb-phase6-5-10-missing-2",
+    ]
+
+
+def test_phase6_5_10_read_batch_blocks_invalid_contract_empty_list() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=[],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.entries is None
+    assert result.notes == {"contract_error": "wallet_binding_ids_required"}
+
+
+def test_phase6_5_10_read_batch_blocks_invalid_contract_blank_entry() -> None:
+    boundary = WalletStateStorageBoundary()
+
+    result = boundary.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=["wb-phase6-5-10-a", "   "],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.entries is None
+
+
+def test_phase6_5_10_read_batch_blocks_ownership_mismatch() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a")
+
+    result = boundary.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=["wb-phase6-5-10-a"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_OWNERSHIP_MISMATCH
+    assert result.entries is None
+
+
+def test_phase6_5_10_read_batch_blocks_wallet_not_active() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-a")
+
+    result = boundary.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=["wb-phase6-5-10-a"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=False,
+        ),
+    )
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_WALLET_NOT_ACTIVE
+    assert result.entries is None
+
+
+def test_phase6_5_10_read_batch_blocks_too_many_wallet_binding_ids() -> None:
+    boundary = WalletStateStorageBoundary()
+    wallet_binding_ids = [f"wb-phase6-5-10-{index}" for index in range(101)]
+    policy = WalletStateReadBatchPolicy(
+        wallet_binding_ids=wallet_binding_ids,
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+
+    assert _validate_state_read_batch_policy(policy) == "wallet_binding_ids_too_many"
+
+    result = boundary.read_state_batch(policy)
+
+    assert result.success is False
+    assert result.blocked_reason == WALLET_STATE_READ_BATCH_BLOCK_TOO_MANY
+    assert result.entries == []
+    assert result.owner_user_id == "user-1"
+
+
+def test_phase6_5_10_read_batch_does_not_expose_other_owner_snapshots() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-shared", owner_user_id="user-2")
+
+    result = boundary.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=["wb-shared"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        ),
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert result.entries[0].state_found is False
+    assert result.entries[0].state_snapshot is None
+    assert result.entries[0].stored_revision is None
+
+
+def test_phase6_5_10_read_batch_single_entry_success() -> None:
+    boundary = WalletStateStorageBoundary()
+    _store_state(boundary=boundary, wallet_binding_id="wb-phase6-5-10-single", nonce=5, available_balance=999.0)
+
+    result = boundary.read_state_batch(
+        _base_batch_read_policy(["wb-phase6-5-10-single"])
+    )
+
+    assert result.success is True
+    assert result.entries is not None
+    assert len(result.entries) == 1
+    assert result.entries[0].state_found is True
+    assert result.entries[0].stored_revision == 1
+    assert result.entries[0].state_snapshot == {
+        "wallet_status": "ready",
+        "available_balance": 999.0,
+        "nonce": 5,
+    }
+    assert result.notes == {"entry_count": 1, "missing_wallet_binding_ids": []}
+
+
+def test_phase6_5_10_prior_phase_read_state_still_passes() -> None:
+    boundary = WalletStateStorageBoundary()
+    from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+        WalletStateReadPolicy,
+    )
+    boundary.store_state(
+        WalletStateStoragePolicy(
+            wallet_binding_id="wb-phase6-5-3-compat",
+            owner_user_id="user-1",
+            wallet_active=True,
+            state_snapshot={"wallet_status": "ready", "available_balance": 50.0, "nonce": 1},
+        )
+    )
+    read_result = boundary.read_state(
+        WalletStateReadPolicy(
+            wallet_binding_id="wb-phase6-5-3-compat",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert read_result.success is True
+    assert read_result.state_found is True
+    assert read_result.state_snapshot == {"wallet_status": "ready", "available_balance": 50.0, "nonce": 1}


### PR DESCRIPTION
Adds WalletStateStorageBoundary.read_state_batch with owner-scoped full
snapshot output, deterministic input-order preservation, and explicit
missing-wallet handling via state_found=False and state_snapshot=None.

Block contracts: invalid contract, ownership mismatch, wallet not active,
too many wallet_binding_ids (max 100). Snapshot returned as copy — caller
mutation cannot corrupt stored state. 12 targeted tests pass; prior 6.5.3
and 6.5.9 tests remain green.

Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION
Report: projects/polymarket/polyquantbot/reports/forge/phase6-5-10_01_wallet-state-exact-batch-read.md