### PR TITLE
Phase 6.6.5: add public-readiness slice opener foundation contract

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 04:43
-Status       : Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 05:10
+Status       : Phase 6.6.5 public-readiness slice opener foundation is in progress on feature/public-readiness-slice-opener-2026-04-18 pending COMMANDER review. Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -17,10 +17,10 @@ Status       : Phase 6.6.4 wallet reconciliation retry/worker foundation is merg
 - Phase 6.6.4 wallet reconciliation retry/worker foundation merged-via PR #561 at WalletReconciliationRetryWorkerBoundary.decide_retry_work_item.
 
 [IN PROGRESS]
-- None.
+- Phase 6.6.5 public-readiness slice opener foundation is active on feature/public-readiness-slice-opener-2026-04-18 for deterministic go/hold/blocked preparation evaluation only.
 
 [NOT STARTED]
-- Phase 6.6.5 and subsequent public-readiness slices have not been opened.
+- Subsequent public-readiness slices after 6.6.5 have not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
@@ -28,7 +28,7 @@ Status       : Phase 6.6.4 wallet reconciliation retry/worker foundation is merg
 - Reconciliation mutation and correction workflow beyond the read-only and append-only boundaries.
 
 [NEXT PRIORITY]
-- Open Phase 6.6.5 as the next public-readiness slice.
+- COMMANDER review for Phase 6.6.5 public-readiness slice opener foundation scope and contracts.
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 04:41
+**Last Updated:** 2026-04-18 05:10
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 04:41
+**Last Updated:** 2026-04-18 05:10
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -73,7 +73,8 @@
 | 6.6.1 | Wallet Lifecycle State Reconciliation Foundation | ✅ Done | Merged-main truth accepted via PR #558 at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state` with deterministic outcome categories: match, state_missing, revision_mismatch, snapshot_mismatch. |
 | 6.6.2 | Wallet Lifecycle Batch Reconciliation | ✅ Done | Merged-main truth accepted via PR #559 at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` with deterministic per-entry outcomes in exact input order. |
 | 6.6.3 | Wallet Reconciliation Mutation Correction Foundation | ✅ Done | Merged-main truth accepted via PR #560 at `WalletReconciliationCorrectionBoundary.apply_correction` with deterministic correction decision categories and block reasons. |
-| 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | 🚧 In Progress | Narrow retry/worker foundation contract implemented on feature/wallet-reconciliation-retry-worker-foundation-2026-04-18; pending COMMANDER review. Explicit exclusions preserved: no scheduler daemon, no background orchestration mesh, no broad automation rollout. |
+| 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | ✅ Done | Merged-main truth accepted via PR #561 at `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` with deterministic accepted/skipped/blocked/exhausted retry preparation outcomes and explicit block contracts. |
+| 6.6.5 | Public Readiness Slice Opener Foundation | 🚧 In Progress | Active on feature/public-readiness-slice-opener-2026-04-18 for evaluation-only go/hold/blocked preparation contract using declared 6.5.x/6.6.x readiness inputs; no live activation, scheduler rollout, settlement automation, or portfolio orchestration claimed. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -77,6 +77,14 @@ WALLET_RETRY_WORK_DECISION_EXHAUSTED = "retry_exhausted"
 WALLET_RETRY_WORKER_ACTION_RETRY = "retry"
 WALLET_RETRY_WORKER_ACTION_SKIP = "skip"
 WALLET_RETRY_WORK_MAX_BUDGET = 10
+WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_PUBLIC_READINESS_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_PUBLIC_READINESS_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_PUBLIC_READINESS_BLOCK_STATE_READ_NOT_READY = "state_read_not_ready"
+WALLET_PUBLIC_READINESS_BLOCK_RECONCILIATION_UNRESOLVED = "reconciliation_unresolved"
+WALLET_PUBLIC_READINESS_RESULT_GO = "go"
+WALLET_PUBLIC_READINESS_RESULT_HOLD = "hold"
+WALLET_PUBLIC_READINESS_RESULT_BLOCKED = "blocked"
 
 
 @dataclass(frozen=True)
