### PR TITLE
forge: phase 6.6.6 public activation gate foundation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 05:10
-Status       : Phase 6.6.5 public-readiness slice opener foundation is in progress on feature/public-readiness-slice-opener-2026-04-18 pending COMMANDER review. Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 08:30
+Status       : Phase 6.6.6 public activation gate foundation is in progress on claude/public-activation-gate-0xLIz pending COMMANDER review. Phase 6.6.5 public-readiness slice opener foundation is in progress on feature/public-readiness-slice-opener-2026-04-18 pending COMMANDER review. Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -18,9 +18,10 @@ Status       : Phase 6.6.5 public-readiness slice opener foundation is in progre
 
 [IN PROGRESS]
 - Phase 6.6.5 public-readiness slice opener foundation is active on feature/public-readiness-slice-opener-2026-04-18 for deterministic go/hold/blocked preparation evaluation only.
+- Phase 6.6.6 public activation gate foundation is active on claude/public-activation-gate-0xLIz for deterministic allowed/denied_hold/denied_blocked gate evaluation consuming 6.6.5 readiness outcomes only.
 
 [NOT STARTED]
-- Subsequent public-readiness slices after 6.6.5 have not been opened.
+- Subsequent public-activation slices after 6.6.6 have not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
@@ -28,7 +29,8 @@ Status       : Phase 6.6.5 public-readiness slice opener foundation is in progre
 - Reconciliation mutation and correction workflow beyond the read-only and append-only boundaries.
 
 [NEXT PRIORITY]
-- COMMANDER review for Phase 6.6.5 public-readiness slice opener foundation scope and contracts.
+- COMMANDER review for Phase 6.6.6 public activation gate foundation on claude/public-activation-gate-0xLIz.
+- COMMANDER review for Phase 6.6.5 public-readiness slice opener foundation on feature/public-readiness-slice-opener-2026-04-18.
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 05:10
+**Last Updated:** 2026-04-18 08:30
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 05:10
+**Last Updated:** 2026-04-18 08:30
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -75,6 +75,7 @@
 | 6.6.3 | Wallet Reconciliation Mutation Correction Foundation | ✅ Done | Merged-main truth accepted via PR #560 at `WalletReconciliationCorrectionBoundary.apply_correction` with deterministic correction decision categories and block reasons. |
 | 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | ✅ Done | Merged-main truth accepted via PR #561 at `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` with deterministic accepted/skipped/blocked/exhausted retry preparation outcomes and explicit block contracts. |
 | 6.6.5 | Public Readiness Slice Opener Foundation | 🚧 In Progress | Active on feature/public-readiness-slice-opener-2026-04-18 for evaluation-only go/hold/blocked preparation contract using declared 6.5.x/6.6.x readiness inputs; no live activation, scheduler rollout, settlement automation, or portfolio orchestration claimed. |
+| 6.6.6 | Public Activation Gate Foundation | 🚧 In Progress | Active on claude/public-activation-gate-0xLIz for deterministic gate-only allowed/denied_hold/denied_blocked evaluation consuming 6.6.5 readiness outcomes; no scheduler daemon, automation rollout, portfolio orchestration, or live trading activation claimed. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -2037,3 +2037,143 @@ def _blocked_public_readiness_result(
         readiness_notes=readiness_notes,
         notes=notes,
     )
