### PR TITLE
Phase 6.6.4: Add wallet reconciliation retry/worker foundation contract

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 03:55
-Status       : Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 04:41
+Status       : Phase 6.6.4 wallet reconciliation retry/worker foundation contract is implemented on feature/wallet-reconciliation-retry-worker-foundation-2026-04-18 and pending COMMANDER review. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -16,10 +16,9 @@ Status       : Phase 6.6.3 wallet reconciliation mutation/correction foundation 
 - Phase 6.6.3 wallet reconciliation mutation/correction foundation merged-via PR #560 at WalletReconciliationCorrectionBoundary.apply_correction.
 
 [IN PROGRESS]
-- None.
+- Phase 6.6.4 wallet reconciliation retry/worker foundation contract is in progress on feature/wallet-reconciliation-retry-worker-foundation-2026-04-18 (FOUNDATION scope only; no scheduler daemon or automation mesh).
 
 [NOT STARTED]
-- Phase 6.6.4 wallet reconciliation retry/worker foundation has not been opened.
 - Phase 6.6.5 and subsequent public-readiness slices have not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -28,7 +27,7 @@ Status       : Phase 6.6.3 wallet reconciliation mutation/correction foundation 
 - Reconciliation mutation and correction workflow beyond the read-only and append-only boundaries.
 
 [NEXT PRIORITY]
-- Open Phase 6.6.4 wallet reconciliation retry/worker foundation as the next forward slice.
+- COMMANDER review for Phase 6.6.4 wallet reconciliation retry/worker foundation contract (STANDARD / FOUNDATION).
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 03:55
+**Last Updated:** 2026-04-18 04:41
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 03:55
+**Last Updated:** 2026-04-18 04:41
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -73,7 +73,7 @@
 | 6.6.1 | Wallet Lifecycle State Reconciliation Foundation | ✅ Done | Merged-main truth accepted via PR #558 at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state` with deterministic outcome categories: match, state_missing, revision_mismatch, snapshot_mismatch. |
 | 6.6.2 | Wallet Lifecycle Batch Reconciliation | ✅ Done | Merged-main truth accepted via PR #559 at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` with deterministic per-entry outcomes in exact input order. |
 | 6.6.3 | Wallet Reconciliation Mutation Correction Foundation | ✅ Done | Merged-main truth accepted via PR #560 at `WalletReconciliationCorrectionBoundary.apply_correction` with deterministic correction decision categories and block reasons. |
-| 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | ❌ Not Started | Next forward reconciliation slice after 6.6.3; introduce narrow retry/worker contract without full automation rollout. |
+| 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | 🚧 In Progress | Narrow retry/worker foundation contract implemented on feature/wallet-reconciliation-retry-worker-foundation-2026-04-18; pending COMMANDER review. Explicit exclusions preserved: no scheduler daemon, no background orchestration mesh, no broad automation rollout. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -65,6 +65,18 @@ WALLET_CORRECTION_RESULT_ACCEPTED = "correction_accepted"
 WALLET_CORRECTION_RESULT_BLOCKED = "correction_blocked"
 WALLET_CORRECTION_RESULT_PATH_BLOCKED = "correction_path_blocked"
 WALLET_CORRECTION_RESULT_NOT_REQUIRED = "correction_not_required"
+WALLET_RETRY_WORK_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_RETRY_WORK_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_RETRY_WORK_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT = "non_retryable_correction_result"
+WALLET_RETRY_WORK_BLOCK_RETRY_BUDGET_EXHAUSTED = "retry_budget_exhausted"
+WALLET_RETRY_WORK_DECISION_ACCEPTED = "retry_accepted"
+WALLET_RETRY_WORK_DECISION_SKIPPED = "retry_skipped"
+WALLET_RETRY_WORK_DECISION_BLOCKED = "retry_blocked"
+WALLET_RETRY_WORK_DECISION_EXHAUSTED = "retry_exhausted"
+WALLET_RETRY_WORKER_ACTION_RETRY = "retry"
+WALLET_RETRY_WORKER_ACTION_SKIP = "skip"
+WALLET_RETRY_WORK_MAX_BUDGET = 10
 
 
 @dataclass(frozen=True)
