### PR TITLE
docs: finalize Phase 7.3 runtime auto-run loop merged-main truth

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-19 02:16
+Last Updated : 2026-04-19 02:24
 Status       : Phase 7.6 state persistence / execution memory FOUNDATION is preserved as completed base layer; Phase 7.7 recovery / resume FOUNDATION safety semantics fix is active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19 with deterministic blocked handling for force_block, non-resume hold handling, and restart_fresh closed-loop terminal states over 7.6 memory only; pending COMMANDER re-review.
 
 [COMPLETED]
@@ -16,9 +16,9 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION is pres
 - Phase 7.4 observability / visibility foundation merged to main; deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py with 45 passing tests.
 - Phase 7.5 operator control / manual override merged to main via PR #575 with deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation through OperatorSchedulerGate + OperatorLoopGate.
 - Phase 7.6 state persistence / execution memory FOUNDATION completed as preserved baseline with deterministic local-file load/store/clear boundary in core/execution_memory_foundation.py for explicit last-run context and invalid_contract blocked behavior.
+- Phase 7.3 runtime auto-run loop FOUNDATION finalized as merged-main truth with preserved bounded synchronous loop behavior and preserved result categories (completed/stopped_hold/stopped_blocked/exhausted) over the Phase 7.2 scheduler boundary.
 
 [IN PROGRESS]
-- Phase 7.3 runtime auto-run loop foundation is active over the 7.2 scheduler boundary; executes bounded synchronous loop with result categories (completed/stopped_hold/stopped_blocked/exhausted) and deterministic stop reasons; no distributed schedulers, async workers, or cron daemon rollout.
 - Phase 7.7 recovery / resume FOUNDATION safety semantics fix active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19 with deterministic force_block -> blocked behavior, non-resume hold handling, and restart_fresh closed-loop terminal state handling (completed/stopped_hold/exhausted) over Phase 7.6 execution memory state only; excludes distributed recovery, daemon orchestration, replay engine, database rollout, Redis, async workers, and crash supervision.
 
 [NOT STARTED]
@@ -27,7 +27,6 @@ Status       : Phase 7.6 state persistence / execution memory FOUNDATION is pres
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review for Phase 7.3 runtime auto-run loop foundation (STANDARD tier; loop over 7.2 scheduler with completed/stopped_hold/stopped_blocked/exhausted result categories).
 - COMMANDER re-review for Phase 7.7 recovery / resume FOUNDATION safety semantics fix (STANDARD tier; deterministic force_block blocked behavior, non-resume hold behavior, and restart_fresh closed-loop terminal handling with targeted tests).
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 02:16
+**Last Updated:** 2026-04-19 02:24
 
 ## Board Overview
 
@@ -87,14 +87,14 @@
 
 **Goal:** Add thin deterministic orchestration contracts over the completed 6.6 baseline without broad automation rollout.  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 02:16
+**Last Updated:** 2026-04-19 02:24
 
 | Sub-Phase | Name | Status | Notes |
 |---|---|---|---|
 | 7.0 | Orchestration and Automation Foundation (Single Public Cycle) | ✅ Done | Deterministic single-cycle orchestration entrypoint `run_public_activation_cycle` merged and preserved as thin synchronous chaining over 6.6.5 -> 6.6.6 -> 6.6.7 -> 6.6.8 -> 6.6.9. |
 | 7.1 | Public Activation Trigger Surface (Single Entrypoint) | ✅ Done | Merged with one synchronous CLI trigger path invoking `run_public_activation_cycle(...)` and explicit completed/stopped_hold/stopped_blocked mapping; excludes scheduler daemons, async workers, settlement automation, portfolio orchestration, and live trading rollout. |
 | 7.2 | Lightweight Automation Scheduler (Single Invocation Cycle) | ✅ Done | Deterministic triggered/skipped/blocked result categories delivered; blocked(invalid_contract) for negative quota; one synchronous invocation cycle only; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
-| 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | 🚧 In Progress | Bounded deterministic loop over the 7.2 scheduler boundary active on claude/runtime-auto-run-loop-cBVTs; loop result categories: completed/stopped_hold/stopped_blocked/exhausted; deterministic stop reasons; excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
+| 7.3 | Runtime Auto-Run Loop Foundation (Bounded Synchronous Loop) | ✅ Done | Finalized as merged-main truth with preserved bounded synchronous loop behavior over the 7.2 scheduler boundary and unchanged loop result categories (completed/stopped_hold/stopped_blocked/exhausted); excludes distributed schedulers, async workers, cron daemon rollout, portfolio orchestration, and live trading. |
 | 7.4 | Observability / Visibility Foundation | ✅ Done | Merged to main. Deterministic visibility records (visible/partial/blocked) over Phase 6.4.1 monitoring evaluations, Phase 7.2 scheduler decisions, and Phase 7.3 loop outcomes in monitoring/observability_foundation.py; 45 passing tests; pure functions only; excludes alert delivery, dashboards, distributed monitoring mesh, async workers, cron daemon rollout. |
 | 7.5 | Operator Control / Manual Override | ✅ Done | Merged to main via PR #575. Deterministic OperatorControlDecision (allow/hold/force_block/force_run) injected before Phase 7.2 scheduler decision and Phase 7.3 loop continuation via pure OperatorSchedulerGate and OperatorLoopGate in core/operator_control.py; 49 targeted tests; 181 total phase 7 suite passing. |
 | 7.6 | State Persistence / Execution Memory Foundation | ✅ Done | Completed baseline preserved in core/execution_memory_foundation.py with deterministic local-file load/store/clear boundary for minimal last-run context and explicit invalid_contract blocked behavior; excludes database rollout, Redis, distributed state, replay engine, and broad recovery orchestration claims. |

