### PR TITLE
feature(execution): phase 6.6.9 minimal execution hook narrow integration

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 08:46
-Status       : Phase 6.6.8 public safety hardening narrow integration is in progress on claude/public-safety-hardening-h1lYy pending COMMANDER review. Phase 6.6.7 minimal public activation flow foundation is in progress on claude/minimal-activation-flow-FUV3u pending COMMANDER review. Phase 6.6.6 public activation gate foundation is in progress on claude/public-activation-gate-0xLIz pending COMMANDER review. Phase 6.6.5 public-readiness slice opener foundation is in progress on feature/public-readiness-slice-opener-2026-04-18 pending COMMANDER review. Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 08:56
+Status       : Phase 6.6.9 minimal execution hook narrow integration is in progress on claude/minimal-execution-hook-xBP8u pending COMMANDER review. Phase 6.6.8 public safety hardening narrow integration is in progress on claude/public-safety-hardening-h1lYy pending COMMANDER review. Phase 6.6.7 minimal public activation flow foundation is in progress on claude/minimal-activation-flow-FUV3u pending COMMANDER review. Phase 6.6.6 public activation gate foundation is in progress on claude/public-activation-gate-0xLIz pending COMMANDER review. Phase 6.6.5 public-readiness slice opener foundation is in progress on feature/public-readiness-slice-opener-2026-04-18 pending COMMANDER review. Phase 6.6.4 wallet reconciliation retry/worker foundation is merged-main truth via PR #561. Phase 6.6.3 wallet reconciliation mutation/correction foundation is merged-main truth via PR #560. Phase 6.6.2 wallet lifecycle batch reconciliation is merged-main truth via PR #559. Phase 6.6.1 reconciliation foundation is merged-main truth. Phase 6.5.10 wallet state exact batch read boundary is merged-main truth via PR #557. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -21,9 +21,10 @@ Status       : Phase 6.6.8 public safety hardening narrow integration is in prog
 - Phase 6.6.6 public activation gate foundation is active on claude/public-activation-gate-0xLIz for deterministic allowed/denied_hold/denied_blocked gate evaluation consuming 6.6.5 readiness outcomes only.
 - Phase 6.6.7 minimal public activation flow foundation is active on claude/minimal-activation-flow-FUV3u for thin-flow-only deterministic completed/stopped_hold/stopped_blocked routing consuming declared 6.6.5 readiness and 6.6.6 gate outputs.
 - Phase 6.6.8 public safety hardening narrow integration is active on claude/public-safety-hardening-h1lYy for deterministic cross-boundary pass/hold/blocked consistency checks across declared 6.6.5/6.6.6/6.6.7 outputs only.
+- Phase 6.6.9 minimal execution hook narrow integration is active on claude/minimal-execution-hook-xBP8u for deterministic executed/stopped_hold/stopped_blocked hook outcome consuming declared 6.6.6/6.6.7/6.6.8 outputs only; no scheduler daemon, no live trading rollout, no portfolio orchestration claimed.
 
 [NOT STARTED]
-- Subsequent public-activation slices after 6.6.8 have not been opened.
+- Subsequent public-activation slices after 6.6.9 have not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
@@ -31,9 +32,9 @@ Status       : Phase 6.6.8 public safety hardening narrow integration is in prog
 - Reconciliation mutation and correction workflow beyond the read-only and append-only boundaries.
 
 [NEXT PRIORITY]
+- COMMANDER review for Phase 6.6.9 minimal execution hook narrow integration on claude/minimal-execution-hook-xBP8u. Source: projects/polymarket/polyquantbot/reports/forge/phase6-6-9_01_minimal-execution-hook.md. Tier: STANDARD.
 - COMMANDER review for Phase 6.6.8 public safety hardening narrow integration on claude/public-safety-hardening-h1lYy. Source: projects/polymarket/polyquantbot/reports/forge/phase6-6-8_01_public-safety-hardening.md. Tier: STANDARD.
 - COMMANDER review for Phase 6.6.7 minimal public activation flow foundation on claude/minimal-activation-flow-FUV3u.
-- COMMANDER review for Phase 6.6.6 public activation gate foundation on claude/public-activation-gate-0xLIz.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 08:46
+**Last Updated:** 2026-04-18 08:56
 
 ## Board Overview
 
