### PR TITLE
Phase 8.1: Crusader multi-user foundation — scope/ownership primitives, in-memory store, services, routes, docs, and tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 06:59
-Status       : Post-merge CrusaderBot smoke verification on main confirms GO-level continuity for Fly-readiness runtime split surfaces; next lane advances to COMMANDER-directed roadmap implementation continuation.
+Last Updated : 2026-04-19 08:07
+Status       : PR #590 remains at SENTINEL CONDITIONAL gate pending executable runtime evidence for phase8.1 test pass in a dependency-complete environment (fastapi + pydantic).
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -15,7 +15,7 @@ Status       : Post-merge CrusaderBot smoke verification on main confirms GO-lev
 - Phase 7.2 CrusaderBot Fly.io deploy-readiness runtime split merged via PR #585; final SENTINEL APPROVED revalidation is recorded in `projects/polymarket/polyquantbot/reports/sentinel/phase7_02_crusaderbot-fly-readiness-revalidation.md`.
 
 [IN PROGRESS]
-- Roadmap continuation planning for the next implementation slice is in progress after GO continuity verification on merged main runtime surfaces.
+- Phase 8.1 Crusader multi-user foundation code is complete; SENTINEL CONDITIONAL closure is in progress pending executable dependency-complete pytest evidence for PR #590.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -23,9 +23,10 @@ Status       : Post-merge CrusaderBot smoke verification on main confirms GO-lev
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Initiate the next roadmap implementation lane under COMMANDER direction using this smoke-verification GO result as continuity baseline evidence.
+- Re-run `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py` in a network-enabled dependency-complete runner, attach passing output to PR #590, then request final SENTINEL confirmation.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.
+- [DEFERRED] Dependency installation for fastapi/pydantic is blocked in current Codex runner due outbound network/proxy restrictions; runtime evidence rerun must be executed in a dependency-complete environment for PR #590.
 - Phase 6.4 narrow monitoring remains intentionally scoped and not yet the active implementation lane.
 - [DEFERRED] Pytest config emits Unknown config option: asyncio_mode warning -- carried forward as non-runtime higiene backlog.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@
 
 | Project | Platform | Status | Current Phase |
 |---|---|---|---|
-| Crusader | Polymarket | Active | Phase 7 — Orchestration & Automation Foundation |
+| Crusader | Polymarket | Active | Phase 8 — Multi-User Foundation |
 | TradingView Indicators | TradingView (Pine Script v5) | ❌ Not Started | — |
 | MT5 Expert Advisors | MT4/MT5 (MQL5) | ❌ Not Started | — |
 | Kalshi Bot | Kalshi | ❌ Not Started | — |
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 11:45
+**Last Updated:** 2026-04-19 07:22
 
 ## Board Overview
 
@@ -36,7 +36,37 @@
 | Phase 4 | Execution Formalization & Boundaries | ✅ Done | Internal |
 | Phase 5 | Real Execution & Capital System | ✅ Done | Internal |
 | Phase 6 | Production Safety & Stabilization | ✅ Done | Public Preparation |
-| Phase 7 | Orchestration & Automation Foundation | In Progress | Public Activation Orchestration |
+| Phase 7 | Orchestration & Automation Foundation | ✅ Done | Public Activation Orchestration |
+| Phase 8 | Multi-User Foundation | 🚧 In Progress | Multi-User Ownership & Tenant Scope |
+
+---
+
+## CrusaderBot — Multi-User Foundation Checklist
+
+**Goal:** Establish truthful backend foundations for user identity, tenant scope, ownership mapping, and scoped storage under `projects/polymarket/polyquantbot/server/`.  
+**Status:** 🚧 In Progress  
+**Last Updated:** 2026-04-19 07:22
+
+### Scope Lock
+- [x] Keep scope on backend multi-user foundations only
+- [x] Treat validation as `MAJOR`
+- [x] Avoid false claims of full auth/session productization
+
+### Foundation Deliverables
+- [x] Add tenant/user scope helpers for ownership boundaries
+- [x] Add schema foundations for `user`, `account`, `wallet`, `user_settings`
+- [x] Add storage foundations for scoped entities
+- [x] Add thin `user`, `account`, and `wallet` service boundaries
+- [x] Add minimal testable API routes for future auth/user/account/wallet surfaces
+- [x] Add tests for scope and ownership guard behavior
+- [x] Add implementation notes in project docs
+
+### Explicit Exclusions
+- [x] Full Telegram auth UX
+- [x] Full web auth flow
+- [x] Production-grade session system
+- [x] Full wallet lifecycle rollout
+- [x] Full RBAC and notification system
 
 ---
 

