### PR TITLE
fix(phase7-2): scheduler invalid-contract returns blocked result; restore PROJECT_STATE history

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,7 +1,15 @@
-Last Updated : 2026-04-18 16:58
-Status       : Phase 7.2 lightweight automation scheduler is now in progress with one synchronous invocation decision cycle over the completed 7.1 trigger surface. Scheduler result categories triggered/skipped/blocked are defined with deterministic skip and block reasons. Scope remains narrow integration only (no distributed schedulers, async workers, or live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 18:01
+Status       : Phase 7.2 lightweight automation scheduler contract fix is active. Scheduler boundary now returns deterministic blocked(invalid_contract) for negative quota instead of raising. All scheduler result categories (triggered/skipped/blocked) are returned as SchedulerInvocationResult. Historical completed entries restored. Scope remains narrow integration only (no distributed schedulers, async workers, or live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
+- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
+- Phase 6.5.3 wallet state read boundary merged via PR #536.
+- Phase 6.5.4 wallet state clear boundary merged via PR #537.
+- Phase 6.5.5 wallet state exists boundary merged via PR #539.
+- Phase 6.5.6 wallet state list metadata boundary merged via PR #541.
+- Phase 6.5.7 wallet state metadata query expansion merged via PR #543.
+- Phase 6.5.8 wallet state metadata exact lookup merged via PR #544.
+- Phase 6.5.9 wallet state metadata exact batch lookup merged via PR #546.
 - Phase 6.5.10 wallet state exact batch read boundary merged via PR #557.
 - Phase 6.6.1 wallet lifecycle state reconciliation foundation merged via PR #558.
 - Phase 6.6.2 wallet lifecycle batch reconciliation merged via PR #559.
@@ -25,7 +33,7 @@ Status       : Phase 7.2 lightweight automation scheduler is now in progress wit
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review for Phase 7.2 lightweight automation scheduler (single synchronous invocation cycle over 7.1 trigger surface only).
+- COMMANDER re-review for Phase 7.2 contract fix (scheduler invalid_contract path returns blocked result; historical PROJECT_STATE.md entries restored).
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,15 +1,7 @@
-Last Updated : 2026-04-18 11:52
-Status       : Phase 7.1 public activation trigger surface is now in progress with one synchronous CLI invocation path over the completed 7.0 deterministic cycle contract. Scope remains narrow integration only (no scheduler/worker/live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
+Last Updated : 2026-04-18 16:58
+Status       : Phase 7.2 lightweight automation scheduler is now in progress with one synchronous invocation decision cycle over the completed 7.1 trigger surface. Scheduler result categories triggered/skipped/blocked are defined with deterministic skip and block reasons. Scope remains narrow integration only (no distributed schedulers, async workers, or live rollout). Phase 6.4.1 remains spec-approved only and is not the active implementation lane.
 
 [COMPLETED]
-- Phase 6.4.3 authorizer-path monitoring narrow integration merged via PR #491 (SENTINEL APPROVED 99/100).
-- Phase 6.5.3 wallet state read boundary merged via PR #536.
-- Phase 6.5.4 wallet state clear boundary merged via PR #537.
-- Phase 6.5.5 wallet state exists boundary merged via PR #539.
-- Phase 6.5.6 wallet state list metadata boundary merged via PR #541.
-- Phase 6.5.7 wallet state metadata query expansion merged via PR #543.
-- Phase 6.5.8 wallet state metadata exact lookup merged via PR #544.
-- Phase 6.5.9 wallet state metadata exact batch lookup merged via PR #546.
 - Phase 6.5.10 wallet state exact batch read boundary merged via PR #557.
 - Phase 6.6.1 wallet lifecycle state reconciliation foundation merged via PR #558.
 - Phase 6.6.2 wallet lifecycle batch reconciliation merged via PR #559.
@@ -20,9 +12,11 @@ Status       : Phase 7.1 public activation trigger surface is now in progress wi
 - Phase 6.6.7 minimal public activation flow merged via PR #564.
 - Phase 6.6.8 public safety hardening merged via PR #565.
 - Phase 6.6.9 minimal execution hook merged via PR #566.
+- Phase 7.0 deterministic public activation cycle orchestration foundation merged and preserved.
+- Phase 7.1 public activation trigger surface merged with one synchronous CLI invocation path mapping run_public_activation_cycle outcomes to explicit completed/stopped_hold/stopped_blocked trigger results.
 
 [IN PROGRESS]
-- Phase 7.1 public activation trigger surface is active with one synchronous CLI invocation path that maps `run_public_activation_cycle(...)` outcomes to explicit completed/stopped_hold/stopped_blocked trigger results.
+- Phase 7.2 lightweight automation scheduler is active with one synchronous invocation decision cycle over the 7.1 trigger surface; defines triggered/skipped/blocked result categories with deterministic skip reasons (already_running, window_not_open, quota_reached) and block reasons (schedule_disabled, invalid_contract).
 
 [NOT STARTED]
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation has not started; prior spec approval does not claim runtime delivery.
@@ -31,7 +25,7 @@ Status       : Phase 7.1 public activation trigger surface is now in progress wi
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review for Phase 7.1 public activation trigger surface (thin CLI invocation path only).
+- COMMANDER review for Phase 7.2 lightweight automation scheduler (single synchronous invocation cycle over 7.1 trigger surface only).
 - Keep Phase 6.4.1 out of active-lane wording until implementation is explicitly resumed.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,13 +87,13 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 16:58
+**Last Updated:** 2026-04-18 18:01
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
 | 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | ✅ Done | Deterministic single-cycle orchestration entrypoint `run_public_activation_cycle` merged and preserved as thin synchronous chaining over 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9. |
 | 7.1 | Public Activation Trigger Surface (Single Entrypoint) | ✅ Done | Merged with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
-| 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | 🚧 In Progress | Active on feature/lightweight-automation-scheduler-2026-04-18 with deterministic triggered/skipped/blocked scheduler result categories and explicit skip reasons (already_running, window_not_open, quota_reached) and block reasons (schedule_disabled, invalid_contract); one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
+| 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | 🚧 In Progress | Contract fix active on feature/lightweight-automation-scheduler-contract-fix-2026-04-18; scheduler boundary returns deterministic blocked(invalid_contract) for negative quota instead of raising; triggered/skipped/blocked result categories fully deterministic; one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 11:52
+**Last Updated:** 2026-04-18 16:58
 
 ## Board Overview
 
@@ -87,12 +87,13 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 11:52
+**Last Updated:** 2026-04-18 16:58
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
 | 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | ✅ Done | Deterministic single-cycle orchestration entrypoint `run_public_activation_cycle` merged and preserved as thin synchronous chaining over 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9. |
-| 7.1 | Public Activation Trigger Surface (Single Entrypoint) | 🚧 In Progress | Active on feature/public-activation-trigger-surface-2026-04-18 with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
+| 7.1 | Public Activation Trigger Surface (Single Entrypoint) | ✅ Done | Merged with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
+| 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | 🚧 In Progress | Active on feature/lightweight-automation-scheduler-2026-04-18 with deterministic triggered/skipped/blocked scheduler result categories and explicit skip reasons (already_running, window_not_open, quota_reached) and block reasons (schedule_disabled, invalid_contract); one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py
+++ b/projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py
@@ -67,8 +67,16 @@ class LightweightActivationSchedulerBoundary:
     """
 
     def decide_and_invoke(self, policy: SchedulerInvocationPolicy) -> SchedulerInvocationResult:
-        """Evaluate scheduling conditions; invoke 7.1 trigger only if all conditions are met."""
-        _validate_scheduler_policy_contract(policy)
+        """Evaluate scheduling conditions; invoke 7.1 trigger only if all conditions are met.
+
+        Decision priority (deterministic, evaluated in order):
+        1. schedule_disabled  -> blocked
+        2. already_running    -> skipped
+        3. window_not_open    -> skipped
+        4. quota_reached      -> skipped  (quota == 0)
+        5. invalid_contract   -> blocked  (quota < 0)
+        6. all conditions met -> triggered
+        """
         notes: list[str] = []
 
         if not policy.schedule_enabled:
@@ -101,12 +109,22 @@ class LightweightActivationSchedulerBoundary:
                 scheduler_notes=notes,
             )
 
-        if policy.invocation_quota_remaining <= 0:
+        if policy.invocation_quota_remaining == 0:
             notes.append("quota_reached: invocation quota is exhausted")
             return SchedulerInvocationResult(
                 scheduler_result=SCHEDULER_RESULT_SKIPPED,
                 skip_reason=SCHEDULER_SKIP_QUOTA_REACHED,
                 block_reason=None,
+                trigger_result=None,
+                scheduler_notes=notes,
+            )
+
+        if policy.invocation_quota_remaining < 0:
+            notes.append("invalid_contract: invocation_quota_remaining must be >= 0")
+            return SchedulerInvocationResult(
+                scheduler_result=SCHEDULER_RESULT_BLOCKED,
+                skip_reason=None,
+                block_reason=SCHEDULER_BLOCK_INVALID_CONTRACT,
                 trigger_result=None,
                 scheduler_notes=notes,
             )
@@ -120,13 +138,6 @@ class LightweightActivationSchedulerBoundary:
             block_reason=None,
             trigger_result=trigger_result,
             scheduler_notes=notes,
-        )
-
-
-def _validate_scheduler_policy_contract(policy: SchedulerInvocationPolicy) -> None:
-    if policy.invocation_quota_remaining < 0:
-        raise ValueError(
-            "invalid scheduler policy: invocation_quota_remaining must be >= 0"
         )
 
 

--- a/projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py
+++ b/projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py
@@ -1,0 +1,135 @@
+"""Phase 7.2 lightweight automation scheduler contract for the public activation trigger.
+
+Single synchronous invocation cycle. No distributed workers, no async queue mesh,
+no cron daemon. Scheduler result categories: triggered / skipped / blocked.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.api.public_activation_trigger_cli import (
+    PublicActivationTriggerResult,
+    invoke_public_activation_cycle_trigger,
+)
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PublicActivationCyclePolicy,
+)
+
+# Scheduler result categories
+SCHEDULER_RESULT_TRIGGERED = "triggered"
+SCHEDULER_RESULT_SKIPPED = "skipped"
+SCHEDULER_RESULT_BLOCKED = "blocked"
+
+# Skip reasons (soft decisions -- conditions not met)
+SCHEDULER_SKIP_ALREADY_RUNNING = "already_running"
+SCHEDULER_SKIP_WINDOW_NOT_OPEN = "window_not_open"
+SCHEDULER_SKIP_QUOTA_REACHED = "quota_reached"
+
+# Block reasons (hard stops)
+SCHEDULER_BLOCK_SCHEDULE_DISABLED = "schedule_disabled"
+SCHEDULER_BLOCK_INVALID_CONTRACT = "invalid_contract"
+
+
+@dataclass(frozen=True)
+class SchedulerInvocationPolicy:
+    """Policy contract for one lightweight scheduler invocation cycle.
+
+    schedule_enabled=False -> blocked (schedule_disabled).
+    concurrent_invocation_active=True -> skipped (already_running).
+    invocation_window_open=False -> skipped (window_not_open).
+    invocation_quota_remaining=0 -> skipped (quota_reached).
+    All conditions met -> trigger invoked via 7.1 surface.
+    """
+
+    trigger_policy: PublicActivationCyclePolicy
+    schedule_enabled: bool
+    invocation_window_open: bool
+    invocation_quota_remaining: int
+    concurrent_invocation_active: bool
+
+
+@dataclass(frozen=True)
+class SchedulerInvocationResult:
+    """Result of one lightweight scheduler invocation decision."""
+
+    scheduler_result: str
+    skip_reason: str | None
+    block_reason: str | None
+    trigger_result: PublicActivationTriggerResult | None
+    scheduler_notes: list[str]
+
+
+class LightweightActivationSchedulerBoundary:
+    """Phase 7.2 deterministic scheduler for the 7.1 public activation trigger.
+
+    One synchronous invocation cycle at a time.
+    No distributed workers, no async queue mesh, no cron daemon rollout.
+    """
+
+    def decide_and_invoke(self, policy: SchedulerInvocationPolicy) -> SchedulerInvocationResult:
+        """Evaluate scheduling conditions; invoke 7.1 trigger only if all conditions are met."""
+        _validate_scheduler_policy_contract(policy)
+        notes: list[str] = []
+
+        if not policy.schedule_enabled:
+            notes.append("schedule_disabled: scheduler is not enabled")
+            return SchedulerInvocationResult(
+                scheduler_result=SCHEDULER_RESULT_BLOCKED,
+                skip_reason=None,
+                block_reason=SCHEDULER_BLOCK_SCHEDULE_DISABLED,
+                trigger_result=None,
+                scheduler_notes=notes,
+            )
+
+        if policy.concurrent_invocation_active:
+            notes.append("already_running: concurrent invocation is active")
+            return SchedulerInvocationResult(
+                scheduler_result=SCHEDULER_RESULT_SKIPPED,
+                skip_reason=SCHEDULER_SKIP_ALREADY_RUNNING,
+                block_reason=None,
+                trigger_result=None,
+                scheduler_notes=notes,
+            )
+
+        if not policy.invocation_window_open:
+            notes.append("window_not_open: invocation window is not open")
+            return SchedulerInvocationResult(
+                scheduler_result=SCHEDULER_RESULT_SKIPPED,
+                skip_reason=SCHEDULER_SKIP_WINDOW_NOT_OPEN,
+                block_reason=None,
+                trigger_result=None,
+                scheduler_notes=notes,
+            )
+
+        if policy.invocation_quota_remaining <= 0:
+            notes.append("quota_reached: invocation quota is exhausted")
+            return SchedulerInvocationResult(
+                scheduler_result=SCHEDULER_RESULT_SKIPPED,
+                skip_reason=SCHEDULER_SKIP_QUOTA_REACHED,
+                block_reason=None,
+                trigger_result=None,
+                scheduler_notes=notes,
+            )
+
+        notes.append("triggering: all scheduling conditions met")
+        trigger_result = invoke_public_activation_cycle_trigger(policy.trigger_policy)
+        notes.append(f"trigger_result={trigger_result.trigger_result}")
+        return SchedulerInvocationResult(
+            scheduler_result=SCHEDULER_RESULT_TRIGGERED,
+            skip_reason=None,
+            block_reason=None,
+            trigger_result=trigger_result,
+            scheduler_notes=notes,
+        )
+
+
+def _validate_scheduler_policy_contract(policy: SchedulerInvocationPolicy) -> None:
+    if policy.invocation_quota_remaining < 0:
+        raise ValueError(
+            "invalid scheduler policy: invocation_quota_remaining must be >= 0"
+        )
+
+
+def decide_and_invoke_scheduler(policy: SchedulerInvocationPolicy) -> SchedulerInvocationResult:
+    """Deterministic lightweight scheduler entrypoint for one synchronous invocation cycle."""
+    return LightweightActivationSchedulerBoundary().decide_and_invoke(policy)

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-2_01_lightweight-automation-scheduler.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-2_01_lightweight-automation-scheduler.md
@@ -1,0 +1,111 @@
+# FORGE-X Report -- Phase 7.2 Lightweight Automation Scheduler
+
+## 1) What was built
+
+Implemented a narrow lightweight automation scheduler contract that can invoke the completed
+Phase 7.1 public activation trigger on a controlled schedule without introducing async worker
+meshes, distributed workers, cron daemon rollout, or live-trading execution claims.
+
+New scheduler boundary:
+- `projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+
+The scheduler surface:
+- defines explicit scheduler result categories: `triggered` / `skipped` / `blocked`
+- defines deterministic skip reasons: `already_running` / `window_not_open` / `quota_reached`
+- defines deterministic block reasons: `schedule_disabled` / `invalid_contract`
+- evaluates scheduling conditions in a strict deterministic order before deciding to invoke
+- invokes the existing 7.1 `invoke_public_activation_cycle_trigger(...)` only when all
+  conditions are met (schedule enabled, no concurrent invocation, window open, quota > 0)
+- preserves 7.0 orchestration and 7.1 CLI trigger contracts exactly as-is
+
+No scheduler daemon, no async worker mesh, no cron rollout, no portfolio orchestration,
+and no real trading hooks were introduced.
+
+## 2) Current system architecture (relevant slice)
+
+Relevant runtime slice after this task:
+
+1. Phase 7.0 orchestration remains authoritative in:
+   - `projects/polymarket/polyquantbot/platform/wallet_auth/wallet_lifecycle_foundation.py`
+2. Phase 7.1 thin CLI trigger surface remains unchanged in:
+   - `projects/polymarket/polyquantbot/api/public_activation_trigger_cli.py`
+3. Phase 7.2 lightweight scheduler is a thin deterministic decision boundary in:
+   - `projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+
+Decision chain (synchronous, deterministic):
+
+```
+SchedulerInvocationPolicy
+    -> contract validation (negative quota -> ValueError)
+    -> schedule_enabled=False -> blocked (schedule_disabled)
+    -> concurrent_invocation_active=True -> skipped (already_running)
+    -> invocation_window_open=False -> skipped (window_not_open)
+    -> invocation_quota_remaining=0 -> skipped (quota_reached)
+    -> all conditions met -> invoke 7.1 trigger -> triggered
+```
+
+The scheduler wraps the 7.1 surface. It does not alter 7.0 or 7.1 contracts.
+Phases 6.5.2 through 6.5.10, 6.6.1 through 6.6.9, 7.0, and 7.1 remain unchanged.
+
+## 3) Files created / modified (full paths)
+
+**Created**
+- `projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-2_01_lightweight-automation-scheduler.md`
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Scheduler boundary exists with one synchronous invocation decision per call.
+- All four scheduling conditions are evaluated in deterministic priority order.
+- Scheduler result categories are explicit: `triggered` / `skipped` / `blocked`.
+- Skip reasons are explicit: `already_running` / `window_not_open` / `quota_reached`.
+- Block reasons are explicit: `schedule_disabled` / `invalid_contract`.
+- `scheduler_notes` list is populated at each decision point for traceability.
+- `SchedulerInvocationResult.trigger_result` is populated only when `triggered`.
+- Contract validation raises `ValueError` on negative quota.
+- 12 targeted tests verify all outcome categories and priority ordering:
+  - triggered when all conditions met (with completed trigger result)
+  - scheduler notes populated on triggered path
+  - blocked for schedule_disabled
+  - blocked note populated
+  - skipped for already_running
+  - skipped for window_not_open
+  - skipped for quota_reached (quota=0)
+  - blocked takes priority over concurrent invocation active
+  - concurrent skips before window check
+  - window skips before quota check
+  - contract validation rejects negative quota
+  - quota=1 is accepted (boundary value)
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=/home/user/walker-ai-team python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py` -- 12 passed
+4. `PYTHONIOENCODING=utf-8 PYTHONPATH=/home/user/walker-ai-team python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py` -- 12 passed (7.0 and 7.1 contracts preserved)
+
+## 5) Known issues
+
+- Scope is intentionally narrow: one synchronous invocation cycle only; broader automation
+  rollout, cron daemon, distributed schedulers, and async worker meshes remain out of scope.
+- Existing deferred repo warning unchanged: `Unknown config option: asyncio_mode` in pytest config.
+- Branch from Codex worktree: actual git branch is `feature/lightweight-automation-scheduler-2026-04-18`.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : lightweight automation scheduler contract only (single synchronous invocation cycle over the 7.1 trigger surface)
+Not in Scope      : distributed schedulers, async workers, settlement automation, portfolio orchestration, live trading enablement, broader production automation, multiple scheduler surfaces in one slice, cron daemon rollout
+Suggested Next    : COMMANDER review
+
+---
+
+**Report Timestamp:** 2026-04-18 16:58 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** phase7-2-lightweight-automation-scheduler
+**Branch:** `feature/lightweight-automation-scheduler-2026-04-18`

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-2_02_lightweight-automation-scheduler-contract-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-2_02_lightweight-automation-scheduler-contract-fix.md
@@ -1,0 +1,93 @@
+# FORGE-X Report -- Phase 7.2 Lightweight Automation Scheduler Contract Fix
+
+## 1) What was built
+
+Fixed the Phase 7.2 lightweight automation scheduler boundary so that all scheduler
+decisions — including invalid contract conditions — return a deterministic
+`SchedulerInvocationResult` instead of raising an exception.
+
+Specific changes:
+- Removed `_validate_scheduler_policy_contract` helper that raised `ValueError` on negative quota.
+- Added explicit inline decision step for `invalid_contract` in the boundary decision chain.
+- Separated `quota == 0` (skipped / quota_reached) from `quota < 0` (blocked / invalid_contract).
+- Documented the deterministic priority order in the `decide_and_invoke` docstring.
+- Updated test file: removed `pytest.raises(ValueError)` test; added three explicit tests:
+  `test_scheduler_returns_blocked_invalid_contract_for_negative_quota`,
+  `test_scheduler_invalid_contract_blocked_note_present`,
+  `test_scheduler_invalid_contract_priority_below_quota_reached`.
+- Restored 8 historically completed entries in PROJECT_STATE.md that were accidentally removed
+  outside scope in the prior 7.2 task (6.4.3, 6.5.3, 6.5.4, 6.5.5, 6.5.6, 6.5.7, 6.5.8, 6.5.9).
+
+## 2) Current system architecture (relevant slice)
+
+Scheduler decision chain after fix (deterministic, evaluated in order):
+
+```
+SchedulerInvocationPolicy
+    1. schedule_enabled=False         -> blocked  (schedule_disabled)
+    2. concurrent_invocation_active   -> skipped  (already_running)
+    3. invocation_window_open=False   -> skipped  (window_not_open)
+    4. invocation_quota_remaining==0  -> skipped  (quota_reached)
+    5. invocation_quota_remaining<0   -> blocked  (invalid_contract)
+    6. all conditions met             -> invoke 7.1 trigger -> triggered
+```
+
+All paths return `SchedulerInvocationResult`. No path raises an exception.
+Phases 6.5.2-6.5.10, 6.6.1-6.6.9, 7.0, and 7.1 contracts remain unchanged.
+
+## 3) Files created / modified (full paths)
+
+**Modified**
+- `projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+**Created**
+- `projects/polymarket/polyquantbot/reports/forge/phase7-2_02_lightweight-automation-scheduler-contract-fix.md`
+
+## 4) What is working
+
+- `decide_and_invoke` returns `blocked(SCHEDULER_BLOCK_INVALID_CONTRACT)` when
+  `invocation_quota_remaining < 0` — no exception raised.
+- `decide_and_invoke` returns `skipped(SCHEDULER_SKIP_QUOTA_REACHED)` when
+  `invocation_quota_remaining == 0` — distinct from invalid_contract path.
+- Priority ordering is deterministic and documented: schedule_disabled > already_running >
+  window_not_open > quota_reached > invalid_contract > triggered.
+- 14 tests pass covering all result categories, priority ordering, boundary values, notes, and
+  the fixed invalid_contract path.
+- 12 prior tests for 7.0 and 7.1 still pass (6 + 6) — contracts preserved.
+- Total: 26 tests pass.
+- PROJECT_STATE.md restored to include all 20 historical completed entries (8 entries previously
+  removed outside scope restored: 6.4.3, 6.5.3, 6.5.4, 6.5.5, 6.5.6, 6.5.7, 6.5.8, 6.5.9).
+  Note: entry count exceeds cap-10 guidance; all entries are reflected in ROADMAP.md per archive
+  rule; COMMANDER may prune oldest at their discretion.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py`
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=/home/user/walker-ai-team python -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py` -- 26 passed
+
+## 5) Known issues
+
+- PROJECT_STATE.md COMPLETED section currently has 20 entries, exceeding the cap-10 guidance.
+  All entries are reflected in ROADMAP.md; oldest entries are candidates for pruning per archive
+  rule. No operational truth is lost since ROADMAP.md is the planning authority.
+- Existing deferred repo warning unchanged: `Unknown config option: asyncio_mode` in pytest config.
+- `core/` imports from `api/` (core -> api layering); this is a cosmetic concern within the
+  narrow scope of 7.2 and is not addressed in this fix to stay within declared scope.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : lightweight automation scheduler contract fix only (invalid_contract blocked path and PROJECT_STATE.md truth restoration)
+Not in Scope      : distributed schedulers, async workers, settlement automation, portfolio orchestration, live trading enablement, cron daemon rollout, broader production automation
+Suggested Next    : COMMANDER re-review
+
+---
+
+**Report Timestamp:** 2026-04-18 18:01 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** phase7-2-lightweight-automation-scheduler-contract-fix
+**Branch:** `feature/lightweight-automation-scheduler-contract-fix-2026-04-18`

--- a/projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import pytest
-
 from projects.polymarket.polyquantbot.core.lightweight_activation_scheduler import (
+    SCHEDULER_BLOCK_INVALID_CONTRACT,
     SCHEDULER_BLOCK_SCHEDULE_DISABLED,
     SCHEDULER_RESULT_BLOCKED,
     SCHEDULER_RESULT_SKIPPED,
@@ -124,9 +123,24 @@ def test_scheduler_window_skips_before_quota_check() -> None:
     assert result.skip_reason == SCHEDULER_SKIP_WINDOW_NOT_OPEN
 
 
-def test_scheduler_contract_rejects_negative_quota() -> None:
-    with pytest.raises(ValueError, match="invocation_quota_remaining must be >= 0"):
-        decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=-1))
+def test_scheduler_returns_blocked_invalid_contract_for_negative_quota() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=-1))
+    assert result.scheduler_result == SCHEDULER_RESULT_BLOCKED
+    assert result.block_reason == SCHEDULER_BLOCK_INVALID_CONTRACT
+    assert result.skip_reason is None
+    assert result.trigger_result is None
+
+
+def test_scheduler_invalid_contract_blocked_note_present() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=-1))
+    assert any("invalid_contract" in note for note in result.scheduler_notes)
+
+
+def test_scheduler_invalid_contract_priority_below_quota_reached() -> None:
+    # quota == 0 must yield skipped(quota_reached), not blocked(invalid_contract)
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=0))
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_QUOTA_REACHED
 
 
 def test_scheduler_quota_of_one_is_accepted() -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from projects.polymarket.polyquantbot.core.lightweight_activation_scheduler import (
+    SCHEDULER_BLOCK_SCHEDULE_DISABLED,
+    SCHEDULER_RESULT_BLOCKED,
+    SCHEDULER_RESULT_SKIPPED,
+    SCHEDULER_RESULT_TRIGGERED,
+    SCHEDULER_SKIP_ALREADY_RUNNING,
+    SCHEDULER_SKIP_QUOTA_REACHED,
+    SCHEDULER_SKIP_WINDOW_NOT_OPEN,
+    SchedulerInvocationPolicy,
+    decide_and_invoke_scheduler,
+)
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PublicActivationCyclePolicy,
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+)
+
+
+def _trigger_policy(**kwargs) -> PublicActivationCyclePolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-1",
+        "owner_user_id": "user-1",
+        "requester_user_id": "user-1",
+        "wallet_active": True,
+        "state_read_batch_ready": True,
+        "reconciliation_outcome": WALLET_RECONCILIATION_OUTCOME_MATCH,
+        "correction_result_category": WALLET_CORRECTION_RESULT_ACCEPTED,
+        "retry_result_category": WALLET_RETRY_WORK_DECISION_SKIPPED,
+    }
+    defaults.update(kwargs)
+    return PublicActivationCyclePolicy(**defaults)
+
+
+def _scheduler_policy(**kwargs) -> SchedulerInvocationPolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "trigger_policy": _trigger_policy(),
+        "schedule_enabled": True,
+        "invocation_window_open": True,
+        "invocation_quota_remaining": 5,
+        "concurrent_invocation_active": False,
+    }
+    defaults.update(kwargs)
+    return SchedulerInvocationPolicy(**defaults)
+
+
+def test_scheduler_returns_triggered_when_all_conditions_met() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy())
+    assert result.scheduler_result == SCHEDULER_RESULT_TRIGGERED
+    assert result.skip_reason is None
+    assert result.block_reason is None
+    assert result.trigger_result is not None
+    assert result.trigger_result.trigger_result == "completed"
+
+
+def test_scheduler_triggered_result_includes_notes() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy())
+    assert any("triggering" in note for note in result.scheduler_notes)
+    assert any("trigger_result" in note for note in result.scheduler_notes)
+
+
+def test_scheduler_returns_blocked_when_schedule_disabled() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(schedule_enabled=False))
+    assert result.scheduler_result == SCHEDULER_RESULT_BLOCKED
+    assert result.block_reason == SCHEDULER_BLOCK_SCHEDULE_DISABLED
+    assert result.skip_reason is None
+    assert result.trigger_result is None
+
+
+def test_scheduler_blocked_has_schedule_disabled_note() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(schedule_enabled=False))
+    assert any("schedule_disabled" in note for note in result.scheduler_notes)
+
+
+def test_scheduler_returns_skipped_when_concurrent_invocation_active() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(concurrent_invocation_active=True))
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_ALREADY_RUNNING
+    assert result.block_reason is None
+    assert result.trigger_result is None
+
+
+def test_scheduler_returns_skipped_when_window_not_open() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_window_open=False))
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_WINDOW_NOT_OPEN
+    assert result.block_reason is None
+    assert result.trigger_result is None
+
+
+def test_scheduler_returns_skipped_when_quota_exhausted() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=0))
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_QUOTA_REACHED
+    assert result.block_reason is None
+    assert result.trigger_result is None
+
+
+def test_scheduler_blocked_takes_priority_over_concurrent_invocation() -> None:
+    result = decide_and_invoke_scheduler(
+        _scheduler_policy(schedule_enabled=False, concurrent_invocation_active=True)
+    )
+    assert result.scheduler_result == SCHEDULER_RESULT_BLOCKED
+    assert result.block_reason == SCHEDULER_BLOCK_SCHEDULE_DISABLED
+
+
+def test_scheduler_concurrent_skips_before_window_check() -> None:
+    result = decide_and_invoke_scheduler(
+        _scheduler_policy(concurrent_invocation_active=True, invocation_window_open=False)
+    )
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_ALREADY_RUNNING
+
+
+def test_scheduler_window_skips_before_quota_check() -> None:
+    result = decide_and_invoke_scheduler(
+        _scheduler_policy(invocation_window_open=False, invocation_quota_remaining=0)
+    )
+    assert result.scheduler_result == SCHEDULER_RESULT_SKIPPED
+    assert result.skip_reason == SCHEDULER_SKIP_WINDOW_NOT_OPEN
+
+
+def test_scheduler_contract_rejects_negative_quota() -> None:
+    with pytest.raises(ValueError, match="invocation_quota_remaining must be >= 0"):
+        decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=-1))
+
+
+def test_scheduler_quota_of_one_is_accepted() -> None:
+    result = decide_and_invoke_scheduler(_scheduler_policy(invocation_quota_remaining=1))
+    assert result.scheduler_result == SCHEDULER_RESULT_TRIGGERED


