### PR TITLE
forge: phase7-4 observability/visibility foundation — visible/partial/blocked records over 6.4.1/7.2/7.3

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-18 22:26
-Status       : Phase 7.3 runtime auto-run loop foundation is active. Phase 6.4.1 monitoring and circuit-breaker FOUNDATION implementation delivered on branch claude/phase6-4-1-monitoring-foundation-5CVsL — deterministic MonitoringDecision (ALLOW/BLOCK/HALT) and MonitoringAnomalyCategory contracts implemented in monitoring/foundation.py with 26 targeted tests; pending COMMANDER review (STANDARD tier).
+Last Updated : 2026-04-18 22:58
+Status       : Phase 7.4 observability / visibility foundation active on branch claude/add-observability-visibility-tydYW — deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes implemented in monitoring/observability_foundation.py with 45 targeted tests; pending COMMANDER review (STANDARD tier).
 
 [COMPLETED]
 - Phase 6.6.3 wallet reconciliation mutation/correction foundation merged via PR #560.
@@ -16,6 +16,7 @@ Status       : Phase 7.3 runtime auto-run loop foundation is active. Phase 6.4.1
 [IN PROGRESS]
 - Phase 6.4.1 Monitoring and Circuit Breaker FOUNDATION implementation delivered on branch claude/phase6-4-1-monitoring-foundation-5CVsL; deterministic evaluation contract in monitoring/foundation.py with 26 targeted tests; pending COMMANDER review (STANDARD tier).
 - Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
+- Phase 7.4 observability / visibility foundation active on branch claude/add-observability-visibility-tydYW; deterministic visibility records (visible/partial/blocked) over 6.4.1 monitoring evaluations, 7.2 scheduler decisions, and 7.3 loop outcomes in monitoring/observability_foundation.py with 45 targeted tests; pending COMMANDER review (STANDARD tier).
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -25,6 +26,7 @@ Status       : Phase 7.3 runtime auto-run loop foundation is active. Phase 6.4.1
 [NEXT PRIORITY]
 - COMMANDER review for Phase 6.4.1 monitoring & circuit-breaker FOUNDATION (STANDARD tier; monitoring/foundation.py with deterministic ALLOW/BLOCK/HALT decision contract and 26 passing tests).
 - COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
+- COMMANDER review for Phase 7.4 observability / visibility foundation (STANDARD tier; monitoring/observability_foundation.py with visible/partial/blocked categories over 6.4.1/7.2/7.3 surfaces and 45 passing tests).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 18:21
+**Last Updated:** 2026-04-18 22:58
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -95,6 +95,7 @@
 | 7.1 | Public Activation Trigger Surface (Single Entrypoint) | ✅ Done | Merged with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
 | 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | ✅ Done | Deterministic triggered/skipped/blocked result categories delivered; blocked(invalid_contract) for negative quota; one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | 🚧 In Progress | Bounded deterministic loop over the 7.2 scheduler boundary active on claude/runtime-auto-run-loop-cBVTs; loop result categories: completed/stopped_hold/stopped_blocked/exhausted; deterministic stop reasons; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
+| 7.4 | Observability / Visibility Foundation | 🚧 In Progress | Narrow deterministic visibility layer over 6.4.1 monitoring evaluations, 7.2 scheduler decisions, and 7.3 loop outcomes; visibility categories: visible/partial/blocked; per-iteration records; pure functions only; active on claude/add-observability-visibility-tydYW; pending COMMANDER review (STANDARD tier). |
 
 ---
 

