### PR TITLE
chore: add post-merge sync rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,9 @@ Immediate FAIL / BLOCKED if:
 - `PROJECT_STATE.md` appended instead of section-replaced
 - `PROJECT_STATE.md` contains markdown headings inside sections
 - project-local `PROJECT_STATE.md` exists alongside repo-root version
+- COMMANDER merged a PR but did not sync PROJECT_STATE.md to reflect merged state
+- COMMANDER merged a PR but did not sync ROADMAP.md when roadmap-level truth changed
+- COMMANDER proceeded to the next build task before post-merge sync was completed
 - SENTINEL opens or recommends direct-to-main bypass of validated source branch
 - file contains mojibake or non-UTF-8 byte sequences (encoding corruption)
 
@@ -533,6 +536,7 @@ Use the checklist matching the declared Validation Tier. Do not run MAJOR checkl
 [ ] Runtime or behavior evidence attached
 [ ] Negative / break-attempt considered for risk-execution paths
 [ ] Max 5 files per commit preferred; split if needed
+[ ] ROADMAP.md updated if roadmap-level truth changed (active phase, milestone, task status)
 ```
 
 If any check fails: fix in same branch, re-run, only open PR after required checks pass.
@@ -819,6 +823,37 @@ Post-merge sync rules:
 - Must complete before next task is opened
 
 Failure to sync before next task = repo state drift.
+
+## POST-MERGE SYNC RULE (COMMANDER — MANDATORY)
+
+After every PR merge, COMMANDER must complete post-merge sync before proceeding.
+
+COMMANDER owns post-merge truth. FORGE-X and SENTINEL update state inside their branches.
+After merge to main, COMMANDER is responsible for verifying that PROJECT_STATE.md and ROADMAP.md
+on main reflect actual merged state.
+
+Post-merge checklist (run after every merge):
+- Read PROJECT_STATE.md on main — verify STATUS, COMPLETED, IN PROGRESS, NEXT PRIORITY are current
+- Read ROADMAP.md on main — verify active phase (🚧), completed phases (✅), and Board Overview are current
+- Verify PROJECT_STATE.md and ROADMAP.md are in sync on active phase and next milestone
+- If any file is stale → generate chore/core-state-sync-{date} fix immediately
+
+When to update PROJECT_STATE.md after merge:
+- FORGE-X PR → verify accuracy, fix if stale
+- SENTINEL PR → update IN PROGRESS and NEXT PRIORITY to reflect verdict
+- Any PR that changes delivery state → update COMPLETED if milestone reached
+
+When to update ROADMAP.md after merge:
+- Phase milestone completed → mark phase ✅, update Board Overview
+- Task within active phase merged → update task status in phase table
+- New tasks added → add rows with ❌
+- Code-only fix with no roadmap impact → no update needed
+- Report-only with no milestone change → no update needed
+
+Hard rule:
+- COMMANDER must not generate the next build task until post-merge sync is verified complete
+- Post-merge state sync qualifies as COMMANDER direct-fix (no FORGE-X task needed)
+- Commit message for sync: chore: post-merge state sync — [task/PR name]
 
 ## REPORT ARCHIVE RULE
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-19 02:24
+Last Updated : 2026-04-19 03:09
 Status       : Phase 7.6 state persistence / execution memory FOUNDATION is preserved as completed base layer; Phase 7.7 recovery / resume FOUNDATION safety semantics fix is active on branch feature/phase7-7-recovery-resume-safety-semantics-fix-2026-04-19 with deterministic blocked handling for force_block, non-resume hold handling, and restart_fresh closed-loop terminal states over 7.6 memory only; pending COMMANDER re-review.
 
 [COMPLETED]

--- a/projects/polymarket/polyquantbot/reports/forge/core_01_agents-post-merge-sync-rules.md
+++ b/projects/polymarket/polyquantbot/reports/forge/core_01_agents-post-merge-sync-rules.md
@@ -1,0 +1,32 @@
+# Forge Report — AGENTS.md Post-Merge Sync Rule Insertions
+
+## 1. What Was Changed
+
+Three targeted insertions made to AGENTS.md (repo root). No existing content was modified or removed.
+
+**Insertion 1 — FAILURE CONDITIONS (GLOBAL)**
+Added three new failure conditions immediately after the `project-local PROJECT_STATE.md exists alongside repo-root version` bullet:
+- COMMANDER merged a PR but did not sync PROJECT_STATE.md to reflect merged state
+- COMMANDER merged a PR but did not sync ROADMAP.md when roadmap-level truth changed
+- COMMANDER proceeded to the next build task before post-merge sync was completed
+
+**Insertion 2 — POST-MERGE SYNC RULE (COMMANDER — MANDATORY)**
+Added new section immediately after the existing `## POST-MERGE SYNC RULE` section (before `## REPORT ARCHIVE RULE`). Section defines COMMANDER ownership of post-merge truth, post-merge checklist, update triggers for PROJECT_STATE.md and ROADMAP.md, and the hard rule that next build task must not be opened until sync is verified complete.
+
+Note: task declared anchor was `## PLATFORM COMPLIANCE (ALL ENVIRONMENTS)` which does not exist in AGENTS.md. COMMANDER confirmed placement after existing `## POST-MERGE SYNC RULE` section.
+
+**Insertion 3 — FORGE-X pre-flight MAJOR checklist**
+Added one line immediately after `[ ] Max 5 files per commit preferred; split if needed` in the MAJOR adds block:
+- `[ ] ROADMAP.md updated if roadmap-level truth changed (active phase, milestone, task status)`
+
+## 2. Files Modified
+
+- `AGENTS.md`
+
+## 3. Validation Declaration
+
+Validation Tier   : MINOR
+Claim Level       : FOUNDATION
+Validation Target : AGENTS.md three new insertions only
+Not in Scope      : any other file, any existing AGENTS.md content, runtime behavior
+Suggested Next    : COMMANDER review


### PR DESCRIPTION
Three insertion-only additions:
1. Three new FAILURE CONDITIONS for missing post-merge state sync
2. New ## POST-MERGE SYNC RULE (COMMANDER — MANDATORY) section with
   COMMANDER ownership, post-merge checklist, and update triggers
3. ROADMAP.md check added to FORGE-X MAJOR pre-flight checklist

No existing content modified.

https://claude.ai/code/session_01Jb5pqmraNi7rnqAs6hWZn7