### PR TITLE
feat: phase 7.0 public activation cycle orchestration foundation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 09:10
-Status       : Phase 6.6.9 minimal execution hook is merged-main truth via PR #566. Phases 6.6.5-6.6.9 are no longer in progress and are treated as completed baseline. Next forward lane is Phase 7.0 orchestration & automation. Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 11:42
+Status       : Phase 7.0 orchestration & automation foundation is now opened with a deterministic single-cycle entrypoint (`run_public_activation_cycle`) over the completed 6.6 public-ready baseline. This remains narrow integration only (no scheduler/worker/live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -22,17 +22,16 @@ Status       : Phase 6.6.9 minimal execution hook is merged-main truth via PR #5
 - Phase 6.6.9 minimal execution hook merged via PR #566.
 
 [IN PROGRESS]
-- None.
+- Phase 7.0 orchestration & automation foundation is active with one deterministic public activation cycle contract (readiness -> gate -> flow -> hardening -> execution hook).
 
 [NOT STARTED]
-- Phase 7.0 orchestration & automation lane has not been opened.
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Open Phase 7.0 orchestration & automation lane as the next forward slice.
+- COMMANDER review for Phase 7.0 deterministic single-cycle orchestration foundation scope.
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@
 
 | Project | Platform | Status | Current Phase |
 |---|---|---|---|
-| Crusader | Polymarket | Active | Phase 6 — Production Safety & Stabilization |
+| Crusader | Polymarket | Active | Phase 7 — Orchestration & Automation Foundation |
 | TradingView Indicators | TradingView (Pine Script v5) | ❌ Not Started | — |
 | MT5 Expert Advisors | MT4/MT5 (MQL5) | ❌ Not Started | — |
 | Kalshi Bot | Kalshi | ❌ Not Started | — |
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 08:56
+**Last Updated:** 2026-04-18 11:42
 
 ## Board Overview
 
@@ -35,15 +35,16 @@
 | Phase 3 | Execution-Safe MVP | ✅ Done | Closed Beta |
 | Phase 4 | Execution Formalization & Boundaries | ✅ Done | Internal |
 | Phase 5 | Real Execution & Capital System | ✅ Done | Internal |
-| Phase 6 | Production Safety & Stabilization | In Progress | Public Preparation |
+| Phase 6 | Production Safety & Stabilization | ✅ Done | Public Preparation |
+| Phase 7 | Orchestration & Automation Foundation | In Progress | Public Activation Orchestration |
 
 ---
 
 ## Phase 6 — Production Safety & Stabilization
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
-**Status:** In Progress  
-**Last Updated:** 2026-04-18 08:56
+**Status:** ✅ Done  
+**Last Updated:** 2026-04-18 11:42
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -74,11 +75,23 @@
 | 6.6.2 | Wallet Lifecycle Batch Reconciliation | ✅ Done | Merged-main truth accepted via PR #559 at `WalletLifecycleReconciliationBoundary.reconcile_wallet_state_batch` with deterministic per-entry outcomes in exact input order. |
 | 6.6.3 | Wallet Reconciliation Mutation Correction Foundation | ✅ Done | Merged-main truth accepted via PR #560 at `WalletReconciliationCorrectionBoundary.apply_correction` with deterministic correction decision categories and block reasons. |
 | 6.6.4 | Wallet Reconciliation Retry/Worker Foundation | ✅ Done | Merged-main truth accepted via PR #561 at `WalletReconciliationRetryWorkerBoundary.decide_retry_work_item` with deterministic accepted/skipped/blocked/exhausted retry preparation outcomes and explicit block contracts. |
-| 6.6.5 | Public Readiness Slice Opener Foundation | 🚧 In Progress | Active on feature/public-readiness-slice-opener-2026-04-18 for evaluation-only go/hold/blocked preparation contract using declared 6.5.x/6.6.x readiness inputs; no live activation, scheduler rollout, settlement automation, or portfolio orchestration claimed. |
-| 6.6.6 | Public Activation Gate Foundation | 🚧 In Progress | Active on claude/public-activation-gate-0xLIz for deterministic gate-only allowed/denied_hold/denied_blocked evaluation consuming 6.6.5 readiness outcomes; no scheduler daemon, automation rollout, portfolio orchestration, or live trading activation claimed. |
-| 6.6.7 | Minimal Public Activation Flow Foundation | 🚧 In Progress | Active on claude/minimal-activation-flow-FUV3u for thin-flow-only deterministic completed/stopped_hold/stopped_blocked routing consuming declared 6.6.5 readiness and 6.6.6 gate outputs; no scheduler daemon, automation rollout, portfolio orchestration, or live trading activation claimed. |
-| 6.6.8 | Public Safety Hardening | 🚧 In Progress | Active on claude/public-safety-hardening-h1lYy for deterministic cross-boundary pass/hold/blocked consistency checks across declared 6.6.5/6.6.6/6.6.7 outputs; no scheduler daemon, live trading rollout, portfolio orchestration, or broader go-live pipeline claimed. |
-| 6.6.9 | Minimal Execution Hook | 🚧 In Progress | Active on claude/minimal-execution-hook-xBP8u for deterministic executed/stopped_hold/stopped_blocked hook outcome consuming declared 6.6.6/6.6.7/6.6.8 outputs; hook-only, no scheduler daemon, live trading rollout, portfolio orchestration, or broader go-live pipeline claimed. |
+| 6.6.5 | Public Readiness Slice Opener Foundation | ✅ Done | Merged via PR #562 with deterministic go/hold/blocked readiness evaluation contract. |
+| 6.6.6 | Public Activation Gate Foundation | ✅ Done | Merged via PR #563 with deterministic allowed/denied_hold/denied_blocked gate outcomes. |
+| 6.6.7 | Minimal Public Activation Flow Foundation | ✅ Done | Merged via PR #564 with deterministic completed/stopped_hold/stopped_blocked thin flow routing. |
+| 6.6.8 | Public Safety Hardening | ✅ Done | Merged via PR #565 with deterministic cross-boundary consistency pass/hold/blocked hardening outcomes. |
+| 6.6.9 | Minimal Execution Hook | ✅ Done | Merged via PR #566 with deterministic executed/stopped_hold/stopped_blocked hook outcomes. |
+
+---
+
+## Phase 7 — Orchestration & Automation Foundation
+
+**Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
+**Status:** In Progress  
+**Last Updated:** 2026-04-18 11:42
+
+| Sub-Phase | Name | Status | Notes |
+|---|---|---|---|
+| 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | 🚧 In Progress | Active on feature/orchestration-and-automation-foundation-2026-04-18 for one synchronous deterministic cycle entrypoint `run_public_activation_cycle` chaining 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9; excludes scheduler daemons, async workers, portfolio orchestration, and live trading rollout. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
+++ b/projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py
@@ -2802,3 +2802,254 @@ def _stopped_execution_hook_result(
         execution_hook_notes=execution_hook_notes,
         notes=notes,
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 7.0 -- Public Activation Cycle Orchestration Foundation
+# ---------------------------------------------------------------------------
+
+PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED = "completed"
+PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD = "stopped_hold"
+PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED = "stopped_blocked"
+
+PUBLIC_ACTIVATION_CYCLE_STOP_INVALID_CONTRACT = "invalid_contract"
+PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_HOLD = "readiness_hold"
+PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_BLOCKED = "readiness_blocked"
+PUBLIC_ACTIVATION_CYCLE_STOP_GATE_DENIED_HOLD = "gate_denied_hold"
+PUBLIC_ACTIVATION_CYCLE_STOP_GATE_DENIED_BLOCKED = "gate_denied_blocked"
+PUBLIC_ACTIVATION_CYCLE_STOP_FLOW_STOPPED_HOLD = "flow_stopped_hold"
+PUBLIC_ACTIVATION_CYCLE_STOP_FLOW_STOPPED_BLOCKED = "flow_stopped_blocked"
+PUBLIC_ACTIVATION_CYCLE_STOP_HARDENING_HOLD = "hardening_hold"
+PUBLIC_ACTIVATION_CYCLE_STOP_HARDENING_BLOCKED = "hardening_blocked"
+PUBLIC_ACTIVATION_CYCLE_STOP_HOOK_STOPPED_HOLD = "hook_stopped_hold"
+PUBLIC_ACTIVATION_CYCLE_STOP_HOOK_STOPPED_BLOCKED = "hook_stopped_blocked"
+
+
+@dataclass(frozen=True)
+class PublicActivationCyclePolicy:
+    wallet_binding_id: str
+    owner_user_id: str
+    requester_user_id: str
+    wallet_active: bool
+    state_read_batch_ready: bool
+    reconciliation_outcome: str
+    correction_result_category: str
+    retry_result_category: str
+
+
+@dataclass(frozen=True)
+class PublicActivationCycleResult:
+    cycle_completed: bool
+    cycle_result_category: str
+    cycle_stop_reason: str | None
+    wallet_binding_id: str
+    owner_user_id: str
+    cycle_notes: list[str]
+    readiness_result: WalletPublicReadinessResult
+    activation_gate_result: WalletPublicActivationGateResult
+    activation_flow_result: MinimalPublicActivationFlowResult
+    hardening_result: PublicSafetyHardeningResult
+    execution_hook_result: MinimalExecutionHookResult
+    notes: dict[str, Any] | None = None
+
+
+class PublicActivationCycleOrchestrationBoundary:
+    """Phase 7.0 thin deterministic public activation cycle orchestration.
+    Runs one synchronous pass through readiness -> gate -> flow -> hardening -> execution hook.
+    No scheduler daemon, no async worker mesh, and no live-trading rollout."""
+
+    def run_public_activation_cycle(
+        self, policy: PublicActivationCyclePolicy
+    ) -> PublicActivationCycleResult:
+        readiness_result = WalletPublicReadinessBoundary().evaluate_public_readiness(
+            WalletPublicReadinessPolicy(
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                requested_by_user_id=policy.requester_user_id,
+                wallet_active=policy.wallet_active,
+                state_read_batch_ready=policy.state_read_batch_ready,
+                reconciliation_outcome=policy.reconciliation_outcome,
+                correction_result_category=policy.correction_result_category,
+                retry_result_category=policy.retry_result_category,
+            )
+        )
+
+        activation_gate_result = WalletPublicActivationGateBoundary().evaluate_activation_gate(
+            WalletPublicActivationGatePolicy(
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                requested_by_user_id=policy.requester_user_id,
+                wallet_active=policy.wallet_active,
+                readiness_result_category=readiness_result.readiness_result_category,
+                readiness_notes=readiness_result.readiness_notes,
+            )
+        )
+
+        activation_flow_result = MinimalPublicActivationFlowBoundary().run_activation_flow(
+            MinimalPublicActivationFlowPolicy(
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                requester_user_id=policy.requester_user_id,
+                wallet_active=policy.wallet_active,
+                readiness_result_category=readiness_result.readiness_result_category,
+                readiness_notes=readiness_result.readiness_notes,
+                activation_result_category=activation_gate_result.activation_result_category,
+                activation_notes=activation_gate_result.activation_notes,
+            )
+        )
+
+        hardening_result = PublicSafetyHardeningBoundary().check_hardening(
+            PublicSafetyHardeningPolicy(
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                requester_user_id=policy.requester_user_id,
+                wallet_active=policy.wallet_active,
+                readiness_result_category=readiness_result.readiness_result_category,
+                activation_result_category=activation_gate_result.activation_result_category,
+                flow_result_category=activation_flow_result.flow_result_category,
+            )
+        )
+
+        execution_hook_result = MinimalExecutionHookBoundary().execute_hook(
+            MinimalExecutionHookPolicy(
+                wallet_binding_id=policy.wallet_binding_id,
+                owner_user_id=policy.owner_user_id,
+                requester_user_id=policy.requester_user_id,
+                wallet_active=policy.wallet_active,
+                hardening_outcome=hardening_result.hardening_outcome,
+                flow_result_category=activation_flow_result.flow_result_category,
+                activation_result_category=activation_gate_result.activation_result_category,
+            )
+        )
+
+        cycle_result_category, cycle_stop_reason = _determine_public_activation_cycle_outcome(
+            readiness_result=readiness_result,
+            activation_gate_result=activation_gate_result,
+            activation_flow_result=activation_flow_result,
+            hardening_result=hardening_result,
+            execution_hook_result=execution_hook_result,
+        )
+        cycle_completed = cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED
+        cycle_notes = _compose_public_activation_cycle_notes(
+            readiness_result=readiness_result,
+            activation_gate_result=activation_gate_result,
+            activation_flow_result=activation_flow_result,
+            hardening_result=hardening_result,
+            execution_hook_result=execution_hook_result,
+            cycle_stop_reason=cycle_stop_reason,
+        )
+
+        return PublicActivationCycleResult(
+            cycle_completed=cycle_completed,
+            cycle_result_category=cycle_result_category,
+            cycle_stop_reason=cycle_stop_reason,
+            wallet_binding_id=policy.wallet_binding_id,
+            owner_user_id=policy.owner_user_id,
+            cycle_notes=cycle_notes,
+            readiness_result=readiness_result,
+            activation_gate_result=activation_gate_result,
+            activation_flow_result=activation_flow_result,
+            hardening_result=hardening_result,
+            execution_hook_result=execution_hook_result,
+            notes={
+                "readiness_result_category": readiness_result.readiness_result_category,
+                "activation_result_category": activation_gate_result.activation_result_category,
+                "flow_result_category": activation_flow_result.flow_result_category,
+                "hardening_outcome": hardening_result.hardening_outcome,
+                "hook_result_category": execution_hook_result.hook_result_category,
+            },
+        )
+
+
+def run_public_activation_cycle(policy: PublicActivationCyclePolicy) -> PublicActivationCycleResult:
+    """Deterministic public activation cycle entrypoint for one synchronous run."""
+    return PublicActivationCycleOrchestrationBoundary().run_public_activation_cycle(policy)
+
+
+def _determine_public_activation_cycle_outcome(
+    *,
+    readiness_result: WalletPublicReadinessResult,
+    activation_gate_result: WalletPublicActivationGateResult,
+    activation_flow_result: MinimalPublicActivationFlowResult,
+    hardening_result: PublicSafetyHardeningResult,
+    execution_hook_result: MinimalExecutionHookResult,
+) -> tuple[str, str | None]:
+    if readiness_result.blocked_reason == WALLET_PUBLIC_READINESS_BLOCK_INVALID_CONTRACT:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_INVALID_CONTRACT,
+        )
+    if readiness_result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_BLOCKED:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_BLOCKED,
+        )
+    if readiness_result.readiness_result_category == WALLET_PUBLIC_READINESS_RESULT_HOLD:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+            PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_HOLD,
+        )
+    if activation_gate_result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_BLOCKED:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_GATE_DENIED_BLOCKED,
+        )
+    if activation_gate_result.activation_result_category == WALLET_ACTIVATION_GATE_RESULT_DENIED_HOLD:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+            PUBLIC_ACTIVATION_CYCLE_STOP_GATE_DENIED_HOLD,
+        )
+    if activation_flow_result.flow_result_category == ACTIVATION_FLOW_RESULT_STOPPED_BLOCKED:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_FLOW_STOPPED_BLOCKED,
+        )
+    if activation_flow_result.flow_result_category == ACTIVATION_FLOW_RESULT_STOPPED_HOLD:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+            PUBLIC_ACTIVATION_CYCLE_STOP_FLOW_STOPPED_HOLD,
+        )
+    if hardening_result.hardening_outcome == PUBLIC_SAFETY_HARDENING_OUTCOME_BLOCKED:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_HARDENING_BLOCKED,
+        )
+    if hardening_result.hardening_outcome == PUBLIC_SAFETY_HARDENING_OUTCOME_HOLD:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+            PUBLIC_ACTIVATION_CYCLE_STOP_HARDENING_HOLD,
+        )
+    if execution_hook_result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_BLOCKED:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+            PUBLIC_ACTIVATION_CYCLE_STOP_HOOK_STOPPED_BLOCKED,
+        )
+    if execution_hook_result.hook_result_category == EXECUTION_HOOK_RESULT_STOPPED_HOLD:
+        return (
+            PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+            PUBLIC_ACTIVATION_CYCLE_STOP_HOOK_STOPPED_HOLD,
+        )
+    return (PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED, None)
+
+
+def _compose_public_activation_cycle_notes(
+    *,
+    readiness_result: WalletPublicReadinessResult,
+    activation_gate_result: WalletPublicActivationGateResult,
+    activation_flow_result: MinimalPublicActivationFlowResult,
+    hardening_result: PublicSafetyHardeningResult,
+    execution_hook_result: MinimalExecutionHookResult,
+    cycle_stop_reason: str | None,
+) -> list[str]:
+    notes: list[str] = [
+        f"readiness:{readiness_result.readiness_result_category}",
+        f"activation_gate:{activation_gate_result.activation_result_category}",
+        f"activation_flow:{activation_flow_result.flow_result_category}",
+        f"hardening:{hardening_result.hardening_outcome}",
+        f"execution_hook:{execution_hook_result.hook_result_category}",
+    ]
+    if cycle_stop_reason is None:
+        notes.append("cycle_completed")
+    else:
+        notes.append(f"cycle_stop_reason:{cycle_stop_reason}")
+    return notes

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-0_01_public-activation-cycle-orchestration-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-0_01_public-activation-cycle-orchestration-foundation.md
@@ -1,0 +1,119 @@
+# FORGE-X Report -- Phase 7.0 Public Activation Cycle Orchestration Foundation
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** Public activation cycle orchestration contract only via `run_public_activation_cycle(...)` and `PublicActivationCycleOrchestrationBoundary.run_public_activation_cycle(...)` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`, plus deterministic targeted tests in `projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py`.
+**Not in Scope:** scheduler daemon, cron/background workers, async worker mesh, settlement automation, portfolio orchestration, monitoring rollout expansion, broader production automation, live trading enablement/rollout.
+**Suggested Next Step:** COMMANDER review required before merge. Auto PR review support optional for STANDARD tier.
+
+---
+
+## 1) What was built
+
+Delivered the first Phase 7.0 thin orchestration foundation for one deterministic synchronous public activation cycle.
+
+Added a narrow orchestration contract that chains the completed 6.6 boundaries in strict deterministic order:
+1. public readiness (6.6.5)
+2. activation gate (6.6.6)
+3. minimal activation flow (6.6.7)
+4. public safety hardening (6.6.8)
+5. minimal execution hook (6.6.9)
+
+New entrypoint:
+- `run_public_activation_cycle(policy: PublicActivationCyclePolicy) -> PublicActivationCycleResult`
+
+New orchestration boundary:
+- `PublicActivationCycleOrchestrationBoundary.run_public_activation_cycle(...)`
+
+New deterministic cycle categories:
+- `completed`
+- `stopped_hold`
+- `stopped_blocked`
+
+New deterministic cycle stop reasons:
+- `invalid_contract`
+- `readiness_hold`
+- `readiness_blocked`
+- `gate_denied_hold`
+- `gate_denied_blocked`
+- `flow_stopped_hold`
+- `flow_stopped_blocked`
+- `hardening_hold`
+- `hardening_blocked`
+- `hook_stopped_hold`
+- `hook_stopped_blocked`
+
+This implementation is intentionally thin and synchronous: one pass, no scheduler, no daemon, no async worker expansion, and no live-trading rollout claim.
+
+## 2) Current system architecture (relevant slice)
+
+Relevant runtime slice after this task:
+
+- 6.6.5 `WalletPublicReadinessBoundary.evaluate_public_readiness` remains unchanged and produces readiness outcome.
+- 6.6.6 `WalletPublicActivationGateBoundary.evaluate_activation_gate` remains unchanged and consumes readiness output.
+- 6.6.7 `MinimalPublicActivationFlowBoundary.run_activation_flow` remains unchanged and consumes readiness + gate outputs.
+- 6.6.8 `PublicSafetyHardeningBoundary.check_hardening` remains unchanged and validates cross-boundary consistency.
+- 6.6.9 `MinimalExecutionHookBoundary.execute_hook` remains unchanged and decides executed/stopped result.
+- New 7.0 orchestration layer invokes these sequentially and returns one aggregate deterministic cycle result object including all stage outputs, stop reason, and cycle notes.
+
+Deterministic outcome mapping priority is explicit and stable:
+- invalid contract/identity contract failure first
+- then readiness
+- then gate
+- then flow
+- then hardening
+- then hook
+- otherwise completed
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-0_01_public-activation-cycle-orchestration-foundation.md`
+
+## 4) What is working
+
+- Deterministic single-cycle entrypoint is available via both function and boundary class.
+- Cycle always executes stage chain in declared order (readiness -> gate -> flow -> hardening -> hook) in one synchronous run.
+- Cycle returns explicit aggregate result category (`completed` / `stopped_hold` / `stopped_blocked`) and deterministic stop reason.
+- Cycle returns stage-level outputs (`readiness_result`, `activation_gate_result`, `activation_flow_result`, `hardening_result`, `execution_hook_result`) for deterministic traceability.
+- Notes include deterministic stage markers for readiness/gate/flow/hardening/hook plus final completion/stop marker.
+- Targeted tests confirm:
+  - completed go-path
+  - contract-invalid blocked path
+  - readiness-hold propagation path
+  - readiness-blocked propagation path
+  - deterministic stage-note composition
+- Existing 6.5.x and 6.6.x contracts were preserved unchanged; orchestration only composes their outputs.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py`
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase6_6_5_public_readiness_slice_opener_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_6_public_activation_gate_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_7_minimal_activation_flow_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_8_public_safety_hardening_20260418.py projects/polymarket/polyquantbot/tests/test_phase6_6_9_minimal_execution_hook_20260418.py`
+
+## 5) Known issues
+
+- Scope is intentionally thin (single-cycle contract only); broader automation rollout remains out of scope.
+- Existing repo warning remains deferred: pytest `Unknown config option: asyncio_mode`.
+- `git rev-parse --abbrev-ref HEAD` returns `work` in Codex worktree context; branch traceability in this report follows COMMANDER-declared branch.
+
+## 6) What is next
+
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: public activation cycle orchestration contract only (`run_public_activation_cycle` and aggregate deterministic result mapping)
+- Not in Scope: scheduler daemon, async workers, settlement automation, portfolio orchestration, live trading rollout, broader production automation
+- Suggested Next: COMMANDER review
+
+---
+
+**Report Timestamp:** 2026-04-18 11:42 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** Phase 7.0 orchestration and automation foundation
+**Branch:** `feature/orchestration-and-automation-foundation-2026-04-18`