--- a/projects/polymarket/polyquantbot/monitoring/observability_foundation.py
+++ b/projects/polymarket/polyquantbot/monitoring/observability_foundation.py
@@ -1,0 +1,339 @@
+"""Phase 7.4 -- Observability / Visibility Foundation.
+
+Narrow deterministic visibility layer over:
+  - Phase 6.4.1 monitoring evaluation results  (MonitoringEvaluationResult)
+  - Phase 7.2 scheduler invocation decisions   (SchedulerInvocationResult)
+  - Phase 7.3 runtime auto-run loop outcomes   (RuntimeAutoRunLoopResult)
+
+Visibility categories (deterministic, pure):
+  visible  -- full trace fields available; anomaly or trigger outcome surfaced
+  partial  -- record available; detail fields absent or non-anomalous
+  blocked  -- evaluation poisoned (INVALID_CONTRACT_INPUT) or scheduler hard-blocked
+
+Visibility status rules:
+  MonitoringEvaluationVisibilityRecord:
+    blocked  if INVALID_CONTRACT_INPUT in all_anomalies
+    partial  if decision == ALLOW (no anomalies)
+    visible  otherwise (anomalies present, contract valid)
+
+  SchedulerDecisionVisibilityRecord:
+    blocked  if scheduler_result == "blocked"
+    partial  if scheduler_result == "skipped"
+    visible  if scheduler_result == "triggered"
+
+  LoopOutcomeVisibilityRecord:
+    blocked  if loop_stop_reason == "invalid_contract"
+    partial  if loop_result == "exhausted" (and not invalid_contract)
+    visible  if loop_result in (completed / stopped_hold / stopped_blocked)
+
+Pure functions -- no state, no side effects, no async, no alert transport.
+No dashboards, no distributed monitoring mesh, no async workers,
+no cron daemon rollout, no remediation automation, no live trading enablement.
+
+Claim Level : NARROW INTEGRATION
+Not in scope: alert delivery, dashboards, distributed monitoring mesh,
+              async workers, cron daemon rollout, remediation automation,
+              live trading enablement, broader production observability program.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from projects.polymarket.polyquantbot.monitoring.foundation import (
+    MonitoringAnomalyCategory,
+    MonitoringDecision,
+    MonitoringEvaluationResult,
+)
+from projects.polymarket.polyquantbot.core.lightweight_activation_scheduler import (
+    SCHEDULER_RESULT_BLOCKED,
+    SCHEDULER_RESULT_TRIGGERED,
+    SchedulerInvocationResult,
+)
+from projects.polymarket.polyquantbot.core.runtime_auto_run_loop import (
+    LOOP_RESULT_COMPLETED,
+    LOOP_RESULT_STOPPED_BLOCKED,
+    LOOP_RESULT_STOPPED_HOLD,
+    LOOP_STOP_INVALID_CONTRACT,
+    RuntimeAutoRunLoopResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Visibility status categories
+# ---------------------------------------------------------------------------
+
+
+class VisibilityStatus(str, Enum):
+    """Deterministic visibility categories for Phase 7.4 observability records."""
+
+    VISIBLE = "visible"    # full trace; anomaly or trigger outcome surfaced
+    PARTIAL = "partial"    # record available; detail absent or non-anomalous
+    BLOCKED = "blocked"    # evaluation poisoned or hard-blocked
+
+
+# ---------------------------------------------------------------------------
+# Per-surface visibility record types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MonitoringEvaluationVisibilityRecord:
+    """Deterministic visibility record for a Phase 6.4.1 monitoring evaluation."""
+
+    trace_id: str
+    visibility_status: VisibilityStatus
+    decision: MonitoringDecision
+    primary_anomaly: Optional[MonitoringAnomalyCategory]
+    all_anomalies: tuple[MonitoringAnomalyCategory, ...]
+    policy_ref: str
+    eval_ref: str
+    timestamp_ms: int
+    visibility_note: str
+
+
+@dataclass(frozen=True)
+class SchedulerDecisionVisibilityRecord:
+    """Deterministic visibility record for a Phase 7.2 scheduler invocation decision."""
+
+    trace_id: str
+    visibility_status: VisibilityStatus
+    scheduler_result: str
+    skip_reason: Optional[str]
+    block_reason: Optional[str]
+    trigger_result_category: Optional[str]
+    visibility_note: str
+
+
+@dataclass(frozen=True)
+class LoopIterationVisibilityRecord:
+    """Per-iteration visibility record within a Phase 7.3 auto-run loop run."""
+
+    trace_id: str
+    iteration_index: int
+    scheduler_visibility: SchedulerDecisionVisibilityRecord
+    iteration_visibility_note: str
+
+
+@dataclass(frozen=True)
+class LoopOutcomeVisibilityRecord:
+    """Deterministic aggregate visibility record for a Phase 7.3 auto-run loop outcome."""
+
+    trace_id: str
+    visibility_status: VisibilityStatus
+    loop_result: str
+    loop_stop_reason: Optional[str]
+    iterations_run: int
+    trigger_fire_count: int
+    iteration_visibility_records: list[LoopIterationVisibilityRecord]
+    visibility_note: str
+
+
+# ---------------------------------------------------------------------------
+# Boundary class -- pure visibility record builder
+# ---------------------------------------------------------------------------
+
+
+class ObservabilityVisibilityBoundary:
+    """Phase 7.4 deterministic visibility record builder.
+
+    Pure methods -- no state, no side effects, no async, no alert transport.
+    Equal inputs always produce equal outputs.
+    """
+
+    def record_monitoring_evaluation(
+        self,
+        trace_id: str,
+        evaluation_result: MonitoringEvaluationResult,
+    ) -> MonitoringEvaluationVisibilityRecord:
+        """Build a deterministic visibility record for one 6.4.1 evaluation result.
+
+        Visibility rules:
+          blocked  if INVALID_CONTRACT_INPUT is in all_anomalies
+          partial  if decision == ALLOW (no anomalies to surface)
+          visible  otherwise
+        """
+        if MonitoringAnomalyCategory.INVALID_CONTRACT_INPUT in evaluation_result.all_anomalies:
+            status = VisibilityStatus.BLOCKED
+            note = (
+                f"monitoring_evaluation: blocked -- INVALID_CONTRACT_INPUT"
+                f" eval_ref={evaluation_result.eval_ref}"
+            )
+        elif evaluation_result.decision == MonitoringDecision.ALLOW:
+            status = VisibilityStatus.PARTIAL
+            note = "monitoring_evaluation: partial -- ALLOW decision, no anomalies"
+        else:
+            status = VisibilityStatus.VISIBLE
+            primary_val = (
+                evaluation_result.primary_anomaly.value
+                if evaluation_result.primary_anomaly is not None
+                else "none"
+            )
+            note = (
+                f"monitoring_evaluation: visible -- {evaluation_result.decision.value}"
+                f" primary_anomaly={primary_val}"
+            )
+
+        return MonitoringEvaluationVisibilityRecord(
+            trace_id=trace_id,
+            visibility_status=status,
+            decision=evaluation_result.decision,
+            primary_anomaly=evaluation_result.primary_anomaly,
+            all_anomalies=evaluation_result.all_anomalies,
+            policy_ref=evaluation_result.policy_ref,
+            eval_ref=evaluation_result.eval_ref,
+            timestamp_ms=evaluation_result.timestamp_ms,
+            visibility_note=note,
+        )
+
+    def record_scheduler_decision(
+        self,
+        trace_id: str,
+        scheduler_result: SchedulerInvocationResult,
+    ) -> SchedulerDecisionVisibilityRecord:
+        """Build a deterministic visibility record for one 7.2 scheduler decision.
+
+        Visibility rules:
+          blocked  if scheduler_result == "blocked"
+          partial  if scheduler_result == "skipped"
+          visible  if scheduler_result == "triggered"
+        """
+        trigger_result_category: Optional[str] = None
+        if (
+            scheduler_result.scheduler_result == SCHEDULER_RESULT_TRIGGERED
+            and scheduler_result.trigger_result is not None
+        ):
+            trigger_result_category = scheduler_result.trigger_result.trigger_result
+
+        if scheduler_result.scheduler_result == SCHEDULER_RESULT_BLOCKED:
+            status = VisibilityStatus.BLOCKED
+            note = (
+                f"scheduler_decision: blocked -- block_reason={scheduler_result.block_reason}"
+            )
+        elif scheduler_result.scheduler_result == SCHEDULER_RESULT_TRIGGERED:
+            status = VisibilityStatus.VISIBLE
+            note = (
+                f"scheduler_decision: visible -- triggered"
+                f" trigger_result={trigger_result_category}"
+            )
+        else:
+            # skipped
+            status = VisibilityStatus.PARTIAL
+            note = (
+                f"scheduler_decision: partial -- {scheduler_result.scheduler_result}"
+                f" skip_reason={scheduler_result.skip_reason}"
+            )
+
+        return SchedulerDecisionVisibilityRecord(
+            trace_id=trace_id,
+            visibility_status=status,
+            scheduler_result=scheduler_result.scheduler_result,
+            skip_reason=scheduler_result.skip_reason,
+            block_reason=scheduler_result.block_reason,
+            trigger_result_category=trigger_result_category,
+            visibility_note=note,
+        )
+
+    def record_loop_outcome(
+        self,
+        trace_id: str,
+        loop_result: RuntimeAutoRunLoopResult,
+    ) -> LoopOutcomeVisibilityRecord:
+        """Build a deterministic visibility record for one 7.3 loop run outcome.
+
+        Per-iteration visibility is built from each LoopIterationRecord.
+        trigger_fire_count is computed from iteration records (scheduler_result == triggered).
+
+        Visibility rules:
+          blocked  if loop_stop_reason == "invalid_contract"
+          partial  if loop_result == "exhausted" (and not invalid_contract)
+          visible  if loop_result in (completed / stopped_hold / stopped_blocked)
+        """
+        trigger_fire_count = 0
+        iter_visibility_records: list[LoopIterationVisibilityRecord] = []
+
+        for iter_rec in loop_result.iteration_records:
+            iter_trace_id = f"{trace_id}:iter={iter_rec.iteration_index}"
+            sched_vis = self.record_scheduler_decision(iter_trace_id, iter_rec.scheduler_result)
+            if iter_rec.scheduler_result.scheduler_result == SCHEDULER_RESULT_TRIGGERED:
+                trigger_fire_count += 1
+            iter_note = (
+                f"iteration={iter_rec.iteration_index}:"
+                f" scheduler_visibility={sched_vis.visibility_status.value}"
+            )
+            iter_visibility_records.append(
+                LoopIterationVisibilityRecord(
+                    trace_id=iter_trace_id,
+                    iteration_index=iter_rec.iteration_index,
+                    scheduler_visibility=sched_vis,
+                    iteration_visibility_note=iter_note,
+                )
+            )
+
+        if loop_result.loop_stop_reason == LOOP_STOP_INVALID_CONTRACT:
+            status = VisibilityStatus.BLOCKED
+            note = "loop_outcome: blocked -- invalid_contract iterations_run=0"
+        elif loop_result.loop_result in (
+            LOOP_RESULT_COMPLETED,
+            LOOP_RESULT_STOPPED_HOLD,
+            LOOP_RESULT_STOPPED_BLOCKED,
+        ):
+            status = VisibilityStatus.VISIBLE
+            note = (
+                f"loop_outcome: visible -- {loop_result.loop_result}"
+                f" iterations_run={loop_result.iterations_run}"
+                f" triggers_fired={trigger_fire_count}"
+            )
+        else:
+            # exhausted (non-invalid-contract)
+            status = VisibilityStatus.PARTIAL
+            note = (
+                f"loop_outcome: partial -- exhausted"
+                f" stop_reason={loop_result.loop_stop_reason}"
+                f" iterations_run={loop_result.iterations_run}"
+            )
+
+        return LoopOutcomeVisibilityRecord(
+            trace_id=trace_id,
+            visibility_status=status,
+            loop_result=loop_result.loop_result,
+            loop_stop_reason=loop_result.loop_stop_reason,
+            iterations_run=loop_result.iterations_run,
+            trigger_fire_count=trigger_fire_count,
+            iteration_visibility_records=iter_visibility_records,
+            visibility_note=note,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level entrypoints
+# ---------------------------------------------------------------------------
+
+
+def record_monitoring_visibility(
+    trace_id: str,
+    evaluation_result: MonitoringEvaluationResult,
+) -> MonitoringEvaluationVisibilityRecord:
+    """Deterministic visibility record entrypoint for a 6.4.1 monitoring evaluation."""
+    return ObservabilityVisibilityBoundary().record_monitoring_evaluation(
+        trace_id, evaluation_result
+    )
+
+
+def record_scheduler_visibility(
+    trace_id: str,
+    scheduler_result: SchedulerInvocationResult,
+) -> SchedulerDecisionVisibilityRecord:
+    """Deterministic visibility record entrypoint for a 7.2 scheduler decision."""
+    return ObservabilityVisibilityBoundary().record_scheduler_decision(
+        trace_id, scheduler_result
+    )
+
+
+def record_loop_visibility(
+    trace_id: str,
+    loop_result: RuntimeAutoRunLoopResult,
+) -> LoopOutcomeVisibilityRecord:
+    """Deterministic visibility record entrypoint for a 7.3 auto-run loop outcome."""
+    return ObservabilityVisibilityBoundary().record_loop_outcome(trace_id, loop_result)

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-4_01_observability-visibility-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-4_01_observability-visibility-foundation.md
@@ -1,0 +1,149 @@
+# FORGE-X Report -- Phase 7.4 Observability / Visibility Foundation
+
+## 1) What was built
+
+Added a narrow observability / visibility foundation layer over the completed Phase 6.4.1
+monitoring evaluation contract and Phase 7.2 / 7.3 scheduler and loop boundaries.
+
+The layer produces deterministic, inspectable per-cycle and per-iteration visibility records
+without introducing alert transport, dashboards, distributed monitoring mesh, async workers,
+cron daemon rollout, or remediation automation.
+
+Specific additions:
+
+- `VisibilityStatus` enum -- three deterministic categories: `visible` / `partial` / `blocked`.
+- `MonitoringEvaluationVisibilityRecord` -- visibility record for one Phase 6.4.1 evaluation
+  result; surfaces decision, primary_anomaly, all_anomalies, policy_ref, eval_ref, timestamp_ms,
+  and a deterministic visibility_note.
+- `SchedulerDecisionVisibilityRecord` -- visibility record for one Phase 7.2 scheduler
+  invocation decision; surfaces scheduler_result, skip_reason, block_reason,
+  trigger_result_category, and visibility_note.
+- `LoopIterationVisibilityRecord` -- per-iteration visibility record within a Phase 7.3
+  loop run; contains iteration_index, a nested SchedulerDecisionVisibilityRecord, and
+  iteration_visibility_note. trace_id carries parent lineage as `{trace_id}:iter={index}`.
+- `LoopOutcomeVisibilityRecord` -- aggregate visibility record for one Phase 7.3 loop run;
+  surfaces loop_result, loop_stop_reason, iterations_run, trigger_fire_count (computed from
+  iteration records), the full list of LoopIterationVisibilityRecord instances, and
+  visibility_note.
+- `ObservabilityVisibilityBoundary` -- pure class with three methods:
+  `record_monitoring_evaluation`, `record_scheduler_decision`, `record_loop_outcome`.
+  No state, no side effects, no async. Equal inputs always produce equal outputs.
+- Three module-level entrypoints: `record_monitoring_visibility`, `record_scheduler_visibility`,
+  `record_loop_visibility`.
+- 45 targeted tests covering all visibility categories, edge cases, field propagation,
+  per-iteration record construction, trace lineage, note token presence, and determinism.
+
+## 2) Current system architecture (relevant slice)
+
+```
+Phase 7.4 Observability / Visibility Foundation
+    ObservabilityVisibilityBoundary (pure -- no state, no side effects)
+        |
+        +-- record_monitoring_evaluation(trace_id, MonitoringEvaluationResult)
+        |       -> MonitoringEvaluationVisibilityRecord
+        |          visibility_status:
+        |            blocked  if INVALID_CONTRACT_INPUT in all_anomalies
+        |            partial  if decision == ALLOW (no anomalies)
+        |            visible  otherwise
+        |
+        +-- record_scheduler_decision(trace_id, SchedulerInvocationResult)
+        |       -> SchedulerDecisionVisibilityRecord
+        |          visibility_status:
+        |            blocked  if scheduler_result == "blocked"
+        |            partial  if scheduler_result == "skipped"
+        |            visible  if scheduler_result == "triggered"
+        |
+        +-- record_loop_outcome(trace_id, RuntimeAutoRunLoopResult)
+                -> LoopOutcomeVisibilityRecord
+                   per-iteration: LoopIterationVisibilityRecord (nested scheduler vis)
+                   visibility_status:
+                     blocked  if loop_stop_reason == "invalid_contract"
+                     partial  if loop_result == "exhausted" (non-invalid-contract)
+                     visible  if loop_result in (completed/stopped_hold/stopped_blocked)
+                   trigger_fire_count: computed from iteration_records
+
+Upstream contracts consumed (read-only, unchanged):
+  Phase 6.4.1  monitoring/foundation.py  -- MonitoringEvaluationResult
+  Phase 7.2    core/lightweight_activation_scheduler.py  -- SchedulerInvocationResult
+  Phase 7.3    core/runtime_auto_run_loop.py  -- RuntimeAutoRunLoopResult / LoopIterationRecord
+```
+
+## 3) Files created / modified (full repo-root paths)
+
+**Created**
+- `projects/polymarket/polyquantbot/monitoring/observability_foundation.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_4_observability_visibility_foundation_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-4_01_observability-visibility-foundation.md`
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- `record_monitoring_evaluation` returns `blocked` when INVALID_CONTRACT_INPUT is in the
+  evaluation result's all_anomalies set; visibility_note contains "blocked" token and eval_ref.
+- `record_monitoring_evaluation` returns `partial` when decision is ALLOW (no anomalies);
+  visibility_note contains "partial" token.
+- `record_monitoring_evaluation` returns `visible` when anomalies are present and contract is
+  valid; primary_anomaly and all_anomalies are surfaced in record.
+- `record_scheduler_decision` returns `blocked` when scheduler_result is "blocked"; block_reason
+  propagated.
+- `record_scheduler_decision` returns `partial` when scheduler_result is "skipped"; skip_reason
+  propagated.
+- `record_scheduler_decision` returns `visible` when scheduler_result is "triggered";
+  trigger_result_category correctly propagated from PublicActivationTriggerResult.
+- `record_loop_outcome` returns `blocked` when loop_stop_reason is "invalid_contract";
+  iteration_visibility_records is empty; trigger_fire_count is 0.
+- `record_loop_outcome` returns `partial` when loop_result is "exhausted" with non-invalid-contract
+  stop reason; iterations_run propagated correctly.
+- `record_loop_outcome` returns `visible` when loop_result is completed, stopped_hold, or
+  stopped_blocked; trigger_fire_count is computed from iteration records.
+- Per-iteration LoopIterationVisibilityRecord instances contain nested SchedulerDecisionVisibilityRecord;
+  count matches iterations_run; trace_id carries parent lineage.
+- Module-level entrypoints (record_monitoring_visibility, record_scheduler_visibility,
+  record_loop_visibility) delegate correctly and return expected record types.
+- All records are frozen dataclasses; equal inputs always produce equal outputs (deterministic).
+- 6.4.1–6.4.10, 6.5.x, 6.6.x, and 7.0–7.3 contracts preserved; their modules are not modified.
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/monitoring/observability_foundation.py`
+   -- OK
+2. `PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/tests/test_phase7_4_observability_visibility_foundation_20260418.py`
+   -- OK
+3. `PYTHONIOENCODING=utf-8 PYTHONPATH=/home/user/walker-ai-team python -m pytest -q \
+   projects/polymarket/polyquantbot/tests/test_phase7_4_observability_visibility_foundation_20260418.py \
+   projects/polymarket/polyquantbot/tests/test_phase7_3_runtime_auto_run_loop_20260418.py \
+   projects/polymarket/polyquantbot/tests/test_phase7_2_lightweight_activation_scheduler_20260418.py \
+   projects/polymarket/polyquantbot/tests/test_phase7_1_public_activation_trigger_surface_20260418.py \
+   projects/polymarket/polyquantbot/tests/test_phase7_0_public_activation_cycle_orchestration_20260418.py \
+   projects/polymarket/polyquantbot/tests/test_monitoring_foundation.py`
+   -- 132 passed, 1 warning (pre-existing asyncio_mode warning, non-runtime)
+
+## 5) Known issues
+
+- Pre-existing deferred repo warning: `Unknown config option: asyncio_mode` in pytest config.
+  Non-runtime hygiene backlog, unchanged from prior phases.
+- `core/` imports from `api/` (core -> api layering direction) carried forward from 7.2/7.3;
+  not addressed in this slice -- stays within declared scope.
+- PROJECT_STATE.md COMPLETED section has exceeded cap-10; all entries are in ROADMAP.md.
+  Oldest entries are candidates for COMMANDER pruning; no operational truth is lost.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : observability / visibility foundation only -- deterministic visibility records
+                    over Phase 6.4.1 monitoring evaluation results, Phase 7.2 scheduler decisions,
+                    and Phase 7.3 runtime auto-run loop outcomes
+Not in Scope      : alert delivery, dashboards, distributed monitoring mesh, async workers,
+                    cron daemon rollout, remediation automation, live trading enablement,
+                    broader production observability program
+Suggested Next    : COMMANDER review
+
+---
+
+**Report Timestamp:** 2026-04-18 22:58 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** phase7-4-observability-visibility-foundation
+**Branch:** `claude/add-observability-visibility-tydYW`

--- a/projects/polymarket/polyquantbot/tests/test_phase7_4_observability_visibility_foundation_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_4_observability_visibility_foundation_20260418.py
@@ -1,0 +1,683 @@
+"""Phase 7.4 -- Observability / Visibility Foundation Tests.
+
+Validates the deterministic visibility record builder implemented in
+monitoring/observability_foundation.py.
+
+Coverage:
+  OBS-01   monitoring: visible when anomaly present (BLOCK decision)
+  OBS-02   monitoring: visible when HALT anomaly (KILL_SWITCH_TRIGGERED)
+  OBS-03   monitoring: visible when multiple anomalies (primary surfaced)
+  OBS-04   monitoring: partial when ALLOW decision (no anomalies)
+  OBS-05   monitoring: blocked when INVALID_CONTRACT_INPUT in anomaly set
+  OBS-06   monitoring: trace_id propagated
+  OBS-07   monitoring: all fields from evaluation_result propagated
+  OBS-08   monitoring: visibility_note contains status token
+  OBS-09   scheduler: visible when triggered
+  OBS-10   scheduler: trigger_result_category propagated on triggered result
+  OBS-11   scheduler: partial when skipped -- already_running
+  OBS-12   scheduler: partial when skipped -- window_not_open
+  OBS-13   scheduler: partial when skipped -- quota_reached
+  OBS-14   scheduler: blocked when blocked -- schedule_disabled
+  OBS-15   scheduler: blocked when blocked -- invalid_contract
+  OBS-16   scheduler: trace_id propagated
+  OBS-17   scheduler: visibility_note contains status token
+  OBS-18   loop: visible when completed
+  OBS-19   loop: visible when stopped_hold
+  OBS-20   loop: visible when stopped_blocked
+  OBS-21   loop: partial when exhausted (no triggers fired)
+  OBS-22   loop: blocked when invalid_contract
+  OBS-23   loop: trigger_fire_count computed correctly
+  OBS-24   loop: iterations_run propagated
+  OBS-25   loop: per-iteration visibility records built
+  OBS-26   loop: iteration_visibility_records count matches iterations_run
+  OBS-27   loop: per-iteration trace_id contains parent trace_id
+  OBS-28   loop: visibility_note contains status token
+  OBS-29   module-level record_monitoring_visibility entrypoint works
+  OBS-30   module-level record_scheduler_visibility entrypoint works
+  OBS-31   module-level record_loop_visibility entrypoint works
+  OBS-32   determinism -- equal inputs produce equal outputs (monitoring)
+  OBS-33   determinism -- equal inputs produce equal outputs (scheduler)
+"""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.api.public_activation_trigger_cli import (
+    PublicActivationTriggerResult,
+)
+from projects.polymarket.polyquantbot.core.lightweight_activation_scheduler import (
+    SCHEDULER_BLOCK_INVALID_CONTRACT,
+    SCHEDULER_BLOCK_SCHEDULE_DISABLED,
+    SCHEDULER_RESULT_BLOCKED,
+    SCHEDULER_RESULT_SKIPPED,
+    SCHEDULER_RESULT_TRIGGERED,
+    SCHEDULER_SKIP_ALREADY_RUNNING,
+    SCHEDULER_SKIP_QUOTA_REACHED,
+    SCHEDULER_SKIP_WINDOW_NOT_OPEN,
+    SchedulerInvocationPolicy,
+    SchedulerInvocationResult,
+    decide_and_invoke_scheduler,
+)
+from projects.polymarket.polyquantbot.core.runtime_auto_run_loop import (
+    LOOP_RESULT_COMPLETED,
+    LOOP_RESULT_EXHAUSTED,
+    LOOP_RESULT_STOPPED_BLOCKED,
+    LOOP_RESULT_STOPPED_HOLD,
+    LOOP_STOP_INVALID_CONTRACT,
+    LOOP_STOP_NO_TRIGGERS_FIRED,
+    run_auto_loop,
+)
+from projects.polymarket.polyquantbot.monitoring.foundation import (
+    MonitoringAnomalyCategory,
+    MonitoringContractInput,
+    MonitoringDecision,
+    evaluate_monitoring_contract,
+)
+from projects.polymarket.polyquantbot.monitoring.observability_foundation import (
+    LoopOutcomeVisibilityRecord,
+    MonitoringEvaluationVisibilityRecord,
+    ObservabilityVisibilityBoundary,
+    SchedulerDecisionVisibilityRecord,
+    VisibilityStatus,
+    record_loop_visibility,
+    record_monitoring_visibility,
+    record_scheduler_visibility,
+)
+from projects.polymarket.polyquantbot.platform.wallet_auth.wallet_lifecycle_foundation import (
+    PublicActivationCyclePolicy,
+    WALLET_CORRECTION_RESULT_ACCEPTED,
+    WALLET_CORRECTION_RESULT_BLOCKED,
+    WALLET_RECONCILIATION_OUTCOME_MATCH,
+    WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH,
+    WALLET_RETRY_WORK_DECISION_SKIPPED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_monitoring_input(**overrides) -> MonitoringContractInput:  # type: ignore[no-untyped-def]
+    defaults: dict = dict(
+        policy_ref="policy-v1",
+        eval_ref="eval-001",
+        timestamp_ms=1_700_000_000_000,
+        exposure_ratio=0.05,
+        position_notional_usd=500.0,
+        total_capital_usd=10_000.0,
+        data_freshness_ms=200,
+        quality_score=0.90,
+        signal_dedup_ok=True,
+        kill_switch_armed=False,
+        kill_switch_triggered=False,
+        monitoring_enabled=True,
+        quality_guard_enabled=True,
+        exposure_guard_enabled=True,
+        max_exposure_ratio=0.10,
+        max_data_freshness_ms=5_000,
+        min_quality_score=0.60,
+    )
+    defaults.update(overrides)
+    return MonitoringContractInput(**defaults)
+
+
+def _triggered_scheduler_result(trigger_result_category: str = "completed") -> SchedulerInvocationResult:
+    trigger = PublicActivationTriggerResult(
+        trigger_result=trigger_result_category,
+        cycle_result_category=trigger_result_category,
+        cycle_stop_reason=None,
+        cycle_completed=(trigger_result_category == "completed"),
+        wallet_binding_id="wallet-obs-1",
+        owner_user_id="user-obs-1",
+        cycle_notes=[],
+    )
+    return SchedulerInvocationResult(
+        scheduler_result=SCHEDULER_RESULT_TRIGGERED,
+        skip_reason=None,
+        block_reason=None,
+        trigger_result=trigger,
+        scheduler_notes=["triggering: all scheduling conditions met"],
+    )
+
+
+def _skipped_scheduler_result(skip_reason: str) -> SchedulerInvocationResult:
+    return SchedulerInvocationResult(
+        scheduler_result=SCHEDULER_RESULT_SKIPPED,
+        skip_reason=skip_reason,
+        block_reason=None,
+        trigger_result=None,
+        scheduler_notes=[f"skipped: {skip_reason}"],
+    )
+
+
+def _blocked_scheduler_result(block_reason: str) -> SchedulerInvocationResult:
+    return SchedulerInvocationResult(
+        scheduler_result=SCHEDULER_RESULT_BLOCKED,
+        skip_reason=None,
+        block_reason=block_reason,
+        trigger_result=None,
+        scheduler_notes=[f"blocked: {block_reason}"],
+    )
+
+
+def _trigger_policy(**kwargs) -> PublicActivationCyclePolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "wallet_binding_id": "wallet-obs-1",
+        "owner_user_id": "user-obs-1",
+        "requester_user_id": "user-obs-1",
+        "wallet_active": True,
+        "state_read_batch_ready": True,
+        "reconciliation_outcome": WALLET_RECONCILIATION_OUTCOME_MATCH,
+        "correction_result_category": WALLET_CORRECTION_RESULT_ACCEPTED,
+        "retry_result_category": WALLET_RETRY_WORK_DECISION_SKIPPED,
+    }
+    defaults.update(kwargs)
+    return PublicActivationCyclePolicy(**defaults)
+
+
+def _scheduler_policy(**kwargs) -> SchedulerInvocationPolicy:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "trigger_policy": _trigger_policy(),
+        "schedule_enabled": True,
+        "invocation_window_open": True,
+        "invocation_quota_remaining": 10,
+        "concurrent_invocation_active": False,
+    }
+    defaults.update(kwargs)
+    return SchedulerInvocationPolicy(**defaults)
+
+
+def _completed_scheduler_policy() -> SchedulerInvocationPolicy:
+    return _scheduler_policy()
+
+
+def _stopped_hold_scheduler_policy() -> SchedulerInvocationPolicy:
+    return _scheduler_policy(
+        trigger_policy=_trigger_policy(correction_result_category=WALLET_CORRECTION_RESULT_BLOCKED)
+    )
+
+
+def _stopped_blocked_scheduler_policy() -> SchedulerInvocationPolicy:
+    return _scheduler_policy(
+        trigger_policy=_trigger_policy(
+            reconciliation_outcome=WALLET_RECONCILIATION_OUTCOME_REVISION_MISMATCH
+        )
+    )
+
+
+def _scheduler_skipped_policy() -> SchedulerInvocationPolicy:
+    return _scheduler_policy(invocation_window_open=False)
+
+
+def _scheduler_blocked_policy() -> SchedulerInvocationPolicy:
+    return _scheduler_policy(schedule_enabled=False)
+
+
+_boundary = ObservabilityVisibilityBoundary()
+
+
+# ---------------------------------------------------------------------------
+# OBS-01  monitoring: visible when anomaly present (BLOCK decision)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_visible_when_block_anomaly() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(exposure_ratio=0.15))
+    record = _boundary.record_monitoring_evaluation("trace-001", result)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+
+
+# ---------------------------------------------------------------------------
+# OBS-02  monitoring: visible when HALT anomaly (KILL_SWITCH_TRIGGERED)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_visible_when_halt_anomaly() -> None:
+    result = evaluate_monitoring_contract(
+        _clean_monitoring_input(kill_switch_armed=True, kill_switch_triggered=True)
+    )
+    record = _boundary.record_monitoring_evaluation("trace-002", result)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+    assert record.decision == MonitoringDecision.HALT
+
+
+# ---------------------------------------------------------------------------
+# OBS-03  monitoring: visible when multiple anomalies (primary surfaced)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_visible_with_multiple_anomalies_surfaces_primary() -> None:
+    result = evaluate_monitoring_contract(
+        _clean_monitoring_input(
+            exposure_ratio=0.15,
+            data_freshness_ms=10_000,
+            quality_score=0.10,
+        )
+    )
+    record = _boundary.record_monitoring_evaluation("trace-003", result)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+    assert len(record.all_anomalies) > 1
+    assert record.primary_anomaly is not None
+
+
+# ---------------------------------------------------------------------------
+# OBS-04  monitoring: partial when ALLOW decision (no anomalies)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_partial_when_allow() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input())
+    record = _boundary.record_monitoring_evaluation("trace-004", result)
+    assert record.visibility_status == VisibilityStatus.PARTIAL
+    assert record.decision == MonitoringDecision.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# OBS-05  monitoring: blocked when INVALID_CONTRACT_INPUT in anomaly set
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_blocked_when_invalid_contract_input() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(policy_ref=""))
+    assert MonitoringAnomalyCategory.INVALID_CONTRACT_INPUT in result.all_anomalies
+    record = _boundary.record_monitoring_evaluation("trace-005", result)
+    assert record.visibility_status == VisibilityStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# OBS-06  monitoring: trace_id propagated
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_trace_id_propagated() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(exposure_ratio=0.15))
+    record = _boundary.record_monitoring_evaluation("my-trace-id", result)
+    assert record.trace_id == "my-trace-id"
+
+
+# ---------------------------------------------------------------------------
+# OBS-07  monitoring: all fields from evaluation_result propagated
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_evaluation_fields_propagated() -> None:
+    inp = _clean_monitoring_input()
+    result = evaluate_monitoring_contract(inp)
+    record = _boundary.record_monitoring_evaluation("trace-007", result)
+    assert record.policy_ref == inp.policy_ref
+    assert record.eval_ref == inp.eval_ref
+    assert record.timestamp_ms == inp.timestamp_ms
+    assert record.decision == result.decision
+    assert record.primary_anomaly == result.primary_anomaly
+    assert record.all_anomalies == result.all_anomalies
+
+
+# ---------------------------------------------------------------------------
+# OBS-08  monitoring: visibility_note contains status token
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_visibility_note_contains_status_token_visible() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(exposure_ratio=0.15))
+    record = _boundary.record_monitoring_evaluation("trace-008", result)
+    assert "visible" in record.visibility_note
+
+
+def test_monitoring_visibility_note_contains_status_token_partial() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input())
+    record = _boundary.record_monitoring_evaluation("trace-008b", result)
+    assert "partial" in record.visibility_note
+
+
+def test_monitoring_visibility_note_contains_status_token_blocked() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(policy_ref=""))
+    record = _boundary.record_monitoring_evaluation("trace-008c", result)
+    assert "blocked" in record.visibility_note
+
+
+# ---------------------------------------------------------------------------
+# OBS-09  scheduler: visible when triggered
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_visible_when_triggered() -> None:
+    sr = _triggered_scheduler_result("completed")
+    record = _boundary.record_scheduler_decision("trace-009", sr)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+
+
+# ---------------------------------------------------------------------------
+# OBS-10  scheduler: trigger_result_category propagated on triggered result
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_trigger_result_category_propagated_completed() -> None:
+    sr = _triggered_scheduler_result("completed")
+    record = _boundary.record_scheduler_decision("trace-010", sr)
+    assert record.trigger_result_category == "completed"
+
+
+def test_scheduler_trigger_result_category_propagated_stopped_hold() -> None:
+    sr = _triggered_scheduler_result("stopped_hold")
+    record = _boundary.record_scheduler_decision("trace-010b", sr)
+    assert record.trigger_result_category == "stopped_hold"
+
+
+def test_scheduler_trigger_result_category_propagated_stopped_blocked() -> None:
+    sr = _triggered_scheduler_result("stopped_blocked")
+    record = _boundary.record_scheduler_decision("trace-010c", sr)
+    assert record.trigger_result_category == "stopped_blocked"
+
+
+# ---------------------------------------------------------------------------
+# OBS-11  scheduler: partial when skipped -- already_running
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_partial_when_skipped_already_running() -> None:
+    sr = _skipped_scheduler_result(SCHEDULER_SKIP_ALREADY_RUNNING)
+    record = _boundary.record_scheduler_decision("trace-011", sr)
+    assert record.visibility_status == VisibilityStatus.PARTIAL
+    assert record.skip_reason == SCHEDULER_SKIP_ALREADY_RUNNING
+
+
+# ---------------------------------------------------------------------------
+# OBS-12  scheduler: partial when skipped -- window_not_open
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_partial_when_skipped_window_not_open() -> None:
+    sr = _skipped_scheduler_result(SCHEDULER_SKIP_WINDOW_NOT_OPEN)
+    record = _boundary.record_scheduler_decision("trace-012", sr)
+    assert record.visibility_status == VisibilityStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# OBS-13  scheduler: partial when skipped -- quota_reached
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_partial_when_skipped_quota_reached() -> None:
+    sr = _skipped_scheduler_result(SCHEDULER_SKIP_QUOTA_REACHED)
+    record = _boundary.record_scheduler_decision("trace-013", sr)
+    assert record.visibility_status == VisibilityStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# OBS-14  scheduler: blocked when blocked -- schedule_disabled
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_blocked_when_schedule_disabled() -> None:
+    sr = _blocked_scheduler_result(SCHEDULER_BLOCK_SCHEDULE_DISABLED)
+    record = _boundary.record_scheduler_decision("trace-014", sr)
+    assert record.visibility_status == VisibilityStatus.BLOCKED
+    assert record.block_reason == SCHEDULER_BLOCK_SCHEDULE_DISABLED
+
+
+# ---------------------------------------------------------------------------
+# OBS-15  scheduler: blocked when blocked -- invalid_contract
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_blocked_when_invalid_contract() -> None:
+    sr = _blocked_scheduler_result(SCHEDULER_BLOCK_INVALID_CONTRACT)
+    record = _boundary.record_scheduler_decision("trace-015", sr)
+    assert record.visibility_status == VisibilityStatus.BLOCKED
+    assert record.block_reason == SCHEDULER_BLOCK_INVALID_CONTRACT
+
+
+# ---------------------------------------------------------------------------
+# OBS-16  scheduler: trace_id propagated
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_trace_id_propagated() -> None:
+    sr = _triggered_scheduler_result("completed")
+    record = _boundary.record_scheduler_decision("sched-trace-id", sr)
+    assert record.trace_id == "sched-trace-id"
+
+
+# ---------------------------------------------------------------------------
+# OBS-17  scheduler: visibility_note contains status token
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_visibility_note_contains_visible_token() -> None:
+    sr = _triggered_scheduler_result("completed")
+    record = _boundary.record_scheduler_decision("trace-017", sr)
+    assert "visible" in record.visibility_note
+
+
+def test_scheduler_visibility_note_contains_partial_token() -> None:
+    sr = _skipped_scheduler_result(SCHEDULER_SKIP_WINDOW_NOT_OPEN)
+    record = _boundary.record_scheduler_decision("trace-017b", sr)
+    assert "partial" in record.visibility_note
+
+
+def test_scheduler_visibility_note_contains_blocked_token() -> None:
+    sr = _blocked_scheduler_result(SCHEDULER_BLOCK_SCHEDULE_DISABLED)
+    record = _boundary.record_scheduler_decision("trace-017c", sr)
+    assert "blocked" in record.visibility_note
+
+
+# ---------------------------------------------------------------------------
+# OBS-18  loop: visible when completed
+# ---------------------------------------------------------------------------
+
+
+def test_loop_visible_when_completed() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=2)
+    assert loop_res.loop_result == LOOP_RESULT_COMPLETED
+    record = _boundary.record_loop_outcome("trace-018", loop_res)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+
+
+# ---------------------------------------------------------------------------
+# OBS-19  loop: visible when stopped_hold
+# ---------------------------------------------------------------------------
+
+
+def test_loop_visible_when_stopped_hold() -> None:
+    loop_res = run_auto_loop(_stopped_hold_scheduler_policy(), max_iterations=3)
+    assert loop_res.loop_result == LOOP_RESULT_STOPPED_HOLD
+    record = _boundary.record_loop_outcome("trace-019", loop_res)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+
+
+# ---------------------------------------------------------------------------
+# OBS-20  loop: visible when stopped_blocked
+# ---------------------------------------------------------------------------
+
+
+def test_loop_visible_when_stopped_blocked() -> None:
+    loop_res = run_auto_loop(_stopped_blocked_scheduler_policy(), max_iterations=3)
+    assert loop_res.loop_result == LOOP_RESULT_STOPPED_BLOCKED
+    record = _boundary.record_loop_outcome("trace-020", loop_res)
+    assert record.visibility_status == VisibilityStatus.VISIBLE
+
+
+# ---------------------------------------------------------------------------
+# OBS-21  loop: partial when exhausted (no triggers fired)
+# ---------------------------------------------------------------------------
+
+
+def test_loop_partial_when_exhausted_no_triggers() -> None:
+    loop_res = run_auto_loop(_scheduler_skipped_policy(), max_iterations=3)
+    assert loop_res.loop_result == LOOP_RESULT_EXHAUSTED
+    assert loop_res.loop_stop_reason == LOOP_STOP_NO_TRIGGERS_FIRED
+    record = _boundary.record_loop_outcome("trace-021", loop_res)
+    assert record.visibility_status == VisibilityStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# OBS-22  loop: blocked when invalid_contract
+# ---------------------------------------------------------------------------
+
+
+def test_loop_blocked_when_invalid_contract() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=0)
+    assert loop_res.loop_stop_reason == LOOP_STOP_INVALID_CONTRACT
+    record = _boundary.record_loop_outcome("trace-022", loop_res)
+    assert record.visibility_status == VisibilityStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# OBS-23  loop: trigger_fire_count computed correctly
+# ---------------------------------------------------------------------------
+
+
+def test_loop_trigger_fire_count_completed_two_iterations() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=2)
+    record = _boundary.record_loop_outcome("trace-023", loop_res)
+    assert record.trigger_fire_count == 2
+
+
+def test_loop_trigger_fire_count_zero_when_all_skipped() -> None:
+    loop_res = run_auto_loop(_scheduler_skipped_policy(), max_iterations=3)
+    record = _boundary.record_loop_outcome("trace-023b", loop_res)
+    assert record.trigger_fire_count == 0
+
+
+def test_loop_trigger_fire_count_one_when_stopped_hold_at_first_iteration() -> None:
+    loop_res = run_auto_loop(_stopped_hold_scheduler_policy(), max_iterations=5)
+    record = _boundary.record_loop_outcome("trace-023c", loop_res)
+    assert record.trigger_fire_count == 1
+
+
+# ---------------------------------------------------------------------------
+# OBS-24  loop: iterations_run propagated
+# ---------------------------------------------------------------------------
+
+
+def test_loop_iterations_run_propagated() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=3)
+    record = _boundary.record_loop_outcome("trace-024", loop_res)
+    assert record.iterations_run == loop_res.iterations_run
+
+
+# ---------------------------------------------------------------------------
+# OBS-25  loop: per-iteration visibility records built
+# ---------------------------------------------------------------------------
+
+
+def test_loop_per_iteration_visibility_records_have_scheduler_visibility() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=2)
+    record = _boundary.record_loop_outcome("trace-025", loop_res)
+    for iter_vis in record.iteration_visibility_records:
+        assert isinstance(iter_vis.scheduler_visibility, SchedulerDecisionVisibilityRecord)
+
+
+# ---------------------------------------------------------------------------
+# OBS-26  loop: iteration_visibility_records count matches iterations_run
+# ---------------------------------------------------------------------------
+
+
+def test_loop_iteration_visibility_records_count_matches_iterations_run() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=3)
+    record = _boundary.record_loop_outcome("trace-026", loop_res)
+    assert len(record.iteration_visibility_records) == loop_res.iterations_run
+
+
+def test_loop_iteration_visibility_records_empty_on_invalid_contract() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=0)
+    record = _boundary.record_loop_outcome("trace-026b", loop_res)
+    assert len(record.iteration_visibility_records) == 0
+
+
+# ---------------------------------------------------------------------------
+# OBS-27  loop: per-iteration trace_id contains parent trace_id
+# ---------------------------------------------------------------------------
+
+
+def test_loop_per_iteration_trace_id_contains_parent_trace_id() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=2)
+    record = _boundary.record_loop_outcome("parent-trace", loop_res)
+    for iter_vis in record.iteration_visibility_records:
+        assert "parent-trace" in iter_vis.trace_id
+
+
+def test_loop_per_iteration_trace_id_contains_iteration_index() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=2)
+    record = _boundary.record_loop_outcome("loop-trace", loop_res)
+    for iter_vis in record.iteration_visibility_records:
+        assert f"iter={iter_vis.iteration_index}" in iter_vis.trace_id
+
+
+# ---------------------------------------------------------------------------
+# OBS-28  loop: visibility_note contains status token
+# ---------------------------------------------------------------------------
+
+
+def test_loop_visibility_note_contains_visible_token() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=1)
+    record = _boundary.record_loop_outcome("trace-028", loop_res)
+    assert "visible" in record.visibility_note
+
+
+def test_loop_visibility_note_contains_partial_token() -> None:
+    loop_res = run_auto_loop(_scheduler_skipped_policy(), max_iterations=2)
+    record = _boundary.record_loop_outcome("trace-028b", loop_res)
+    assert "partial" in record.visibility_note
+
+
+def test_loop_visibility_note_contains_blocked_token() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=0)
+    record = _boundary.record_loop_outcome("trace-028c", loop_res)
+    assert "blocked" in record.visibility_note
+
+
+# ---------------------------------------------------------------------------
+# OBS-29  module-level record_monitoring_visibility entrypoint works
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_record_monitoring_visibility_returns_correct_type() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input())
+    record = record_monitoring_visibility("trace-029", result)
+    assert isinstance(record, MonitoringEvaluationVisibilityRecord)
+
+
+# ---------------------------------------------------------------------------
+# OBS-30  module-level record_scheduler_visibility entrypoint works
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_record_scheduler_visibility_returns_correct_type() -> None:
+    sr = _triggered_scheduler_result("completed")
+    record = record_scheduler_visibility("trace-030", sr)
+    assert isinstance(record, SchedulerDecisionVisibilityRecord)
+
+
+# ---------------------------------------------------------------------------
+# OBS-31  module-level record_loop_visibility entrypoint works
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_record_loop_visibility_returns_correct_type() -> None:
+    loop_res = run_auto_loop(_completed_scheduler_policy(), max_iterations=1)
+    record = record_loop_visibility("trace-031", loop_res)
+    assert isinstance(record, LoopOutcomeVisibilityRecord)
+
+
+# ---------------------------------------------------------------------------
+# OBS-32  determinism -- equal inputs produce equal outputs (monitoring)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_determinism_equal_inputs_equal_outputs() -> None:
+    result = evaluate_monitoring_contract(_clean_monitoring_input(exposure_ratio=0.15))
+    r1 = _boundary.record_monitoring_evaluation("trace-det", result)
+    r2 = _boundary.record_monitoring_evaluation("trace-det", result)
+    assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# OBS-33  determinism -- equal inputs produce equal outputs (scheduler)
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_determinism_equal_inputs_equal_outputs() -> None:
+    sr = _triggered_scheduler_result("completed")
+    r1 = _boundary.record_scheduler_decision("trace-det", sr)
+    r2 = _boundary.record_scheduler_decision("trace-det", sr)
+    assert r1 == r2


### PR DESCRIPTION
- monitoring/observability_foundation.py: VisibilityStatus enum (visible/partial/blocked),
  MonitoringEvaluationVisibilityRecord, SchedulerDecisionVisibilityRecord,
  LoopIterationVisibilityRecord, LoopOutcomeVisibilityRecord, ObservabilityVisibilityBoundary
  with three pure record-building methods, three module-level entrypoints
- tests/test_phase7_4_observability_visibility_foundation_20260418.py: 45 tests covering
  all visibility categories, edge cases, field propagation, per-iteration records, trace
  lineage, note token presence, and determinism; 132 total tests pass (new + 7.0-7.3 + 6.4.1)
- reports/forge/phase7-4_01_observability-visibility-foundation.md: forge report
- PROJECT_STATE.md: updated with 7.4 active state (Asia/Jakarta 2026-04-18 22:58)
- ROADMAP.md: 7.4 row added as In Progress

Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION

https://claude.ai/code/session_01QhGq49wTAHnN8EMEp91nMU