@@ -43,7 +43,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 08:46
+**Last Updated:** 2026-04-18 08:56
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -78,6 +78,7 @@
 | 6.6.6 | Public Activation Gate Foundation | 🚧 In Progress | Active on claude/public-activation-gate-0xLIz for deterministic gate-only allowed/denied_hold/denied_blocked evaluation consuming 6.6.5 readiness outcomes; no scheduler daemon, automation rollout, portfolio orchestration, or live trading activation claimed. |
 | 6.6.7 | Minimal Public Activation Flow Foundation | 🚧 In Progress | Active on claude/minimal-activation-flow-FUV3u for thin-flow-only deterministic completed/stopped_hold/stopped_blocked routing consuming declared 6.6.5 readiness and 6.6.6 gate outputs; no scheduler daemon, automation rollout, portfolio orchestration, or live trading activation claimed. |
 | 6.6.8 | Public Safety Hardening | 🚧 In Progress | Active on claude/public-safety-hardening-h1lYy for deterministic cross-boundary pass/hold/blocked consistency checks across declared 6.6.5/6.6.6/6.6.7 outputs; no scheduler daemon, live trading rollout, portfolio orchestration, or broader go-live pipeline claimed. |
+| 6.6.9 | Minimal Execution Hook | 🚧 In Progress | Active on claude/minimal-execution-hook-xBP8u for deterministic executed/stopped_hold/stopped_blocked hook outcome consuming declared 6.6.6/6.6.7/6.6.8 outputs; hook-only, no scheduler daemon, live trading rollout, portfolio orchestration, or broader go-live pipeline claimed. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -2581,3 +2581,224 @@ def _validate_hardening_policy(policy: PublicSafetyHardeningPolicy) -> str | Non
     ):
         return "flow_result_category_invalid"
     return None
