### PR TITLE
forge: phase 6.6.2 wallet lifecycle batch reconciliation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,8 +1,7 @@
-Last Updated : 2026-04-18 03:30
-Status       : Phase 6.6.1 wallet lifecycle state reconciliation foundation is in progress on branch claude/wallet-reconciliation-foundation-Atfev. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 03:41
+Status       : Phase 6.6.2 wallet lifecycle batch reconciliation is in progress on branch claude/wallet-batch-reconciliation-Oe4uk. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
-- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
 - Phase 6.5.3 wallet state read boundary narrow slice merged via PR #536 at WalletStateStorageBoundary.read_state, preserving narrow-scope exclusions.
 - Phase 6.5.4 wallet state clear boundary merged via PR #537 at WalletStateStorageBoundary.clear_state, preserving narrow-scope exclusions.
 - Phase 6.5.5 wallet state exists boundary merged via PR #539 at WalletStateStorageBoundary.has_state with deterministic success true/false and block contracts for invalid contract, ownership mismatch, and wallet not active.
@@ -13,13 +12,14 @@ Status       : Phase 6.6.1 wallet lifecycle state reconciliation foundation is i
 - Phase 6.5.8 wallet state metadata exact lookup merged via PR #544 at WalletStateStorageBoundary.get_state_metadata with deterministic metadata-only exact lookup and block contracts for invalid contract, ownership mismatch, inactive wallet, and not found.
 - Phase 6.5.9 wallet state metadata exact batch lookup merged via PR #546 at WalletStateStorageBoundary.get_state_metadata_batch with owner-scoped metadata-only output, deterministic input-order preservation, and explicit missing-wallet handling via stored_revision=None.
 - Phase 6.5.10 wallet state exact batch read boundary delivered at WalletStateStorageBoundary.read_state_batch with owner-scoped full snapshot output, deterministic input-order preservation, and explicit missing-wallet handling via state_found=False and state_snapshot=None.
+- Phase 6.6.1 wallet lifecycle state reconciliation foundation delivered at WalletLifecycleReconciliationBoundary.reconcile_wallet_state with deterministic outcome categories (match, state_missing, revision_mismatch, snapshot_mismatch) and block contracts. Merged-main truth on branch claude/wallet-reconciliation-foundation-Atfev.
 
 [IN PROGRESS]
-- Phase 6.6.1 wallet lifecycle state reconciliation foundation is open on branch claude/wallet-reconciliation-foundation-Atfev — narrow read/evaluate reconciliation contract with deterministic outcome categories (match, state_missing, revision_mismatch, snapshot_mismatch) pending COMMANDER review.
+- Phase 6.6.2 wallet lifecycle batch reconciliation is open on branch claude/wallet-batch-reconciliation-Oe4uk — owner-scoped batch read/evaluate reconciliation at WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch with deterministic per-entry outcomes in exact input order, pending COMMANDER review.
 
 [NOT STARTED]
 - Phase 6.5.11 wallet state batch read query expansion has not been opened.
-- Phase 6.6.2 and subsequent reconciliation slices (batch reconciliation, mutation correction, retry workers) have not been opened.
+- Phase 6.6.3 and subsequent reconciliation slices (mutation correction, retry workers) have not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
@@ -27,7 +27,7 @@ Status       : Phase 6.6.1 wallet lifecycle state reconciliation foundation is i
 - Reconciliation mutation and correction workflow beyond the delivered read-only and append-only boundaries.
 
 [NEXT PRIORITY]
-- COMMANDER review of Phase 6.6.1 wallet lifecycle state reconciliation foundation (branch claude/wallet-reconciliation-foundation-Atfev, report projects/polymarket/polyquantbot/reports/forge/phase6-6-1_01_wallet-reconciliation-foundation.md). Tier: STANDARD.
+- COMMANDER review of Phase 6.6.2 wallet lifecycle batch reconciliation (branch claude/wallet-batch-reconciliation-Oe4uk, report projects/polymarket/polyquantbot/reports/forge/phase6-6-2_01_wallet-reconciliation-batch.md). Tier: STANDARD.
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 03:30
+**Last Updated:** 2026-04-18 03:41
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 03:30
+**Last Updated:** 2026-04-18 03:41
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -70,7 +70,8 @@
 | 6.5.8 | Wallet Lifecycle Foundation — State Metadata Exact Lookup | ✅ Done | Merged-main truth accepted via PR #544 at `WalletStateStorageBoundary.get_state_metadata` with deterministic metadata-only exact lookup and deterministic block contracts for invalid contract, ownership mismatch, inactive wallet, and not found. |
 | 6.5.9 | Wallet Lifecycle Foundation — State Metadata Exact Batch Lookup | ✅ Done | Merged-main truth accepted via PR #546 at `WalletStateStorageBoundary.get_state_metadata_batch` with owner-scoped metadata-only output, deterministic input-order preservation, and explicit missing-wallet handling via `stored_revision=None`. |
 | 6.5.10 | Wallet Lifecycle Foundation — State Exact Batch Read Boundary | ✅ Done | Merged-main truth accepted via PR #557 at `WalletStateStorageBoundary.read_state_batch` with owner-scoped full snapshot output, deterministic input-order preservation, and explicit missing-wallet handling via `state_found=False`. |
