### PR TITLE
feat: phase 7.6 execution memory persistence foundation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 01:51
-Status       : Phase 7.6 state persistence / execution memory FOUNDATION active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file load/store/clear boundary for last-run context; Phase 7.5 operator control / manual override remains active on branch claude/operator-control-override-q2r4g (PR #574); pending COMMANDER review (STANDARD tier).
+Last Updated : 2026-04-19 02:00
+Status       : Phase 7.5 operator control / manual override is merged-main truth via PR #575; Phase 7.6 state persistence / execution memory FOUNDATION remains active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file load/store/clear boundary for last-run context; pending COMMANDER review (MINOR tier repo-truth fix).
 
 [COMPLETED]
 - Phase 6.4.1 monitoring and circuit-breaker FOUNDATION implementation merged via PR #572 at monitoring/foundation.py with deterministic ALLOW/BLOCK/HALT contract and 26 targeted tests.
@@ -14,10 +14,10 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION active 
 - Phase 7.1 public activation trigger surface merged with one synchronous CLI invocation path mapping run_public_activation_cycle outcomes to explicit completed/stopped_hold/stopped_blocked trigger results.
 - Phase 7.2 lightweight automation scheduler merged with deterministic triggered/skipped/blocked result categories and invalid_contract blocked path for negative quota.
 - Phase 7.4 observability / visibility foundation merged to main; deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py with 45 passing tests.
+- Phase 7.5 operator control / manual override merged to main via PR #575 with deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation through OperatorSchedulerGate + OperatorLoopGate.
 
 [IN PROGRESS]
 - Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
-- Phase 7.5 operator control / manual override active on branch claude/operator-control-override-q2r4g (PR #574); deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py with 49 targeted tests; 181 total phase 7 suite passing; pending COMMANDER review (STANDARD tier).
 - Phase 7.6 state persistence / execution memory FOUNDATION active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file boundary in core/execution_memory_foundation.py for explicit load/store/clear of last_run_result, last_scheduler_decision, last_loop_outcome, optional last_operator_control_decision, and last_observability_trace_summary; excludes database/Redis/distributed state/replay/recovery orchestration.
 
 [NOT STARTED]
@@ -27,7 +27,6 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION active 
 
 [NEXT PRIORITY]
 - COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
-- COMMANDER review and merge for Phase 7.5 operator control / manual override (STANDARD tier; core/operator_control.py with OperatorSchedulerGate + OperatorLoopGate + OperatorControlledLoopBoundary; 49 passing tests; 181 total phase 7 suite passing; PR #574).
 - COMMANDER review for Phase 7.6 state persistence / execution memory FOUNDATION (STANDARD tier; deterministic local-file load/store/clear boundary with invalid_contract blocked behavior and targeted tests).
 
 [KNOWN ISSUES]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 00:54
-Status       : Phase 7.5 operator control / manual override active on branch claude/operator-control-override-q2r4g (PR #574) — deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation; Phase 7.4 observability / visibility foundation merged to main; pending COMMANDER review (STANDARD tier).
+Last Updated : 2026-04-19 01:51
+Status       : Phase 7.6 state persistence / execution memory FOUNDATION active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file load/store/clear boundary for last-run context; Phase 7.5 operator control / manual override remains active on branch claude/operator-control-override-q2r4g (PR #574); pending COMMANDER review (STANDARD tier).
 
 [COMPLETED]
 - Phase 6.4.1 monitoring and circuit-breaker FOUNDATION implementation merged via PR #572 at monitoring/foundation.py with deterministic ALLOW/BLOCK/HALT contract and 26 targeted tests.
@@ -18,6 +18,7 @@ Status       : Phase 7.5 operator control / manual override active on branch cla
 [IN PROGRESS]
 - Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
 - Phase 7.5 operator control / manual override active on branch claude/operator-control-override-q2r4g (PR #574); deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py with 49 targeted tests; 181 total phase 7 suite passing; pending COMMANDER review (STANDARD tier).
+- Phase 7.6 state persistence / execution memory FOUNDATION active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file boundary in core/execution_memory_foundation.py for explicit load/store/clear of last_run_result, last_scheduler_decision, last_loop_outcome, optional last_operator_control_decision, and last_observability_trace_summary; excludes database/Redis/distributed state/replay/recovery orchestration.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -27,6 +28,7 @@ Status       : Phase 7.5 operator control / manual override active on branch cla
 [NEXT PRIORITY]
 - COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
 - COMMANDER review and merge for Phase 7.5 operator control / manual override (STANDARD tier; core/operator_control.py with OperatorSchedulerGate + OperatorLoopGate + OperatorControlledLoopBoundary; 49 passing tests; 181 total phase 7 suite passing; PR #574).
+- COMMANDER review for Phase 7.6 state persistence / execution memory FOUNDATION (STANDARD tier; deterministic local-file load/store/clear boundary with invalid_contract blocked behavior and targeted tests).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 01:51
+**Last Updated:** 2026-04-19 02:00
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -96,7 +96,7 @@
 | 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | ✅ Done | Deterministic triggered/skipped/blocked result categories delivered; blocked(invalid_contract) for negative quota; one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | 🚧 In Progress | Bounded deterministic loop over the 7.2 scheduler boundary active on claude/runtime-auto-run-loop-cBVTs; loop result categories: completed/stopped_hold/stopped_blocked/exhausted; deterministic stop reasons; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.4 | Observability / Visibility Foundation | ✅ Done | Merged to main. Deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py; 45 passing tests; pure functions only; excludes alert delivery, dashboards, distributed monitoring mesh, async workers, cron daemon rollout. |
-| 7.5 | Operator Control / Manual Override | 🚧 In Progress | Active on branch claude/operator-control-override-q2r4g (PR #574). Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing; pending COMMANDER review (STANDARD tier). |
+| 7.5 | Operator Control / Manual Override | ✅ Done | Merged to main via PR #575. Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing. |
 | 7.6 | State Persistence / Execution Memory Foundation | 🚧 In Progress | Active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18. Deterministic local-file load/store/clear boundary in core/execution_memory_foundation.py for minimal last-run context (run result, scheduler decision, loop outcome, optional operator control decision, observability trace summary); explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, recovery orchestration, async workers, and cron daemon rollout. |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 00:54
+**Last Updated:** 2026-04-19 01:51
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -97,6 +97,7 @@
 | 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | 🚧 In Progress | Bounded deterministic loop over the 7.2 scheduler boundary active on claude/runtime-auto-run-loop-cBVTs; loop result categories: completed/stopped_hold/stopped_blocked/exhausted; deterministic stop reasons; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.4 | Observability / Visibility Foundation | ✅ Done | Merged to main. Deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py; 45 passing tests; pure functions only; excludes alert delivery, dashboards, distributed monitoring mesh, async workers, cron daemon rollout. |
 | 7.5 | Operator Control / Manual Override | 🚧 In Progress | Active on branch claude/operator-control-override-q2r4g (PR #574). Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing; pending COMMANDER review (STANDARD tier). |
+| 7.6 | State Persistence / Execution Memory Foundation | 🚧 In Progress | Active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18. Deterministic local-file load/store/clear boundary in core/execution_memory_foundation.py for minimal last-run context (run result, scheduler decision, loop outcome, optional operator control decision, observability trace summary); explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, recovery orchestration, async workers, and cron daemon rollout. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/execution_memory_foundation.py
+++ b/projects/polymarket/polyquantbot/core/execution_memory_foundation.py
@@ -1,0 +1,316 @@
+"""Phase 7.6 -- state persistence / execution memory foundation.
+
+Deterministic local-file persistence boundary for minimal last-run runtime context.
+This slice is FOUNDATION only:
+  - no database rollout
+  - no Redis
+  - no distributed state
+  - no async persistence workers
+  - no replay or recovery orchestration
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+EXECUTION_MEMORY_STORE_STORED = "stored"
+EXECUTION_MEMORY_STORE_BLOCKED = "blocked"
+EXECUTION_MEMORY_LOAD_LOADED = "loaded"
+EXECUTION_MEMORY_LOAD_NOT_FOUND = "not_found"
+EXECUTION_MEMORY_LOAD_BLOCKED = "blocked"
+EXECUTION_MEMORY_CLEAR_CLEARED = "cleared"
+EXECUTION_MEMORY_CLEAR_NOT_FOUND = "not_found"
+EXECUTION_MEMORY_CLEAR_BLOCKED = "blocked"
+EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT = "invalid_contract"
+EXECUTION_MEMORY_BLOCK_RUNTIME_ERROR = "runtime_error"
+
+_MEMORY_FILE_NAME = "phase7_execution_memory.json"
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryState:
+    """Minimal deterministic execution memory snapshot for phase 7 runtime surfaces."""
+
+    last_run_result: str
+    last_scheduler_decision: str
+    last_loop_outcome: str
+    last_operator_control_decision: str | None
+    last_observability_trace_summary: str
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryContract:
+    """Persistence contract with explicit owner and deterministic storage path."""
+
+    owner_ref: str
+    storage_dir: str
+    state: ExecutionMemoryState
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryReadContract:
+    """Read / clear contract without requiring a state payload."""
+
+    owner_ref: str
+    storage_dir: str
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryStoreResult:
+    success: bool
+    result_category: str
+    blocked_reason: str | None
+    memory_state: ExecutionMemoryState | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryLoadResult:
+    success: bool
+    result_category: str
+    blocked_reason: str | None
+    memory_found: bool
+    memory_state: ExecutionMemoryState | None
+    notes: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionMemoryClearResult:
+    success: bool
+    result_category: str
+    blocked_reason: str | None
+    memory_cleared: bool
+    notes: dict[str, Any] | None = None
+
+
+class ExecutionMemoryPersistenceBoundary:
+    """Deterministic local-file execution memory boundary (load/store/clear)."""
+
+    def store(self, contract: ExecutionMemoryContract) -> ExecutionMemoryStoreResult:
+        contract_error = _validate_store_contract(contract)
+        if contract_error is not None:
+            return ExecutionMemoryStoreResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_STORE_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+                memory_state=None,
+                notes={"contract_error": contract_error},
+            )
+
+        try:
+            storage_file = _resolve_storage_file(contract.owner_ref, contract.storage_dir)
+            storage_file.parent.mkdir(parents=True, exist_ok=True)
+            payload = _serialize_payload(contract.owner_ref, contract.state)
+            with storage_file.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            return ExecutionMemoryStoreResult(
+                success=True,
+                result_category=EXECUTION_MEMORY_STORE_STORED,
+                blocked_reason=None,
+                memory_state=contract.state,
+                notes={"storage_file": str(storage_file)},
+            )
+        except Exception as exc:
+            return ExecutionMemoryStoreResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_STORE_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_RUNTIME_ERROR,
+                memory_state=None,
+                notes={"error_type": type(exc).__name__},
+            )
+
+    def load(self, contract: ExecutionMemoryReadContract) -> ExecutionMemoryLoadResult:
+        contract_error = _validate_read_contract(contract)
+        if contract_error is not None:
+            return ExecutionMemoryLoadResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_LOAD_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+                memory_found=False,
+                memory_state=None,
+                notes={"contract_error": contract_error},
+            )
+
+        storage_file = _resolve_storage_file(contract.owner_ref, contract.storage_dir)
+        if not storage_file.exists():
+            return ExecutionMemoryLoadResult(
+                success=True,
+                result_category=EXECUTION_MEMORY_LOAD_NOT_FOUND,
+                blocked_reason=None,
+                memory_found=False,
+                memory_state=None,
+                notes={"storage_file": str(storage_file)},
+            )
+
+        try:
+            with storage_file.open("r", encoding="utf-8") as handle:
+                raw_payload = json.load(handle)
+            parsed = _parse_payload(
+                owner_ref=contract.owner_ref,
+                payload=raw_payload,
+            )
+            if isinstance(parsed, str):
+                return ExecutionMemoryLoadResult(
+                    success=False,
+                    result_category=EXECUTION_MEMORY_LOAD_BLOCKED,
+                    blocked_reason=EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+                    memory_found=False,
+                    memory_state=None,
+                    notes={"contract_error": parsed},
+                )
+
+            return ExecutionMemoryLoadResult(
+                success=True,
+                result_category=EXECUTION_MEMORY_LOAD_LOADED,
+                blocked_reason=None,
+                memory_found=True,
+                memory_state=parsed,
+                notes={"storage_file": str(storage_file)},
+            )
+        except Exception as exc:
+            return ExecutionMemoryLoadResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_LOAD_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_RUNTIME_ERROR,
+                memory_found=False,
+                memory_state=None,
+                notes={"error_type": type(exc).__name__},
+            )
+
+    def clear(self, contract: ExecutionMemoryReadContract) -> ExecutionMemoryClearResult:
+        contract_error = _validate_read_contract(contract)
+        if contract_error is not None:
+            return ExecutionMemoryClearResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_CLEAR_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+                memory_cleared=False,
+                notes={"contract_error": contract_error},
+            )
+
+        storage_file = _resolve_storage_file(contract.owner_ref, contract.storage_dir)
+        if not storage_file.exists():
+            return ExecutionMemoryClearResult(
+                success=True,
+                result_category=EXECUTION_MEMORY_CLEAR_NOT_FOUND,
+                blocked_reason=None,
+                memory_cleared=False,
+                notes={"storage_file": str(storage_file)},
+            )
+
+        try:
+            storage_file.unlink()
+            return ExecutionMemoryClearResult(
+                success=True,
+                result_category=EXECUTION_MEMORY_CLEAR_CLEARED,
+                blocked_reason=None,
+                memory_cleared=True,
+                notes={"storage_file": str(storage_file)},
+            )
+        except Exception as exc:
+            return ExecutionMemoryClearResult(
+                success=False,
+                result_category=EXECUTION_MEMORY_CLEAR_BLOCKED,
+                blocked_reason=EXECUTION_MEMORY_BLOCK_RUNTIME_ERROR,
+                memory_cleared=False,
+                notes={"error_type": type(exc).__name__},
+            )
+
+
+def _resolve_storage_file(owner_ref: str, storage_dir: str) -> Path:
+    return Path(storage_dir) / owner_ref / _MEMORY_FILE_NAME
+
+
+def _serialize_payload(owner_ref: str, state: ExecutionMemoryState) -> dict[str, Any]:
+    return {
+        "owner_ref": owner_ref,
+        "state": asdict(state),
+    }
+
+
+def _parse_payload(owner_ref: str, payload: Any) -> ExecutionMemoryState | str:
+    if not isinstance(payload, dict):
+        return "payload_must_be_dict"
+    if payload.get("owner_ref") != owner_ref:
+        return "owner_ref_mismatch"
+    state = payload.get("state")
+    if not isinstance(state, dict):
+        return "state_must_be_dict"
+
+    required_keys = {
+        "last_run_result",
+        "last_scheduler_decision",
+        "last_loop_outcome",
+        "last_operator_control_decision",
+        "last_observability_trace_summary",
+    }
+    if set(state.keys()) != required_keys:
+        return "state_keys_invalid"
+
+    string_fields = (
+        "last_run_result",
+        "last_scheduler_decision",
+        "last_loop_outcome",
+        "last_observability_trace_summary",
+    )
+    for field_name in string_fields:
+        value = state.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            return f"{field_name}_required"
+
+    operator_decision = state.get("last_operator_control_decision")
+    if operator_decision is not None and (
+        not isinstance(operator_decision, str) or not operator_decision.strip()
+    ):
+        return "last_operator_control_decision_invalid"
+
+    return ExecutionMemoryState(
+        last_run_result=state["last_run_result"],
+        last_scheduler_decision=state["last_scheduler_decision"],
+        last_loop_outcome=state["last_loop_outcome"],
+        last_operator_control_decision=operator_decision,
+        last_observability_trace_summary=state["last_observability_trace_summary"],
+    )
+
+
+def _validate_store_contract(contract: ExecutionMemoryContract) -> str | None:
+    read_error = _validate_read_contract(
+        ExecutionMemoryReadContract(
+            owner_ref=contract.owner_ref,
+            storage_dir=contract.storage_dir,
+        )
+    )
+    if read_error is not None:
+        return read_error
+
+    state = contract.state
+    if not isinstance(state, ExecutionMemoryState):
+        return "state_required"
+    if not state.last_run_result.strip():
+        return "last_run_result_required"
+    if not state.last_scheduler_decision.strip():
+        return "last_scheduler_decision_required"
+    if not state.last_loop_outcome.strip():
+        return "last_loop_outcome_required"
+    if not state.last_observability_trace_summary.strip():
+        return "last_observability_trace_summary_required"
+    if state.last_operator_control_decision is not None and not state.last_operator_control_decision.strip():
+        return "last_operator_control_decision_invalid"
+    return None
+
+
+def _validate_read_contract(contract: ExecutionMemoryReadContract) -> str | None:
+    if not isinstance(contract.owner_ref, str) or not contract.owner_ref.strip():
+        return "owner_ref_required"
+    if not isinstance(contract.storage_dir, str) or not contract.storage_dir.strip():
+        return "storage_dir_required"
+
+    normalized = os.path.normpath(contract.storage_dir)
+    if normalized in {"", ".", ".."}:
+        return "storage_dir_invalid"
+    if normalized.startswith(".."):
+        return "storage_dir_invalid"
+    return None

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-6_01_state-persistence-execution-memory-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-6_01_state-persistence-execution-memory-foundation.md
@@ -1,0 +1,90 @@
+# FORGE-X Report -- Phase 7.6 State Persistence / Execution Memory Foundation
+
+## 1) What was built
+
+Implemented a narrow FOUNDATION-only execution memory persistence boundary at:
+
+- `projects/polymarket/polyquantbot/core/execution_memory_foundation.py`
+
+Delivered deterministic local-file load/store/clear behavior for minimal last-run
+context fields only:
+- `last_run_result`
+- `last_scheduler_decision`
+- `last_loop_outcome`
+- `last_operator_control_decision` (optional)
+- `last_observability_trace_summary`
+
+Added explicit deterministic result categories and blocked behavior:
+- Store: `stored` / `blocked`
+- Load: `loaded` / `not_found` / `blocked`
+- Clear: `cleared` / `not_found` / `blocked`
+- Block reasons include `invalid_contract` and runtime-safe `runtime_error`.
+
+No changes were made to Phase 6.4.1 monitoring, Phase 7.2 scheduler,
+Phase 7.3 loop, Phase 7.4 observability, or Phase 7.5 operator-control contracts.
+
+## 2) Current system architecture (relevant slice)
+
+```
+Phase 7 runtime surfaces (preserved):
+  6.4.1 monitoring -> 7.2 scheduler -> 7.3 loop -> 7.4 observability -> 7.5 operator control
+
+New Phase 7.6 foundation (narrow side boundary):
+  ExecutionMemoryPersistenceBoundary
+    - store(ExecutionMemoryContract)
+    - load(ExecutionMemoryReadContract)
+    - clear(ExecutionMemoryReadContract)
+
+Persistence medium:
+  deterministic local file only:
+  {storage_dir}/{owner_ref}/phase7_execution_memory.json
+
+Stored payload:
+  owner_ref + exact minimal state field set (5 fields above)
+```
+
+## 3) Files created / modified (full repo-root paths)
+
+**Created**
+- `projects/polymarket/polyquantbot/core/execution_memory_foundation.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-6_01_state-persistence-execution-memory-foundation.md`
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Deterministic load/store/clear API boundary exists with explicit contracts.
+- Store writes UTF-8 JSON payload with exact field schema and owner scope.
+- Load returns deterministic `not_found` when state file does not exist.
+- Clear returns deterministic `not_found` when no file exists.
+- Invalid contracts are deterministically blocked with `invalid_contract`.
+- Invalid persisted payload shape is deterministically blocked on load.
+- Optional operator control decision is supported as `None`.
+- Targeted pytest coverage for store/load/clear and invalid-contract paths passes.
+
+## 5) Known issues
+
+- This is FOUNDATION scope only; no integration yet into scheduler/loop runtime
+  orchestration lifecycle.
+- No database, Redis, distributed synchronization, replay engine, or recovery
+  orchestration is introduced in this slice by design.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : state persistence / execution memory foundation only
+Not in Scope      : database rollout, Redis integration, distributed state sync,
+                    recovery orchestration, replay engine, async workers, cron
+                    daemon rollout, broader production storage program
+Suggested Next    : COMMANDER review
+
+---
+
+Report Timestamp: 2026-04-19 01:51 (Asia/Jakarta)
+Role: FORGE-X (NEXUS)
+Task: phase7-6-state-persistence-execution-memory-foundation
+Branch: feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-6_02_repo-truth-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-6_02_repo-truth-fix.md
@@ -1,0 +1,41 @@
+# FORGE-X Report -- Phase 7.6 Repo-Truth Fix (7.5 merged-main / 7.6 active)
+
+## 1) What was changed
+
+Doc-only repo-truth alignment update for PR #576 blocker:
+
+- `PROJECT_STATE.md`
+  - Removed stale wording that Phase 7.5 is still active on PR #574.
+  - Added Phase 7.5 merged-main truth in `[COMPLETED]` via PR #575.
+  - Kept Phase 7.6 in `[IN PROGRESS]` as the active state persistence slice.
+  - Removed stale 7.5 review/merge item from `[NEXT PRIORITY]`.
+  - Updated `Last Updated` to `2026-04-19 02:00` (Asia/Jakarta).
+
+- `ROADMAP.md`
+  - Updated Phase 7 section `Last Updated` to `2026-04-19 02:00`.
+  - Changed Phase 7.5 status from `🚧 In Progress` to `✅ Done`.
+  - Updated Phase 7.5 notes to merged-main truth via PR #575.
+  - Kept Phase 7.6 as `🚧 In Progress`.
+
+No runtime files, persistence logic, tests, or behavior were changed.
+
+## 2) Files modified (full repo-root paths)
+
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-6_02_repo-truth-fix.md`
+
+## 3) Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
+
+Validation Tier   : MINOR
+Claim Level       : DOC TRUTH FIX
+Validation Target : repo-truth alignment only for PR #576 (7.5 merged-main truth; 7.6 remains in progress)
+Not in Scope      : execution_memory_foundation.py logic, test changes, storage behavior, scheduler/loop/operator-control changes, API/UI expansion, async workers, distributed state, broader roadmap reshuffling
+Suggested Next    : COMMANDER re-review
+
+---
+
+Report Timestamp: 2026-04-19 02:00 (Asia/Jakarta)
+Role: FORGE-X (NEXUS)
+Task: phase7-6-state-persistence-repo-truth-fix
+Branch: feature/phase7-6-state-persistence-repo-truth-fix-2026-04-19

--- a/projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+
+from projects.polymarket.polyquantbot.core.execution_memory_foundation import (
+    EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+    EXECUTION_MEMORY_CLEAR_CLEARED,
+    EXECUTION_MEMORY_CLEAR_NOT_FOUND,
+    EXECUTION_MEMORY_LOAD_BLOCKED,
+    EXECUTION_MEMORY_LOAD_LOADED,
+    EXECUTION_MEMORY_LOAD_NOT_FOUND,
+    EXECUTION_MEMORY_STORE_STORED,
+    ExecutionMemoryContract,
+    ExecutionMemoryPersistenceBoundary,
+    ExecutionMemoryReadContract,
+    ExecutionMemoryState,
+)
+
+
+def _state(**kwargs) -> ExecutionMemoryState:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "last_run_result": "completed",
+        "last_scheduler_decision": "triggered",
+        "last_loop_outcome": "completed",
+        "last_operator_control_decision": "allow",
+        "last_observability_trace_summary": "visible:trace-001",
+    }
+    defaults.update(kwargs)
+    return ExecutionMemoryState(**defaults)
+
+
+def _store_contract(tmp_path, **kwargs):  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "owner_ref": "owner-1",
+        "storage_dir": str(tmp_path),
+        "state": _state(),
+    }
+    defaults.update(kwargs)
+    return ExecutionMemoryContract(**defaults)
+
+
+def _read_contract(tmp_path, **kwargs):  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "owner_ref": "owner-1",
+        "storage_dir": str(tmp_path),
+    }
+    defaults.update(kwargs)
+    return ExecutionMemoryReadContract(**defaults)
+
+
+def test_phase7_6_store_then_load_is_deterministic(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    contract = _store_contract(tmp_path)
+
+    store = boundary.store(contract)
+    load = boundary.load(_read_contract(tmp_path))
+
+    assert store.success is True
+    assert store.result_category == EXECUTION_MEMORY_STORE_STORED
+    assert store.memory_state == contract.state
+    assert load.success is True
+    assert load.result_category == EXECUTION_MEMORY_LOAD_LOADED
+    assert load.memory_found is True
+    assert load.memory_state == contract.state
+
+
+def test_phase7_6_load_not_found_is_deterministic(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    result = boundary.load(_read_contract(tmp_path))
+
+    assert result.success is True
+    assert result.result_category == EXECUTION_MEMORY_LOAD_NOT_FOUND
+    assert result.memory_found is False
+    assert result.memory_state is None
+
+
+def test_phase7_6_clear_not_found_is_deterministic(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    result = boundary.clear(_read_contract(tmp_path))
+
+    assert result.success is True
+    assert result.result_category == EXECUTION_MEMORY_CLEAR_NOT_FOUND
+    assert result.memory_cleared is False
+
+
+def test_phase7_6_clear_removes_stored_state(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    boundary.store(_store_contract(tmp_path))
+
+    clear_result = boundary.clear(_read_contract(tmp_path))
+    load_after = boundary.load(_read_contract(tmp_path))
+
+    assert clear_result.success is True
+    assert clear_result.result_category == EXECUTION_MEMORY_CLEAR_CLEARED
+    assert clear_result.memory_cleared is True
+    assert load_after.result_category == EXECUTION_MEMORY_LOAD_NOT_FOUND
+
+
+def test_phase7_6_blocks_invalid_store_contract(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    result = boundary.store(_store_contract(tmp_path, owner_ref="", state=_state()))
+
+    assert result.success is False
+    assert result.blocked_reason == EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT
+    assert result.memory_state is None
+    assert result.notes == {"contract_error": "owner_ref_required"}
+
+
+def test_phase7_6_blocks_invalid_read_contract(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    result = boundary.load(_read_contract(tmp_path, storage_dir=".."))
+
+    assert result.success is False
+    assert result.result_category == EXECUTION_MEMORY_LOAD_BLOCKED
+    assert result.blocked_reason == EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT
+    assert result.notes == {"contract_error": "storage_dir_invalid"}
+
+
+def test_phase7_6_load_blocks_on_invalid_persisted_payload(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    contract = _store_contract(tmp_path)
+    boundary.store(contract)
+
+    bad_file = tmp_path / "owner-1" / "phase7_execution_memory.json"
+    with bad_file.open("w", encoding="utf-8") as handle:
+        json.dump({"owner_ref": "owner-1", "state": {"bad_key": "x"}}, handle)
+
+    result = boundary.load(_read_contract(tmp_path))
+
+    assert result.success is False
+    assert result.result_category == EXECUTION_MEMORY_LOAD_BLOCKED
+    assert result.blocked_reason == EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT
+    assert result.notes == {"contract_error": "state_keys_invalid"}
+
+
+def test_phase7_6_store_supports_none_operator_decision(tmp_path) -> None:
+    boundary = ExecutionMemoryPersistenceBoundary()
+    state = _state(last_operator_control_decision=None)
+    contract = _store_contract(tmp_path, state=state)
+
+    store = boundary.store(contract)
+    load = boundary.load(_read_contract(tmp_path))
+
+    assert store.success is True
+    assert load.success is True
+    assert load.memory_state is not None
+    assert load.memory_state.last_operator_control_decision is None


### PR DESCRIPTION
### Motivation
- Provide a narrow, deterministic execution-memory persistence boundary so Phase 7 runtime surfaces can preserve last-run context across process restarts without introducing databases, Redis, distributed state, or async persistence workers. 
- Keep scope FOUNDATION-only and preserve existing Phase 6.4.1/7.2/7.3/7.4/7.5 contracts exactly as-is while exposing explicit `load`/`store`/`clear` boundaries and deterministic blocked/NotFound behavior. 

### Description
- Add `projects/polymarket/polyquantbot/core/execution_memory_foundation.py` implementing `ExecutionMemoryState`, `ExecutionMemoryContract` / `ExecutionMemoryReadContract`, and `ExecutionMemoryPersistenceBoundary` with deterministic local-file `store/load/clear` semantics and explicit result categories and blocked reasons (`invalid_contract`, `runtime_error`). 
- Persisted payload format is UTF-8 JSON at `{storage_dir}/{owner_ref}/phase7_execution_memory.json` and contains the exact minimal fields: `last_run_result`, `last_scheduler_decision`, `last_loop_outcome`, optional `last_operator_control_decision`, and `last_observability_trace_summary`. 
- Add targeted unit tests at `projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py` covering store/load/clear, not-found behavior, invalid-contract blocking, invalid persisted payload blocking, and optional `None` operator decision support. 
- Update repository truth files: `PROJECT_STATE.md` and `ROADMAP.md` to open Phase 7.6 as in-progress and add the FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase7-6_01_state-persistence-execution-memory-foundation.md`. 

### Testing
- Ran `python3 -m py_compile` on the new module and test file and it passed. 
- Ran the new tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py` and they passed (`8 passed`). 
- Ran the broader Phase 7 suite with `PYTHONPATH=/workspace/walker-ai-team pytest -q` for the phase7 scheduler/loop/observability/operator-control tests and they passed (`143 passed`). 
- Note: an initial pytest collection attempt failed due to missing `PYTHONPATH` which was corrected and final automated test runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d214b0948325b36df5a875265bbd)