+
+
+# ---------------------------------------------------------------------------
+# Phase 6.6.9 -- Minimal Execution Hook
+# ---------------------------------------------------------------------------
+
+EXECUTION_HOOK_STOP_INVALID_CONTRACT = "invalid_contract"
+EXECUTION_HOOK_STOP_HARDENING_BLOCKED = "hardening_blocked"
+EXECUTION_HOOK_STOP_HARDENING_HOLD = "hardening_hold"
+EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED = "flow_not_completed"
+EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED = "gate_not_allowed"
+
+EXECUTION_HOOK_RESULT_EXECUTED = "executed"
+EXECUTION_HOOK_RESULT_STOPPED_HOLD = "stopped_hold"
+EXECUTION_HOOK_RESULT_STOPPED_BLOCKED = "stopped_blocked"
+
+_EXECUTION_HOOK_VALID_HARDENING_OUTCOMES: frozenset[str] = frozenset({
+    PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+    PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+    PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+})
+_EXECUTION_HOOK_VALID_FLOW_RESULTS: frozenset[str] = frozenset({
+    ACTIVATION_FLOW_RESULT_COMPLETED,
+    ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+    ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+})
+_EXECUTION_HOOK_VALID_GATE_RESULTS: frozenset[str] = frozenset({
+    WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+})
+
+
+@dataclass(frozen=True)
+class MinimalExecutionHookPolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requester_user_id: str
+    wallet_active: bool
+    hardening_outcome: str
+    flow_result_category: str
+    activation_result_category: str
+
+
+@dataclass(frozen=True)
+class MinimalExecutionHookResult:
+    hook_executed: bool
+    stop_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    hook_result_category: str
+    execution_hook_notes: list[str]
+    notes: dict[str, Any] | None = None
+
+
+class MinimalExecutionHookBoundary:
+    """Phase 6.6.9 minimal execution hook.
+    Executes only when the cross-boundary path is explicitly safe and completed.
+    Consumes declared outputs from 6.6.6 gate, 6.6.7 flow, and 6.6.8 hardening.
+    Hook-only: no scheduler daemon, no live trading rollout, no portfolio orchestration."""
+
+    def execute_hook(
+        self, policy: MinimalExecutionHookPolicy
+    ) -> MinimalExecutionHookResult:
+        contract_error = _validate_execution_hook_policy(policy)
+        if contract_error is not None:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_INVALID_CONTRACT,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["contract_error"],
+                notes={"contract_error": contract_error},
+            )
+
+        if policy.requester_user_id != policy.owner_user_id:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_INVALID_CONTRACT,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["owner_mismatch"],
+                notes={"owner_user_id": policy.owner_user_id},
+            )
+
+        if not policy.wallet_active:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_INVALID_CONTRACT,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["wallet_not_active"],
+                notes={"wallet_active": False},
+            )
+
+        if policy.hardening_outcome == PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_HARDENING_BLOCKED,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["hardening_blocked"],
+                notes={"hardening_outcome": policy.hardening_outcome},
+            )
+
+        if policy.hardening_outcome == PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_HARDENING_HOLD,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_HOLD,
+                execution_hook_notes=["hardening_hold"],
+                notes={"hardening_outcome": policy.hardening_outcome},
+            )
+
+        # hardening_outcome == PASS from here
+        if policy.flow_result_category == ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["flow_stopped_blocked"],
+                notes={
+                    "hardening_outcome": policy.hardening_outcome,
+                    "flow_result_category": policy.flow_result_category,
+                },
+            )
+
+        if policy.flow_result_category == ACTIVATION_FLOW_RESULT_STOPPED_HOLD:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_HOLD,
+                execution_hook_notes=["flow_stopped_hold"],
+                notes={
+                    "hardening_outcome": policy.hardening_outcome,
+                    "flow_result_category": policy.flow_result_category,
+                },
+            )
+
+        # flow_result_category == COMPLETED from here
+        if policy.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+                execution_hook_notes=["gate_denied_blocked"],
+                notes={
+                    "hardening_outcome": policy.hardening_outcome,
+                    "flow_result_category": policy.flow_result_category,
+                    "activation_result_category": policy.activation_result_category,
+                },
+            )
+
+        if policy.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD:
+            return _stopped_execution_hook_result(
+                policy=policy,
+                stop_reason=EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED,
+                hook_result_category=EXECUTION_HOOK_RESULT_STOPPED_HOLD,
+                execution_hook_notes=["gate_denied_hold"],
+                notes={
+                    "hardening_outcome": policy.hardening_outcome,
+                    "flow_result_category": policy.flow_result_category,
+                    "activation_result_category": policy.activation_result_category,
+                },
+            )
+
+        return MinimalExecutionHookResult(
+            hook_executed=True,
+            stop_reason=None,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            hook_result_category=EXECUTION_HOOK_RESULT_EXECUTED,
+            execution_hook_notes=["hardening_pass", "flow_completed", "gate_allowed"],
+            notes={
+                "hardening_outcome": policy.hardening_outcome,
+                "flow_result_category": policy.flow_result_category,
+                "activation_result_category": policy.activation_result_category,
+            },
+        )
+
+
+def _validate_execution_hook_policy(policy: MinimalExecutionHookPolicy) -> str | None:
+    if not isinstance(policy.wallet_binding_id, str) or not policy.wallet_binding_id.strip():
+        return "wallet_binding_id_required"
+    if not isinstance(policy.owner_user_id, str) or not policy.owner_user_id.strip():
+        return "owner_user_id_required"
+    if not isinstance(policy.requester_user_id, str) or not policy.requester_user_id.strip():
+        return "requester_user_id_required"
+    if not isinstance(policy.wallet_active, bool):
+        return "wallet_active_must_be_bool"
+    if (
+        not isinstance(policy.hardening_outcome, str)
+        or policy.hardening_outcome not in _EXECUTION_HOOK_VALID_HARDENING_OUTCOMES
+    ):
+        return "hardening_outcome_invalid"
+    if (
+        not isinstance(policy.flow_result_category, str)
+        or policy.flow_result_category not in _EXECUTION_HOOK_VALID_FLOW_RESULTS
+    ):
+        return "flow_result_category_invalid"
+    if (
+        not isinstance(policy.activation_result_category, str)
+        or policy.activation_result_category not in _EXECUTION_HOOK_VALID_GATE_RESULTS
+    ):
+        return "activation_result_category_invalid"
+    return None
+
+
+def _stopped_execution_hook_result(
+    *,
+    policy: MinimalExecutionHookPolicy,
+    stop_reason: str,
+    hook_result_category: str,
+    execution_hook_notes: list[str],
+    notes: dict[str, Any] | None,
+) -> MinimalExecutionHookResult:
+    return MinimalExecutionHookResult(
+        hook_executed=False,
+        stop_reason=stop_reason,
+        wallet_binding_id=policy.wallet_binding_id,
+        owner_user_id=policy.owner_user_id,
+        hook_result_category=hook_result_category,
+        execution_hook_notes=execution_hook_notes,
+        notes=notes,
+    )