@@ -1831,5 +1839,201 @@ def _blocked_retry_work_result(
         retry_attempt=policy.retry_attempt,
         retry_budget=policy.retry_budget,
         next_retry_attempt=None,
+        notes=notes,
+    )
+
+
+@dataclass(frozen=True)
+class WalletPublicReadinessPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+    state_read_batch_ready: bool
+    reconciliation_outcome: str
+    correction_result_category: str
+    retry_result_category: str
+
+
+@dataclass(frozen=True)
+class WalletPublicReadinessResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    readiness_result_category: str
+    readiness_notes: list[str]
+    notes: dict[str, Any] | None = None
+
+
+_WALLET_PUBLIC_READINESS_VALID_RECONCILIATION_OUTCOMES: frozenset[str] = frozenset({
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_STATE_MISSING,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RECONCILIATION_OUTCOME_SNAPSHOT_MISMATCH,
+})
+_WALLET_PUBLIC_READINESS_VALID_CORRECTION_RESULTS: frozenset[str] = frozenset({
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+    WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+})
+_WALLET_PUBLIC_READINESS_VALID_RETRY_RESULTS: frozenset[str] = frozenset({
+    WALLET_RETRY_WORK_DECISION_ACCEPTED,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+    WALLET_RETRY_WORK_DECISION_BLOCKED,
+    WALLET_RETRY_WORK_DECISION_EXHAUSTED,
+})
+
+
+class WalletPublicReadinessBoundary:
+    """Phase 6.6.5 narrow public-readiness slice opener.
+    Evaluate deterministic go-live preparation status from existing 6.5.x/6.6.x inputs only.
+    Evaluation-only contract: no activation, scheduler, or orchestration rollout."""
+
+    def evaluate_public_readiness(self, policy: WalletPublicReadinessPolicy) -> WalletPublicReadinessResult:
+        contract_error = _validate_public_readiness_policy(policy)
+        if contract_error is not None:
+            return _blocked_public_readiness_result(
+                policy=policy,
+                blocked_reason=WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT,
+                readiness_notes=["contract_error"],
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_public_readiness_result(
+                policy=policy,
+                blocked_reason=WALLET_PUBLIC_READINESS_BLOCK_OWNERSHIP_MISMATCH,
+                readiness_notes=["owner_mismatch"],
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_public_readiness_result(
+                policy=policy,
+                blocked_reason=WALLET_PUBLIC_READINESS_BLOCK_WALLET_NOT_ACTIVE,
+                readiness_notes=["wallet_not_active"],
+                notes={"wallet_active": False},
+            )
+
+        if policy.state_read_batch_ready is not True:
+            return _blocked_public_readiness_result(
+                policy=policy,
+                blocked_reason=WALLET_PUBLIC_READINESS_BLOCK_STATE_READ_NOT_READY,
+                readiness_notes=["state_read_batch_not_ready"],
+                notes={"state_read_batch_ready": False},
+            )
+
+        if policy.reconciliation_outcome != WALLET_RECONCILIATION_OUTCOME_MATCH:
+            return _blocked_public_readiness_result(
+                policy=policy,
+                blocked_reason=WALLET_PUBLIC_READINESS_BLOCK_RECONCILIATION_UNRESOLVED,
+                readiness_notes=["reconciliation_unresolved"],
+                notes={"reconciliation_outcome": policy.reconciliation_outcome},
+            )
+
+        readiness_notes = [
+            "state_boundary_ready",
+            "reconciliation_match",
+        ]
+
+        if policy.correction_result_category == WALLET_CORRECTION_RESULT_NOT_REQUIRED:
+            readiness_notes.append("correction_not_required")
+        elif policy.correction_result_category == WALLET_CORRECTION_RESULT_ACCEPTED:
+            readiness_notes.append("correction_applied")
+        else:
+            return WalletPublicReadinessResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD,
+                readiness_notes=readiness_notes + ["correction_resolution_pending"],
+                notes={
+                    "correction_result_category": policy.correction_result_category,
+                    "retry_result_category": policy.retry_result_category,
+                },
+            )
+
+        if policy.retry_result_category == WALLET_RETRY_WORK_DECISION_EXHAUSTED:
+            return WalletPublicReadinessResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD,
+                readiness_notes=readiness_notes + ["retry_budget_exhausted"],
+                notes={"retry_result_category": policy.retry_result_category},
+            )
+
+        if policy.retry_result_category in {
+            WALLET_RETRY_WORK_DECISION_ACCEPTED,
+            WALLET_RETRY_WORK_DECISION_BLOCKED,
+        }:
+            return WalletPublicReadinessResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD,
+                readiness_notes=readiness_notes + ["retry_resolution_pending"],
+                notes={"retry_result_category": policy.retry_result_category},
+            )
+
+        return WalletPublicReadinessResult(
+            success=True,
+            blocked_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_GO,
+            readiness_notes=readiness_notes + ["retry_lane_clear"],
+            notes={"retry_result_category": policy.retry_result_category},
+        )
+
+
+def _validate_public_readiness_policy(policy: WalletPublicReadinessPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if not isinstance(policy.state_read_batch_ready, bool):
+        return "state_read_batch_ready_must_be_bool"
+    if (
+        not isinstance(policy.reconciliation_outcome, str)
+        or policy.reconciliation_outcome not in _WALLET_PUBLIC_READINESS_VALID_RECONCILIATION_OUTCOMES
+    ):
+        return "reconciliation_outcome_invalid"
+    if (
+        not isinstance(policy.correction_result_category, str)
+        or policy.correction_result_category not in _WALLET_PUBLIC_READINESS_VALID_CORRECTION_RESULTS
+    ):
+        return "correction_result_category_invalid"
+    if (
+        not isinstance(policy.retry_result_category, str)
+        or policy.retry_result_category not in _WALLET_PUBLIC_READINESS_VALID_RETRY_RESULTS
+    ):
+        return "retry_result_category_invalid"
+    return None
+
+
+def _blocked_public_readiness_result(
+    *,
+    policy: WalletPublicReadinessPolicy,
+    blocked_reason: str,
+    readiness_notes: list[str],
+    notes: dict[str, Any] | None,
+) -> WalletPublicReadinessResult:
+    return WalletPublicReadinessResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_BLOCKED,
+        readiness_notes=readiness_notes,
         notes=notes,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-6-5_01_public-readiness-slice-opener.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-6-5_01_public-readiness-slice-opener.md
@@ -1,0 +1,101 @@
+# FORGE-X Report -- Phase 6.6.5 Public Readiness Slice Opener Foundation
+
+**Validation Tier:** STANDARD  
+**Claim Level:** FOUNDATION  
+**Validation Target:** `WalletPublicReadinessBoundary.evaluate_public_readiness` contract only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused deterministic outcome/block tests in `projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py`.  
+**Not in Scope:** full production activation, live trading enablement, scheduler daemon rollout, settlement automation, portfolio orchestration, monitoring rollout, broader go-live pipeline automation, or platform-wide orchestration.  
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered a narrow Phase 6.6.5 public-readiness preparation contract that evaluates existing wallet lifecycle reconciliation/correction/retry signals without activating runtime automation.
+
+Added new readiness block constants:
+- `WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT`
+- `WALLET_PUBLIC_READINESS_BLOCK_OWNERSHIP_MISMATCH`
+- `WALLET_PUBLIC_READINESS_BLOCK_WALLET_NOT_ACTIVE`
+- `WALLET_PUBLIC_READINESS_BLOCK_STATE_READ_NOT_READY`
+- `WALLET_PUBLIC_READINESS_BLOCK_RECONCILIATION_UNRESOLVED`
+
+Added deterministic readiness result categories:
+- `WALLET_PUBLIC_READINESS_RESULT_GO`
+- `WALLET_PUBLIC_READINESS_RESULT_HOLD`
+- `WALLET_PUBLIC_READINESS_RESULT_BLOCKED`
+
+Added new dataclasses and boundary:
+- `WalletPublicReadinessPolicy`
+- `WalletPublicReadinessResult`
+- `WalletPublicReadinessBoundary.evaluate_public_readiness(policy)`
+
+Deterministic evaluation behavior:
+1. Contract validation and owner/wallet-active checks.
+2. Require declared `state_read_batch_ready` input as true.
+3. Require reconciliation outcome to be `match`; unresolved reconciliation blocks readiness.
+4. Convert correction/retry states into deterministic readiness categories:
+   - GO: reconciliation match + correction accepted/not-required + retry skipped.
+   - HOLD: correction unresolved, retry pending, or retry exhausted.
+   - BLOCKED: contract/ownership/wallet-active/state-read/reconciliation gates fail.
+
+This slice remains evaluation-only and introduces no scheduler, no live activation, and no broad automation rollout.
+
+## 2) Current system architecture (relevant slice)
+
+- 6.5.x storage/read boundaries remain unchanged and are consumed as declared readiness input (`state_read_batch_ready`).
+- 6.6.1-6.6.2 reconciliation boundaries remain unchanged and provide the declared `reconciliation_outcome` input.
+- 6.6.3 correction boundary remains unchanged and provides the declared `correction_result_category` input.
+- 6.6.4 retry worker boundary remains unchanged and provides the declared `retry_result_category` input.
+- New 6.6.5 readiness boundary is evaluation-only:
+  - emits deterministic `go` / `hold` / `blocked` categories,
+  - emits explicit block reasons,
+  - emits structured readiness notes,
+  - does not execute runtime activation paths.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-6-5_01_public-readiness-slice-opener.md`
+
+## 4) What is working
+
+- Public-readiness contract validation rejects malformed inputs deterministically.
+- Owner mismatch, inactive wallet, state-read-not-ready, and unresolved-reconciliation produce deterministic BLOCKED decisions with explicit block reasons.
+- GO decision is deterministic for reconciliation match + correction resolved + retry lane clear (`retry_skipped`).
+- HOLD decision is deterministic for correction unresolved, retry pending (`retry_accepted` / `retry_blocked`), and retry exhausted.
+- Readiness notes are explicitly populated for block/hold/go outcomes.
+- Existing 6.5.x and 6.6.1-6.6.4 foundations were preserved; this slice adds evaluation contract only.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py`
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_3_wallet_reconciliation_correction_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_1_wallet_reconciliation_foundation_20260418.py`
+5. UTF-8/mojibake scan on touched files.
+
+## 5) Known issues
+
+- This slice is foundation-only preparation evaluation; no live go-live automation path is introduced.
+- Retry and correction signals are consumed as declared readiness inputs only; no automatic retry scheduler or settlement orchestration is included.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: FOUNDATION
+- Validation Target: `WalletPublicReadinessBoundary.evaluate_public_readiness` contract only
+- Not in Scope: full production activation, live trading enablement, scheduler rollout, settlement automation, portfolio orchestration, monitoring rollout, broader go-live pipeline
+- Suggested Next: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 05:10 (Asia/Jakarta)  
+**Role:** FORGE-X (NEXUS)  
+**Task:** Phase 6.6.5 public-readiness slice opener foundation  
+**Branch:** `feature/public-readiness-slice-opener-2026-04-18`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+    WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+    WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT,
+    WALLET_PUBLIC_READINESS_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_PUBLIC_READINESS_BLOCK_RECONCILIATION_UNRESOLVED,
+    WALLET_PUBLIC_READINESS_BLOCK_STATE_READ_NOT_READY,
+    WALLET_PUBLIC_READINESS_BLOCK_WALLET_NOT_ACTIVE,
+    WALLET_PUBLIC_READINESS_RESULT_BLOCKED,
+    WALLET_PUBLIC_READINESS_RESULT_GO,
+    WALLET_PUBLIC_READINESS_RESULT_HOLD,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RETRY_WORK_DECISION_ACCEPTED,
+    WALLET_RETRY_WORK_DECISION_BLOCKED,
+    WALLET_RETRY_WORK_DECISION_EXHAUSTED,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+    WalletPublicReadinessBoundary,
+    WalletPublicReadinessPolicy,
+    _validate_public_readiness_policy,
+)
+
+
+def _boundary() -> WalletPublicReadinessBoundary:
+    return WalletPublicReadinessBoundary()
+
+
+def _policy(**kwargs) -> WalletPublicReadinessPolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requested_by_user_id": "user-1",
+        "wallet_active": True,
+        "state_read_batch_ready": True,
+        "reconciliation_outcome": WALLET_RECONCILIATION_OUTCOME_MATCH,
+        "correction_result_category": WALLET_CORRECTION_RESULT_NOT_REQUIRED,
+        "retry_result_category": WALLET_RETRY_WORK_DECISION_SKIPPED,
+    }
+    defaults.update(kwargs)
+    return WalletPublicReadinessPolicy(**defaults)
+
+
+# --- Validator ---
+
+
+def test_validate_public_readiness_policy_accepts_valid_policy() -> None:
+    assert _validate_public_readiness_policy(_policy()) is None
+
+
+def test_validate_public_readiness_policy_requires_wallet_binding_id() -> None:
+    assert _validate_public_readiness_policy(_policy(wallet_binding_id=" ")) == "wallet_binding_id_required"
+
+
+def test_validate_public_readiness_policy_requires_bool_state_ready() -> None:
+    assert (
+        _validate_public_readiness_policy(_policy(state_read_batch_ready="yes"))  # type: ignore[arg-type]
+        == "state_read_batch_ready_must_be_bool"
+    )
+
+
+def test_validate_public_readiness_policy_requires_known_retry_result() -> None:
+    assert _validate_public_readiness_policy(_policy(retry_result_category="unknown")) == "retry_result_category_invalid"
+
+
+# --- Deterministic readiness outcomes ---
+
+
+def test_readiness_returns_go_for_match_not_required_and_retry_skipped() -> None:
+    result = _boundary().evaluate_public_readiness(_policy())
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_GO
+    assert "retry_lane_clear" in result.readiness_notes
+
+
+def test_readiness_returns_go_for_match_correction_accepted_and_retry_skipped() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(correction_result_category=WALLET_CORRECTION_RESULT_ACCEPTED)
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_GO
+    assert "correction_applied" in result.readiness_notes
+
+
+def test_readiness_returns_hold_for_retry_accepted() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_ACCEPTED,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_ACCEPTED,
+        )
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD
+    assert "retry_resolution_pending" in result.readiness_notes
+
+
+def test_readiness_returns_hold_for_retry_blocked() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_ACCEPTED,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_BLOCKED,
+        )
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD
+
+
+def test_readiness_returns_hold_for_retry_exhausted() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_ACCEPTED,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_EXHAUSTED,
+        )
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD
+    assert "retry_budget_exhausted" in result.readiness_notes
+
+
+def test_readiness_returns_hold_for_correction_pending_path_blocked() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_PATH_BLOCKED,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_SKIPPED,
+        )
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD
+    assert "correction_resolution_pending" in result.readiness_notes
+
+
+def test_readiness_returns_hold_for_correction_pending_blocked() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(
+            correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED,
+            retry_result_category=WALLET_RETRY_WORK_DECISION_SKIPPED,
+        )
+    )
+    assert result.success is True
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD
+
+
+# --- Block contracts ---
+
+
+def test_readiness_blocks_ownership_mismatch() -> None:
+    result = _boundary().evaluate_public_readiness(_policy(requested_by_user_id="user-2"))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_OWNERSHIP_MISMATCH
+    assert result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_BLOCKED
+
+
+def test_readiness_blocks_inactive_wallet() -> None:
+    result = _boundary().evaluate_public_readiness(_policy(wallet_active=False))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_WALLET_NOT_ACTIVE
+
+
+def test_readiness_blocks_state_read_not_ready() -> None:
+    result = _boundary().evaluate_public_readiness(_policy(state_read_batch_ready=False))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_STATE_READ_NOT_READY
+
+
+def test_readiness_blocks_reconciliation_unresolved() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH)
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_RECONCILIATION_UNRESOLVED
+
+
+def test_readiness_blocks_invalid_contract() -> None:
+    result = _boundary().evaluate_public_readiness(
+        _policy(reconciliation_outcome="invalid")  # type: ignore[arg-type]
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT


### PR DESCRIPTION
### Motivation
- Open a narrow Phase 6.6.5 public-readiness evaluation slice that produces deterministic preparation outcomes (go / hold / blocked) without enabling any live activation or orchestration. 
- Provide a clear, evaluation-only contract that consumes existing 6.5.x and 6.6.x readiness inputs (storage/read, reconciliation, correction, retry) and preserves all prior contracts. 
- Prevent scope creep by explicitly encoding block reasons and readiness notes so COMMANDER can review go/hold/blocked determinations before any automation rollout. 

### Description
- Added readiness constants, dataclasses (`WalletPublicReadinessPolicy`, `WalletPublicReadinessResult`), validator, and the evaluation boundary `WalletPublicReadinessBoundary.evaluate_public_readiness` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`. 
- Implemented deterministic rules that require `state_read_batch_ready` and reconciliation `match` for `go`, and convert correction/retry signals into `go` / `hold` / `blocked` categories with explicit block reasons. 
- Added unit tests `projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py` and a FORGE-X report `projects/polymarket/polyquantbot/reports/forge/phase6-6-5_01_public-readiness-slice-opener.md`. 
- Updated `PROJECT_STATE.md` and `ROADMAP.md` to open Phase 6.6.5 (and mark 6.6.4 as merged-main truth) and committed the changes on branch `feature/public-readiness-slice-opener-2026-04-18`. 

### Testing
- Ran compilation checks with `python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` and `python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py`, both of which succeeded. 
- Executed unit tests with `PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py` and the broader reconciliation test set with `PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_4_wallet_reconciliation_retry_worker_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_3_wallet_reconciliation_correction_foundation_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_2_wallet_reconciliation_batch_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_1_wallet_reconciliation_foundation_20260418.py`, which completed successfully with all tests passing (102 passed, 1 Pytest config warning). 
- Performed UTF-8/mojibake fixed-string scans on touched files (`â€`, `â†`, `ðŸ`, `\udc`, `�`) and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2af5d0ab483258834b9a2095b4b33)