--- a/projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED,
+    PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+    PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+    PUBLIC_ACTIVATION_CYCLE_STOP_INVALID_CONTRACT,
+    PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_BLOCKED,
+    PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_HOLD,
+    PublicActivationCycleOrchestrationBoundary,
+    PublicActivationCyclePolicy,
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+    run_public_activation_cycle,
+)
+
+
+def _boundary() -> PublicActivationCycleOrchestrationBoundary:
+    return PublicActivationCycleOrchestrationBoundary()
+
+
+def _policy(**kwargs) -> PublicActivationCyclePolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requester_user_id": "user-1",
+        "wallet_active": True,
+        "state_read_batch_ready": True,
+        "reconciliation_outcome": WALLET_RECONCILIATION_OUTCOME_MATCH,
+        "correction_result_category": WALLET_CORRECTION_RESULT_ACCEPTED,
+        "retry_result_category": WALLET_RETRY_WORK_DECISION_SKIPPED,
+    }
+    defaults.update(kwargs)
+    return PublicActivationCyclePolicy(**defaults)
+
+
+def test_cycle_entrypoint_returns_completed_for_go_path() -> None:
+    result = run_public_activation_cycle(_policy())
+    assert result.cycle_completed is True
+    assert result.cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED
+    assert result.cycle_stop_reason is None
+    assert "cycle_completed" in result.cycle_notes
+
+
+def test_cycle_boundary_returns_stage_outputs_for_traceability() -> None:
+    result = _boundary().run_public_activation_cycle(_policy())
+    assert result.readiness_result.readiness_result_category == "go"
+    assert result.activation_gate_result.activation_result_category == "allowed"
+    assert result.activation_flow_result.flow_result_category == "completed"
+    assert result.hardening_result.hardening_outcome == "pass"
+    assert result.execution_hook_result.hook_result_category == "executed"
+
+
+def test_cycle_stops_blocked_on_invalid_contract() -> None:
+    result = _boundary().run_public_activation_cycle(_policy(wallet_binding_id=""))
+    assert result.cycle_completed is False
+    assert result.cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED
+    assert result.cycle_stop_reason == PUBLIC_ACTIVATION_CYCLE_STOP_INVALID_CONTRACT
+    assert result.readiness_result.blocked_reason == "invalid_contract"
+
+
+def test_cycle_stops_hold_when_readiness_is_hold() -> None:
+    result = _boundary().run_public_activation_cycle(
+        _policy(correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED)
+    )
+    assert result.cycle_completed is False
+    assert result.cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD
+    assert result.cycle_stop_reason == PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_HOLD
+    assert result.readiness_result.readiness_result_category == "hold"
+    assert result.activation_gate_result.activation_result_category == "denied_hold"
+    assert result.activation_flow_result.flow_result_category == "stopped_hold"
+
+
+def test_cycle_stops_blocked_when_readiness_is_blocked() -> None:
+    result = _boundary().run_public_activation_cycle(
+        _policy(reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH)
+    )
+    assert result.cycle_completed is False
+    assert result.cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED
+    assert result.cycle_stop_reason == PUBLIC_ACTIVATION_CYCLE_STOP_READINESS_BLOCKED
+    assert result.readiness_result.readiness_result_category == "blocked"
+    assert result.activation_gate_result.activation_result_category == "denied_blocked"
+    assert result.activation_flow_result.flow_result_category == "stopped_blocked"
+
+
+def test_cycle_notes_include_deterministic_stage_markers() -> None:
+    result = _boundary().run_public_activation_cycle(
+        _policy(reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH)
+    )
+    assert "readiness:blocked" in result.cycle_notes
+    assert "activation_gate:denied_blocked" in result.cycle_notes
+    assert "activation_flow:stopped_blocked" in result.cycle_notes
+    assert "hardening:pass" in result.cycle_notes
+    assert "execution_hook:stopped_blocked" in result.cycle_notes