--- a/projects/polymarket/polyquantbot/reports/forge/phase6-6-9_01_minimal-execution-hook.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase6-6-9_01_minimal-execution-hook.md
@@ -1,0 +1,146 @@
+# FORGE-X Report -- Phase 6.6.9 Minimal Execution Hook
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** `MinimalExecutionHookBoundary.execute_hook` contract only in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, with focused deterministic execute/stop outcome tests in `projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py`.
+**Not in Scope:** full production activation rollout, scheduler daemon, settlement automation, portfolio orchestration, live trading enablement, monitoring rollout, broader go-live pipeline automation, re-evaluation of readiness, gate, flow, or hardening logic, runtime orchestration beyond the execution hook contract.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional. Tier: STANDARD.
+
+---
+
+## 1) What was built
+
+Delivered the Phase 6.6.9 minimal execution hook contract. This slice adds a deterministic `MinimalExecutionHookBoundary.execute_hook` method that allows hook execution only when the cross-boundary path is explicitly safe and completed, consuming declared outputs from 6.6.6 activation gate, 6.6.7 minimal activation flow, and 6.6.8 public safety hardening.
+
+**New execution hook result constants:**
+- `EXECUTION_HOOK_RESULT_EXECUTED` -- "executed" -- all three boundary conditions confirmed and hook ran
+- `EXECUTION_HOOK_RESULT_STOPPED_HOLD` -- "stopped_hold" -- deterministic hold stop
+- `EXECUTION_HOOK_RESULT_STOPPED_BLOCKED` -- "stopped_blocked" -- deterministic blocked stop
+
+**New stop reason constants:**
+- `EXECUTION_HOOK_STOP_INVALID_CONTRACT` -- "invalid_contract" -- contract/ownership/wallet gate failed
+- `EXECUTION_HOOK_STOP_HARDENING_BLOCKED` -- "hardening_blocked" -- 6.6.8 hardening outcome is blocked
+- `EXECUTION_HOOK_STOP_HARDENING_HOLD` -- "hardening_hold" -- 6.6.8 hardening outcome is hold
+- `EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED` -- "flow_not_completed" -- 6.6.7 flow did not complete
+- `EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED` -- "gate_not_allowed" -- 6.6.6 gate did not allow
+
+**New dataclasses:**
+- `MinimalExecutionHookPolicy` -- accepts wallet identity + hardening_outcome + flow_result_category + activation_result_category
+- `MinimalExecutionHookResult` -- carries `hook_executed`, `hook_result_category`, `stop_reason`, `execution_hook_notes`, `notes`
+
+**New boundary:**
+- `MinimalExecutionHookBoundary.execute_hook(policy)`
+
+**Deterministic evaluation logic (ordered):**
+1. Contract validation: malformed inputs produce STOPPED_BLOCKED with `stop_reason=invalid_contract`.
+2. Ownership check: requester must equal owner; mismatch produces STOPPED_BLOCKED with `stop_reason=invalid_contract`.
+3. Wallet active check: inactive wallet produces STOPPED_BLOCKED with `stop_reason=invalid_contract`.
+4. Hardening outcome check: BLOCKED produces STOPPED_BLOCKED with `stop_reason=hardening_blocked`; HOLD produces STOPPED_HOLD with `stop_reason=hardening_hold`.
+5. Flow result check (only if hardening PASS): stopped_blocked produces STOPPED_BLOCKED with `stop_reason=flow_not_completed`; stopped_hold produces STOPPED_HOLD with `stop_reason=flow_not_completed`.
+6. Gate result check (only if hardening PASS and flow completed): denied_blocked produces STOPPED_BLOCKED with `stop_reason=gate_not_allowed`; denied_hold produces STOPPED_HOLD with `stop_reason=gate_not_allowed`.
+7. All conditions met (hardening=pass, flow=completed, gate=allowed): EXECUTED with `stop_reason=None`.
+
+**EXECUTED condition (all three required simultaneously):**
+- `hardening_outcome == "pass"` (from 6.6.8 -- transitively confirms 6.6.5/6.6.6/6.6.7 consistency)
+- `flow_result_category == "completed"` (explicit 6.6.7 confirmation)
+- `activation_result_category == "allowed"` (explicit 6.6.6 confirmation)
+
+**STOPPED_HOLD conditions (recoverable, re-evaluation possible):**
+- `hardening_outcome == "hold"` -- hold consistency mismatch needs review
+- `flow_result_category == "stopped_hold"` (with hardening PASS) -- flow paused on hold
+- `activation_result_category == "denied_hold"` (with hardening PASS and flow completed) -- gate held on hold
+
+**STOPPED_BLOCKED conditions (deterministic stop, escalation required):**
+- Contract, ownership, or wallet_active failure
+- `hardening_outcome == "blocked"` -- safety-relevant inconsistency detected
+- `flow_result_category == "stopped_blocked"` (with hardening PASS) -- flow blocked
+- `activation_result_category == "denied_blocked"` (with hardening PASS and flow completed) -- gate blocked
+
+This slice is hook-only: no scheduler daemon, no broad automation rollout, no portfolio orchestration, no live trading rollout claim. It does not modify or re-evaluate readiness, gate, flow, or hardening logic.
+
+## 2) Current system architecture (relevant slice)
+
+- 6.5.x storage/read boundaries remain unchanged and are upstream of all readiness inputs.
+- 6.6.1-6.6.2 reconciliation boundaries remain unchanged.
+- 6.6.3 correction boundary remains unchanged.
+- 6.6.4 retry worker boundary remains unchanged.
+- 6.6.5 public-readiness boundary remains unchanged and produces `readiness_result_category` (go/hold/blocked).
+- 6.6.6 activation gate boundary remains unchanged and produces `activation_result_category` (allowed/denied_hold/denied_blocked).
+- 6.6.7 minimal activation flow boundary remains unchanged and produces `flow_result_category` (completed/stopped_hold/stopped_blocked).
+- 6.6.8 public safety hardening boundary remains unchanged and produces `hardening_outcome` (pass/hold/blocked).
+- New 6.6.9 execution hook boundary is a post-hardening execution gate:
+  - accepts declared hardening outcome, flow result, and activation gate result,
+  - evaluates execution eligibility in priority order (contract -> ownership -> wallet -> hardening -> flow -> gate),
+  - emits deterministic EXECUTED/STOPPED_HOLD/STOPPED_BLOCKED outcome,
+  - emits explicit stop_reason on all non-executed paths,
+  - does not modify any prior boundary behavior or introduce any orchestration.
+
+Execution eligibility matrix (condensed):
+
+| hardening | flow | gate | hook outcome |
+|---|---|---|---|
+| pass | completed | allowed | EXECUTED |
+| pass | completed | denied_hold | STOPPED_HOLD |
+| pass | completed | denied_blocked | STOPPED_BLOCKED |
+| pass | stopped_hold | any | STOPPED_HOLD |
+| pass | stopped_blocked | any | STOPPED_BLOCKED |
+| hold | any | any | STOPPED_HOLD |
+| blocked | any | any | STOPPED_BLOCKED |
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase6-6-9_01_minimal-execution-hook.md`
+
+## 4) What is working
+
+- Contract validation blocks malformed inputs deterministically with `stop_reason=invalid_contract` and STOPPED_BLOCKED outcome.
+- Ownership mismatch produces STOPPED_BLOCKED with `stop_reason=invalid_contract` and `owner_mismatch` note.
+- Inactive wallet produces STOPPED_BLOCKED with `stop_reason=invalid_contract` and `wallet_not_active` note.
+- Hardening BLOCKED produces STOPPED_BLOCKED with `stop_reason=hardening_blocked` and `hardening_blocked` note.
+- Hardening HOLD produces STOPPED_HOLD with `stop_reason=hardening_hold` and `hardening_hold` note.
+- Hardening BLOCKED stops before checking flow or gate (priority order enforced).
+- Flow stopped_blocked (with hardening PASS) produces STOPPED_BLOCKED with `stop_reason=flow_not_completed` and `flow_stopped_blocked` note.
+- Flow stopped_hold (with hardening PASS) produces STOPPED_HOLD with `stop_reason=flow_not_completed` and `flow_stopped_hold` note.
+- Gate denied_blocked (with hardening PASS and flow completed) produces STOPPED_BLOCKED with `stop_reason=gate_not_allowed` and `gate_denied_blocked` note.
+- Gate denied_hold (with hardening PASS and flow completed) produces STOPPED_HOLD with `stop_reason=gate_not_allowed` and `gate_denied_hold` note.
+- All three conditions met (pass + completed + allowed): EXECUTED with `stop_reason=None`, `hook_executed=True`, and notes containing all three markers.
+- `execution_hook_notes` carries human-readable stop/pass markers on all outcomes.
+- `notes` dict carries all three category values on executed path; carries relevant category values on stop paths.
+- All result objects carry `wallet_binding_id` and `owner_user_id` for identity traceability.
+- `hook_executed=False` on all stop paths; `hook_executed=True` only on EXECUTED.
+- `stop_reason=None` only on EXECUTED path.
+- Existing 6.5.x and 6.6.1-6.6.8 foundations fully preserved; no prior boundary or test was modified.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` -- OK
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py` -- OK
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py` -- 29 passed
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q ...test_phase6_6_8... ...test_phase6_6_7... ...test_phase6_6_6... ...test_phase6_6_5... ...test_phase6_6_4... ...test_phase6_6_3... ...test_phase6_6_2... ...test_phase6_6_1...` -- 212 passed (regression clean)
+
+## 5) Known issues
+
+- This slice is execution hook contract only; no live go-live automation, scheduler, or activation path is introduced.
+- The `execute_hook` method evaluates declared boundary outputs as inputs; it does not re-execute readiness, gate, flow, or hardening logic.
+- Existing deferred warning remains: pytest `Unknown config option: asyncio_mode`.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `MinimalExecutionHookBoundary.execute_hook` contract only -- deterministic execute/stop outcome categories across declared 6.6.6/6.6.7/6.6.8 outputs
+- Not in Scope: full production activation rollout, scheduler daemon, settlement automation, portfolio orchestration, live trading enablement, monitoring rollout, broader go-live pipeline, re-evaluation of 6.6.5/6.6.6/6.6.7/6.6.8 logic
+- Suggested Next: COMMANDER review (auto PR review optional support)
+
+---
+
+**Report Timestamp:** 2026-04-18 08:56 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 6.6.9 minimal execution hook
+**Branch:** `claude/minimal-execution-hook-xBP8u`

--- a/projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    ACTIVATION_FLOW_RESULT_COMPLETED,
+    ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+    ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+    EXECUTION_HOOK_RESULT_EXECUTED,
+    EXECUTION_HOOK_RESULT_STOPPED_BLOCKED,
+    EXECUTION_HOOK_RESULT_STOPPED_HOLD,
+    EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED,
+    EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED,
+    EXECUTION_HOOK_STOP_HARDENING_BLOCKED,
+    EXECUTION_HOOK_STOP_HARDENING_HOLD,
+    EXECUTION_HOOK_STOP_INVALID_CONTRACT,
+    MinimalExecutionHookBoundary,
+    MinimalExecutionHookPolicy,
+    PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+    PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+    PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+    WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+    WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+    _validate_execution_hook_policy,
+)
+
+
+def _boundary() -> MinimalExecutionHookBoundary:
+    return MinimalExecutionHookBoundary()
+
+
+def _policy(**kwargs) -> MinimalExecutionHookPolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requester_user_id": "user-1",
+        "wallet_active": True,
+        "hardening_outcome": PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+        "flow_result_category": ACTIVATION_FLOW_RESULT_COMPLETED,
+        "activation_result_category": WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+    }
+    defaults.update(kwargs)
+    return MinimalExecutionHookPolicy(**defaults)
+
+
+# --- Validator ---
+
+
+def test_validate_accepts_valid_pass_completed_allowed_policy() -> None:
+    assert _validate_execution_hook_policy(_policy()) is None
+
+
+def test_validate_accepts_valid_hold_stopped_hold_denied_hold_policy() -> None:
+    assert _validate_execution_hook_policy(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+        )
+    ) is None
+
+
+def test_validate_accepts_valid_blocked_stopped_blocked_denied_blocked_policy() -> None:
+    assert _validate_execution_hook_policy(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+        )
+    ) is None
+
+
+def test_validate_requires_wallet_binding_id() -> None:
+    assert _validate_execution_hook_policy(_policy(wallet_binding_id="")) == "wallet_binding_id_required"
+    assert _validate_execution_hook_policy(_policy(wallet_binding_id=" ")) == "wallet_binding_id_required"
+
+
+def test_validate_requires_owner_user_id() -> None:
+    assert _validate_execution_hook_policy(_policy(owner_user_id="")) == "owner_user_id_required"
+
+
+def test_validate_requires_requester_user_id() -> None:
+    assert _validate_execution_hook_policy(_policy(requester_user_id="")) == "requester_user_id_required"
+
+
+def test_validate_requires_bool_wallet_active() -> None:
+    assert (
+        _validate_execution_hook_policy(_policy(wallet_active="yes"))  # type: ignore[arg-type]
+        == "wallet_active_must_be_bool"
+    )
+
+
+def test_validate_requires_known_hardening_outcome() -> None:
+    assert (
+        _validate_execution_hook_policy(_policy(hardening_outcome="unknown"))
+        == "hardening_outcome_invalid"
+    )
+
+
+def test_validate_requires_known_flow_result() -> None:
+    assert (
+        _validate_execution_hook_policy(_policy(flow_result_category="unknown"))
+        == "flow_result_category_invalid"
+    )
+
+
+def test_validate_requires_known_gate_result() -> None:
+    assert (
+        _validate_execution_hook_policy(_policy(activation_result_category="unknown"))
+        == "activation_result_category_invalid"
+    )
+
+
+# --- EXECUTED path ---
+
+
+def test_hook_executed_on_pass_completed_allowed() -> None:
+    result = _boundary().execute_hook(_policy())
+    assert result.hook_executed is True
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_EXECUTED
+    assert result.stop_reason is None
+
+
+def test_hook_executed_notes_contain_all_three_pass_markers() -> None:
+    result = _boundary().execute_hook(_policy())
+    assert "hardening_pass" in result.execution_hook_notes
+    assert "flow_completed" in result.execution_hook_notes
+    assert "gate_allowed" in result.execution_hook_notes
+
+
+def test_hook_executed_notes_dict_carries_all_categories() -> None:
+    result = _boundary().execute_hook(_policy())
+    assert result.notes is not None
+    assert result.notes["hardening_outcome"] == PUBLIC_SAFETY_HARDENING_OUTCOME_PASS
+    assert result.notes["flow_result_category"] == ACTIVATION_FLOW_RESULT_COMPLETED
+    assert result.notes["activation_result_category"] == WALLET_ACTIVATION_GATE_RESULT_ALLOWED
+
+
+def test_hook_executed_result_carries_identity_fields() -> None:
+    result = _boundary().execute_hook(_policy())
+    assert result.wallet_binding_id == "wallet-1"
+    assert result.owner_user_id == "user-1"
+
+
+# --- Contract / ownership / wallet-active stop paths ---
+
+
+def test_hook_stopped_blocked_on_invalid_contract_empty_wallet_binding_id() -> None:
+    result = _boundary().execute_hook(_policy(wallet_binding_id=""))
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_INVALID_CONTRACT
+    assert "contract_error" in result.execution_hook_notes
+
+
+def test_hook_stopped_blocked_on_invalid_contract_unknown_hardening_outcome() -> None:
+    result = _boundary().execute_hook(_policy(hardening_outcome="unknown"))
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_INVALID_CONTRACT
+
+
+def test_hook_stopped_blocked_on_owner_mismatch() -> None:
+    result = _boundary().execute_hook(_policy(requester_user_id="other-user"))
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_INVALID_CONTRACT
+    assert "owner_mismatch" in result.execution_hook_notes
+
+
+def test_hook_stopped_blocked_on_inactive_wallet() -> None:
+    result = _boundary().execute_hook(_policy(wallet_active=False))
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_INVALID_CONTRACT
+    assert "wallet_not_active" in result.execution_hook_notes
+
+
+# --- Hardening stop paths ---
+
+
+def test_hook_stopped_blocked_on_hardening_blocked() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_HARDENING_BLOCKED
+    assert "hardening_blocked" in result.execution_hook_notes
+
+
+def test_hook_stopped_hold_on_hardening_hold() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_HOLD
+    assert result.stop_reason == EXECUTION_HOOK_STOP_HARDENING_HOLD
+    assert "hardening_hold" in result.execution_hook_notes
+
+
+def test_hook_hardening_blocked_stops_before_checking_flow_or_gate() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+            flow_result_category=ACTIVATION_FLOW_RESULT_COMPLETED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+        )
+    )
+    assert result.stop_reason == EXECUTION_HOOK_STOP_HARDENING_BLOCKED
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+
+
+# --- Flow stop paths (with hardening PASS) ---
+
+
+def test_hook_stopped_blocked_on_flow_stopped_blocked() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED
+    assert "flow_stopped_blocked" in result.execution_hook_notes
+
+
+def test_hook_stopped_hold_on_flow_stopped_hold() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+            flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_ALLOWED,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_HOLD
+    assert result.stop_reason == EXECUTION_HOOK_STOP_FLOW_NOT_COMPLETED
+    assert "flow_stopped_hold" in result.execution_hook_notes
+
+
+# --- Gate stop paths (with hardening PASS, flow COMPLETED) ---
+
+
+def test_hook_stopped_blocked_on_gate_denied_blocked() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+            flow_result_category=ACTIVATION_FLOW_RESULT_COMPLETED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED
+    assert result.stop_reason == EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED
+    assert "gate_denied_blocked" in result.execution_hook_notes
+
+
+def test_hook_stopped_hold_on_gate_denied_hold() -> None:
+    result = _boundary().execute_hook(
+        _policy(
+            hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_PASS,
+            flow_result_category=ACTIVATION_FLOW_RESULT_COMPLETED,
+            activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD,
+        )
+    )
+    assert result.hook_executed is False
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_HOLD
+    assert result.stop_reason == EXECUTION_HOOK_STOP_GATE_NOT_ALLOWED
+    assert "gate_denied_hold" in result.execution_hook_notes
+
+
+# --- Structural / result integrity ---
+
+
+def test_hook_stop_reason_is_none_only_on_executed() -> None:
+    result = _boundary().execute_hook(_policy())
+    assert result.stop_reason is None
+    assert result.hook_executed is True
+
+
+def test_hook_executed_is_false_on_all_stop_paths() -> None:
+    stop_policies = [
+        _policy(wallet_binding_id=""),
+        _policy(requester_user_id="other"),
+        _policy(wallet_active=False),
+        _policy(hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+                flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED),
+        _policy(hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+                flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD),
+        _policy(flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED),
+        _policy(flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD),
+        _policy(activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED),
+        _policy(activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD),
+    ]
+    for pol in stop_policies:
+        result = _boundary().execute_hook(pol)
+        assert result.hook_executed is False, f"Expected hook_executed=False for policy: {pol}"
+
+
+def test_hook_result_carries_wallet_binding_id_and_owner_on_all_outcomes() -> None:
+    policies = [
+        _policy(),
+        _policy(hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED,
+                flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED),
+        _policy(hardening_outcome=PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD,
+                flow_result_category=ACTIVATION_FLOW_RESULT_STOPPED_HOLD,
+                activation_result_category=WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD),
+    ]
+    for pol in policies:
+        result = _boundary().execute_hook(pol)
+        assert result.wallet_binding_id == "wallet-1"
+        assert result.owner_user_id == "user-1"
+
+
+def test_hook_stopped_blocked_result_category_never_has_none_stop_reason() -> None:
+    result = _boundary().execute_hook(_policy(wallet_active=False))
+    assert result.stop_reason is not None
+    assert result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED


### PR DESCRIPTION
Add MinimalExecutionHookBoundary.execute_hook consuming declared 6.6.6/6.6.7/6.6.8
outputs with deterministic executed/stopped_hold/stopped_blocked hook outcome and
explicit stop reasons for all non-executed paths. 29 tests pass; 212 regression
tests clean. Hook-only -- no scheduler daemon, live trading rollout, or portfolio
orchestration claimed.

https://claude.ai/code/session_01Lihp8Ly7boE2oNmjmrm9AA