### PR TITLE
Phase 7.1: add thin public activation CLI trigger surface

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 11:42
-Status       : Phase 7.0 orchestration & automation foundation is now opened with a deterministic single-cycle entrypoint (`run_public_activation_cycle`) over the completed 6.6 public-ready baseline. This remains narrow integration only (no scheduler/worker/live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 11:52
+Status       : Phase 7.1 public activation trigger surface is now in progress with one synchronous CLI invocation path over the completed 7.0 deterministic cycle contract. Scope remains narrow integration only (no scheduler/worker/live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
 - Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
@@ -22,7 +22,7 @@ Status       : Phase 7.0 orchestration & automation foundation is now opened wit
 - Phase 6.6.9 minimal execution hook merged via PR #566.
 
 [IN PROGRESS]
-- Phase 7.0 orchestration & automation foundation is active with one deterministic public activation cycle contract (readiness -> gate -> flow -> hardening -> execution hook).
+- Phase 7.1 public activation trigger surface is active with one synchronous CLI invocation path that maps `run_public_activation_cycle(...)` outcomes to explicit completed/stopped_hold/stopped_blocked trigger results.
 
 [NOT STARTED]
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
@@ -31,7 +31,7 @@ Status       : Phase 7.0 orchestration & automation foundation is now opened wit
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review for Phase 7.0 deterministic single-cycle orchestration foundation scope.
+- COMMANDER review for Phase 7.1 public activation trigger surface (thin CLI invocation path only).
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 11:42
+**Last Updated:** 2026-04-18 11:52
 
 ## Board Overview
 
@@ -44,7 +44,7 @@
 
 **Goal:** Ensure production-grade safety, stability, and operational truth.  
 **Status:** ✅ Done  
-**Last Updated:** 2026-04-18 11:42
+**Last Updated:** 2026-04-18 11:52
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -87,11 +87,12 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 11:42
+**Last Updated:** 2026-04-18 11:52
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
-| 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | 🚧 In Progress | Active on feature/orchestration-and-automation-foundation-2026-04-18 for one synchronous deterministic cycle entrypoint `run_public_activation_cycle` chaining 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9; excludes scheduler daemons, async workers, portfolio orchestration, and live trading rollout. |
+| 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | ✅ Done | Deterministic single-cycle orchestration entrypoint `run_public_activation_cycle` merged and preserved as thin synchronous chaining over 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9. |
+| 7.1 | Public Activation Trigger Surface (Single Entrypoint) | 🚧 In Progress | Active on feature/public-activation-trigger-surface-2026-04-18 with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py
+++ b/projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py
@@ -1,0 +1,146 @@
+"""Phase 7.1 thin CLI trigger surface for deterministic public activation cycle.
+
+This module exposes one synchronous invocation path only: a CLI entrypoint that
+builds a :class:`PublicActivationCyclePolicy`, runs the existing
+``run_public_activation_cycle(...)`` contract, validates the returned contract,
+and maps it to explicit invocation outcomes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Sequence
+
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED,
+    PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+    PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD,
+    PublicActivationCyclePolicy,
+    PublicActivationCycleResult,
+    run_public_activation_cycle,
+)
+
+_TRIGGER_RESULT_COMPLETED = "completed"
+_TRIGGER_RESULT_STOPPED_HOLD = "stopped_hold"
+_TRIGGER_RESULT_STOPPED_BLOCKED = "stopped_blocked"
+
+
+@dataclass(frozen=True)
+class PublicActivationTriggerResult:
+    """Thin trigger output mapped from cycle result categories."""
+
+    trigger_result: str
+    cycle_result_category: str
+    cycle_stop_reason: str | None
+    cycle_completed: bool
+    wallet_binding_id: str
+    owner_user_id: str
+    cycle_notes: list[str]
+
+
+def invoke_public_activation_cycle_trigger(
+    policy: PublicActivationCyclePolicy,
+) -> PublicActivationTriggerResult:
+    """Run one deterministic public activation cycle through the CLI trigger surface."""
+    _validate_trigger_policy_contract(policy)
+    cycle_result = run_public_activation_cycle(policy)
+    return _map_trigger_result(cycle_result)
+
+
+def _validate_trigger_policy_contract(policy: PublicActivationCyclePolicy) -> None:
+    if not policy.wallet_binding_id.strip():
+        raise ValueError("invalid trigger policy: wallet_binding_id must be non-empty")
+    if not policy.owner_user_id.strip():
+        raise ValueError("invalid trigger policy: owner_user_id must be non-empty")
+    if not policy.requester_user_id.strip():
+        raise ValueError("invalid trigger policy: requester_user_id must be non-empty")
+
+
+def _map_trigger_result(cycle_result: PublicActivationCycleResult) -> PublicActivationTriggerResult:
+    mapped_result = {
+        PUBLIC_ACTIVATION_CYCLE_RESULT_COMPLETED: _TRIGGER_RESULT_COMPLETED,
+        PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_HOLD: _TRIGGER_RESULT_STOPPED_HOLD,
+        PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED: _TRIGGER_RESULT_STOPPED_BLOCKED,
+    }.get(cycle_result.cycle_result_category)
+    if mapped_result is None:
+        raise ValueError(
+            "invalid cycle result contract: unsupported cycle_result_category="
+            f"{cycle_result.cycle_result_category!r}"
+        )
+
+    if mapped_result == _TRIGGER_RESULT_COMPLETED and cycle_result.cycle_stop_reason is not None:
+        raise ValueError(
+            "invalid cycle result contract: completed result must not include cycle_stop_reason"
+        )
+    if mapped_result != _TRIGGER_RESULT_COMPLETED and cycle_result.cycle_stop_reason is None:
+        raise ValueError(
+            "invalid cycle result contract: stopped result must include cycle_stop_reason"
+        )
+
+    return PublicActivationTriggerResult(
+        trigger_result=mapped_result,
+        cycle_result_category=cycle_result.cycle_result_category,
+        cycle_stop_reason=cycle_result.cycle_stop_reason,
+        cycle_completed=cycle_result.cycle_completed,
+        wallet_binding_id=cycle_result.wallet_binding_id,
+        owner_user_id=cycle_result.owner_user_id,
+        cycle_notes=list(cycle_result.cycle_notes),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="public-activation-trigger",
+        description="Run one deterministic public activation cycle via the Phase 7.1 trigger surface.",
+    )
+    parser.add_argument("--wallet-binding-id", required=True)
+    parser.add_argument("--owner-user-id", required=True)
+    parser.add_argument("--requester-user-id", required=True)
+    parser.add_argument("--wallet-active", required=True, choices=("true", "false"))
+    parser.add_argument("--state-read-batch-ready", required=True, choices=("true", "false"))
+    parser.add_argument("--reconciliation-outcome", required=True)
+    parser.add_argument("--correction-result-category", required=True)
+    parser.add_argument("--retry-result-category", required=True)
+    return parser
+
+
+def _to_bool(value: str) -> bool:
+    return value == "true"
+
+
+def _policy_from_args(args: argparse.Namespace) -> PublicActivationCyclePolicy:
+    return PublicActivationCyclePolicy(
+        wallet_binding_id=args.wallet_binding_id,
+        owner_user_id=args.owner_user_id,
+        requester_user_id=args.requester_user_id,
+        wallet_active=_to_bool(args.wallet_active),
+        state_read_batch_ready=_to_bool(args.state_read_batch_ready),
+        reconciliation_outcome=args.reconciliation_outcome,
+        correction_result_category=args.correction_result_category,
+        retry_result_category=args.retry_result_category,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    trigger_result = invoke_public_activation_cycle_trigger(_policy_from_args(args))
+    print(
+        json.dumps(
+            {
+                "trigger_result": trigger_result.trigger_result,
+                "cycle_result_category": trigger_result.cycle_result_category,
+                "cycle_stop_reason": trigger_result.cycle_stop_reason,
+                "cycle_completed": trigger_result.cycle_completed,
+                "wallet_binding_id": trigger_result.wallet_binding_id,
+                "owner_user_id": trigger_result.owner_user_id,
+                "cycle_notes": trigger_result.cycle_notes,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-1_01_public-activation-trigger-surface.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-1_01_public-activation-trigger-surface.md
@@ -1,0 +1,84 @@
+# FORGE-X Report -- Phase 7.1 Public Activation Trigger Surface
+
+## 1) What was built
+
+Implemented one thin synchronous trigger surface for the existing Phase 7.0 deterministic public activation cycle via a CLI entrypoint.
+
+New trigger path:
+- `python -m projects.polymarket.polyquantbot.api.public_activation_trigger_cli ...`
+
+The trigger surface:
+- builds `PublicActivationCyclePolicy`
+- invokes `run_public_activation_cycle(...)` without altering 7.0 orchestration logic
+- validates trigger input contract (non-empty identity fields)
+- validates cycle output contract (supported result category and stop-reason consistency)
+- maps cycle outputs to explicit trigger outcomes:
+  - `completed`
+  - `stopped_hold`
+  - `stopped_blocked`
+
+No scheduler daemon, async worker, settlement automation, portfolio orchestration, or live-trading rollout was introduced.
+
+## 2) Current system architecture (relevant slice)
+
+Relevant runtime slice after this task:
+
+1. Existing 7.0 orchestration remains authoritative in:
+   - `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. New 7.1 trigger surface is a thin adapter in:
+   - `projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py`
+3. Invocation flow is deterministic and synchronous:
+   - CLI args -> `PublicActivationCyclePolicy` -> `run_public_activation_cycle(...)` -> contract validation -> explicit trigger result mapping -> JSON stdout
+
+This keeps 6.5.2-6.5.10, 6.6.1-6.6.9, and 7.0 contracts preserved and unchanged.
+
+## 3) Files created / modified (full paths)
+
+**Created**
+- `projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-1_01_public-activation-trigger-surface.md`
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- One thin trigger surface exists and uses exactly one invocation path (CLI).
+- Trigger invocation is synchronous and deterministic.
+- Trigger outputs are explicitly mapped to `completed` / `stopped_hold` / `stopped_blocked` from existing cycle results.
+- Contract validation is explicit for both trigger input (identity fields) and cycle output mapping rules.
+- Targeted tests verify:
+  - completed outcome mapping
+  - stopped_hold outcome mapping
+  - stopped_blocked outcome mapping
+  - contract validation failure on invalid trigger policy
+  - contract validation failure on unsupported cycle result category
+  - CLI JSON output shape and result mapping
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py`
+
+## 5) Known issues
+
+- Scope remains intentionally narrow to one trigger path only; broader automation rollout is still out of scope.
+- Existing deferred repo warning remains unchanged: `Unknown config option: asyncio_mode` in pytest config.
+- `git rev-parse --abbrev-ref HEAD` returns `work` in Codex worktree context; branch traceability follows COMMANDER-declared branch.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : public activation trigger surface only (single CLI entrypoint over `run_public_activation_cycle`)
+Not in Scope      : scheduler daemon, async workers, settlement automation, portfolio orchestration, live trading enablement, broader production automation, multiple trigger surfaces in one slice
+Suggested Next    : COMMANDER review
+
+---
+
+**Report Timestamp:** 2026-04-18 11:52 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** phase7-1-public-activation-trigger-surface
+**Branch:** `feature/public-activation-trigger-surface-2026-04-18`

--- a/projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from projects.polymarket.polyquantbot.api.public_activation_trigger_cli import (
+    _TRIGGER_RESULT_COMPLETED,
+    _TRIGGER_RESULT_STOPPED_BLOCKED,
+    _TRIGGER_RESULT_STOPPED_HOLD,
+    _map_trigger_result,
+    invoke_public_activation_cycle_trigger,
+    main,
+)
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED,
+    PublicActivationCyclePolicy,
+    PublicActivationCycleResult,
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+)
+
+
+def _policy(**kwargs) -> PublicActivationCyclePolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requester_user_id": "user-1",
+        "wallet_active": True,
+        "state_read_batch_ready": True,
+        "reconciliation_outcome": WALLET_RECONCILIATION_OUTCOME_MATCH,
+        "correction_result_category": WALLET_CORRECTION_RESULT_ACCEPTED,
+        "retry_result_category": WALLET_RETRY_WORK_DECISION_SKIPPED,
+    }
+    defaults.update(kwargs)
+    return PublicActivationCyclePolicy(**defaults)
+
+
+def test_trigger_surface_returns_completed_for_go_path() -> None:
+    result = invoke_public_activation_cycle_trigger(_policy())
+    assert result.trigger_result == _TRIGGER_RESULT_COMPLETED
+    assert result.cycle_result_category == "completed"
+    assert result.cycle_stop_reason is None
+
+
+def test_trigger_surface_returns_stopped_hold_for_hold_path() -> None:
+    result = invoke_public_activation_cycle_trigger(
+        _policy(correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED)
+    )
+    assert result.trigger_result == _TRIGGER_RESULT_STOPPED_HOLD
+    assert result.cycle_result_category == "stopped_hold"
+    assert result.cycle_stop_reason == "readiness_hold"
+
+
+def test_trigger_surface_returns_stopped_blocked_for_blocked_path() -> None:
+    result = invoke_public_activation_cycle_trigger(
+        _policy(reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH)
+    )
+    assert result.trigger_result == _TRIGGER_RESULT_STOPPED_BLOCKED
+    assert result.cycle_result_category == PUBLIC_ACTIVATION_CYCLE_RESULT_STOPPED_BLOCKED
+    assert result.cycle_stop_reason == "readiness_blocked"
+
+
+def test_trigger_surface_policy_contract_requires_non_empty_identity_fields() -> None:
+    with pytest.raises(ValueError, match="wallet_binding_id"):
+        invoke_public_activation_cycle_trigger(_policy(wallet_binding_id=""))
+
+
+def test_result_mapping_rejects_unknown_cycle_category() -> None:
+    invalid_cycle_result = PublicActivationCycleResult(
+        cycle_completed=False,
+        cycle_result_category="unknown-category",
+        cycle_stop_reason="bad",
+        wallet_binding_id="wallet-1",
+        owner_user_id="user-1",
+        cycle_notes=[],
+        readiness_result=None,  # type: ignore[arg-type]
+        activation_gate_result=None,  # type: ignore[arg-type]
+        activation_flow_result=None,  # type: ignore[arg-type]
+        hardening_result=None,  # type: ignore[arg-type]
+        execution_hook_result=None,  # type: ignore[arg-type]
+    )
+    with pytest.raises(ValueError, match="unsupported cycle_result_category"):
+        _map_trigger_result(invalid_cycle_result)
+
+
+def test_cli_main_emits_json_payload_for_trigger_result(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(
+        [
+            "--wallet-binding-id",
+            "wallet-1",
+            "--owner-user-id",
+            "user-1",
+            "--requester-user-id",
+            "user-1",
+            "--wallet-active",
+            "true",
+            "--state-read-batch-ready",
+            "true",
+            "--reconciliation-outcome",
+            WALLET_RECONCILIATION_OUTCOME_MATCH,
+            "--correction-result-category",
+            WALLET_CORRECTION_RESULT_ACCEPTED,
+            "--retry-result-category",
+            WALLET_RETRY_WORK_DECISION_SKIPPED,
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["trigger_result"] == _TRIGGER_RESULT_COMPLETED
+    assert payload["cycle_result_category"] == "completed"
+    assert payload["cycle_stop_reason"] is None


### PR DESCRIPTION
### Motivation
- Expose the completed Phase 7.0 deterministic public activation cycle via a single, thin, synchronous entrypoint so the system can be invoked directly without adding schedulers, async workers, or live-trading rollout.
- Preserve all existing 6.5.x / 6.6.x / 7.0 contracts exactly while providing an explicit invocation contract and deterministic mapping of outcomes.

### Description
- Added a CLI trigger adapter at `projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py` that implements `invoke_public_activation_cycle_trigger`, `_validate_trigger_policy_contract`, `_map_trigger_result`, and `main`, which builds a `PublicActivationCyclePolicy`, calls `run_public_activation_cycle(...)`, validates the cycle contract, and maps results to `completed` / `stopped_hold` / `stopped_blocked`.
- Added targeted tests at `projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py` validating mapping, input contract checks, unknown-category rejection, and CLI JSON output, while keeping the 7.0 orchestration logic in `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py` unchanged.
- Updated project metadata: `PROJECT_STATE.md` now reflects Phase 7.1 in progress and `ROADMAP.md` marks 7.0 done and 7.1 `🚧 In Progress`, and added the FORGE-X report at `projects/polymarket/polyquantbot/reports/forge/phase7-1_01_public-activation-trigger-surface.md`.
- No scheduler daemons, cron/background workers, async worker mesh, settlement automation, portfolio orchestration, or live-trading hooks were introduced.

### Testing
- Ran `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py` and `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py` with no errors.
- Ran `PYTHONIOENCODING=utf-8 PYTHONPATH=. python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py` and observed `12 passed, 1 warning` (warning is the known deferred `Unknown config option: asyncio_mode`).
- Performed mojibake checks and locale / `PYTHONIOENCODING` verification for touched files with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30d9d77788325a768be6e4e2fa28e)