--- a/projects/polymarket/polyquantbot/docs/crusader_multi_user_foundation.md
+++ b/projects/polymarket/polyquantbot/docs/crusader_multi_user_foundation.md
@@ -1,0 +1,40 @@
+# Crusader Multi-User Foundation (Lane 8.1)
+
+This document records the first backend implementation lane for Crusader multi-user isolation foundations.
+
+## What exists now
+
+- `projects/polymarket/polyquantbot/server/core/scope.py`
+  - scope resolution helper (`tenant_id` + `user_id` required)
+  - ownership check and ownership enforcement helpers
+- `projects/polymarket/polyquantbot/server/schemas/multi_user.py`
+  - schema foundation for `user`, `account`, `wallet`, and `user_settings`
+- `projects/polymarket/polyquantbot/server/storage/in_memory_store.py`
+  - minimal scoped storage boundary for foundation entities
+- `projects/polymarket/polyquantbot/server/services/`
+  - `user_service.py`
+  - `account_service.py`
+  - `wallet_service.py`
+- `projects/polymarket/polyquantbot/server/api/multi_user_foundation_routes.py`
+  - minimal testable backend routes under `/foundation`
+
+## Scope and truth boundaries
+
+This lane introduces ownership and tenant scope primitives only.
+
+Included:
+- identity and ownership mapping primitives
+- tenant/user scope resolution
+- user/account/wallet/user_settings schema + storage foundation
+- thin service boundaries and minimal API surface for these entities
+
+Not included:
+- full auth/session UX
+- production session hardening
+- full wallet lifecycle orchestration
+- delegated signing rollout
+- full RBAC and notification system
+
+## Why this matters
+
+The backend now has explicit per-user ownership boundaries that future auth/session, wallet linking, and per-user portfolio isolation lanes can build on without pretending full product completeness.

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-1_01_crusader-multi-user-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-1_01_crusader-multi-user-foundation.md
@@ -1,0 +1,65 @@
+# What was built
+
+Implemented the first Crusader multi-user backend foundation lane under `projects/polymarket/polyquantbot/server/` with explicit tenant/user scope primitives, ownership guard helpers, and minimal but real model/service/API foundations for `user`, `account`, `wallet`, and `user_settings`.
+
+# Current system architecture
+
+Scoped architecture added in this lane:
+- `server/core/scope.py` resolves tenant/user scope and enforces ownership checks.
+- `server/schemas/multi_user.py` defines schema contracts for user/account/wallet/user_settings.
+- `server/storage/in_memory_store.py` provides a scoped storage boundary for foundation entities.
+- `server/services/user_service.py` creates user + default user_settings ownership records.
+- `server/services/account_service.py` enforces account ownership to existing scoped users.
+- `server/services/wallet_service.py` enforces wallet ownership against account and scope.
+- `server/api/multi_user_foundation_routes.py` exposes minimal `/foundation` backend routes.
+- `server/main.py` now wires the store + services + multi-user foundation router.
+
+# Files created / modified
+
+Created:
+- `projects/polymarket/polyquantbot/server/schemas/__init__.py`
+- `projects/polymarket/polyquantbot/server/schemas/multi_user.py`
+- `projects/polymarket/polyquantbot/server/storage/__init__.py`
+- `projects/polymarket/polyquantbot/server/storage/models.py`
+- `projects/polymarket/polyquantbot/server/storage/in_memory_store.py`
+- `projects/polymarket/polyquantbot/server/services/__init__.py`
+- `projects/polymarket/polyquantbot/server/services/user_service.py`
+- `projects/polymarket/polyquantbot/server/services/account_service.py`
+- `projects/polymarket/polyquantbot/server/services/wallet_service.py`
+- `projects/polymarket/polyquantbot/server/core/scope.py`
+- `projects/polymarket/polyquantbot/server/api/multi_user_foundation_routes.py`
+- `projects/polymarket/polyquantbot/docs/crusader_multi_user_foundation.md`
+- `projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py`
+
+Modified:
+- `projects/polymarket/polyquantbot/server/main.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+# What is working
+
+- Tenant/user scope resolution helper rejects incomplete scope context.
+- Ownership guard foundation can deterministically deny cross-user wallet reads.
+- User creation now seeds `user_settings` foundation records.
+- Account creation enforces owner-user existence and tenant consistency.
+- Wallet creation enforces account tenant/user ownership mapping.
+- Minimal `/foundation/users`, `/foundation/accounts`, `/foundation/wallets`, and scoped wallet read routes are testable through FastAPI.
+- New tests cover scope rejection, ownership mismatch detection, and route-level ownership enforcement.
+
+# Known issues
+
+- Storage boundary is currently in-memory and non-persistent by design for this foundation lane.
+- No production auth/session integration yet; scope headers are currently explicit input for ownership checks.
+- No full wallet signing lifecycle or delegated execution integration in this lane.
+
+# What is next
+
+- Add auth/session lane to bind scope context derivation to trusted identity sources.
+- Add persistent storage/migration layer for multi-user entities.
+- Expand ownership guards into portfolio and execution surfaces after auth foundation is present.
+
+Validation Tier   : MAJOR
+Claim Level       : FOUNDATION
+Validation Target : Tenant/user scope helpers, ownership enforcement, user/account/wallet/user_settings backend foundations, and minimal `/foundation` route behavior in `projects/polymarket/polyquantbot/server/`.
+Not in Scope      : Full auth/session rollout, full wallet lifecycle/signing, RBAC, notification system, and persistence migration rollout.
+Suggested Next    : SENTINEL required before merge.

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-1_02_conditional-gate-runtime-evidence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-1_02_conditional-gate-runtime-evidence.md
@@ -1,0 +1,48 @@
+# What was built
+
+Executed the scoped FORGE-X follow-up for PR #590 SENTINEL CONDITIONAL gate: attempted dependency installation and attempted to prepare runtime test rerun evidence for `test_phase8_1_multi_user_foundation_20260419.py`.
+
+No application code paths were changed in this pass.
+
+# Current system architecture
+
+Architecture remains unchanged from `phase8-1_01_crusader-multi-user-foundation.md`.
+
+This pass only targeted validation evidence readiness:
+- runtime dependency installation (`fastapi`, `pydantic`)
+- executable pytest evidence command for Phase 8.1 test scope
+
+# Files created / modified
+
+Created:
+- `projects/polymarket/polyquantbot/reports/forge/phase8-1_02_conditional-gate-runtime-evidence.md`
+
+Modified:
+- `PROJECT_STATE.md`
+
+# What is working
+
+- Scope guard followed: no broadened implementation scope.
+- Dependency install attempts were executed with:
+  - default pip configuration
+  - explicit `--index-url https://pypi.org/simple`
+  - proxy-unset environment (`env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY`)
+- All attempts failed consistently due environment network restrictions (`403 Forbidden` proxy tunnel and direct `Network is unreachable`).
+
+# Known issues
+
+- Current Codex runner cannot install required dependencies (`fastapi`, `pydantic`) because outbound package fetch is blocked.
+- Therefore executable passing pytest evidence for PR #590 cannot be produced in this runner.
+
+# What is next
+
+- Run in a dependency-complete environment (preinstalled or network-enabled for pip):
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py`
+- Post passing output on PR #590.
+- Request final SENTINEL confirmation (or COMMANDER merge decision) using the attached passing evidence.
+
+Validation Tier   : MAJOR
+Claim Level       : FOUNDATION
+Validation Target : Runtime evidence closure for PR #590 SENTINEL CONDITIONAL gate by executing phase8.1 pytest in dependency-complete environment.
+Not in Scope      : Code refactor, feature expansion, claim-level change, architecture changes, or merge decision.
+Suggested Next    : COMMANDER/SENTINEL to run or provide dependency-complete runner and finalize gate after passing evidence is attached.

--- a/projects/polymarket/polyquantbot/server/api/multi_user_foundation_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/multi_user_foundation_routes.py
@@ -1,0 +1,54 @@
+"""Minimal API foundation routes for user/account/wallet ownership boundaries."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Header, HTTPException
+
+from projects.polymarket.polyquantbot.server.core.scope import ScopeResolutionError, resolve_scope
+from projects.polymarket.polyquantbot.server.schemas.multi_user import AccountCreate, ScopeContext, UserCreate, WalletCreate
+from projects.polymarket.polyquantbot.server.services.account_service import AccountService
+from projects.polymarket.polyquantbot.server.services.user_service import UserService
+from projects.polymarket.polyquantbot.server.services.wallet_service import WalletService
+
+
+def build_multi_user_router(
+    user_service: UserService,
+    account_service: AccountService,
+    wallet_service: WalletService,
+) -> APIRouter:
+    router = APIRouter(prefix="/foundation", tags=["multi-user-foundation"])
+
+    @router.post("/users")
+    async def create_user(payload: UserCreate) -> dict[str, object]:
+        user, settings = user_service.create_user(payload)
+        return {"user": user.model_dump(), "user_settings": settings.model_dump()}
+
+    @router.post("/accounts")
+    async def create_account(payload: AccountCreate) -> dict[str, object]:
+        try:
+            account = account_service.create_account(payload)
+        except ScopeResolutionError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"account": account.model_dump()}
+
+    @router.post("/wallets")
+    async def create_wallet(payload: WalletCreate) -> dict[str, object]:
+        try:
+            wallet = wallet_service.create_wallet(payload)
+        except ScopeResolutionError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"wallet": wallet.model_dump()}
+
+    @router.get("/wallets/{wallet_id}")
+    async def get_wallet(
+        wallet_id: str,
+        x_tenant_id: str = Header(alias="X-Tenant-Id"),
+        x_user_id: str = Header(alias="X-User-Id"),
+    ) -> dict[str, object]:
+        try:
+            scope: ScopeContext = resolve_scope(tenant_id=x_tenant_id, user_id=x_user_id)
+            wallet = wallet_service.get_wallet_for_scope(scope=scope, wallet_id=wallet_id)
+        except ScopeResolutionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"wallet": wallet.model_dump()}
+
+    return router

--- a/projects/polymarket/polyquantbot/server/core/scope.py
+++ b/projects/polymarket/polyquantbot/server/core/scope.py
@@ -1,0 +1,46 @@
+"""Tenant/user scope resolution and ownership guards for multi-user foundation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from projects.polymarket.polyquantbot.server.schemas.multi_user import OwnershipCheckResult, ScopeContext
+
+
+class ScopeResolutionError(RuntimeError):
+    """Raised when tenant/user scope cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class ResourceOwnership:
+    resource_type: str
+    resource_id: str
+    tenant_id: str
+    user_id: str
+
+
+def resolve_scope(tenant_id: str | None, user_id: str | None) -> ScopeContext:
+    if not tenant_id or not tenant_id.strip():
+        raise ScopeResolutionError("tenant_id is required for scope resolution")
+    if not user_id or not user_id.strip():
+        raise ScopeResolutionError("user_id is required for scope resolution")
+    return ScopeContext(tenant_id=tenant_id.strip(), user_id=user_id.strip())
+
+
+def check_ownership(scope: ScopeContext, ownership: ResourceOwnership) -> OwnershipCheckResult:
+    is_owner = scope.user_id == ownership.user_id and scope.tenant_id == ownership.tenant_id
+    return OwnershipCheckResult(
+        resource_type=ownership.resource_type,
+        resource_id=ownership.resource_id,
+        owner_user_id=ownership.user_id,
+        owner_tenant_id=ownership.tenant_id,
+        is_owner=is_owner,
+    )
+
+
+def require_ownership(scope: ScopeContext, ownership: ResourceOwnership) -> None:
+    check = check_ownership(scope=scope, ownership=ownership)
+    if not check.is_owner:
+        raise ScopeResolutionError(
+            f"scope mismatch for {check.resource_type}:{check.resource_id} "
+            f"expected tenant={check.owner_tenant_id} user={check.owner_user_id}"
+        )

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -8,7 +8,12 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
+from projects.polymarket.polyquantbot.server.api.multi_user_foundation_routes import build_multi_user_router
 from projects.polymarket.polyquantbot.server.api.routes import build_router
+from projects.polymarket.polyquantbot.server.services.account_service import AccountService
+from projects.polymarket.polyquantbot.server.services.user_service import UserService
+from projects.polymarket.polyquantbot.server.services.wallet_service import WalletService
+from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
 from projects.polymarket.polyquantbot.server.core.runtime import (
     ApiSettings,
     RuntimeState,
@@ -39,8 +44,25 @@ def create_app() -> FastAPI:
     app.state.crusader_settings = settings
     app.state.crusader_runtime = state
 
+    store = InMemoryMultiUserStore()
+    user_service = UserService(store=store)
+    account_service = AccountService(store=store)
+    wallet_service = WalletService(store=store)
+
+    app.state.multi_user_store = store
+    app.state.user_service = user_service
+    app.state.account_service = account_service
+    app.state.wallet_service = wallet_service
+
     router = build_router(settings=settings, state=state)
     app.include_router(router)
+    app.include_router(
+        build_multi_user_router(
+            user_service=user_service,
+            account_service=account_service,
+            wallet_service=wallet_service,
+        )
+    )
 
     @app.get("/")
     async def root() -> JSONResponse:

--- a/projects/polymarket/polyquantbot/server/schemas/__init__.py
+++ b/projects/polymarket/polyquantbot/server/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Server schemas package."""

--- a/projects/polymarket/polyquantbot/server/schemas/multi_user.py
+++ b/projects/polymarket/polyquantbot/server/schemas/multi_user.py
@@ -1,0 +1,88 @@
+"""Minimal multi-user schemas for Crusader foundation services."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+ScopeStatus = Literal["active", "inactive"]
+WalletStatus = Literal["linked", "unlinked"]
+
+
+class UserCreate(BaseModel):
+    tenant_id: str = Field(min_length=1)
+    external_id: str = Field(min_length=1)
+    display_name: str | None = None
+
+
+class UserRecord(BaseModel):
+    user_id: str
+    tenant_id: str
+    external_id: str
+    display_name: str | None = None
+    status: ScopeStatus = "active"
+    created_at: datetime
+
+
+class UserSettingsRecord(BaseModel):
+    settings_id: str
+    tenant_id: str
+    user_id: str
+    timezone: str = "UTC"
+    notifications_enabled: bool = True
+    created_at: datetime
+
+
+class AccountCreate(BaseModel):
+    tenant_id: str = Field(min_length=1)
+    user_id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+
+
+class AccountRecord(BaseModel):
+    account_id: str
+    tenant_id: str
+    user_id: str
+    label: str
+    status: ScopeStatus = "active"
+    created_at: datetime
+
+
+class WalletCreate(BaseModel):
+    tenant_id: str = Field(min_length=1)
+    user_id: str = Field(min_length=1)
+    account_id: str = Field(min_length=1)
+    address: str = Field(min_length=1)
+
+
+class WalletRecord(BaseModel):
+    wallet_id: str
+    tenant_id: str
+    user_id: str
+    account_id: str
+    address: str
+    status: WalletStatus = "linked"
+    created_at: datetime
+
+
+class ScopeContext(BaseModel):
+    tenant_id: str = Field(min_length=1)
+    user_id: str = Field(min_length=1)
+
+
+class OwnershipCheckResult(BaseModel):
+    resource_type: str
+    resource_id: str
+    owner_user_id: str
+    owner_tenant_id: str
+    is_owner: bool
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:12]}"

--- a/projects/polymarket/polyquantbot/server/services/__init__.py
+++ b/projects/polymarket/polyquantbot/server/services/__init__.py
@@ -1,0 +1,1 @@
+"""Server services package."""

--- a/projects/polymarket/polyquantbot/server/services/account_service.py
+++ b/projects/polymarket/polyquantbot/server/services/account_service.py
@@ -1,0 +1,31 @@
+"""Account service foundation for multi-user ownership mapping."""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.server.core.scope import ScopeResolutionError
+from projects.polymarket.polyquantbot.server.schemas.multi_user import AccountCreate, AccountRecord, new_id, now_utc
+from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
+
+
+class AccountService:
+    def __init__(self, store: InMemoryMultiUserStore) -> None:
+        self._store = store
+
+    def create_account(self, payload: AccountCreate) -> AccountRecord:
+        user = self._store.get_user(payload.user_id)
+        if user is None:
+            raise ScopeResolutionError(f"user not found: {payload.user_id}")
+        if user.tenant_id != payload.tenant_id:
+            raise ScopeResolutionError("account tenant_id must match owner user tenant_id")
+
+        account = AccountRecord(
+            account_id=new_id("acct"),
+            tenant_id=payload.tenant_id,
+            user_id=payload.user_id,
+            label=payload.label,
+            created_at=now_utc(),
+        )
+        self._store.put_account(account)
+        return account
+
+    def get_account(self, account_id: str) -> AccountRecord | None:
+        return self._store.get_account(account_id)

--- a/projects/polymarket/polyquantbot/server/services/user_service.py
+++ b/projects/polymarket/polyquantbot/server/services/user_service.py
@@ -1,0 +1,37 @@
+"""User service foundation for multi-user user and user_settings ownership."""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.server.schemas.multi_user import (
+    UserCreate,
+    UserRecord,
+    UserSettingsRecord,
+    new_id,
+    now_utc,
+)
+from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
+
+
+class UserService:
+    def __init__(self, store: InMemoryMultiUserStore) -> None:
+        self._store = store
+
+    def create_user(self, payload: UserCreate) -> tuple[UserRecord, UserSettingsRecord]:
+        user = UserRecord(
+            user_id=new_id("usr"),
+            tenant_id=payload.tenant_id,
+            external_id=payload.external_id,
+            display_name=payload.display_name,
+            created_at=now_utc(),
+        )
+        settings = UserSettingsRecord(
+            settings_id=new_id("uset"),
+            tenant_id=payload.tenant_id,
+            user_id=user.user_id,
+            created_at=now_utc(),
+        )
+        self._store.put_user(user)
+        self._store.put_user_settings(settings)
+        return user, settings
+
+    def get_user(self, user_id: str) -> UserRecord | None:
+        return self._store.get_user(user_id)

--- a/projects/polymarket/polyquantbot/server/services/wallet_service.py
+++ b/projects/polymarket/polyquantbot/server/services/wallet_service.py
@@ -1,0 +1,47 @@
+"""Wallet service foundation for tenant/user/account ownership boundaries."""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.server.core.scope import ResourceOwnership, ScopeResolutionError, require_ownership
+from projects.polymarket.polyquantbot.server.schemas.multi_user import ScopeContext, WalletCreate, WalletRecord, new_id, now_utc
+from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
+
+
+class WalletService:
+    def __init__(self, store: InMemoryMultiUserStore) -> None:
+        self._store = store
+
+    def create_wallet(self, payload: WalletCreate) -> WalletRecord:
+        account = self._store.get_account(payload.account_id)
+        if account is None:
+            raise ScopeResolutionError(f"account not found: {payload.account_id}")
+        if account.tenant_id != payload.tenant_id:
+            raise ScopeResolutionError("wallet tenant_id must match owner account tenant_id")
+        if account.user_id != payload.user_id:
+            raise ScopeResolutionError("wallet user_id must match owner account user_id")
+
+        wallet = WalletRecord(
+            wallet_id=new_id("wlt"),
+            tenant_id=payload.tenant_id,
+            user_id=payload.user_id,
+            account_id=payload.account_id,
+            address=payload.address,
+            created_at=now_utc(),
+        )
+        self._store.put_wallet(wallet)
+        return wallet
+
+    def get_wallet_for_scope(self, scope: ScopeContext, wallet_id: str) -> WalletRecord:
+        wallet = self._store.get_wallet(wallet_id)
+        if wallet is None:
+            raise ScopeResolutionError(f"wallet not found: {wallet_id}")
+
+        require_ownership(
+            scope=scope,
+            ownership=ResourceOwnership(
+                resource_type="wallet",
+                resource_id=wallet_id,
+                tenant_id=wallet.tenant_id,
+                user_id=wallet.user_id,
+            ),
+        )
+        return wallet

--- a/projects/polymarket/polyquantbot/server/storage/__init__.py
+++ b/projects/polymarket/polyquantbot/server/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Server storage package."""

--- a/projects/polymarket/polyquantbot/server/storage/in_memory_store.py
+++ b/projects/polymarket/polyquantbot/server/storage/in_memory_store.py
@@ -1,0 +1,38 @@
+"""In-memory storage boundary for multi-user foundation entities."""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.server.schemas.multi_user import (
+    AccountRecord,
+    UserRecord,
+    UserSettingsRecord,
+    WalletRecord,
+)
+
+
+class InMemoryMultiUserStore:
+    def __init__(self) -> None:
+        self.users: dict[str, UserRecord] = {}
+        self.user_settings: dict[str, UserSettingsRecord] = {}
+        self.accounts: dict[str, AccountRecord] = {}
+        self.wallets: dict[str, WalletRecord] = {}
+
+    def put_user(self, user: UserRecord) -> None:
+        self.users[user.user_id] = user
+
+    def put_user_settings(self, settings: UserSettingsRecord) -> None:
+        self.user_settings[settings.settings_id] = settings
+
+    def put_account(self, account: AccountRecord) -> None:
+        self.accounts[account.account_id] = account
+
+    def put_wallet(self, wallet: WalletRecord) -> None:
+        self.wallets[wallet.wallet_id] = wallet
+
+    def get_user(self, user_id: str) -> UserRecord | None:
+        return self.users.get(user_id)
+
+    def get_account(self, account_id: str) -> AccountRecord | None:
+        return self.accounts.get(account_id)
+
+    def get_wallet(self, wallet_id: str) -> WalletRecord | None:
+        return self.wallets.get(wallet_id)

--- a/projects/polymarket/polyquantbot/server/storage/models.py
+++ b/projects/polymarket/polyquantbot/server/storage/models.py
@@ -1,0 +1,45 @@
+"""Storage-model foundation for multi-user user/account/wallet state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UserModel:
+    user_id: str
+    tenant_id: str
+    external_id: str
+    display_name: str | None
+    status: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class UserSettingsModel:
+    settings_id: str
+    tenant_id: str
+    user_id: str
+    timezone: str
+    notifications_enabled: bool
+    created_at: str
+
+
+@dataclass(frozen=True)
+class AccountModel:
+    account_id: str
+    tenant_id: str
+    user_id: str
+    label: str
+    status: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class WalletModel:
+    wallet_id: str
+    tenant_id: str
+    user_id: str
+    account_id: str
+    address: str
+    status: str
+    created_at: str

--- a/projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from projects.polymarket.polyquantbot.server.core.scope import ResourceOwnership, ScopeResolutionError, check_ownership, resolve_scope
+from projects.polymarket.polyquantbot.server.main import create_app
+
+
+def test_scope_resolution_rejects_empty_tenant() -> None:
+    try:
+        resolve_scope(tenant_id="", user_id="user-1")
+    except ScopeResolutionError as exc:
+        assert "tenant_id" in str(exc)
+    else:
+        raise AssertionError("resolve_scope should reject empty tenant_id")
+
+
+def test_scope_ownership_detects_mismatch() -> None:
+    scope = resolve_scope(tenant_id="tenant-alpha", user_id="user-a")
+    check = check_ownership(
+        scope=scope,
+        ownership=ResourceOwnership(
+            resource_type="wallet",
+            resource_id="wallet-1",
+            tenant_id="tenant-alpha",
+            user_id="user-b",
+        ),
+    )
+    assert check.is_owner is False
+
+
+def test_multi_user_routes_enforce_wallet_scope(monkeypatch) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+
+    app = create_app()
+    with TestClient(app) as client:
+        user_response = client.post(
+            "/foundation/users",
+            json={"tenant_id": "tenant-alpha", "external_id": "tg_1001", "display_name": "alice"},
+        )
+        assert user_response.status_code == 200
+        user_payload = user_response.json()["user"]
+
+        account_response = client.post(
+            "/foundation/accounts",
+            json={
+                "tenant_id": user_payload["tenant_id"],
+                "user_id": user_payload["user_id"],
+                "label": "primary",
+            },
+        )
+        assert account_response.status_code == 200
+        account_payload = account_response.json()["account"]
+
+        wallet_response = client.post(
+            "/foundation/wallets",
+            json={
+                "tenant_id": user_payload["tenant_id"],
+                "user_id": user_payload["user_id"],
+                "account_id": account_payload["account_id"],
+                "address": "0xabc123",
+            },
+        )
+        assert wallet_response.status_code == 200
+        wallet_payload = wallet_response.json()["wallet"]
+
+        denied_response = client.get(
+            f"/foundation/wallets/{wallet_payload['wallet_id']}",
+            headers={"X-Tenant-Id": "tenant-alpha", "X-User-Id": "intruder-user"},
+        )
+        assert denied_response.status_code == 403
+
+        allowed_response = client.get(
+            f"/foundation/wallets/{wallet_payload['wallet_id']}",
+            headers={"X-Tenant-Id": user_payload["tenant_id"], "X-User-Id": user_payload["user_id"]},
+        )
+        assert allowed_response.status_code == 200
+        assert allowed_response.json()["wallet"]["address"] == "0xabc123"


### PR DESCRIPTION
### Motivation
- Establish explicit tenant/user scope and ownership primitives as the backend foundation for multi-user isolation and future auth/session integration.
- Provide minimal but testable service, storage, and API boundaries so subsequent lanes (auth, persistence, wallet lifecycle) can build on truthful ownership guarantees.
- Record current validation state and gate the PR behind executable pytest evidence for Phase 8.1 in a dependency-complete environment.

### Description
- Add tenant/user scope resolution and ownership guards in `server/core/scope.py` with `resolve_scope`, `check_ownership`, and `require_ownership` helpers and a `ScopeResolutionError` class.
- Introduce Pydantic schemas for user/account/wallet/user_settings and support helpers in `server/schemas/multi_user.py` and package `server/schemas`.
- Implement an in-memory storage boundary in `server/storage/in_memory_store.py` plus storage models in `server/storage/models.py` and package `server/storage`.
- Provide thin service layers in `server/services/` for `UserService`, `AccountService`, and `WalletService` enforcing ownership and tenant consistency.
- Expose minimal testable API under `/foundation` via `server/api/multi_user_foundation_routes.py` and wire services into the FastAPI app in `server/main.py`.
- Add documentation and forge reports: `docs/crusader_multi_user_foundation.md` and `reports/forge/*` and update `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 8 and the SENTINEL conditional gate.
- Add unit/integration-style tests in `projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py` that exercise scope resolution, ownership checks, and route-level enforcement.

### Testing
- Created `projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py` which uses `TestClient` to validate scope rejection, ownership mismatch detection, and allowed/denied wallet reads; the tests are present but were not executed successfully in this runner due to missing dependencies.
- Attempted to prepare runtime evidence by installing `fastapi` and `pydantic` and running `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py`, but dependency installation failed in the Codex runner with network/proxy errors, so no passing pytest output could be produced here.
- To validate locally or in CI, run `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py` in a dependency-complete environment; this is the required executable evidence for closing the SENTINEL conditional gate for PR #590.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41f795ac08325bfb0638a43987ce3)