### PR DESCRIPTION
### Motivation
- Open Phase 7.0 with a thin, deterministic orchestration contract that runs the completed 6.6 public-ready baseline in a single synchronous activation cycle. 
- Provide a narrow integration entrypoint for traceable, reproducible evaluation of readiness -> gate -> flow -> hardening -> execution-hook without introducing schedulers, daemons, async workers, or live-trading rollout.

### Description
- Added Phase 7.0 orchestration types and boundary: `PublicActivationCyclePolicy`, `PublicActivationCycleResult`, `PublicActivationCycleOrchestrationBoundary.run_public_activation_cycle(...)`, and module entrypoint `run_public_activation_cycle(...)` in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` to synchronously compose 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9 and return an aggregate cycle result. 
- Introduced deterministic cycle result categories and explicit stop reasons (e.g. `completed`, `stopped_hold`, `stopped_blocked`, `invalid_contract`, `readiness_hold`, `readiness_blocked`, `gate_denied_*`, `flow_stopped_*`, `hardening_*`, `hook_stopped_*`) and composed human-readable stage notes for traceability. 
- Preserved all existing 6.5.x and 6.6.x contracts unchanged; orchestration only consumes and composes their outputs (no re-evaluation or modifications). 
- Added targeted end-to-end tests `projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py` and a FORGE report `projects/polymarket/polyquantbot/reports/forge/phase7-0_01_public-activation-cycle-orchestration-foundation.md`. 
- Updated `PROJECT_STATE.md` and `ROADMAP.md` to open Phase 7.0 and align roadmap/state truth with the new orchestration foundation.

### Testing
- Ran `PYTHONIOENCODING=utf-8 python -m py_compile` on the modified files and compilation succeeded for `wallet_lifecycle_foundation.py` and the new test file. 
- Ran `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py` and the new orchestration tests passed (6 passed). 
- Ran regression tests over the related 6.6 families: `pytest` for the 6.6.* suites passed (summary: 139 passed across the referenced 6.6 tests) with one known non-blocking warning `Unknown config option: asyncio_mode`. 
- Environment note: attempt to derive Asia/Jakarta timestamp via `pytz` failed in this environment so `TZ=Asia/Jakarta date '+%Y-%m-%d %H:%M'` was used as a safe fallback to produce `Last Updated`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30b2899688325bd10c21cdb711c83)