--- a/projects/polymarket/polyquantbot/reports/forge/phase7-3_02_runtime-auto-run-loop-finalization.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase7-3_02_runtime-auto-run-loop-finalization.md
@@ -1,0 +1,69 @@
+# FORGE-X Report -- Phase 7.3 Runtime Auto-Run Loop Finalization
+
+## 1) What was built
+
+Executed a narrow finalization pass for Phase 7.3 merged-main truth only.
+
+No runtime code changes were introduced. This pass only finalized state and roadmap truth for
+Phase 7.3 after confirming the existing bounded synchronous loop behavior remains preserved over
+Phase 7.2 scheduler invocation.
+
+Preserved scope and behavior:
+- bounded synchronous loop behavior is unchanged
+- loop result categories are unchanged: completed / stopped_hold / stopped_blocked / exhausted
+- no daemon mode, no cron rollout, no async workers, no distributed scheduler, and no runtime
+  behavior expansion
+
+## 2) Current system architecture (relevant slice)
+
+```
+Phase 7.3 RuntimeAutoRunLoopBoundary.run_loop(...)
+    -> loops over Phase 7.2 decide_and_invoke_scheduler(...)
+    -> bounded by max_iterations
+    -> terminal results preserved: completed / stopped_hold / stopped_blocked / exhausted
+```
+
+This finalization pass did not modify runtime architecture.
+
+## 3) Files created / modified (full paths)
+
+**Created**
+- `projects/polymarket/polyquantbot/reports/forge/phase7-3_02_runtime-auto-run-loop-finalization.md`
+
+**Modified**
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4) What is working
+
+- `PROJECT_STATE.md` no longer lists Phase 7.3 as in progress and now reflects completed merged-main
+  truth for the preserved 7.3 runtime loop scope.
+- `ROADMAP.md` Phase 7.3 row is finalized to ✅ Done while preserving all existing 7.4, 7.5, 7.6,
+  and 7.7 merged/in-progress truths as-is.
+- Runtime behavior remained unchanged (documentation/state finalization only).
+
+Validation commands run:
+1. `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/core/runtime_auto_run_loop.py`
+2. `PYTHONIOENCODING=utf-8 PYTHONPATH=. python3 -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_3_runtime_auto_run_loop_20260418.py`
+
+## 5) Known issues
+
+- Pre-existing deferred pytest warning remains unchanged: `Unknown config option: asyncio_mode`.
+- Existing out-of-scope roadmap/state lines for other phases were intentionally preserved.
+
+## 6) What is next
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : Phase 7.3 runtime auto-run loop finalization truth only
+Not in Scope      : daemon orchestration, unbounded loops, cron rollout, async workers,
+                    distributed schedulers, recovery expansion, persistence expansion,
+                    operator-control changes, broader runtime refactor
+Suggested Next    : COMMANDER review
+
+---
+
+**Report Timestamp:** 2026-04-19 02:24 (Asia/Jakarta)
+**Role:** FORGE-X (NEXUS)
+**Task:** phase7-3-runtime-auto-run-loop-finalization
+**Branch:** `feature/phase7-3-runtime-auto-run-loop-finalization-2026-04-19`


### PR DESCRIPTION
### Motivation
- Finalize Phase 7.3 runtime auto-run loop as merged-main truth by removing the stale in-progress lane and marking the phase completed. 
- Preserve the existing bounded synchronous loop behavior and result categories exactly and avoid introducing any runtime changes or expanded scope.

### Description
- Update `PROJECT_STATE.md` to set `Last Updated` and move Phase 7.3 from `[IN PROGRESS]` into `[COMPLETED]` with preserved wording for the bounded synchronous loop and existing result categories. 
- Update `ROADMAP.md` to set Phase 7.3 row to `✅ Done` and refresh the Phase 7 `Last Updated` timestamp while preserving 7.4/7.5/7.6/7.7 truth. 
- Add a narrow FORGE-X finalization report at `projects/polymarket/polyquantbot/reports/forge/phase7-3_02_runtime-auto-run-loop-finalization.md` documenting the finalization, validation tier, claim level, validation target, and suggested next step; no runtime code changes were made.

### Testing
- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/core/runtime_auto_run_loop.py` which succeeded. 
- Ran `PYTHONIOENCODING=utf-8 PYTHONPATH=. python3 -m pytest -q projects/polymarket/polyquantbot/tests/test_phase7_3_runtime_auto_run_loop_20260418.py` which passed `35` tests with `1` pre-existing warning. 
- Verified locale (`C.UTF-8`) and performed a mojibake scan on touched files (no matches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3da6050088325ba4c21e58ebbd448)