### PR TITLE
feat(core): add Phase 7.7 recovery/resume foundation over Phase 7.6 memory

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 02:00
-Status       : Phase 7.5 operator control / manual override is merged-main truth via PR #575; Phase 7.6 state persistence / execution memory FOUNDATION remains active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file load/store/clear boundary for last-run context; pending COMMANDER review (MINOR tier repo-truth fix).
+Last Updated : 2026-04-19 02:07
+Status       : Phase 7.6 state persistence / execution memory FOUNDATION is preserved as completed base layer; Phase 7.7 recovery / resume FOUNDATION is active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19 with deterministic resume/restart_fresh/blocked/no_memory decisions over 7.6 memory only; pending COMMANDER review.
 
 [COMPLETED]
 - Phase 6.4.1 monitoring and circuit-breaker FOUNDATION implementation merged via PR #572 at monitoring/foundation.py with deterministic ALLOW/BLOCK/HALT contract and 26 targeted tests.
@@ -15,10 +15,11 @@ Status       : Phase 7.5 operator control / manual override is merged-main truth
 - Phase 7.2 lightweight automation scheduler merged with deterministic triggered/skipped/blocked result categories and invalid_contract blocked path for negative quota.
 - Phase 7.4 observability / visibility foundation merged to main; deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py with 45 passing tests.
 - Phase 7.5 operator control / manual override merged to main via PR #575 with deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation through OperatorSchedulerGate + OperatorLoopGate.
+- Phase 7.6 state persistence / execution memory FOUNDATION completed as preserved baseline with deterministic local-file load/store/clear boundary in core/execution_memory_foundation.py for explicit last-run context and invalid_contract blocked behavior.
 
 [IN PROGRESS]
 - Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
-- Phase 7.6 state persistence / execution memory FOUNDATION active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18 with deterministic local-file boundary in core/execution_memory_foundation.py for explicit load/store/clear of last_run_result, last_scheduler_decision, last_loop_outcome, optional last_operator_control_decision, and last_observability_trace_summary; excludes database/Redis/distributed state/replay/recovery orchestration.
+- Phase 7.7 recovery / resume FOUNDATION active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19 with deterministic decision categories (resume/restart_fresh/blocked/no_memory), explicit reasons/notes, and strict consumption of Phase 7.6 execution memory state only; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, and crash supervision.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -27,7 +28,7 @@ Status       : Phase 7.5 operator control / manual override is merged-main truth
 
 [NEXT PRIORITY]
 - COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
-- COMMANDER review for Phase 7.6 state persistence / execution memory FOUNDATION (STANDARD tier; deterministic local-file load/store/clear boundary with invalid_contract blocked behavior and targeted tests).
+- COMMANDER review for Phase 7.7 recovery / resume FOUNDATION (STANDARD tier; deterministic resume/restart_fresh/blocked/no_memory outcomes over Phase 7.6 execution memory boundary with explicit reasons and targeted tests).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 02:07
-Status       : Phase 7.6 state persistence / execution memory FOUNDATION is preserved as completed base layer; Phase 7.7 recovery / resume FOUNDATION is active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19 with deterministic resume/restart_fresh/blocked/no_memory decisions over 7.6 memory only; pending COMMANDER review.
+Last Updated : 2026-04-19 02:16
+Status       : Phase 7.6 state persistence / execution memory FOUNDATION is preserved as completed base layer; Phase 7.7 recovery / resume FOUNDATION safety semantics fix is active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19 with deterministic blocked handling for force_block, non-resume hold handling, and restart_fresh closed-loop terminal states over 7.6 memory only; pending COMMANDER re-review.
 
 [COMPLETED]
 - Phase 6.4.1 monitoring and circuit-breaker FOUNDATION implementation merged via PR #572 at monitoring/foundation.py with deterministic ALLOW/BLOCK/HALT contract and 26 targeted tests.
@@ -19,7 +19,7 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION is pres
 
 [IN PROGRESS]
 - Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