### PR DESCRIPTION
## Summary

- **Scheduler contract fix**: `decide_and_invoke` now returns `blocked(SCHEDULER_BLOCK_INVALID_CONTRACT)` when `invocation_quota_remaining < 0` — no exception raised from the boundary
- Separated `quota == 0` → `skipped(quota_reached)` from `quota < 0` → `blocked(invalid_contract)`
- Removed `_validate_scheduler_policy_contract` helper that raised `ValueError`
- Documented deterministic decision priority in `decide_and_invoke` docstring: `schedule_disabled > already_running > window_not_open > quota_reached > invalid_contract > triggered`
- **PROJECT_STATE.md**: restored 8 historically completed entries removed outside scope in prior 7.2 task (6.4.3, 6.5.3, 6.5.4, 6.5.5, 6.5.6, 6.5.7, 6.5.8, 6.5.9)

## Validation

- Validation Tier: STANDARD
- Claim Level: NARROW INTEGRATION
- Validation Target: scheduler invalid_contract blocked path + PROJECT_STATE.md truth restoration
- Not in Scope: distributed schedulers, async workers, settlement automation, portfolio orchestration, live trading enablement, cron daemon rollout

## Test results

- `py_compile` passes for both touched Python files
- 26 tests pass: 14 phase7-2 (added 3 new invalid_contract tests, removed 1 raises test), 6 phase7-1, 6 phase7-0
- All 7.0 and 7.1 contracts preserved

## Files modified

- `projects/polymarket/polyquantbot/core/lightweight_activation_scheduler.py`
- `projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py`
- `projects/polymarket/polyquantbot/reports/forge/phase7-2_02_lightweight-automation-scheduler-contract-fix.md` (new)
- `PROJECT_STATE.md`
- `ROADMAP.md`

## Known issues noted in report

- PROJECT_STATE.md COMPLETED section has 20 entries (over cap-10 guidance); all entries are in ROADMAP.md per archive rule; COMMANDER may prune oldest at their discretion

## Next gate

COMMANDER re-review