+
+
+WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT = "invalid_contract"
+WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH = "ownership_mismatch"
+WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE = "wallet_not_active"
+WALLET_ACTIVATION_GATE_BLOCK_READINESS_HOLD = "readiness_hold"
+WALLET_ACTIVATION_GATE_BLOCK_READINESS_BLOCKED = "readiness_blocked"
+WALLET_ACTIVATION_GATE_RESULT_ALLOWED = "allowed"
+WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD = "denied_hold"
+WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED = "denied_blocked"
+
+_WALLET_ACTIVATION_GATE_VALID_READINESS_RESULTS: frozenset[str] = frozenset({
+    WALLET_PUBLIC_READINESS_RESULT_GO,
+    WALLET_PUBLIC_READINESS_RESULT_HOLD,
+    WALLET_PUBLIC_READINESS_RESULT_BLOCKED,
+})
+
+
+@dataclass(frozen=True)
+class WalletPublicActivationGatePolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requested_by_user_id: str
+    wallet_active: bool
+    readiness_result_category: str
+    readiness_notes: list[str]
+
+
+@dataclass(frozen=True)
+class WalletPublicActivationGateResult:
+    success: bool
+    blocked_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    activation_result_category: str
+    activation_notes: list[str]
+    notes: dict[str, Any] | None = None
+
+
+class WalletPublicActivationGateBoundary:
+    """Phase 6.6.6 narrow public activation gate.
+    Consumes 6.6.5 readiness outcome and deterministically allows or blocks activation.
+    Gate-only: no scheduler daemon, no automation rollout, no live trading claim."""
+
+    def evaluate_activation_gate(
+        self, policy: WalletPublicActivationGatePolicy
+    ) -> WalletPublicActivationGateResult:
+        contract_error = _validate_activation_gate_policy(policy)
+        if contract_error is not None:
+            return _blocked_activation_gate_result(
+                policy=policy,
+                blocked_reason=WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+                activation_notes=["contract_error"],
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requested_by_user_id != policy.owner_user_id:
+            return _blocked_activation_gate_result(
+                policy=policy,
+                blocked_reason=WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+                activation_notes=["owner_mismatch"],
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if policy.wallet_active is not True:
+            return _blocked_activation_gate_result(
+                policy=policy,
+                blocked_reason=WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+                activation_notes=["wallet_not_active"],
+                notes={"wallet_active": False},
+            )
+
+        if policy.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_GO:
+            return WalletPublicActivationGateResult(
+                success=True,
+                blocked_reason=None,
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+                activation_notes=list(policy.readiness_notes) + ["readiness_go_confirmed"],
+                notes={"readiness_result_category": policy.readiness_result_category},
+            )
+
+        if policy.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD:
+            return _blocked_activation_gate_result(
+                policy=policy,
+                blocked_reason=WALLET_ACTIVATION_GATE_BLOCK_READINESS_HOLD,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+                activation_notes=list(policy.readiness_notes) + ["readiness_hold_pending"],
+                notes={"readiness_result_category": policy.readiness_result_category},
+            )
+
+        return _blocked_activation_gate_result(
+            policy=policy,
+            blocked_reason=WALLET_ACTIVATION_GATE_BLOCK_READINESS_BLOCKED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+            activation_notes=list(policy.readiness_notes) + ["readiness_blocked"],
+            notes={"readiness_result_category": policy.readiness_result_category},
+        )
+
+
+def _validate_activation_gate_policy(policy: WalletPublicActivationGatePolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requested_by_user_id, str) or not policy.requested_by_user_id.strip():
+        return "requested_by_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if (
+        not isinstance(policy.readiness_result_category, str)
+        or policy.readiness_result_category not in _WALLET_ACTIVATION_GATE_VALID_READINESS_RESULTS
+    ):
+        return "readiness_result_category_invalid"
+    if not isinstance(policy.readiness_notes, list):
+        return "readiness_notes_must_be_list"
+    return None
+
+
+def _blocked_activation_gate_result(
+    *,
+    policy: WalletPublicActivationGatePolicy,
+    blocked_reason: str,
+    activation_result_category: str,
+    activation_notes: list[str],
+    notes: dict[str, Any] | None,
+) -> WalletPublicActivationGateResult:
+    return WalletPublicActivationGateResult(
+        success=False,
+        blocked_reason=blocked_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        activation_result_category=activation_result_category,
+        activation_notes=activation_notes,
+        notes=notes,
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-6-6_01_public-activation-gate.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-6-6_01_public-activation-gate.md
@@ -1,0 +1,105 @@
+# FORGE-X Report -- Phase 6.6.6 Public Activation Gate
+
+**Validation Tier:** STANDARD
+**Claim Level:** FOUNDATION
+**Validation Target:** `WalletPublicActivationGateBoundary.evaluate_activation_gate` contract only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused deterministic allow/block gate outcome tests in `projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py`.
+**Not in Scope:** full production activation rollout, scheduler daemon, settlement automation, portfolio orchestration, live trading enablement, monitoring rollout, broader go-live pipeline automation, platform-wide orchestration.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered a narrow Phase 6.6.6 public activation gate contract that consumes the declared 6.6.5 public-readiness outcome and deterministically allows or blocks activation without introducing any scheduler, automation, or runtime orchestration.
+
+Added new activation gate block constants:
+- `WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT`
+- `WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH`
+- `WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE`
+- `WALLET_ACTIVATION_GATE_BLOCK_READINESS_HOLD`
+- `WALLET_ACTIVATION_GATE_BLOCK_READINESS_BLOCKED`
+
+Added deterministic activation result categories:
+- `WALLET_ACTIVATION_GATE_RESULT_ALLOWED`
+- `WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD`
+- `WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED`
+
+Added new dataclasses and boundary:
+- `WalletPublicActivationGatePolicy`
+- `WalletPublicActivationGateResult`
+- `WalletPublicActivationGateBoundary.evaluate_activation_gate(policy)`
+
+Deterministic gate evaluation behavior:
+1. Contract validation: invalid policy inputs block with `WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT` and `denied_blocked`.
+2. Ownership check: requester must be the declared owner; mismatch blocks with `WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH` and `denied_blocked`.
+3. Wallet active check: inactive wallet blocks with `WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE` and `denied_blocked`.
+4. Readiness gate routing:
+   - `go` readiness result -> `allowed` activation with forwarded readiness notes + `readiness_go_confirmed`.
+   - `hold` readiness result -> `denied_hold` with forwarded readiness notes + `readiness_hold_pending`.
+   - `blocked` readiness result -> `denied_blocked` with forwarded readiness notes + `readiness_blocked`.
+
+This slice is gate-only and introduces no scheduler daemon, no broad automation rollout, no portfolio orchestration, and no live trading activation claim.
+
+## 2) Current system architecture (relevant slice)
+
+- 6.5.x storage/read boundaries remain unchanged and are upstream of the readiness input.
+- 6.6.1-6.6.2 reconciliation boundaries remain unchanged and feed reconciliation outcomes upstream.
+- 6.6.3 correction boundary remains unchanged and feeds correction outcomes upstream.
+- 6.6.4 retry worker boundary remains unchanged and feeds retry outcomes upstream.
+- 6.6.5 public-readiness boundary remains unchanged and produces the `readiness_result_category` (go/hold/blocked) consumed by this gate.
+- New 6.6.6 activation gate boundary is gate-only:
+  - consumes declared `readiness_result_category` and `readiness_notes` from 6.6.5 output,
+  - emits deterministic `allowed` / `denied_hold` / `denied_blocked` activation categories,
+  - emits explicit gate block reasons,
+  - forwards readiness notes into activation notes for full trace lineage,
+  - does not execute runtime activation, scheduler, or orchestration.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-6-6_01_public-activation-gate.md`
+
+## 4) What is working
+
+- Contract validation blocks malformed inputs deterministically with `invalid_contract` block reason and `denied_blocked` category.
+- Ownership mismatch produces deterministic `denied_blocked` with explicit `ownership_mismatch` block reason.
+- Inactive wallet produces deterministic `denied_blocked` with explicit `wallet_not_active` block reason.
+- `go` readiness input produces deterministic `allowed` activation result with forwarded readiness notes and `readiness_go_confirmed` appended.
+- `hold` readiness input produces deterministic `denied_hold` with forwarded readiness notes and `readiness_hold_pending` appended.
+- `blocked` readiness input produces deterministic `denied_blocked` with forwarded readiness notes and `readiness_blocked` appended.
+- Empty readiness_notes list is accepted; gate appends its own deterministic note.
+- All result objects carry `wallet_binding_id`, `owner_user_id`, `activation_result_category`, `activation_notes`, and a `notes` dict with `readiness_result_category` for traceability.
+- Existing 6.5.x and 6.6.1-6.6.5 foundations were fully preserved; this slice adds the gate contract only.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` -- OK
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py` -- OK
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py` -- 24 passed
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q ...test_phase6_6_5... ...test_phase6_6_4... ...test_phase6_6_3...` -- 72 passed (regression clean)
+
+## 5) Known issues
+
+- This slice is gate-only evaluation; no live go-live automation or activation path is introduced.
+- Readiness notes are forwarded as-is from the caller; no deduplication is performed (acceptable at foundation claim level).
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: FOUNDATION
+- Validation Target: `WalletPublicActivationGateBoundary.evaluate_activation_gate` contract only
+- Not in Scope: full production activation rollout, scheduler daemon, settlement automation, portfolio orchestration, live trading enablement, monitoring rollout, broader go-live pipeline
+- Suggested Next: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 08:30 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.6.6 public activation gate
+**Branch:** `claude/public-activation-gate-0xLIz`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT,
+    WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH,
+    WALLET_ACTIVATION_GATE_BLOCK_READINESS_BLOCKED,
+    WALLET_ACTIVATION_GATE_BLOCK_READINESS_HOLD,
+    WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE,
+    WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+    WALLET_PUBLIC_READINESS_RESULT_BLOCKED,
+    WALLET_PUBLIC_READINESS_RESULT_GO,
+    WALLET_PUBLIC_READINESS_RESULT_HOLD,
+    WalletPublicActivationGateBoundary,
+    WalletPublicActivationGatePolicy,
+    _validate_activation_gate_policy,
+)
+
+
+def _boundary() -> WalletPublicActivationGateBoundary:
+    return WalletPublicActivationGateBoundary()
+
+
+def _policy(**kwargs) -> WalletPublicActivationGatePolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requested_by_user_id": "user-1",
+        "wallet_active": True,
+        "readiness_result_category": WALLET_PUBLIC_READINESS_RESULT_GO,
+        "readiness_notes": ["state_boundary_ready", "reconciliation_match", "retry_lane_clear"],
+    }
+    defaults.update(kwargs)
+    return WalletPublicActivationGatePolicy(**defaults)
+
+
+# --- Validator ---
+
+
+def test_validate_activation_gate_policy_accepts_valid_go_policy() -> None:
+    assert _validate_activation_gate_policy(_policy()) is None
+
+
+def test_validate_activation_gate_policy_accepts_valid_hold_policy() -> None:
+    assert _validate_activation_gate_policy(_policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD)) is None
+
+
+def test_validate_activation_gate_policy_accepts_valid_blocked_policy() -> None:
+    assert _validate_activation_gate_policy(_policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_BLOCKED)) is None
+
+
+def test_validate_activation_gate_policy_requires_wallet_binding_id() -> None:
+    assert _validate_activation_gate_policy(_policy(wallet_binding_id=" ")) == "wallet_binding_id_required"
+
+
+def test_validate_activation_gate_policy_requires_owner_user_id() -> None:
+    assert _validate_activation_gate_policy(_policy(owner_user_id="")) == "owner_user_id_required"
+
+
+def test_validate_activation_gate_policy_requires_requested_by_user_id() -> None:
+    assert _validate_activation_gate_policy(_policy(requested_by_user_id="")) == "requested_by_user_id_required"
+
+
+def test_validate_activation_gate_policy_requires_bool_wallet_active() -> None:
+    assert (
+        _validate_activation_gate_policy(_policy(wallet_active="yes"))  # type: ignore[arg-type]
+        == "wallet_active_must_be_bool"
+    )
+
+
+def test_validate_activation_gate_policy_requires_known_readiness_result() -> None:
+    assert (
+        _validate_activation_gate_policy(_policy(readiness_result_category="unknown"))
+        == "readiness_result_category_invalid"
+    )
+
+
+def test_validate_activation_gate_policy_requires_readiness_notes_list() -> None:
+    assert (
+        _validate_activation_gate_policy(_policy(readiness_notes="not_a_list"))  # type: ignore[arg-type]
+        == "readiness_notes_must_be_list"
+    )
+
+
+# --- Contract / identity gate blocks ---
+
+
+def test_gate_blocks_invalid_contract_empty_wallet_binding_id() -> None:
+    result = _boundary().evaluate_activation_gate(_policy(wallet_binding_id=""))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_ACTIVATION_GATE_BLOCK_INVALID_CONTRACT
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED
+    assert "contract_error" in result.activation_notes
+
+
+def test_gate_blocks_ownership_mismatch() -> None:
+    result = _boundary().evaluate_activation_gate(_policy(requested_by_user_id="other-user"))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_ACTIVATION_GATE_BLOCK_OWNERSHIP_MISMATCH
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED
+    assert "owner_mismatch" in result.activation_notes
+
+
+def test_gate_blocks_wallet_not_active() -> None:
+    result = _boundary().evaluate_activation_gate(_policy(wallet_active=False))
+    assert result.success is False
+    assert result.blocked_reason == WALLET_ACTIVATION_GATE_BLOCK_WALLET_NOT_ACTIVE
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED
+    assert "wallet_not_active" in result.activation_notes
+
+
+# --- Deterministic activation outcomes ---
+
+
+def test_gate_allows_when_readiness_is_go() -> None:
+    result = _boundary().evaluate_activation_gate(_policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_GO))
+    assert result.success is True
+    assert result.blocked_reason is None
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_ALLOWED
+    assert "readiness_go_confirmed" in result.activation_notes
+
+
+def test_gate_allows_and_forwards_readiness_notes() -> None:
+    notes = ["state_boundary_ready", "reconciliation_match", "correction_not_required", "retry_lane_clear"]
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_GO, readiness_notes=notes)
+    )
+    assert result.success is True
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_ALLOWED
+    for note in notes:
+        assert note in result.activation_notes
+    assert "readiness_go_confirmed" in result.activation_notes
+
+
+def test_gate_denies_hold_when_readiness_is_hold() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD)
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_ACTIVATION_GATE_BLOCK_READINESS_HOLD
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD
+    assert "readiness_hold_pending" in result.activation_notes
+
+
+def test_gate_denies_hold_and_forwards_readiness_notes() -> None:
+    notes = ["state_boundary_ready", "reconciliation_match", "retry_budget_exhausted"]
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD, readiness_notes=notes)
+    )
+    assert result.success is False
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD
+    for note in notes:
+        assert note in result.activation_notes
+    assert "readiness_hold_pending" in result.activation_notes
+
+
+def test_gate_denies_blocked_when_readiness_is_blocked() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_BLOCKED)
+    )
+    assert result.success is False
+    assert result.blocked_reason == WALLET_ACTIVATION_GATE_BLOCK_READINESS_BLOCKED
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED
+    assert "readiness_blocked" in result.activation_notes
+
+
+def test_gate_denies_blocked_and_forwards_readiness_notes() -> None:
+    notes = ["reconciliation_unresolved"]
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_BLOCKED, readiness_notes=notes)
+    )
+    assert result.success is False
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED
+    assert "reconciliation_unresolved" in result.activation_notes
+    assert "readiness_blocked" in result.activation_notes
+
+
+# --- Result fields completeness ---
+
+
+def test_gate_result_always_carries_wallet_binding_id_and_owner() -> None:
+    result = _boundary().evaluate_activation_gate(_policy())
+    assert result.wallet_binding_id == "wallet-1"
+    assert result.owner_user_id == "user-1"
+
+
+def test_gate_result_notes_dict_present_on_allowed() -> None:
+    result = _boundary().evaluate_activation_gate(_policy())
+    assert result.notes is not None
+    assert result.notes.get("readiness_result_category") == WALLET_PUBLIC_READINESS_RESULT_GO
+
+
+def test_gate_result_notes_dict_present_on_denied_hold() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD)
+    )
+    assert result.notes is not None
+    assert result.notes.get("readiness_result_category") == WALLET_PUBLIC_READINESS_RESULT_HOLD
+
+
+def test_gate_result_notes_dict_present_on_denied_blocked() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_BLOCKED)
+    )
+    assert result.notes is not None
+    assert result.notes.get("readiness_result_category") == WALLET_PUBLIC_READINESS_RESULT_BLOCKED
+
+
+# --- Empty readiness_notes is accepted ---
+
+
+def test_gate_accepts_empty_readiness_notes_list_on_go() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_GO, readiness_notes=[])
+    )
+    assert result.success is True
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_ALLOWED
+    assert "readiness_go_confirmed" in result.activation_notes
+
+
+def test_gate_accepts_empty_readiness_notes_list_on_hold() -> None:
+    result = _boundary().evaluate_activation_gate(
+        _policy(readiness_result_category=WALLET_PUBLIC_READINESS_RESULT_HOLD, readiness_notes=[])
+    )
+    assert result.success is False
+    assert result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD
+    assert "readiness_hold_pending" in result.activation_notes


### PR DESCRIPTION
## Summary

- Adds `WalletPublicActivationGateBoundary.evaluate_activation_gate` — gate-only contract that consumes 6.6.5 `readiness_result_category` (go/hold/blocked) and produces deterministic `allowed` / `denied_hold` / `denied_blocked` activation decisions
- 5 block constants, 3 activation result categories, `WalletPublicActivationGatePolicy` + `WalletPublicActivationGateResult` dataclasses
- 24 new tests, all pass; 72 prior 6.6.3-6.6.5 regression tests clean
- Forge report, PROJECT_STATE.md, and ROADMAP.md updated

**Validation Tier:** STANDARD
**Claim Level:** FOUNDATION
**Validation Target:** `WalletPublicActivationGateBoundary.evaluate_activation_gate` contract only
**Not in Scope:** full production activation rollout, scheduler daemon, settlement automation, portfolio orchestration, live trading enablement, monitoring rollout, broader go-live pipeline

## Test plan

- [x] `py_compile` passes on `wallet_lifecycle_foundation.py` and test file
- [x] 24 new gate tests pass (contract blocks, ownership, wallet-active, go/hold/blocked routing, notes forwarding)
- [x] 72 prior phase tests (6.6.3-6.6.5) pass — no regression
- [x] UTF-8/mojibake scan clean on all touched files
- [x] Forge report at `projects/polymarket/polyquantbot/reports/forge/phase6-6-6_01_public-activation-gate.md` with all 6 sections
- [x] PROJECT_STATE.md and ROADMAP.md updated truthfully

## Next gate

COMMANDER review. FORGE-X does not merge.

https://claude.ai/code/session_011eLLPhqiAFuiYocTMBi6Tk