-- Phase 7.7 recovery / resume FOUNDATION active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19 with deterministic decision categories (resume/restart_fresh/blocked/no_memory), explicit reasons/notes, and strict consumption of Phase 7.6 execution memory state only; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, and crash supervision.
+- Phase 7.7 recovery / resume FOUNDATION safety semantics fix active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19 with deterministic force_block -> blocked behavior, non-resume hold handling, and restart_fresh closed-loop terminal state handling (completed/stopped_hold/exhausted) over Phase 7.6 execution memory state only; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, and crash supervision.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -28,7 +28,7 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION is pres
 
 [NEXT PRIORITY]
 - COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
-- COMMANDER review for Phase 7.7 recovery / resume FOUNDATION (STANDARD tier; deterministic resume/restart_fresh/blocked/no_memory outcomes over Phase 7.6 execution memory boundary with explicit reasons and targeted tests).
+- COMMANDER re-review for Phase 7.7 recovery / resume FOUNDATION safety semantics fix (STANDARD tier; deterministic force_block blocked behavior, non-resume hold behavior, and restart_fresh closed-loop terminal handling with targeted tests).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 02:07
+**Last Updated:** 2026-04-19 02:16
 
 ## Board Overview
 
@@ -87,7 +87,7 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 02:07
+**Last Updated:** 2026-04-19 02:16
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -98,7 +98,7 @@
 | 7.4 | Observability / Visibility Foundation | ✅ Done | Merged to main. Deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py; 45 passing tests; pure functions only; excludes alert delivery, dashboards, distributed monitoring mesh, async workers, cron daemon rollout. |
 | 7.5 | Operator Control / Manual Override | ✅ Done | Merged to main via PR #575. Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing. |
 | 7.6 | State Persistence / Execution Memory Foundation | ✅ Done | Completed baseline preserved in core/execution_memory_foundation.py with deterministic local-file load/store/clear boundary for minimal last-run context and explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, and broad recovery orchestration claims. |
-| 7.7 | Recovery / Resume Foundation | 🚧 In Progress | Active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19. Deterministic recovery decision categories (resume/restart_fresh/blocked/no_memory) over Phase 7.6 execution memory load state only with explicit reasons/notes; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, crash supervision, and broader production failover program. |
+| 7.7 | Recovery / Resume Foundation | 🚧 In Progress | Active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19. Safety semantics fix in progress: deterministic force_block memory -> blocked, hold memory -> non-resume, and closed terminal loop outcomes (completed/stopped_hold/exhausted) -> restart_fresh over Phase 7.6 execution memory only; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, crash supervision, and broader production failover program. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-18 22:35
+**Last Updated:** 2026-04-19 02:07
 
 ## Board Overview
 
@@ -87,7 +87,7 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 02:00
+**Last Updated:** 2026-04-19 02:07
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
@@ -97,7 +97,8 @@
 | 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | 🚧 In Progress | Bounded deterministic loop over the 7.2 scheduler boundary active on claude/runtime-auto-run-loop-cBVTs; loop result categories: completed/stopped_hold/stopped_blocked/exhausted; deterministic stop reasons; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.4 | Observability / Visibility Foundation | ✅ Done | Merged to main. Deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py; 45 passing tests; pure functions only; excludes alert delivery, dashboards, distributed monitoring mesh, async workers, cron daemon rollout. |
 | 7.5 | Operator Control / Manual Override | ✅ Done | Merged to main via PR #575. Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing. |
-| 7.6 | State Persistence / Execution Memory Foundation | 🚧 In Progress | Active on branch feature/phase7-6-state-persistence-execution-memory-foundation-2026-04-18. Deterministic local-file load/store/clear boundary in core/execution_memory_foundation.py for minimal last-run context (run result, scheduler decision, loop outcome, optional operator control decision, observability trace summary); explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, recovery orchestration, async workers, and cron daemon rollout. |
+| 7.6 | State Persistence / Execution Memory Foundation | ✅ Done | Completed baseline preserved in core/execution_memory_foundation.py with deterministic local-file load/store/clear boundary for minimal last-run context and explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, and broad recovery orchestration claims. |
+| 7.7 | Recovery / Resume Foundation | 🚧 In Progress | Active on branch feature/phase7-7-recovery-resume-foundation-2026-04-19. Deterministic recovery decision categories (resume/restart_fresh/blocked/no_memory) over Phase 7.6 execution memory load state only with explicit reasons/notes; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, crash supervision, and broader production failover program. |
 
 ---
 