@@ -1624,5 +1636,200 @@ def _blocked_correction_result(
         owner_user_id=policy.owner_user_id,
         correction_result_category=correction_result_category,
         applied_revision=None,
+        notes=notes,
+    )
+
+
+@dataclass(frozen=True)
+class WalletReconciliationRetryWorkPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+    correction_result_category: str
+    correction_blocked_reason: str | None
+    retry_attempt: int
+    retry_budget: int
+    worker_action: str
+
+
+@dataclass(frozen=True)
+class WalletReconciliationRetryWorkResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    retry_result_category: str
+    accepted_for_retry: bool
+    retry_attempt: int
+    retry_budget: int
+    next_retry_attempt: int | None
+    notes: dict[str, Any] | None = None
+
+
+_WALLET_RETRY_VALID_CORRECTION_RESULT_CATEGORIES: frozenset[str] = frozenset({
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+    WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+})
+_WALLET_RETRY_RETRYABLE_CORRECTION_BLOCKS: frozenset[str] = frozenset({
+    WALLET_CORRECTION_BLOCK_REVISION_CONFLICT,
+})
+_WALLET_RETRY_VALID_WORKER_ACTIONS: frozenset[str] = frozenset({
+    WALLET_RETRY_WORKER_ACTION_RETRY,
+    WALLET_RETRY_WORKER_ACTION_SKIP,
+})
+
+
+class WalletReconciliationRetryWorkerBoundary:
+    """Phase 6.6.4 narrow reconciliation retry/worker foundation.
+    Accept deterministic owner-scoped retry work items from correction outcomes.
+    Foundation only: no scheduler daemon, no background orchestration mesh."""
+
+    def decide_retry_work_item(
+        self,
+        policy: WalletReconciliationRetryWorkPolicy,
+    ) -> WalletReconciliationRetryWorkResult:
+        contract_error = _validate_retry_work_policy(policy)
+        if contract_error is not None:
+            return _blocked_retry_work_result(
+                policy=policy,
+                blocked_reason=WALLET_RETRY_WORK_BLOCK_INVALID_CONTRACT,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_BLOCKED,
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_retry_work_result(
+                policy=policy,
+                blocked_reason=WALLET_RETRY_WORK_BLOCK_OWNERSHIP_MISMATCH,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_BLOCKED,
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_retry_work_result(
+                policy=policy,
+                blocked_reason=WALLET_RETRY_WORK_BLOCK_WALLET_NOT_ACTIVE,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_BLOCKED,
+                notes={"wallet_active": False},
+            )
+
+        if policy.worker_action == WALLET_RETRY_WORKER_ACTION_SKIP:
+            return WalletReconciliationRetryWorkResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_SKIPPED,
+                accepted_for_retry=False,
+                retry_attempt=policy.retry_attempt,
+                retry_budget=policy.retry_budget,
+                next_retry_attempt=None,
+                notes={"worker_action": policy.worker_action},
+            )
+
+        if not _is_retryable_correction_path(policy):
+            return _blocked_retry_work_result(
+                policy=policy,
+                blocked_reason=WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_BLOCKED,
+                notes={
+                    "correction_result_category": policy.correction_result_category,
+                    "correction_blocked_reason": policy.correction_blocked_reason,
+                },
+            )
+
+        if policy.retry_attempt > policy.retry_budget:
+            return _blocked_retry_work_result(
+                policy=policy,
+                blocked_reason=WALLET_RETRY_WORK_BLOCK_RETRY_BUDGET_EXHAUSTED,
+                retry_result_category=WALLET_RETRY_WORK_DECISION_EXHAUSTED,
+                notes={
+                    "retry_attempt": policy.retry_attempt,
+                    "retry_budget": policy.retry_budget,
+                },
+            )
+
+        next_retry_attempt = (
+            policy.retry_attempt + 1
+            if policy.retry_attempt < policy.retry_budget
+            else None
+        )
+        return WalletReconciliationRetryWorkResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_ACCEPTED,
+            accepted_for_retry=True,
+            retry_attempt=policy.retry_attempt,
+            retry_budget=policy.retry_budget,
+            next_retry_attempt=next_retry_attempt,
+            notes={
+                "worker_action": policy.worker_action,
+                "retry_budget_remaining": policy.retry_budget - policy.retry_attempt,
+            },
+        )
+
+
+def _validate_retry_work_policy(policy: WalletReconciliationRetryWorkPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if (
+        not isinstance(policy.correction_result_category, str)
+        or policy.correction_result_category not in _WALLET_RETRY_VALID_CORRECTION_RESULT_CATEGORIES
+    ):
+        return "correction_result_category_invalid"
+    if policy.correction_blocked_reason is not None and not isinstance(policy.correction_blocked_reason, str):
+        return "correction_blocked_reason_must_be_str_or_none"
+    if isinstance(policy.retry_attempt, bool) or not isinstance(policy.retry_attempt, int):
+        return "retry_attempt_must_be_int"
+    if policy.retry_attempt < 1:
+        return "retry_attempt_must_be_positive"
+    if isinstance(policy.retry_budget, bool) or not isinstance(policy.retry_budget, int):
+        return "retry_budget_must_be_int"
+    if policy.retry_budget < 1:
+        return "retry_budget_must_be_positive"
+    if policy.retry_budget > WALLET_RETRY_WORK_MAX_BUDGET:
+        return "retry_budget_exceeds_max"
+    if not isinstance(policy.worker_action, str) or policy.worker_action not in _WALLET_RETRY_VALID_WORKER_ACTIONS:
+        return "worker_action_invalid"
+    return None
+
+
+def _is_retryable_correction_path(policy: WalletReconciliationRetryWorkPolicy) -> bool:
+    if policy.correction_result_category == WALLET_CORRECTION_RESULT_PATH_BLOCKED:
+        return True
+    return (
+        policy.correction_result_category == WALLET_CORRECTION_RESULT_BLOCKED
+        and policy.correction_blocked_reason in _WALLET_RETRY_RETRYABLE_CORRECTION_BLOCKS
+    )
+
+
+def _blocked_retry_work_result(
+    *,
+    policy: WalletReconciliationRetryWorkPolicy,
+    blocked_reason: str,
+    retry_result_category: str,
+    notes: dict[str, Any] | None,
+) -> WalletReconciliationRetryWorkResult:
+    return WalletReconciliationRetryWorkResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        retry_result_category=retry_result_category,
+        accepted_for_retry=False,
+        retry_attempt=policy.retry_attempt,
+        retry_budget=policy.retry_budget,
+        next_retry_attempt=None,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-6-4_01_wallet-reconciliation-retry-worker-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-6-4_01_wallet-reconciliation-retry-worker-foundation.md
@@ -1,0 +1,120 @@
+# FORGE-X Report -- Phase 6.6.4 Wallet Reconciliation Retry/Worker Foundation
+
+**Validation Tier:** STANDARD  
+**Claim Level:** FOUNDATION  
+**Validation Target:** `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` contract only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused behavior tests in `projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py`.  
+**Not in Scope:** automatic correction rollout, scheduler service, background orchestration mesh, settlement automation, portfolio orchestration, live trading, monitoring rollout, broader reconciliation workflow beyond this retry/worker foundation contract path.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered Phase 6.6.4 retry/worker foundation contract as a narrow extension of the 6.6 reconciliation lane.
+
+Added new retry/worker block constants:
+- `WALLET_RETRY_WORK_BLOCK_INVALID_CONTRACT`
+- `WALLET_RETRY_WORK_BLOCK_OWNERSHIP_MISMATCH`
+- `WALLET_RETRY_WORK_BLOCK_WALLET_NOT_ACTIVE`
+- `WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT`
+- `WALLET_RETRY_WORK_BLOCK_RETRY_BUDGET_EXHAUSTED`
+
+Added new deterministic retry/worker decision categories:
+- `WALLET_RETRY_WORK_DECISION_ACCEPTED`
+- `WALLET_RETRY_WORK_DECISION_SKIPPED`
+- `WALLET_RETRY_WORK_DECISION_BLOCKED`
+- `WALLET_RETRY_WORK_DECISION_EXHAUSTED`
+
+Added new worker-action constants and retry budget cap:
+- `WALLET_RETRY_WORKER_ACTION_RETRY`
+- `WALLET_RETRY_WORKER_ACTION_SKIP`
+- `WALLET_RETRY_WORK_MAX_BUDGET = 10`
+
+Added new dataclasses:
+- `WalletReconciliationRetryWorkPolicy` -- deterministic owner-scoped retry work input derived from correction outcomes.
+- `WalletReconciliationRetryWorkResult` -- deterministic worker decision output (accepted/skipped/blocked/exhausted).
+
+Added new boundary:
+- `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item(policy)`
+
+Deterministic decision sequence:
+1. Contract validation (`_validate_retry_work_policy`).
+2. Ownership enforcement (`requested_by_user_id == owner_user_id`).
+3. Wallet active enforcement (`wallet_active is True`).
+4. Explicit worker action handling:
+   - `skip` -> decision `retry_skipped` (`success=True`, no queue accept).
+   - `retry` -> evaluate retryability + budget rules.
+5. Retryability rules:
+   - `correction_result_category == correction_path_blocked` is retryable.
+   - `correction_result_category == correction_blocked` is retryable only when `correction_blocked_reason == revision_conflict`.
+   - all other correction outcomes are blocked (`non_retryable_correction_result`).
+6. Retry budget rules:
+   - `retry_attempt > retry_budget` -> exhausted (`retry_budget_exhausted`, decision `retry_exhausted`).
+   - `retry_attempt <= retry_budget` -> accepted (`retry_accepted`) with deterministic `next_retry_attempt`.
+
+No scheduler, queue daemon, or background orchestration was introduced.
+
+## 2) Current system architecture (relevant slice)
+
+- `WalletStateStorageBoundary` (6.5.2-6.5.10) remains unchanged and preserved.
+- `WalletLifecycleReconciliationBoundary` (6.6.1-6.6.2) remains unchanged and preserved.
+- `WalletReconciliationCorrectionBoundary` (6.6.3) remains unchanged and preserved.
+- New narrow contract in `WalletReconciliationRetryWorkerBoundary` (6.6.4):
+  - accepts deterministic owner-scoped retry work items derived from correction outcomes,
+  - returns explicit decision categories (`accepted`, `skipped`, `blocked`, `exhausted`),
+  - enforces retry budget and block contracts deterministically,
+  - does not perform background execution.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-6-4_01_wallet-reconciliation-retry-worker-foundation.md`
+
+**Updated**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Contract validation blocks invalid retry work policies with deterministic contract errors.
+- Ownership mismatch returns `ownership_mismatch` block deterministically.
+- Inactive wallet returns `wallet_not_active` block deterministically.
+- Explicit `skip` worker action returns `retry_skipped` with `success=True` and `accepted_for_retry=False`.
+- Retry action accepts retryable correction outcomes (`correction_path_blocked` and `correction_blocked+revision_conflict`).
+- Retry action blocks non-retryable correction outcomes (`correction_accepted`, `correction_not_required`, or non-retryable blocked reasons).
+- Retry action returns exhausted decision when `retry_attempt > retry_budget`.
+- Retry action accepts edge budget (`retry_attempt == retry_budget`) and sets `next_retry_attempt=None`.
+- Retry result notes include deterministic worker action and retry budget metadata.
+- Existing 6.6.1-6.6.3 tests remain passing.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py`
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_3_wallet_reconciliation_correction_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_1_wallet_reconciliation_foundation_20260418.py`
+5. UTF-8/mojibake scan on touched files.
+
+## 5) Known issues
+
+- This slice is foundation only; no scheduler daemon, no background orchestration mesh, and no broad automation rollout are included.
+- Retryability is intentionally narrow to deterministic correction outcomes only; broader runtime execution routing is deferred.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: FOUNDATION
+- Validation Target: `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` contract only
+- Not in Scope: automatic correction rollout, scheduler service, settlement automation, portfolio orchestration, live trading, monitoring rollout, broader reconciliation workflow
+- Suggested Next: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 04:41 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.6.4 wallet reconciliation retry/worker foundation  
+**Branch:** `feature/wallet-reconciliation-retry-worker-foundation-2026-04-18`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_CORRECTION_BLOCK_INVALID_SNAPSHOT,
+    WALLET_CORRECTION_BLOCK_REVISION_CONFLICT,
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+    WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+    WALLET_RETRY_WORK_BLOCK_INVALID_CONTRACT,
+    WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT,
+    WALLET_RETRY_WORK_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_RETRY_WORK_BLOCK_RETRY_BUDGET_EXHAUSTED,
+    WALLET_RETRY_WORK_BLOCK_WALLET_NOT_ACTIVE,
+    WALLET_RETRY_WORK_DECISION_ACCEPTED,
+    WALLET_RETRY_WORK_DECISION_BLOCKED,
+    WALLET_RETRY_WORK_DECISION_EXHAUSTED,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+    WALLET_RETRY_WORK_MAX_BUDGET,
+    WALLET_RETRY_WORKER_ACTION_RETRY,
+    WALLET_RETRY_WORKER_ACTION_SKIP,
+    WalletReconciliationRetryWorkPolicy,
+    WalletReconciliationRetryWorkerBoundary,
+    _validate_retry_work_policy,
+)
+
+
+def _boundary() -> WalletReconciliationRetryWorkerBoundary:
+    return WalletReconciliationRetryWorkerBoundary()
+
+
+def _policy(**kwargs) -> WalletReconciliationRetryWorkPolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requested_by_user_id": "user-1",
+        "wallet_active": True,
+        "correction_result_category": WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+        "correction_blocked_reason": None,
+        "retry_attempt": 1,
+        "retry_budget": 3,
+        "worker_action": WALLET_RETRY_WORKER_ACTION_RETRY,
+    }
+    defaults.update(kwargs)
+    return WalletReconciliationRetryWorkPolicy(**defaults)
+
+
+# --- Validator ---
+
+def test_validate_retry_policy_accepts_valid_path_blocked_retry() -> None:
+    assert _validate_retry_work_policy(_policy()) is None
+
+
+def test_validate_retry_policy_requires_wallet_binding_id() -> None:
+    assert _validate_retry_work_policy(_policy(wallet_binding_id="  ")) == "wallet_binding_id_required"
+
+
+def test_validate_retry_policy_requires_valid_result_category() -> None:
+    assert (
+        _validate_retry_work_policy(_policy(correction_result_category="unknown"))
+        == "correction_result_category_invalid"
+    )
+
+
+def test_validate_retry_policy_rejects_non_str_block_reason() -> None:
+    assert (
+        _validate_retry_work_policy(_policy(correction_blocked_reason=123))  # type: ignore[arg-type]
+        == "correction_blocked_reason_must_be_str_or_none"
+    )
+
+
+def test_validate_retry_policy_rejects_non_positive_retry_attempt() -> None:
+    assert _validate_retry_work_policy(_policy(retry_attempt=0)) == "retry_attempt_must_be_positive"
+
+
+def test_validate_retry_policy_rejects_budget_above_max() -> None:
+    assert (
+        _validate_retry_work_policy(_policy(retry_budget=WALLET_RETRY_WORK_MAX_BUDGET + 1))
+        == "retry_budget_exceeds_max"
+    )
+
+
+def test_validate_retry_policy_rejects_unknown_worker_action() -> None:
+    assert _validate_retry_work_policy(_policy(worker_action="hold")) == "worker_action_invalid"
+
+
+# --- Worker decisions ---
+
+def test_worker_skip_returns_skipped_success() -> None:
+    result = _boundary().decide_retry_work_item(_policy(worker_action=WALLET_RETRY_WORKER_ACTION_SKIP))
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_SKIPPED
+    assert result.accepted_for_retry is False
+    assert result.next_retry_attempt is None
+
+
+def test_worker_retry_accepts_path_blocked_result() -> None:
+    result = _boundary().decide_retry_work_item(_policy())
+    assert result.success is True
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_ACCEPTED
+    assert result.accepted_for_retry is True
+    assert result.retry_attempt == 1
+    assert result.retry_budget == 3
+    assert result.next_retry_attempt == 2
+
+
+def test_worker_retry_accepts_revision_conflict_blocked_result() -> None:
+    result = _boundary().decide_retry_work_item(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED,
+            correction_blocked_reason=WALLET_CORRECTION_BLOCK_REVISION_CONFLICT,
+        )
+    )
+    assert result.success is True
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_ACCEPTED
+    assert result.blocked_reason is None
+
+
+def test_worker_retry_blocks_non_retryable_block_reason() -> None:
+    result = _boundary().decide_retry_work_item(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED,
+            correction_blocked_reason=WALLET_CORRECTION_BLOCK_INVALID_SNAPSHOT,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_retry_blocks_non_retryable_accepted_correction_result() -> None:
+    result = _boundary().decide_retry_work_item(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_ACCEPTED,
+            correction_blocked_reason=None,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_retry_blocks_non_retryable_not_required_correction_result() -> None:
+    result = _boundary().decide_retry_work_item(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+            correction_blocked_reason=None,
+        )
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_NON_RETRYABLE_RESULT
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_retry_attempt_above_budget_returns_exhausted() -> None:
+    result = _boundary().decide_retry_work_item(_policy(retry_attempt=4, retry_budget=3))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_RETRY_BUDGET_EXHAUSTED
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_EXHAUSTED
+
+
+def test_worker_retry_on_budget_edge_is_accepted_with_no_next_attempt() -> None:
+    result = _boundary().decide_retry_work_item(_policy(retry_attempt=3, retry_budget=3))
+    assert result.success is True
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_ACCEPTED
+    assert result.next_retry_attempt is None
+
+
+def test_worker_ownership_mismatch_returns_blocked() -> None:
+    result = _boundary().decide_retry_work_item(_policy(requested_by_user_id="user-2"))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_OWNERSHIP_MISMATCH
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_inactive_wallet_returns_blocked() -> None:
+    result = _boundary().decide_retry_work_item(_policy(wallet_active=False))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_WALLET_NOT_ACTIVE
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_invalid_contract_returns_blocked() -> None:
+    result = _boundary().decide_retry_work_item(_policy(retry_budget=0))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_RETRY_WORK_BLOCK_INVALID_CONTRACT
+    assert result.retry_result_category == WALLET_RETRY_WORK_DECISION_BLOCKED
+
+
+def test_worker_exhausted_notes_include_budget_and_attempt() -> None:
+    result = _boundary().decide_retry_work_item(_policy(retry_attempt=8, retry_budget=2))
+    assert result.notes is not None
+    assert result.notes.get("retry_attempt") == 8
+    assert result.notes.get("retry_budget") == 2
+
+
+def test_worker_accepted_notes_include_remaining_budget() -> None:
+    result = _boundary().decide_retry_work_item(_policy(retry_attempt=2, retry_budget=5))
+    assert result.notes is not None
+    assert result.notes.get("retry_budget_remaining") == 3
+    assert result.notes.get("worker_action") == WALLET_RETRY_WORKER_ACTION_RETRY
+
+
+def test_worker_skip_notes_include_worker_action() -> None:
+    result = _boundary().decide_retry_work_item(_policy(worker_action=WALLET_RETRY_WORKER_ACTION_SKIP))
+    assert result.notes is not None
+    assert result.notes.get("worker_action") == WALLET_RETRY_WORKER_ACTION_SKIP


### PR DESCRIPTION
### Motivation
- Provide a narrow foundation for deterministic retry/worker decisions after reconciliation corrections so correction work can be queued and re-evaluated without introducing schedulers or broad automation.
- Preserve existing 6.5.x read/storage boundaries and 6.6.1–6.6.3 reconciliation/correction contracts while enabling owner-scoped retry decisions for follow-on slices.

### Description
- Added deterministic retry/worker constants, dataclasses, and policy/result contracts including `WalletReconciliationRetryWorkPolicy` and `WalletReconciliationRetryWorkResult` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`.
- Implemented `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` with contract validation (`_validate_retry_work_policy`), ownership/active gating, explicit worker actions (`retry`/`skip`), retryability rules (`_is_retryable_correction_path`), and retry budget handling with a `WALLET_RETRY_WORK_MAX_BUDGET` cap.
- Preserved all prior contracts (`WalletStateStorageBoundary`, `WalletLifecycleReconciliationBoundary`, and `WalletReconciliationCorrectionBoundary`) and added targeted tests at `projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py` and a FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase6-6-4_01_wallet-reconciliation-retry-worker-foundation.md`.
- Updated `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 6.6.4 `🚧 In Progress` status and included the Asia/Jakarta timestamp, preserving out-of-scope entries.

### Testing
- Ran `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` and `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py` with no compile errors.
- Ran `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py` which passed `21` tests (1 non-blocking pytest config warning about `asyncio_mode`).
- Ran `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_3_wallet_reconciliation_correction_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_1_wallet_reconciliation_foundation_20260418.py` which passed `81` tests (same non-blocking warning).
- Performed UTF-8/mojibake scans on touched files (fixed-string checks) with no mojibake hits found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a874c6788325bfc5a3f91a163283)