-| 6.6.1 | Wallet Lifecycle State Reconciliation Foundation | 🚧 In Progress | Narrow read/evaluate reconciliation foundation at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state` with deterministic outcome categories: match, state_missing, revision_mismatch, snapshot_mismatch. Pending COMMANDER review on branch claude/wallet-reconciliation-foundation-Atfev. |
+| 6.6.1 | Wallet Lifecycle State Reconciliation Foundation | ✅ Done | Narrow read/evaluate reconciliation foundation at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state` with deterministic outcome categories: match, state_missing, revision_mismatch, snapshot_mismatch. Merged-main truth on branch claude/wallet-reconciliation-foundation-Atfev. |
+| 6.6.2 | Wallet Lifecycle Batch Reconciliation | 🚧 In Progress | Owner-scoped batch read/evaluate reconciliation at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` with deterministic per-entry outcomes in exact input order. Pending COMMANDER review on branch claude/wallet-batch-reconciliation-Oe4uk. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -49,6 +49,11 @@ WALLET_RECONCILIATION_OUTCOME_MATCH = "match"
 WALLET_RECONCILIATION_OUTCOME_STATE_MISSING = "state_missing"
 WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH = "revision_mismatch"
 WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH = "snapshot_mismatch"
+WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_RECONCILIATION_BATCH_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_RECONCILIATION_BATCH_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY = "wallet_entries_too_many"
+WALLET_RECONCILIATION_BATCH_MAX_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -1050,6 +1055,39 @@ class WalletReconciliationResult:
     notes: dict[str, Any] | None = None
 
 
+@dataclass(frozen=True)
+class WalletBatchReconciliationEntry:
+    wallet_binding_id: str
+    expected_state_snapshot: dict[str, Any]
+    expected_revision: int | None = None
+
+
+@dataclass(frozen=True)
+class WalletBatchReconciliationPolicy:
+    entries: list[WalletBatchReconciliationEntry]
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+
+
+@dataclass(frozen=True)
+class WalletBatchReconciliationResultEntry:
+    wallet_binding_id: str
+    reconciliation_outcome: str
+    stored_revision: int | None
+    expected_revision: int | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class WalletBatchReconciliationResult:
+    success: bool
+    blocked_reason: str | None
+    owner_user_id: str
+    entries: list[WalletBatchReconciliationResultEntry] | None
+    notes: dict[str, Any] | None = None
+
+
 class WalletLifecycleReconciliationBoundary:
     """Phase 6.6.1 narrow reconciliation foundation: compare expected vs stored wallet lifecycle state.
     Read and evaluate only — no mutation, correction, retry, or automation."""
@@ -1160,6 +1198,143 @@ class WalletLifecycleReconciliationBoundary:
             notes={"stored_revision": stored_revision},
         )
 
+    def reconcile_wallet_state_batch(
+        self, policy: WalletBatchReconciliationPolicy
+    ) -> WalletBatchReconciliationResult:
+        """Phase 6.6.2 batch reconciliation: evaluate multiple expected wallet states against stored states.
+        Deterministic per-entry outcomes in exact input order. Read and evaluate only — no mutation or correction."""
+        contract_error = _validate_batch_reconciliation_policy(policy)
+        if contract_error is not None:
+            blocked_reason = WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+            if contract_error == WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY:
+                blocked_reason = WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY
+            return _blocked_batch_reconciliation_result(
+                policy=policy,
+                blocked_reason=blocked_reason,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_batch_reconciliation_result(
+                policy=policy,
+                blocked_reason=WALLET_RECONCILIATION_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_batch_reconciliation_result(
+                policy=policy,
+                blocked_reason=WALLET_RECONCILIATION_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+                notes={"wallet_active": False},
+            )
+
+        wallet_binding_ids = [e.wallet_binding_id for e in policy.entries]
+        batch_read = self._storage.read_state_batch(
+            WalletStateReadBatchPolicy(
+                wallet_binding_ids=wallet_binding_ids,
+                owner_user_id=policy.owner_user_id,
+                requested_by_user_id=policy.requested_by_user_id,
+                wallet_active=policy.wallet_active,
+            )
+        )
+
+        if not batch_read.success or batch_read.entries is None:
+            return _blocked_batch_reconciliation_result(
+                policy=policy,
+                blocked_reason=WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT,
+                notes={"storage_block": batch_read.blocked_reason},
+            )
+
+        stored_by_id: dict[str, WalletStateReadBatchEntry] = {
+            e.wallet_binding_id: e for e in batch_read.entries
+        }
+
+        result_entries: list[WalletBatchReconciliationResultEntry] = []
+        outcome_counts: dict[str, int] = {
+            WALLET_RECONCILIATION_OUTCOME_MATCH: 0,
+            WALLET_RECONCILIATION_OUTCOME_STATE_MISSING: 0,
+            WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH: 0,
+            WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH: 0,
+        }
+
+        for entry in policy.entries:
+            stored = stored_by_id.get(entry.wallet_binding_id)
+
+            if stored is None or not stored.state_found:
+                result_entries.append(
+                    WalletBatchReconciliationResultEntry(
+                        wallet_binding_id=entry.wallet_binding_id,
+                        reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_STATE_MISSING,
+                        stored_revision=None,
+                        expected_revision=entry.expected_revision,
+                        notes={"wallet_binding_id": entry.wallet_binding_id},
+                    )
+                )
+                outcome_counts[WALLET_RECONCILIATION_OUTCOME_STATE_MISSING] += 1
+                continue
+
+            stored_revision = stored.stored_revision
+            stored_snapshot = stored.state_snapshot
+
+            if (
+                entry.expected_revision is not None
+                and stored_revision != entry.expected_revision
+            ):
+                result_entries.append(
+                    WalletBatchReconciliationResultEntry(
+                        wallet_binding_id=entry.wallet_binding_id,
+                        reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+                        stored_revision=stored_revision,
+                        expected_revision=entry.expected_revision,
+                        notes={
+                            "stored_revision": stored_revision,
+                            "expected_revision": entry.expected_revision,
+                        },
+                    )
+                )
+                outcome_counts[WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH] += 1
+                continue
+
+            if stored_snapshot != entry.expected_state_snapshot:
+                mismatched_keys = sorted(
+                    k
+                    for k in set(list(stored_snapshot.keys()) + list(entry.expected_state_snapshot.keys()))
+                    if stored_snapshot.get(k) != entry.expected_state_snapshot.get(k)
+                )
+                result_entries.append(
+                    WalletBatchReconciliationResultEntry(
+                        wallet_binding_id=entry.wallet_binding_id,
+                        reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH,
+                        stored_revision=stored_revision,
+                        expected_revision=entry.expected_revision,
+                        notes={"mismatch_keys": mismatched_keys},
+                    )
+                )
+                outcome_counts[WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH] += 1
+                continue
+
+            result_entries.append(
+                WalletBatchReconciliationResultEntry(
+                    wallet_binding_id=entry.wallet_binding_id,
+                    reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_MATCH,
+                    stored_revision=stored_revision,
+                    expected_revision=entry.expected_revision,
+                    notes={"stored_revision": stored_revision},
+                )
+            )
+            outcome_counts[WALLET_RECONCILIATION_OUTCOME_MATCH] += 1
+
+        return WalletBatchReconciliationResult(
+            success=True,
+            blocked_reason=None,
+            owner_user_id=policy.owner_user_id,
+            entries=result_entries,
+            notes={
+                "entry_count": len(result_entries),
+                "outcome_counts": outcome_counts,
+            },
+        )
+
 
 def _validate_reconciliation_policy(policy: WalletReconciliationPolicy) -> str | None:
     if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
@@ -1194,5 +1369,46 @@ def _blocked_reconciliation_result(
         reconciliation_outcome=None,
         stored_revision=None,
         expected_revision=policy.expected_revision if hasattr(policy, "expected_revision") else None,
+        notes=notes,
+    )
+
+
+def _validate_batch_reconciliation_policy(policy: WalletBatchReconciliationPolicy) -> str | None:
+    if not isinstance(policy.entries, list):
+        return "entries_must_be_list"
+    if len(policy.entries) == 0:
+        return "entries_required"
+    if len(policy.entries) > WALLET_RECONCILIATION_BATCH_MAX_SIZE:
+        return WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY
+    for entry in policy.entries:
+        if not isinstance(entry.wallet_binding_id, str) or not entry.wallet_binding_id.strip():
+            return "wallet_binding_id_required"
+        if not isinstance(entry.expected_state_snapshot, dict):
+            return "expected_state_snapshot_must_be_dict"
+        if entry.expected_revision is not None:
+            if isinstance(entry.expected_revision, bool) or not isinstance(entry.expected_revision, int):
+                return "expected_revision_must_be_int_or_none"
+            if entry.expected_revision < 1:
+                return "expected_revision_must_be_positive"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    return None
+
+
+def _blocked_batch_reconciliation_result(
+    *,
+    policy: WalletBatchReconciliationPolicy,
+    blocked_reason: str,
+    notes: dict[str, Any] | None,
+) -> WalletBatchReconciliationResult:
+    return WalletBatchReconciliationResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        owner_user_id=policy.owner_user_id,
+        entries=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-6-2_01_wallet-reconciliation-batch.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-6-2_01_wallet-reconciliation-batch.md
@@ -1,0 +1,126 @@
+# FORGE-X Report -- Phase 6.6.2 Wallet Lifecycle Batch Reconciliation
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` batch reconciliation path only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py`.
+**Not in Scope:** state mutation, auto-correction, retry workers, settlement automation, portfolio orchestration, live trading, monitoring rollout, reconciliation scheduling, broader reconciliation workflow beyond the declared batch read/evaluate path.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered Phase 6.6.2 batch reconciliation on top of the 6.6.1 single-wallet reconciliation foundation.
+
+Added new batch block constants:
+
+- `WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT`
+- `WALLET_RECONCILIATION_BATCH_BLOCK_OWNERSHIP_MISMATCH`
+- `WALLET_RECONCILIATION_BATCH_BLOCK_WALLET_NOT_ACTIVE`
+- `WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY`
+- `WALLET_RECONCILIATION_BATCH_MAX_SIZE = 100`
+
+Added new dataclasses:
+
+- `WalletBatchReconciliationEntry` -- per-entry input contract with `wallet_binding_id`, `expected_state_snapshot`, and optional `expected_revision`.
+- `WalletBatchReconciliationPolicy` -- batch-level gate with `entries`, `owner_user_id`, `requested_by_user_id`, `wallet_active`.
+- `WalletBatchReconciliationResultEntry` -- per-entry output with `wallet_binding_id`, `reconciliation_outcome`, `stored_revision`, `expected_revision`, `notes`.
+- `WalletBatchReconciliationResult` -- batch output with `success`, `blocked_reason`, `owner_user_id`, `entries`, `notes`.
+
+Added `reconcile_wallet_state_batch(policy: WalletBatchReconciliationPolicy) -> WalletBatchReconciliationResult` method on `WalletLifecycleReconciliationBoundary`.
+
+Batch-level block contracts (fail-fast before per-entry evaluation):
+
+- `invalid_contract` -- empty entries list, blank wallet_binding_id per entry, non-dict expected_state_snapshot per entry, non-positive or non-int expected_revision per entry, blank owner_user_id, blank requested_by_user_id, non-bool wallet_active.
+- `too_many` -- entries count exceeds `WALLET_RECONCILIATION_BATCH_MAX_SIZE`.
+- `ownership_mismatch` -- `requested_by_user_id != owner_user_id`.
+- `wallet_not_active` -- `wallet_active is not True`.
+
+Deterministic per-entry evaluation in exact input order:
+
+1. Batch-level block validation.
+2. Ownership check.
+3. Wallet active check.
+4. Single `read_state_batch` call with all wallet_binding_ids (inheriting 6.5.10 owner-scope isolation).
+5. For each entry in input order:
+   - `state_missing` if stored entry not found or owner mismatch.
+   - `revision_mismatch` if `expected_revision` provided and `stored_revision != expected_revision` (priority over snapshot check).
+   - `snapshot_mismatch` if `stored_snapshot != expected_state_snapshot`; notes include sorted `mismatch_keys`.
+   - `match` if all checks pass.
+6. Batch result includes `entry_count` and `outcome_counts` per outcome category in notes.
+
+Added validator `_validate_batch_reconciliation_policy` and helper `_blocked_batch_reconciliation_result`.
+
+All 6.5.x and 6.6.1 contracts remain unchanged.
+
+## 2) Current system architecture
+
+Wallet lifecycle storage boundaries in `WalletStateStorageBoundary` remain unchanged at 6.5.2-6.5.10 contracts.
+
+Reconciliation boundaries in `WalletLifecycleReconciliationBoundary`:
+
+- `reconcile_wallet_state` (6.6.1) -- single-wallet read/evaluate reconciliation, unchanged.
+- `reconcile_wallet_state_batch` (6.6.2) -- owner-scoped batch read/evaluate reconciliation with deterministic per-entry outcomes.
+
+The batch method calls `read_state_batch` (6.5.10) once for all wallet_binding_ids in the batch, then evaluates each entry in input order against its stored counterpart. No separate per-entry storage reads are made.
+
+All boundaries remain in-memory only. No vault, scheduler, portfolio, or orchestration wiring is claimed. No reconciliation mutation, correction, or retry is introduced.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+
+**Created**
+
+- `projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-6-2_01_wallet-reconciliation-batch.md`
+
+**Updated**
+
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Batch reconciliation evaluates multiple expected wallet lifecycle states against stored states in one pass.
+- Deterministic per-entry outcomes in exact input order confirmed: `match`, `state_missing`, `revision_mismatch`, `snapshot_mismatch`.
+- Batch-level block contracts confirmed: empty entries, blank wallet_binding_id per entry, non-dict snapshot per entry, non-positive revision per entry, bool revision per entry, blank owner_user_id, too_many, ownership_mismatch, wallet_not_active.
+- `revision_mismatch` takes priority over `snapshot_mismatch` per entry confirmed.
+- `state_missing` returned per entry when stored entry not found or owner mismatch.
+- `snapshot_mismatch` notes include sorted `mismatch_keys` confirmed.
+- `match` returned per entry when both snapshot and revision (if provided) match confirmed.
+- Owner isolation per entry confirmed: wallet stored for user-2 returns `state_missing` when user-1 reconciles batch.
+- Batch notes include `entry_count` and `outcome_counts` per category confirmed.
+- Single `read_state_batch` call used for the full batch (not per-entry reads).
+- All 6.5.x and 6.6.1 prior-phase tests remain passing.
+
+Validation commands run:
+
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` -- OK
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py` -- OK
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py` -- 27 passed, 0 failures
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q [prior-phase tests: 6.6.1, 6.5.10, 6.5.9, 6.5.3]` -- 44 passed, 0 failures
+5. Mojibake check on touched files -- clean
+
+## 5) Known issues
+
+- Batch reconciliation boundary is read/evaluate only and intentionally excludes mutation, correction, retry, scheduling, and orchestration.
+- All wallet lifecycle boundaries remain in-memory; no vault, scheduler, portfolio, or settlement expansion is claimed.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` batch reconciliation path only
+- Not in Scope: state mutation, auto-correction, retry workers, settlement automation, portfolio orchestration, live trading, monitoring rollout, broader reconciliation workflow
+- Suggested Next Step: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 03:41 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.6.2 wallet lifecycle batch reconciliation
+**Branch:** `claude/wallet-batch-reconciliation-Oe4uk`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT,
+    WALLET_RECONCILIATION_BATCH_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY,
+    WALLET_RECONCILIATION_BATCH_BLOCK_WALLET_NOT_ACTIVE,
+    WALLET_RECONCILIATION_BATCH_MAX_SIZE,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH,
+    WALLET_RECONCILIATION_OUTCOME_STATE_MISSING,
+    WalletBatchReconciliationEntry,
+    WalletBatchReconciliationPolicy,
+    WalletLifecycleReconciliationBoundary,
+    WalletStateStorageBoundary,
+    WalletStateStoragePolicy,
+    _validate_batch_reconciliation_policy,
+)
+
+_SNAPSHOT_READY = {"wallet_status": "ready", "available_balance": 100.0, "nonce": 1}
+_SNAPSHOT_ALT = {"wallet_status": "suspended", "available_balance": 0.0, "nonce": 99}
+
+
+def _make_storage_with(
+    entries: list[tuple[str, str, dict]],
+) -> WalletStateStorageBoundary:
+    boundary = WalletStateStorageBoundary()
+    for wallet_binding_id, owner_user_id, snapshot in entries:
+        result = boundary.store_state(
+            WalletStateStoragePolicy(
+                wallet_binding_id=wallet_binding_id,
+                owner_user_id=owner_user_id,
+                wallet_active=True,
+                state_snapshot=snapshot,
+            )
+        )
+        assert result.success is True
+    return boundary
+
+
+def _make_recon(storage: WalletStateStorageBoundary | None = None) -> WalletLifecycleReconciliationBoundary:
+    return WalletLifecycleReconciliationBoundary(storage or WalletStateStorageBoundary())
+
+
+def _base_policy(
+    *,
+    entries: list[WalletBatchReconciliationEntry],
+    owner_user_id: str = "user-1",
+    requested_by_user_id: str | None = None,
+    wallet_active: bool = True,
+) -> WalletBatchReconciliationPolicy:
+    return WalletBatchReconciliationPolicy(
+        entries=entries,
+        owner_user_id=owner_user_id,
+        requested_by_user_id=requested_by_user_id if requested_by_user_id is not None else owner_user_id,
+        wallet_active=wallet_active,
+    )
+
+
+def _entry(
+    wallet_binding_id: str,
+    snapshot: dict | None = None,
+    expected_revision: int | None = None,
+) -> WalletBatchReconciliationEntry:
+    return WalletBatchReconciliationEntry(
+        wallet_binding_id=wallet_binding_id,
+        expected_state_snapshot=snapshot if snapshot is not None else dict(_SNAPSHOT_READY),
+        expected_revision=expected_revision,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block contracts — batch-level gate
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_blocks_invalid_contract_empty_entries() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.entries is None
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "entries_required"
+
+
+def test_phase6_6_2_blocks_invalid_contract_entry_blank_wallet_binding_id() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[
+                WalletBatchReconciliationEntry(
+                    wallet_binding_id="   ",
+                    expected_state_snapshot=dict(_SNAPSHOT_READY),
+                )
+            ],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "wallet_binding_id_required"
+
+
+def test_phase6_6_2_blocks_invalid_contract_entry_snapshot_not_dict() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[
+                WalletBatchReconciliationEntry(
+                    wallet_binding_id="wb-662-a",
+                    expected_state_snapshot=None,  # type: ignore[arg-type]
+                )
+            ],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "expected_state_snapshot_must_be_dict"
+
+
+def test_phase6_6_2_blocks_invalid_contract_entry_expected_revision_zero() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", expected_revision=0)])
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "expected_revision_must_be_positive"
+
+
+def test_phase6_6_2_blocks_invalid_contract_entry_expected_revision_bool() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[
+                WalletBatchReconciliationEntry(
+                    wallet_binding_id="wb-662-a",
+                    expected_state_snapshot=dict(_SNAPSHOT_READY),
+                    expected_revision=True,  # type: ignore[arg-type]
+                )
+            ],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "expected_revision_must_be_int_or_none"
+
+
+def test_phase6_6_2_blocks_invalid_contract_blank_owner_user_id() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[_entry("wb-662-a")],
+            owner_user_id="",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_INVALID_CONTRACT
+    assert result.notes is not None
+    assert result.notes["contract_error"] == "owner_user_id_required"
+
+
+def test_phase6_6_2_blocks_too_many_entries() -> None:
+    recon = _make_recon()
+    entries = [_entry(f"wb-{i}") for i in range(WALLET_RECONCILIATION_BATCH_MAX_SIZE + 1)]
+    result = recon.reconcile_wallet_state_batch(_base_policy(entries=entries))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_TOO_MANY
+    assert result.entries is None
+
+
+def test_phase6_6_2_blocks_ownership_mismatch() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        WalletBatchReconciliationPolicy(
+            entries=[_entry("wb-662-a")],
+            owner_user_id="user-1",
+            requested_by_user_id="user-2",
+            wallet_active=True,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_OWNERSHIP_MISMATCH
+    assert result.entries is None
+
+
+def test_phase6_6_2_blocks_wallet_not_active() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a")], wallet_active=False)
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RECONCILIATION_BATCH_BLOCK_WALLET_NOT_ACTIVE
+    assert result.entries is None
+
+
+# ---------------------------------------------------------------------------
+# Outcome: state_missing — per entry
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_outcome_state_missing_when_no_stored_state() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-notfound")])
+    )
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.entries is not None
+    assert len(result.entries) == 1
+    e = result.entries[0]
+    assert e.wallet_binding_id == "wb-662-notfound"
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_STATE_MISSING
+    assert e.stored_revision is None
+    assert e.expected_revision is None
+
+
+def test_phase6_6_2_outcome_state_missing_with_expected_revision() -> None:
+    recon = _make_recon()
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-notfound", expected_revision=5)])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_STATE_MISSING
+    assert e.stored_revision is None
+    assert e.expected_revision == 5
+
+
+# ---------------------------------------------------------------------------
+# Outcome: match — per entry
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_outcome_match_when_snapshot_matches() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", dict(_SNAPSHOT_READY))])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_MATCH
+    assert e.stored_revision == 1
+    assert e.expected_revision is None
+
+
+def test_phase6_6_2_outcome_match_when_snapshot_and_revision_match() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", dict(_SNAPSHOT_READY), expected_revision=1)])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_MATCH
+    assert e.stored_revision == 1
+    assert e.expected_revision == 1
+
+
+# ---------------------------------------------------------------------------
+# Outcome: revision_mismatch — per entry
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_outcome_revision_mismatch_when_revision_differs() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", dict(_SNAPSHOT_READY), expected_revision=99)])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH
+    assert e.stored_revision == 1
+    assert e.expected_revision == 99
+    assert e.notes is not None
+    assert e.notes["stored_revision"] == 1
+    assert e.notes["expected_revision"] == 99
+
+
+def test_phase6_6_2_revision_mismatch_takes_priority_over_snapshot_mismatch() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", dict(_SNAPSHOT_ALT), expected_revision=99)])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Outcome: snapshot_mismatch — per entry
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_outcome_snapshot_mismatch_when_snapshot_differs() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", dict(_SNAPSHOT_ALT))])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH
+    assert e.stored_revision == 1
+    assert e.notes is not None
+    assert "available_balance" in e.notes["mismatch_keys"]
+    assert "wallet_status" in e.notes["mismatch_keys"]
+    assert "nonce" in e.notes["mismatch_keys"]
+
+
+def test_phase6_6_2_snapshot_mismatch_reports_sorted_keys() -> None:
+    stored_snap = {"wallet_status": "ready", "available_balance": 100.0, "nonce": 1}
+    expected_snap = {"wallet_status": "suspended", "available_balance": 200.0, "nonce": 1}
+    storage = _make_storage_with([("wb-662-a", "user-1", stored_snap)])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a", expected_snap)])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    e = result.entries[0]
+    assert e.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH
+    assert e.notes is not None
+    assert e.notes["mismatch_keys"] == ["available_balance", "wallet_status"]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic input-order preservation
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_deterministic_input_order_multi_entry() -> None:
+    storage = _make_storage_with([
+        ("wb-662-a", "user-1", dict(_SNAPSHOT_READY)),
+        ("wb-662-b", "user-1", dict(_SNAPSHOT_ALT)),
+    ])
+    recon = _make_recon(storage)
+
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[
+            _entry("wb-662-notfound"),
+            _entry("wb-662-a", dict(_SNAPSHOT_READY)),
+            _entry("wb-662-b", dict(_SNAPSHOT_READY), expected_revision=99),
+            _entry("wb-662-a", {"wallet_status": "suspended", "available_balance": 100.0, "nonce": 1}),
+        ])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    assert len(result.entries) == 4
+
+    assert result.entries[0].wallet_binding_id == "wb-662-notfound"
+    assert result.entries[0].reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_STATE_MISSING
+
+    assert result.entries[1].wallet_binding_id == "wb-662-a"
+    assert result.entries[1].reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_MATCH
+
+    assert result.entries[2].wallet_binding_id == "wb-662-b"
+    assert result.entries[2].reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH
+
+    assert result.entries[3].wallet_binding_id == "wb-662-a"
+    assert result.entries[3].reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH
+
+
+def test_phase6_6_2_all_four_outcomes_in_one_batch() -> None:
+    storage = _make_storage_with([
+        ("wb-match", "user-1", dict(_SNAPSHOT_READY)),
+        ("wb-rev", "user-1", dict(_SNAPSHOT_READY)),
+        ("wb-snap", "user-1", dict(_SNAPSHOT_READY)),
+    ])
+    recon = _make_recon(storage)
+
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[
+            _entry("wb-match", dict(_SNAPSHOT_READY)),
+            _entry("wb-missing"),
+            _entry("wb-rev", dict(_SNAPSHOT_READY), expected_revision=99),
+            _entry("wb-snap", {"wallet_status": "suspended", "available_balance": 100.0, "nonce": 1}),
+        ])
+    )
+    assert result.success is True
+    assert result.entries is not None
+    outcomes = [e.reconciliation_outcome for e in result.entries]
+    assert outcomes == [
+        WALLET_RECONCILIATION_OUTCOME_MATCH,
+        WALLET_RECONCILIATION_OUTCOME_STATE_MISSING,
+        WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+        WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# outcome_counts in notes
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_notes_contain_accurate_outcome_counts() -> None:
+    storage = _make_storage_with([
+        ("wb-662-a", "user-1", dict(_SNAPSHOT_READY)),
+        ("wb-662-b", "user-1", dict(_SNAPSHOT_READY)),
+    ])
+    recon = _make_recon(storage)
+
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[
+            _entry("wb-662-a", dict(_SNAPSHOT_READY)),
+            _entry("wb-662-b", dict(_SNAPSHOT_READY), expected_revision=99),
+            _entry("wb-662-notfound"),
+        ])
+    )
+    assert result.success is True
+    assert result.notes is not None
+    assert result.notes["entry_count"] == 3
+    counts = result.notes["outcome_counts"]
+    assert counts[WALLET_RECONCILIATION_OUTCOME_MATCH] == 1
+    assert counts[WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH] == 1
+    assert counts[WALLET_RECONCILIATION_OUTCOME_STATE_MISSING] == 1
+    assert counts[WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH] == 0
+
+
+# ---------------------------------------------------------------------------
+# Owner isolation
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_owner_isolation_cross_owner_returns_state_missing() -> None:
+    storage = _make_storage_with([("wb-662-a", "user-2", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state_batch(
+        _base_policy(entries=[_entry("wb-662-a")], owner_user_id="user-1")
+    )
+    assert result.success is True
+    assert result.entries is not None
+    assert result.entries[0].reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_STATE_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_validator_rejects_blank_requested_by_user_id() -> None:
+    policy = WalletBatchReconciliationPolicy(
+        entries=[_entry("wb-662-a")],
+        owner_user_id="user-1",
+        requested_by_user_id="",
+        wallet_active=True,
+    )
+    error = _validate_batch_reconciliation_policy(policy)
+    assert error == "requested_by_user_id_required"
+
+
+def test_phase6_6_2_validator_rejects_non_bool_wallet_active() -> None:
+    policy = WalletBatchReconciliationPolicy(
+        entries=[_entry("wb-662-a")],
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active="yes",  # type: ignore[arg-type]
+    )
+    error = _validate_batch_reconciliation_policy(policy)
+    assert error == "wallet_active_must_be_bool"
+
+
+def test_phase6_6_2_validator_accepts_valid_policy_no_revision() -> None:
+    policy = WalletBatchReconciliationPolicy(
+        entries=[_entry("wb-662-a")],
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+    error = _validate_batch_reconciliation_policy(policy)
+    assert error is None
+
+
+def test_phase6_6_2_validator_accepts_valid_policy_with_revision() -> None:
+    policy = WalletBatchReconciliationPolicy(
+        entries=[_entry("wb-662-a", expected_revision=3)],
+        owner_user_id="user-1",
+        requested_by_user_id="user-1",
+        wallet_active=True,
+    )
+    error = _validate_batch_reconciliation_policy(policy)
+    assert error is None
+
+
+# ---------------------------------------------------------------------------
+# Prior phase preservation smoke tests
+# ---------------------------------------------------------------------------
+
+def test_phase6_6_2_prior_phase_single_reconcile_still_passes() -> None:
+    from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+        WALLET_RECONCILIATION_OUTCOME_MATCH,
+        WalletReconciliationPolicy,
+    )
+    storage = _make_storage_with([("wb-compat-661", "user-1", dict(_SNAPSHOT_READY))])
+    recon = _make_recon(storage)
+    result = recon.reconcile_wallet_state(
+        WalletReconciliationPolicy(
+            wallet_binding_id="wb-compat-661",
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+            expected_state_snapshot=dict(_SNAPSHOT_READY),
+        )
+    )
+    assert result.success is True
+    assert result.reconciliation_outcome == WALLET_RECONCILIATION_OUTCOME_MATCH
+
+
+def test_phase6_6_2_prior_phase_read_state_batch_still_passes() -> None:
+    from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+        WalletStateReadBatchPolicy,
+    )
+    storage = _make_storage_with([("wb-compat-6510", "user-1", dict(_SNAPSHOT_READY))])
+    batch_result = storage.read_state_batch(
+        WalletStateReadBatchPolicy(
+            wallet_binding_ids=["wb-compat-6510"],
+            owner_user_id="user-1",
+            requested_by_user_id="user-1",
+            wallet_active=True,
+        )
+    )
+    assert batch_result.success is True
+    assert batch_result.entries is not None
+    assert batch_result.entries[0].state_found is True


### PR DESCRIPTION
## Summary

- Adds `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` — owner-scoped batch read/evaluate reconciliation with deterministic per-entry outcomes in exact input order
- Four explicit per-entry outcomes: `match`, `state_missing`, `revision_mismatch`, `snapshot_mismatch`
- Batch-level gates: `invalid_contract`, `ownership_mismatch`, `wallet_not_active`, `wallet_entries_too_many` (max 100 entries)
- Single `read_state_batch` call for full batch — no per-entry storage reads
- All 6.5.x and 6.6.1 contracts fully preserved (44 prior-phase tests pass)
- 27 new targeted tests, 0 failures

## Validation

- Validation Tier: STANDARD
- Claim Level: NARROW INTEGRATION
- Validation Target: `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` batch path only
- Not in Scope: mutation/correction, retry workers, scheduling, settlement automation, portfolio orchestration, live trading, monitoring rollout
- py_compile: OK on all touched files
- pytest: 27 passed (new) + 44 passed (prior-phase regression)

## Report

`projects/polymarket/polyquantbot/reports/forge/phase6-6-2_01_wallet-reconciliation-batch.md`

## Next Gate

COMMANDER review required before merge.

https://claude.ai/code/session_01UJxdz3GSWJiPYBqMamrJcg