--- a/projects/polymarket/polyquantbot/core/recovery_resume_foundation.py
+++ b/projects/polymarket/polyquantbot/core/recovery_resume_foundation.py
@@ -1,0 +1,159 @@
+"""Phase 7.7 -- recovery / resume foundation.
+
+Narrow deterministic recovery decision boundary over Phase 7.6 execution memory only.
+
+This slice is FOUNDATION only:
+  - no distributed recovery
+  - no daemon orchestration
+  - no replay engine
+  - no database rollout
+  - no Redis
+  - no async workers
+  - no crash supervisor
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from projects.polymarket.polyquantbot.core.execution_memory_foundation import (
+    EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT,
+    EXECUTION_MEMORY_LOAD_BLOCKED,
+    EXECUTION_MEMORY_LOAD_LOADED,
+    EXECUTION_MEMORY_LOAD_NOT_FOUND,
+    ExecutionMemoryLoadResult,
+    ExecutionMemoryPersistenceBoundary,
+    ExecutionMemoryReadContract,
+)
+
+RECOVERY_DECISION_RESUME = "resume"
+RECOVERY_DECISION_RESTART_FRESH = "restart_fresh"
+RECOVERY_DECISION_BLOCKED = "blocked"
+RECOVERY_DECISION_NO_MEMORY = "no_memory"
+
+RECOVERY_REASON_MEMORY_VALID_INTERRUPTED = "memory_valid_interrupted"
+RECOVERY_REASON_MEMORY_VALID_CLOSED = "memory_valid_closed"
+RECOVERY_REASON_MEMORY_NOT_FOUND = "memory_not_found"
+RECOVERY_REASON_MEMORY_INVALID_CONTRACT = "memory_invalid_contract"
+RECOVERY_REASON_MEMORY_RUNTIME_ERROR = "memory_runtime_error"
+RECOVERY_REASON_PREVIOUS_BLOCKED = "previous_blocked"
+
+
+@dataclass(frozen=True)
+class RecoveryResumeContract:
+    """Deterministic recovery contract using only Phase 7.6 memory boundary."""
+
+    owner_ref: str
+    storage_dir: str
+
+
+@dataclass(frozen=True)
+class RecoveryResumeDecision:
+    """Deterministic recovery decision categories and explicit reason/notes."""
+
+    success: bool
+    decision_category: str
+    reason: str
+    notes: dict[str, Any] | None = None
+
+
+class RecoveryResumeFoundationBoundary:
+    """Deterministic recovery decision boundary over execution memory state."""
+
+    def decide(self, contract: RecoveryResumeContract) -> RecoveryResumeDecision:
+        if not isinstance(contract.owner_ref, str) or not contract.owner_ref.strip():
+            return RecoveryResumeDecision(
+                success=False,
+                decision_category=RECOVERY_DECISION_BLOCKED,
+                reason=RECOVERY_REASON_MEMORY_INVALID_CONTRACT,
+                notes={"contract_error": "owner_ref_required"},
+            )
+        if not isinstance(contract.storage_dir, str) or not contract.storage_dir.strip():
+            return RecoveryResumeDecision(
+                success=False,
+                decision_category=RECOVERY_DECISION_BLOCKED,
+                reason=RECOVERY_REASON_MEMORY_INVALID_CONTRACT,
+                notes={"contract_error": "storage_dir_required"},
+            )
+
+        read_contract = ExecutionMemoryReadContract(
+            owner_ref=contract.owner_ref,
+            storage_dir=contract.storage_dir,
+        )
+        load_result = ExecutionMemoryPersistenceBoundary().load(read_contract)
+        return _decide_from_load_result(load_result)
+
+
+def _decide_from_load_result(load_result: ExecutionMemoryLoadResult) -> RecoveryResumeDecision:
+    if load_result.result_category == EXECUTION_MEMORY_LOAD_NOT_FOUND:
+        return RecoveryResumeDecision(
+            success=True,
+            decision_category=RECOVERY_DECISION_NO_MEMORY,
+            reason=RECOVERY_REASON_MEMORY_NOT_FOUND,
+            notes=load_result.notes,
+        )
+
+    if load_result.result_category == EXECUTION_MEMORY_LOAD_BLOCKED:
+        if load_result.blocked_reason == EXECUTION_MEMORY_BLOCK_INVALID_CONTRACT:
+            return RecoveryResumeDecision(
+                success=False,
+                decision_category=RECOVERY_DECISION_BLOCKED,
+                reason=RECOVERY_REASON_MEMORY_INVALID_CONTRACT,
+                notes=load_result.notes,
+            )
+
+        return RecoveryResumeDecision(
+            success=False,
+            decision_category=RECOVERY_DECISION_BLOCKED,
+            reason=RECOVERY_REASON_MEMORY_RUNTIME_ERROR,
+            notes=load_result.notes,
+        )
+
+    if load_result.result_category != EXECUTION_MEMORY_LOAD_LOADED or load_result.memory_state is None:
+        return RecoveryResumeDecision(
+            success=False,
+            decision_category=RECOVERY_DECISION_BLOCKED,
+            reason=RECOVERY_REASON_MEMORY_RUNTIME_ERROR,
+            notes={"error": "unexpected_memory_load_result", "load_result": load_result.result_category},
+        )
+
+    memory = load_result.memory_state
+
+    if (
+        memory.last_run_result == "stopped_blocked"
+        or memory.last_scheduler_decision == "blocked"
+        or memory.last_loop_outcome == "stopped_blocked"
+    ):
+        return RecoveryResumeDecision(
+            success=False,
+            decision_category=RECOVERY_DECISION_BLOCKED,
+            reason=RECOVERY_REASON_PREVIOUS_BLOCKED,
+            notes={
+                "last_run_result": memory.last_run_result,
+                "last_scheduler_decision": memory.last_scheduler_decision,
+                "last_loop_outcome": memory.last_loop_outcome,
+            },
+        )
+
+    if memory.last_loop_outcome in {"completed", "stopped_hold"}:
+        return RecoveryResumeDecision(
+            success=True,
+            decision_category=RECOVERY_DECISION_RESTART_FRESH,
+            reason=RECOVERY_REASON_MEMORY_VALID_CLOSED,
+            notes={
+                "last_run_result": memory.last_run_result,
+                "last_scheduler_decision": memory.last_scheduler_decision,
+                "last_loop_outcome": memory.last_loop_outcome,
+            },
+        )
+
+    return RecoveryResumeDecision(
+        success=True,
+        decision_category=RECOVERY_DECISION_RESUME,
+        reason=RECOVERY_REASON_MEMORY_VALID_INTERRUPTED,
+        notes={
+            "last_run_result": memory.last_run_result,
+            "last_scheduler_decision": memory.last_scheduler_decision,
+            "last_loop_outcome": memory.last_loop_outcome,
+        },
+    )

--- a/projects/polymarket/polyquantbot/core/recovery_resume_foundation.py
+++ b/projects/polymarket/polyquantbot/core/recovery_resume_foundation.py
@@ -37,6 +37,7 @@ RECOVERY_REASON_MEMORY_NOT_FOUND = "memory_not_found"
 RECOVERY_REASON_MEMORY_INVALID_CONTRACT = "memory_invalid_contract"
 RECOVERY_REASON_MEMORY_RUNTIME_ERROR = "memory_runtime_error"
 RECOVERY_REASON_PREVIOUS_BLOCKED = "previous_blocked"
+RECOVERY_REASON_OPERATOR_HOLD = "operator_hold"
 
 
 @dataclass(frozen=True)
@@ -123,6 +124,7 @@ def _decide_from_load_result(load_result: ExecutionMemoryLoadResult) -> Recovery
         memory.last_run_result == "stopped_blocked"
         or memory.last_scheduler_decision == "blocked"
         or memory.last_loop_outcome == "stopped_blocked"
+        or memory.last_operator_control_decision == "force_block"
     ):
         return RecoveryResumeDecision(
             success=False,
@@ -132,10 +134,24 @@ def _decide_from_load_result(load_result: ExecutionMemoryLoadResult) -> Recovery
                 "last_run_result": memory.last_run_result,
                 "last_scheduler_decision": memory.last_scheduler_decision,
                 "last_loop_outcome": memory.last_loop_outcome,
+                "last_operator_control_decision": memory.last_operator_control_decision,
             },
         )
 
-    if memory.last_loop_outcome in {"completed", "stopped_hold"}:
+    if memory.last_operator_control_decision == "hold":
+        return RecoveryResumeDecision(
+            success=True,
+            decision_category=RECOVERY_DECISION_RESTART_FRESH,
+            reason=RECOVERY_REASON_OPERATOR_HOLD,
+            notes={
+                "last_run_result": memory.last_run_result,
+                "last_scheduler_decision": memory.last_scheduler_decision,
+                "last_loop_outcome": memory.last_loop_outcome,
+                "last_operator_control_decision": memory.last_operator_control_decision,
+            },
+        )
+
+    if memory.last_loop_outcome in {"completed", "stopped_hold", "exhausted"}:
         return RecoveryResumeDecision(
             success=True,
             decision_category=RECOVERY_DECISION_RESTART_FRESH,

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-7_01_recovery-resume-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-7_01_recovery-resume-foundation.md
@@ -1,0 +1,67 @@
+# FORGE-X Report -- Phase 7.7 Recovery / Resume Foundation
+
+## 1) What was built
+
+Implemented a narrow Phase 7.7 recovery/resume FOUNDATION boundary that consumes Phase 7.6 execution memory only and returns deterministic recovery outcomes:
+
+- `resume`
+- `restart_fresh`
+- `blocked`
+- `no_memory`
+
+The boundary is implemented in `projects/polymarket/polyquantbot/core/recovery_resume_foundation.py` with explicit reason constants and notes forwarding for traceability. It preserves 6.4.1, 7.2, 7.3, 7.4, 7.5, and 7.6 contracts unchanged.
+
+## 2) Current system architecture (relevant slice)
+
+Narrow FOUNDATION slice:
+
+1. `RecoveryResumeFoundationBoundary.decide(...)` validates a small recovery contract (`owner_ref`, `storage_dir`).
+2. It calls the existing `ExecutionMemoryPersistenceBoundary.load(...)` from Phase 7.6.
+3. Decision mapping is deterministic:
+   - load `not_found` -> `no_memory`
+   - load `blocked` (invalid contract/runtime error) -> `blocked` with explicit reason
+   - load `loaded` + previous blocked indicators -> `blocked`
+   - load `loaded` + closed loop indicators (`completed` / `stopped_hold`) -> `restart_fresh`
+   - load `loaded` + non-closed/interrupt-style indicators -> `resume`
+
+No distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, or crash supervision was added.
+
+## 3) Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/core/recovery_resume_foundation.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-7_01_recovery-resume-foundation.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Deterministic recovery decisions over 7.6 memory boundary for:
+  - valid memory -> `resume` / `restart_fresh`
+  - missing memory -> `no_memory`
+  - invalid memory contract payload -> `blocked`
+  - previously blocked state indicators -> `blocked`
+- Explicit reason and notes outputs on every decision path.
+- Targeted tests pass for the scoped recovery categories and invalid contract path.
+
+## 5) Known issues
+
+- Existing repo warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode` (pre-existing, non-runtime warning).
+- Phase 7.3 remains in progress separately and is not altered by this slice.
+
+## 6) What is next
+
+- COMMANDER review for Phase 7.7 recovery / resume FOUNDATION.
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : recovery / resume foundation only
+Not in Scope      : distributed recovery, crash supervision, replay engine, database rollout, Redis integration, async workers, cron daemon rollout, broader production failover program
+Suggested Next    : COMMANDER review
+
+---
+
+Report Timestamp: 2026-04-19 02:07 (Asia/Jakarta)
+Role: FORGE-X (NEXUS)
+Task: phase7-7-recovery-resume-foundation
+Branch: feature/phase7-7-recovery-resume-foundation-2026-04-19

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-7_02_recovery-resume-safety-semantics-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-7_02_recovery-resume-safety-semantics-fix.md
@@ -1,0 +1,60 @@
+# FORGE-X Report -- Phase 7.7 Recovery / Resume Safety Semantics Fix
+
+## 1) What was built
+
+Applied a narrow semantics fix to `projects/polymarket/polyquantbot/core/recovery_resume_foundation.py` so Phase 7.7 recovery decisions respect Phase 7.5 operator intent and terminal loop closure behavior.
+
+Implemented deterministic semantics:
+- `last_operator_control_decision == "force_block"` -> `blocked`
+- `last_operator_control_decision == "hold"` -> non-`resume` path (`restart_fresh`)
+- terminal loop outcomes `completed`, `stopped_hold`, and `exhausted` -> `restart_fresh`
+- `resume` retained only for genuinely interrupted / non-closed states
+
+## 2) Current system architecture (relevant slice)
+
+1. Recovery boundary still reads Phase 7.6 memory through `ExecutionMemoryPersistenceBoundary.load(...)` only.
+2. Decision order now enforces safety semantics before resume:
+   - memory load blocked/not_found handling unchanged
+   - previous blocked indicators include `force_block`
+   - operator `hold` is explicitly routed to `restart_fresh`
+   - closed loop outcomes (`completed`, `stopped_hold`, `exhausted`) route to `restart_fresh`
+   - fallback remains `resume` for non-closed interrupted flow
+3. No change to Phase 7.6 persistence contract or Phase 7.5 operator control contract structures.
+
+## 3) Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/core/recovery_resume_foundation.py`
+- `projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase7-7_02_recovery-resume-safety-semantics-fix.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- Deterministic `blocked` when persisted operator decision is `force_block`.
+- Deterministic non-`resume` behavior for persisted `hold` operator decision.
+- Deterministic `restart_fresh` for terminal `exhausted` loop outcome (plus existing `completed` and `stopped_hold`).
+- Existing `no_memory`, invalid-contract blocked, and previous blocked paths preserved.
+- Targeted tests covering all requested semantics pass.
+
+## 5) Known issues
+
+- Existing repo warning remains: `PytestConfigWarning: Unknown config option: asyncio_mode` (pre-existing, non-runtime warning).
+- This slice remains FOUNDATION only and does not include distributed recovery / replay / daemon orchestration.
+
+## 6) What is next
+
+- COMMANDER re-review for Phase 7.7 recovery semantics fix.
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : recovery / resume decision semantics only
+Not in Scope      : distributed recovery, replay engine, daemon orchestration, database rollout, Redis integration, async workers, crash supervision, broader failover rollout, unrelated phase reshuffling
+Suggested Next    : COMMANDER re-review
+
+---
+
+Report Timestamp: 2026-04-19 02:16 (Asia/Jakarta)
+Role: FORGE-X (NEXUS)
+Task: phase7-7-recovery-resume-safety-semantics-fix
+Branch: feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19

--- a/projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+
+from projects.polymarket.polyquantbot.core.execution_memory_foundation import (
+    ExecutionMemoryContract,
+    ExecutionMemoryPersistenceBoundary,
+    ExecutionMemoryState,
+)
+from projects.polymarket.polyquantbot.core.recovery_resume_foundation import (
+    RECOVERY_DECISION_BLOCKED,
+    RECOVERY_DECISION_NO_MEMORY,
+    RECOVERY_DECISION_RESUME,
+    RECOVERY_DECISION_RESTART_FRESH,
+    RECOVERY_REASON_MEMORY_INVALID_CONTRACT,
+    RECOVERY_REASON_MEMORY_NOT_FOUND,
+    RECOVERY_REASON_MEMORY_VALID_INTERRUPTED,
+    RECOVERY_REASON_PREVIOUS_BLOCKED,
+    RecoveryResumeContract,
+    RecoveryResumeFoundationBoundary,
+)
+
+
+def _state(**kwargs) -> ExecutionMemoryState:  # type: ignore[no-untyped-def]
+    defaults: dict = {
+        "last_run_result": "completed",
+        "last_scheduler_decision": "triggered",
+        "last_loop_outcome": "completed",
+        "last_operator_control_decision": "allow",
+        "last_observability_trace_summary": "visible:trace-001",
+    }
+    defaults.update(kwargs)
+    return ExecutionMemoryState(**defaults)
+
+
+def _store_memory(tmp_path, **state_kwargs):  # type: ignore[no-untyped-def]
+    contract = ExecutionMemoryContract(
+        owner_ref="owner-1",
+        storage_dir=str(tmp_path),
+        state=_state(**state_kwargs),
+    )
+    result = ExecutionMemoryPersistenceBoundary().store(contract)
+    assert result.success is True
+
+
+def test_phase7_7_returns_no_memory_when_memory_is_missing(tmp_path) -> None:
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is True
+    assert decision.decision_category == RECOVERY_DECISION_NO_MEMORY
+    assert decision.reason == RECOVERY_REASON_MEMORY_NOT_FOUND
+
+
+def test_phase7_7_returns_restart_fresh_when_memory_is_closed(tmp_path) -> None:
+    _store_memory(tmp_path, last_run_result="completed", last_scheduler_decision="triggered", last_loop_outcome="completed")
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is True
+    assert decision.decision_category == RECOVERY_DECISION_RESTART_FRESH
+
+
+def test_phase7_7_returns_resume_when_memory_shows_interrupted_flow(tmp_path) -> None:
+    _store_memory(tmp_path, last_run_result="triggered", last_scheduler_decision="triggered", last_loop_outcome="exhausted")
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is True
+    assert decision.decision_category == RECOVERY_DECISION_RESUME
+    assert decision.reason == RECOVERY_REASON_MEMORY_VALID_INTERRUPTED
+
+
+def test_phase7_7_returns_blocked_when_memory_shows_blocked_condition(tmp_path) -> None:
+    _store_memory(tmp_path, last_run_result="stopped_blocked", last_scheduler_decision="blocked", last_loop_outcome="stopped_blocked")
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is False
+    assert decision.decision_category == RECOVERY_DECISION_BLOCKED
+    assert decision.reason == RECOVERY_REASON_PREVIOUS_BLOCKED
+
+
+def test_phase7_7_returns_blocked_when_persisted_memory_contract_is_invalid(tmp_path) -> None:
+    _store_memory(tmp_path)
+
+    bad_file = tmp_path / "owner-1" / "phase7_execution_memory.json"
+    with bad_file.open("w", encoding="utf-8") as handle:
+        json.dump({"owner_ref": "owner-1", "state": {"invalid": "payload"}}, handle)
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is False
+    assert decision.decision_category == RECOVERY_DECISION_BLOCKED
+    assert decision.reason == RECOVERY_REASON_MEMORY_INVALID_CONTRACT
+
+
+def test_phase7_7_blocks_invalid_recovery_contract(tmp_path) -> None:
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is False
+    assert decision.decision_category == RECOVERY_DECISION_BLOCKED
+    assert decision.reason == RECOVERY_REASON_MEMORY_INVALID_CONTRACT
+    assert decision.notes == {"contract_error": "owner_ref_required"}

--- a/projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py
@@ -15,6 +15,7 @@ from projects.polymarket.polyquantbot.core.recovery_resume_foundation import (
     RECOVERY_REASON_MEMORY_INVALID_CONTRACT,
     RECOVERY_REASON_MEMORY_NOT_FOUND,
     RECOVERY_REASON_MEMORY_VALID_INTERRUPTED,
+    RECOVERY_REASON_OPERATOR_HOLD,
     RECOVERY_REASON_PREVIOUS_BLOCKED,
     RecoveryResumeContract,
     RecoveryResumeFoundationBoundary,
@@ -65,7 +66,7 @@ def test_phase7_7_returns_restart_fresh_when_memory_is_closed(tmp_path) -> None:
 
 
 def test_phase7_7_returns_resume_when_memory_shows_interrupted_flow(tmp_path) -> None:
-    _store_memory(tmp_path, last_run_result="triggered", last_scheduler_decision="triggered", last_loop_outcome="exhausted")
+    _store_memory(tmp_path, last_run_result="triggered", last_scheduler_decision="triggered", last_loop_outcome="in_progress")
 
     decision = RecoveryResumeFoundationBoundary().decide(
         RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
@@ -86,6 +87,58 @@ def test_phase7_7_returns_blocked_when_memory_shows_blocked_condition(tmp_path) 
     assert decision.success is False
     assert decision.decision_category == RECOVERY_DECISION_BLOCKED
     assert decision.reason == RECOVERY_REASON_PREVIOUS_BLOCKED
+
+
+def test_phase7_7_returns_blocked_when_operator_memory_is_force_block(tmp_path) -> None:
+    _store_memory(
+        tmp_path,
+        last_run_result="triggered",
+        last_scheduler_decision="triggered",
+        last_loop_outcome="in_progress",
+        last_operator_control_decision="force_block",
+    )
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is False
+    assert decision.decision_category == RECOVERY_DECISION_BLOCKED
+    assert decision.reason == RECOVERY_REASON_PREVIOUS_BLOCKED
+
+
+def test_phase7_7_returns_restart_fresh_when_memory_is_exhausted(tmp_path) -> None:
+    _store_memory(
+        tmp_path,
+        last_run_result="exhausted",
+        last_scheduler_decision="triggered",
+        last_loop_outcome="exhausted",
+    )
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is True
+    assert decision.decision_category == RECOVERY_DECISION_RESTART_FRESH
+
+
+def test_phase7_7_returns_non_resume_when_operator_memory_is_hold(tmp_path) -> None:
+    _store_memory(
+        tmp_path,
+        last_run_result="triggered",
+        last_scheduler_decision="triggered",
+        last_loop_outcome="in_progress",
+        last_operator_control_decision="hold",
+    )
+
+    decision = RecoveryResumeFoundationBoundary().decide(
+        RecoveryResumeContract(owner_ref="owner-1", storage_dir=str(tmp_path))
+    )
+
+    assert decision.success is True
+    assert decision.decision_category == RECOVERY_DECISION_RESTART_FRESH
+    assert decision.reason == RECOVERY_REASON_OPERATOR_HOLD
 
 
 def test_phase7_7_returns_blocked_when_persisted_memory_contract_is_invalid(tmp_path) -> None:


### PR DESCRIPTION
### Motivation
- Provide a narrow, deterministic recovery / resume contract that decides whether to `resume`, `restart_fresh`, `blocked`, or `no_memory` after an interrupted runtime by consuming only the Phase 7.6 execution memory snapshot. 
- Keep the slice strictly FOUNDATION-scoped and avoid distributed recovery, replay, database/Redis rollout, async workers, or crash supervision claims. 
- Preserve existing Phase 6.4.1, 7.2, 7.3, 7.4, 7.5, and 7.6 contracts exactly as-is and surface a clear next gate for COMMANDER review.

### Description
- Added `projects/polymarket/polyquantbot/core/recovery_resume_foundation.py` implementing `RecoveryResumeFoundationBoundary` with deterministic decision categories (`resume`, `restart_fresh`, `blocked`, `no_memory`) and explicit reason constants and notes forwarding. 
- Added targeted tests in `projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py` covering missing memory, closed memory (restart fresh), interrupted memory (resume), previous blocked state, invalid persisted payload, and invalid recovery contract. 
- Updated repo state and planning: `PROJECT_STATE.md` updated with Asia/Jakarta timestamp `2026-04-19 02:07` and `ROADMAP.md` updated to mark 7.6 as preserved baseline and open 7.7 as in progress. 
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase7-7_01_recovery-resume-foundation.md` and committed code/tests/report/state together; claim level: `FOUNDATION`, validation tier: `STANDARD`.

### Testing
- Ran `python3 -m py_compile projects/polymarket/polyquantbot/core/recovery_resume_foundation.py projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py` and compilation passed. 
- Ran tests with `PYTHONPATH=/workspace/walker-ai-team pytest -q projects/polymarket/polyquantbot/tests/test_phase7_7_recovery_resume_foundation_20260419.py projects/polymarket/polyquantbot/tests/test_phase7_6_execution_memory_foundation_20260418.py` and the suite passed: `14 passed, 1 warning` (warning is pre-existing `asyncio_mode` config notice). 
- Verified runtime import and constant with `PYTHONPATH=/workspace/walker-ai-team python3 -c "import projects.polymarket.polyquantbot.core.recovery_resume_foundation as m; print(m.RECOVERY_DECISION_RESUME)"` which printed `resume`. 
- Performed mojibake scan on touched files for sequences `â€`, `â†`, `ðŸ`, `\udc`, `�` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d5f7ccac83258e29646c3793ae77)