### PR TITLE
FORGE-X: phase 8.5 persistent wallet-link storage / lifecycle foundation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 11:20
-Status       : Phase 8.4 client auth handoff / wallet-link foundation — pytest gate closed: 25/25 pass in dependency-complete environment. PR #598 is mergeable. SENTINEL CONDITIONAL gate satisfied.
+Last Updated : 2026-04-19 11:28
+Status       : Phase 8.4 merged (PR #598). Phase 8.5 persistent wallet-link storage / lifecycle foundation in progress on branch claude/phase8-5-wallet-link-persistence-ExuR9. SENTINEL validation required before merge.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -19,16 +19,15 @@ Status       : Phase 8.4 client auth handoff / wallet-link foundation — pytest
 - Phase 8.4 client auth handoff / wallet-link foundation built: client auth handoff contract (core/client_auth_handoff.py), wallet-link schemas/storage/service, authenticated /auth/handoff + /auth/wallet-links routes. Pytest gate closed: 25/25 pass (Python 3.11.15, pytest-9.0.2). Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-4_02_pytest-evidence-pass.md`. PR #598 mergeable. SENTINEL CONDITIONAL gate satisfied.
 
 [IN PROGRESS]
-- None.
+- Phase 8.5 persistent wallet-link storage / lifecycle foundation: PersistentWalletLinkStore (local-file JSON), unlink lifecycle (active → unlinked), authenticated unlink route. Branch: claude/phase8-5-wallet-link-persistence-ExuR9.
 
 [NOT STARTED]
-- Persistent wallet-link storage (restart-safe wallet-link records beyond in-memory boundary).
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
 - Portfolio management logic and multi-wallet orchestration.
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER reviews PR #598 and decides merge. PR #599 can be closed after merge (SENTINEL CONDITIONAL gate now satisfied by pytest evidence in phase8-4_02_pytest-evidence-pass.md).
+- SENTINEL validation required for Phase 8.5 persistent wallet-link foundation before merge. Source: projects/polymarket/polyquantbot/reports/forge/phase8-5_01_persistent-wallet-link-foundation.md. Tier: MAJOR.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,8 +137,8 @@
 ## CrusaderBot — Client Auth Handoff / Wallet-Link Foundation Checklist (Phase 8.4)
 
 **Goal:** Establish truthful client-to-backend identity handoff and user-owned wallet-link foundation over the persistent session backbone under `projects/polymarket/polyquantbot/server/`.  
-**Status:** 🚧 In Progress — SENTINEL validation required before merge  
-**Last Updated:** 2026-04-19 11:10
+**Status:** ✅ Done (Merged via PR #598. SENTINEL CONDITIONAL gate satisfied. Pytest gate: 25/25 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-4_02_pytest-evidence-pass.md`)  
+**Last Updated:** 2026-04-19 11:28
 
 ### Scope Lock
 - [x] Keep scope on client auth handoff contract + wallet-link foundation only
@@ -170,6 +170,41 @@
 - [x] On-chain settlement rollout
 - [x] Persistent wallet-link storage (deferred follow-up lane)
 - [x] Broad portfolio engine work
+
+---
+
+## CrusaderBot — Persistent Wallet-Link Storage / Lifecycle Foundation Checklist (Phase 8.5)
+
+**Goal:** Replace in-memory-only wallet-link records with restart-safe persistent storage and add minimal truthful wallet-link lifecycle controls under `projects/polymarket/polyquantbot/server/`.  
+**Status:** 🚧 In Progress — SENTINEL validation required before merge  
+**Last Updated:** 2026-04-19 11:28
+
+### Scope Lock
+- [x] Keep scope on persistent wallet-link storage + minimal lifecycle foundation only
+- [x] Treat validation as `MAJOR`
+- [x] Avoid false claims of full wallet lifecycle completion or production orchestration
+
+### Foundation Deliverables
+- [x] Introduce `PersistentWalletLinkStore` with deterministic local-file JSON persistence (atomic overwrite)
+- [x] Convert `WalletLinkStore` to abstract base class (SessionStore pattern)
+- [x] Switch `server/main.py` off in-memory `WalletLinkStore` to `PersistentWalletLinkStore`
+- [x] Add `CRUSADER_WALLET_LINK_STORAGE_PATH` env var for configurable storage path
+- [x] Add `set_link_status` lifecycle method to storage boundary
+- [x] Add `unlink_link` method to `WalletLinkService` (ownership-enforced `active` → `unlinked`)
+- [x] Expose `PATCH /auth/wallet-links/{link_id}/unlink` authenticated route
+- [x] Add tests for persisted readback, restart-safe continuity, unlink behavior, cross-user isolation
+- [x] Update forge report, PROJECT_STATE.md, ROADMAP.md
+
+### Explicit Exclusions
+- [x] Full wallet lifecycle orchestration
+- [x] Delegated signing lifecycle
+- [x] Exchange signing rollout
+- [x] On-chain settlement rollout
+- [x] Full RBAC
+- [x] OAuth rollout
+- [x] Production token rotation platform
+- [x] Broad portfolio engine work
+- [x] Full database migration platform
 
 ---
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-5_01_persistent-wallet-link-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-5_01_persistent-wallet-link-foundation.md
@@ -1,0 +1,226 @@
+# Phase 8.5 — Persistent Wallet-Link Storage / Lifecycle Foundation
+
+**Date:** 2026-04-19 11:28
+**Branch:** claude/phase8-5-wallet-link-persistence-ExuR9
+**Validation Tier:** MAJOR
+**Claim Level:** FOUNDATION
+**Validation Target:** persistent wallet-link storage boundary + minimal unlink lifecycle + authenticated ownership enforcement
+**Not in Scope:** full wallet lifecycle orchestration, delegated signing lifecycle, exchange signing rollout, on-chain settlement rollout, full RBAC, OAuth rollout, production token rotation platform, broad portfolio engine work, full database migration platform
+**Suggested Next:** SENTINEL validation required before merge
+
+---
+
+## 1. What Was Built
+
+### Part A — Phase 8.4 Post-Merge Truth Sync
+
+- `PROJECT_STATE.md` updated: Phase 8.4 moved from pending-COMMANDER to confirmed merged; Phase 8.5 moved from NOT STARTED to IN PROGRESS; NEXT PRIORITY updated to SENTINEL for Phase 8.5
+- `ROADMAP.md` updated: Phase 8.4 section status changed from `🚧 In Progress — SENTINEL validation required before merge` to `✅ Done (Merged via PR #598)`; Phase 8.5 checklist section added
+
+### Part B — Phase 8.5 Persistent Wallet-Link Storage / Lifecycle Foundation
+
+**1. Persistent Wallet-Link Storage Boundary (`server/storage/wallet_link_store.py`)**
+
+Refactored from single concrete in-memory class to abstract base + persistent implementation:
+
+- `WalletLinkStore` — abstract base class with `put_link`, `get_link`, `list_links_for_user`, `set_link_status` (SessionStore pattern)
+- `WalletLinkStorageError` — typed exception for storage read/write failures
+- `PersistentWalletLinkStore` — local-file JSON storage with:
+  - Deterministic atomic overwrite via temp-file replace (same pattern as `PersistentSessionStore`)
+  - `_load_from_disk()` on init — restart-safe record recovery
+  - `_persist_to_disk()` on every write — format version 1, sorted by link_id
+  - `set_link_status()` — lifecycle state transition with persistence
+  - Configurable path via `CRUSADER_WALLET_LINK_STORAGE_PATH` env var
+
+**2. Wallet-Link Lifecycle Methods (`server/services/wallet_link_service.py`)**
+
+Added two error classes and one lifecycle method to `WalletLinkService`:
+- `WalletLinkNotFoundError` — raised when link_id not in store
+- `WalletLinkOwnershipError` — raised when authenticated user does not own the record
+- `unlink_link(scope, link_id)` — ownership-enforced `active → unlinked` transition; delegates to `store.set_link_status`
+
+**3. Unlink Route (`server/api/client_auth_routes.py`)**
+
+Added one authenticated route to the existing client auth router:
+- `PATCH /auth/wallet-links/{link_id}/unlink`
+  - Requires valid authenticated session via `get_authenticated_scope` dependency
+  - Returns 404 if link_id not found
+  - Returns 403 if link belongs to a different user
+  - Returns 200 with updated `WalletLinkRecord` on success
+
+**4. App Wiring (`server/main.py`)**
+
+- Replaced `WalletLinkStore()` (in-memory) with `PersistentWalletLinkStore(storage_path=wallet_link_storage_path)`
+- Added `CRUSADER_WALLET_LINK_STORAGE_PATH` env var (default: `/tmp/crusaderbot/runtime/wallet_links.json`)
+- Added `wallet_link_storage_path` to `app.state` for observability
+- Phase log updated to `8.5`
+
+---
+
+## 2. Current System Architecture (Relevant Slice)
+
+```
+Client (Telegram / Web)
+        |
+        v
+POST /auth/handoff
+        |
+        v
+AuthSessionService.issue_session()
+        |
+        v
+PersistentSessionStore (sessions.json) ← restart-safe
+
+Authenticated client
+        |
+        v
+POST /auth/wallet-links             create — owned by authenticated user
+GET  /auth/wallet-links             list — scoped to authenticated user
+PATCH /auth/wallet-links/{id}/unlink  lifecycle: active -> unlinked
+        |
+        v
+WalletLinkService
+  create_link  -> PersistentWalletLinkStore.put_link    -> disk write
+  list_links   -> PersistentWalletLinkStore.list_links_for_user
+  unlink_link  -> ownership check -> .set_link_status("unlinked") -> disk write
+        |
+        v
+PersistentWalletLinkStore (wallet_links.json) ← restart-safe
+  _load_from_disk()  on init
+  _persist_to_disk() on every mutation  (atomic temp-file replace)
+  JSON format: { "version": 1, "records": [...] }
+```
+
+Ownership chain is unbroken:
+- Session scope is derived from authenticated headers (not request body)
+- Wallet-link create binds record to authenticated `tenant_id` + `user_id`
+- Unlink verifies record ownership before mutation — no cross-user state change possible
+- Persistent store is user-isolated at query time (`list_links_for_user` filters by tenant_id + user_id)
+
+---
+
+## 3. Files Created / Modified (Full Repo-Root Paths)
+
+### Created
+- `projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase8-5_01_persistent-wallet-link-foundation.md` (this file)
+
+### Modified
+- `projects/polymarket/polyquantbot/server/storage/wallet_link_store.py` (abstract base + PersistentWalletLinkStore)
+- `projects/polymarket/polyquantbot/server/services/wallet_link_service.py` (unlink_link + error classes)
+- `projects/polymarket/polyquantbot/server/api/client_auth_routes.py` (PATCH unlink route)
+- `projects/polymarket/polyquantbot/server/main.py` (PersistentWalletLinkStore wiring + env var)
+- `PROJECT_STATE.md` (Part A truth sync + Part B state)
+- `ROADMAP.md` (Phase 8.4 close + Phase 8.5 checklist)
+
+---
+
+## 4. What Is Working
+
+**Persistent Storage (unit-tested directly on PersistentWalletLinkStore):**
+- `put_link` writes to disk and reads back correctly after fresh init
+- `_load_from_disk()` recovers all records on a second store instance (simulated restart)
+- `set_link_status` updates status and persists — reloaded store shows updated state
+- `set_link_status` raises `WalletLinkStorageError` for unknown link_id
+- `list_links_for_user` returns only matching user's records — cross-user isolation at storage level
+
+**Restart-Safe Readback (integration-tested via HTTP):**
+- Wallet-link created in app instance 1 — present in app instance 2 with same storage path
+- Multiple users' wallet-links survive restart with correct cross-user isolation
+- Unlinked status persists across simulated restart
+
+**Unlink Lifecycle (integration-tested via HTTP):**
+- `PATCH /auth/wallet-links/{link_id}/unlink` sets status to `unlinked` and returns updated record
+- Unlink by non-owner returns 403 — ownership enforcement holds
+- Unlink for unknown link_id returns 404
+- Unauthenticated unlink attempt returns 403 (scope dependency enforced)
+
+**Regression (Phase 8.4 + 8.1 tests):**
+- All 20 prior tests pass — 0 regressions
+
+**Full pytest evidence (33/33 pass):**
+```
+platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
+rootdir: /home/user/walker-ai-team
+configfile: pytest.ini
+plugins: anyio-4.13.0
+
+Phase 8.5 tests (13/13):
+test_persistent_store_put_and_get_roundtrip                    PASSED
+test_persistent_store_load_from_disk_on_init                   PASSED
+test_persistent_store_set_link_status                          PASSED
+test_persistent_store_set_link_status_not_found_raises         PASSED
+test_persistent_store_list_for_user_scoped                     PASSED
+test_wallet_link_persists_across_app_restart                   PASSED
+test_multiple_users_wallet_links_survive_restart               PASSED
+test_unlink_wallet_link_sets_status_unlinked                   PASSED
+test_unlink_status_persists_after_restart                      PASSED
+test_unlink_not_found_returns_404                              PASSED
+test_unlink_cross_user_denied_returns_403                      PASSED
+test_unlink_requires_authenticated_session                     PASSED
+test_persistent_cross_user_isolation_via_http                  PASSED
+
+Phase 8.4 regression (12/12):
+test_handoff_validates_known_telegram_client                   PASSED
+test_handoff_validates_known_web_client                        PASSED
+test_handoff_rejects_unsupported_client_type                   PASSED
+test_handoff_rejects_empty_claim                               PASSED
+test_handoff_rejects_empty_scope                               PASSED
+test_client_handoff_issues_session_for_known_user              PASSED
+test_client_handoff_rejects_unknown_user                       PASSED
+test_client_handoff_rejects_unsupported_client_type_via_route  PASSED
+test_wallet_link_create_and_read_for_authenticated_user        PASSED
+test_wallet_link_requires_authenticated_session                PASSED
+test_wallet_link_cross_user_isolation                          PASSED
+test_wallet_link_cross_tenant_session_denied                   PASSED
+
+Phase 8.1 regression (8/8):
+test_scope_resolution_rejects_empty_tenant                     PASSED
+test_scope_ownership_detects_mismatch                          PASSED
+test_multi_user_routes_enforce_wallet_scope                    PASSED
+test_scope_dependency_rejects_missing_session                  PASSED
+test_scope_dependency_derives_authenticated_scope              PASSED
+test_persisted_session_readback_and_restart_safe_scope         PASSED
+test_revoked_session_is_rejected                               PASSED
+test_expired_session_is_rejected                               PASSED
+
+33 passed, 1 warning in 4.42s
+```
+
+---
+
+## 5. Known Issues
+
+- `WalletLinkStore` (abstract base) has `raise NotImplementedError` methods — not an ABC-enforced contract; this is intentional to preserve the SessionStore pattern and avoid over-engineering at this foundation stage
+- `client_identity_claim` remains structurally validated only — no cryptographic verification (explicit deferred gate; consistent with Phase 8.4 FOUNDATION scope)
+- `Unknown config option: asyncio_mode` warning in pytest is pre-existing hygiene backlog (carried from Phase 8.3, non-runtime)
+- `InMemoryMultiUserStore` (Phase 8.1 user store) is still in-memory — persistent user store is a future lane
+
+---
+
+## 6. What Is Next
+
+SENTINEL validation required for Phase 8.5 before merge.
+
+Source: `projects/polymarket/polyquantbot/reports/forge/phase8-5_01_persistent-wallet-link-foundation.md`
+Tier: MAJOR
+
+Validation Target:
+- `PersistentWalletLinkStore` persistence contract (put/load/restart roundtrip)
+- `set_link_status` lifecycle boundary (not-found error, status persistence)
+- `unlink_link` ownership enforcement (cross-user denial, 403 path)
+- Authenticated scope on all wallet-link routes (403 on missing session)
+- Regression coverage on Phase 8.4 + 8.1 test suites
+
+After SENTINEL validates and COMMANDER approves merge, the next public-readiness lanes are:
+- Persistent multi-user store (user/account/wallet records beyond in-memory)
+- Telegram bot handler thin integration (client-side handoff surface)
+- RBAC / permission scope hardening (further production gate)
+
+---
+
+**Validation Tier:** MAJOR
+**Claim Level:** FOUNDATION
+**Validation Target:** persistent wallet-link storage boundary + minimal unlink lifecycle enforcement + authenticated ownership isolation
+**Not in Scope:** full wallet lifecycle orchestration, delegated signing, exchange/on-chain rollout, full RBAC, OAuth, production token rotation, broad portfolio engine, full DB migration platform
+**Suggested Next:** SENTINEL validation required before merge

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-5_02_pytest-evidence-pass.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-5_02_pytest-evidence-pass.md
@@ -1,0 +1,92 @@
+# Phase 8.5 — Pytest Gate Evidence (Pass)
+
+**Date:** 2026-04-19 12:04
+**Branch:** claude/phase8-5-wallet-link-persistence-ExuR9
+**PR:** #600
+**SENTINEL PR:** #601 (CONDITIONAL — gate satisfied by this evidence)
+
+---
+
+## Required Command
+
+```
+pytest -q projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py
+```
+
+## Extended Command (full regression)
+
+```
+pytest -q \
+  projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py
+```
+
+---
+
+## Output
+
+```
+============================= test session starts ==============================
+platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/user/walker-ai-team
+configfile: pytest.ini
+plugins: anyio-4.13.0
+collecting ... collected 33 items
+
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_store_put_and_get_roundtrip PASSED [  3%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_store_load_from_disk_on_init PASSED [  6%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_store_set_link_status PASSED [  9%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_store_set_link_status_not_found_raises PASSED [ 12%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_store_list_for_user_scoped PASSED [ 15%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_wallet_link_persists_across_app_restart PASSED [ 18%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_multiple_users_wallet_links_survive_restart PASSED [ 21%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_unlink_wallet_link_sets_status_unlinked PASSED [ 24%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_unlink_status_persists_after_restart PASSED [ 27%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_unlink_not_found_returns_404 PASSED [ 30%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_unlink_cross_user_denied_returns_403 PASSED [ 33%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_unlink_requires_authenticated_session PASSED [ 36%]
+projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py::test_persistent_cross_user_isolation_via_http PASSED [ 39%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_handoff_validates_known_telegram_client PASSED [ 42%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_handoff_validates_known_web_client PASSED [ 45%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_handoff_rejects_unsupported_client_type PASSED [ 48%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_handoff_rejects_empty_claim PASSED [ 51%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_handoff_rejects_empty_scope PASSED [ 54%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_client_handoff_issues_session_for_known_user PASSED [ 57%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_client_handoff_rejects_unknown_user PASSED [ 60%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_client_handoff_rejects_unsupported_client_type_via_route PASSED [ 63%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_wallet_link_create_and_read_for_authenticated_user PASSED [ 66%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_wallet_link_requires_authenticated_session PASSED [ 69%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_wallet_link_cross_user_isolation PASSED [ 72%]
+projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py::test_wallet_link_cross_tenant_session_denied PASSED [ 75%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_scope_resolution_rejects_empty_tenant PASSED [ 78%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_scope_ownership_detects_mismatch PASSED [ 81%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_multi_user_routes_enforce_wallet_scope PASSED [ 84%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_scope_dependency_rejects_missing_session PASSED [ 87%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_scope_dependency_derives_authenticated_scope PASSED [ 90%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_persisted_session_readback_and_restart_safe_scope PASSED [ 93%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_revoked_session_is_rejected PASSED [ 96%]
+projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py::test_expired_session_is_rejected PASSED [100%]
+
+=============================== warnings summary ===============================
+../../../usr/local/lib/python3.11/dist-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 33 passed, 1 warning in 2.23s =========================
+```
+
+---
+
+## Summary
+
+| Scope | Tests | Result |
+|---|---|---|
+| Phase 8.5 (new) | 13 | PASS |
+| Phase 8.4 regression | 12 | PASS |
+| Phase 8.1 regression | 8 | PASS |
+| **Total** | **33** | **PASS** |
+
+Environment: Python 3.11.15, pytest-9.0.3, fastapi-0.136.0, pydantic-v2
+
+**SENTINEL CONDITIONAL gate satisfied.** PR #601 can be closed after COMMANDER merges PR #600.

--- a/projects/polymarket/polyquantbot/server/api/client_auth_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/client_auth_routes.py
@@ -11,7 +11,11 @@ from projects.polymarket.polyquantbot.server.core.scope import ScopeResolutionEr
 from projects.polymarket.polyquantbot.server.schemas.auth_session import AuthMethod, SessionCreateRequest
 from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkCreateRequest
 from projects.polymarket.polyquantbot.server.services.auth_session_service import AuthSessionService
-from projects.polymarket.polyquantbot.server.services.wallet_link_service import WalletLinkService
+from projects.polymarket.polyquantbot.server.services.wallet_link_service import (
+    WalletLinkNotFoundError,
+    WalletLinkOwnershipError,
+    WalletLinkService,
+)
 
 
 class ClientHandoffRequestBody(BaseModel):
@@ -73,5 +77,18 @@ def build_client_auth_router(
     ) -> dict[str, object]:
         links = wallet_link_service.list_links(scope=auth_scope)
         return {"wallet_links": [r.model_dump() for r in links]}
+
+    @router.patch("/wallet-links/{link_id}/unlink")
+    async def unlink_wallet_link(
+        link_id: str,
+        auth_scope=Depends(get_authenticated_scope),
+    ) -> dict[str, object]:
+        try:
+            record = wallet_link_service.unlink_link(scope=auth_scope, link_id=link_id)
+        except WalletLinkNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except WalletLinkOwnershipError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"wallet_link": record.model_dump()}
 
     return router

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -26,7 +26,7 @@ from projects.polymarket.polyquantbot.server.services.wallet_link_service import
 from projects.polymarket.polyquantbot.server.services.wallet_service import WalletService
 from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
 from projects.polymarket.polyquantbot.server.storage.session_store import PersistentSessionStore
-from projects.polymarket.polyquantbot.server.storage.wallet_link_store import WalletLinkStore
+from projects.polymarket.polyquantbot.server.storage.wallet_link_store import PersistentWalletLinkStore
 
 log = structlog.get_logger(__name__)
 
@@ -65,7 +65,13 @@ def create_app() -> FastAPI:
     persistent_session_store = PersistentSessionStore(storage_path=session_storage_path)
     auth_session_service = AuthSessionService(store=store, session_store=persistent_session_store)
 
-    wallet_link_store = WalletLinkStore()
+    wallet_link_storage_path = Path(
+        os.getenv(
+            "CRUSADER_WALLET_LINK_STORAGE_PATH",
+            "/tmp/crusaderbot/runtime/wallet_links.json",
+        )
+    )
+    wallet_link_store = PersistentWalletLinkStore(storage_path=wallet_link_storage_path)
     wallet_link_service = WalletLinkService(store=wallet_link_store)
 
     app.state.multi_user_store = store
@@ -74,6 +80,7 @@ def create_app() -> FastAPI:
     app.state.account_service = account_service
     app.state.wallet_service = wallet_service
     app.state.auth_session_service = auth_session_service
+    app.state.wallet_link_storage_path = wallet_link_storage_path
     app.state.wallet_link_store = wallet_link_store
     app.state.wallet_link_service = wallet_link_service
 
@@ -110,7 +117,8 @@ def create_app() -> FastAPI:
         port=settings.port,
         trading_mode=settings.trading_mode,
         session_storage_path=str(session_storage_path),
-        phase="8.4",
+        wallet_link_storage_path=str(wallet_link_storage_path),
+        phase="8.5",
     )
     return app
 

--- a/projects/polymarket/polyquantbot/server/services/wallet_link_service.py
+++ b/projects/polymarket/polyquantbot/server/services/wallet_link_service.py
@@ -11,6 +11,14 @@ from projects.polymarket.polyquantbot.server.storage.wallet_link_store import Wa
 log = structlog.get_logger(__name__)
 
 
+class WalletLinkNotFoundError(LookupError):
+    """Raised when a wallet link record cannot be found."""
+
+
+class WalletLinkOwnershipError(PermissionError):
+    """Raised when the authenticated user does not own the referenced wallet link."""
+
+
 class WalletLinkService:
     def __init__(self, store: WalletLinkStore) -> None:
         self._store = store
@@ -44,3 +52,20 @@ class WalletLinkService:
             tenant_id=scope.tenant_id,
             user_id=scope.user_id,
         )
+
+    def unlink_link(self, scope: AuthenticatedScope, link_id: str) -> WalletLinkRecord:
+        record = self._store.get_link(link_id)
+        if record is None:
+            raise WalletLinkNotFoundError(f"wallet link not found: {link_id}")
+        if record.tenant_id != scope.tenant_id or record.user_id != scope.user_id:
+            raise WalletLinkOwnershipError(
+                "wallet link does not belong to authenticated user"
+            )
+        updated = self._store.set_link_status(link_id, "unlinked")
+        log.info(
+            "wallet_link_unlinked",
+            link_id=link_id,
+            user_id=scope.user_id,
+            tenant_id=scope.tenant_id,
+        )
+        return updated

--- a/projects/polymarket/polyquantbot/server/storage/wallet_link_store.py
+++ b/projects/polymarket/polyquantbot/server/storage/wallet_link_store.py
@@ -1,20 +1,49 @@
-"""In-memory wallet-link storage boundary."""
+"""Wallet-link storage boundary — abstract base and persistent implementation."""
 from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final
 
 import structlog
 
-from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord
+from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord, WalletLinkStatus
 
 log = structlog.get_logger(__name__)
 
 
+class WalletLinkStorageError(RuntimeError):
+    """Raised when wallet-link data cannot be read or written."""
+
+
 class WalletLinkStore:
-    def __init__(self) -> None:
+    def put_link(self, record: WalletLinkRecord) -> None:
+        raise NotImplementedError
+
+    def get_link(self, link_id: str) -> WalletLinkRecord | None:
+        raise NotImplementedError
+
+    def list_links_for_user(self, tenant_id: str, user_id: str) -> list[WalletLinkRecord]:
+        raise NotImplementedError
+
+    def set_link_status(self, link_id: str, status: WalletLinkStatus) -> WalletLinkRecord:
+        raise NotImplementedError
+
+
+class PersistentWalletLinkStore(WalletLinkStore):
+    """Local-file JSON wallet-link storage with deterministic overwrite semantics."""
+
+    _FORMAT_VERSION: Final[int] = 1
+
+    def __init__(self, storage_path: Path) -> None:
+        self._storage_path = storage_path
         self._records: dict[str, WalletLinkRecord] = {}
+        self._load_from_disk()
 
     def put_link(self, record: WalletLinkRecord) -> None:
         self._records[record.link_id] = record
-        log.debug("wallet_link_stored", link_id=record.link_id, user_id=record.user_id)
+        self._persist_to_disk()
+        log.debug("wallet_link_persisted", link_id=record.link_id, user_id=record.user_id)
 
     def get_link(self, link_id: str) -> WalletLinkRecord | None:
         return self._records.get(link_id)
@@ -24,3 +53,58 @@ class WalletLinkStore:
             r for r in self._records.values()
             if r.tenant_id == tenant_id and r.user_id == user_id
         ]
+
+    def set_link_status(self, link_id: str, status: WalletLinkStatus) -> WalletLinkRecord:
+        record = self._records.get(link_id)
+        if record is None:
+            raise WalletLinkStorageError(f"wallet link not found: {link_id}")
+        updated = record.model_copy(update={"status": status})
+        self._records[link_id] = updated
+        self._persist_to_disk()
+        return updated
+
+    def _load_from_disk(self) -> None:
+        if not self._storage_path.exists():
+            return
+
+        try:
+            raw_payload = json.loads(self._storage_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise WalletLinkStorageError(
+                "persistent wallet link store contains invalid JSON"
+            ) from exc
+
+        if not isinstance(raw_payload, dict):
+            raise WalletLinkStorageError(
+                "persistent wallet link store payload must be an object"
+            )
+
+        version = raw_payload.get("version")
+        if version != self._FORMAT_VERSION:
+            raise WalletLinkStorageError(
+                f"unsupported persistent wallet link store version: {version}"
+            )
+
+        raw_records = raw_payload.get("records")
+        if not isinstance(raw_records, list):
+            raise WalletLinkStorageError(
+                "persistent wallet link store records field must be a list"
+            )
+
+        for item in raw_records:
+            record = WalletLinkRecord.model_validate(item)
+            self._records[record.link_id] = record
+
+    def _persist_to_disk(self) -> None:
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": self._FORMAT_VERSION,
+            "records": [
+                record.model_dump(mode="json")
+                for record in sorted(self._records.values(), key=lambda r: r.link_id)
+            ],
+        }
+
+        temp_path = self._storage_path.with_suffix(f"{self._storage_path.suffix}.tmp")
+        temp_path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+        temp_path.replace(self._storage_path)

--- a/projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py
@@ -1,0 +1,415 @@
+"""Phase 8.5 tests — persistent wallet-link storage + lifecycle foundation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from projects.polymarket.polyquantbot.server.main import create_app
+from projects.polymarket.polyquantbot.server.storage.wallet_link_store import (
+    PersistentWalletLinkStore,
+    WalletLinkStorageError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(monkeypatch, tmp_path: Path, *, wallet_storage_name: str = "wallet_links.json"):
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("CRUSADER_SESSION_STORAGE_PATH", str(tmp_path / "sessions.json"))
+    monkeypatch.setenv("CRUSADER_WALLET_LINK_STORAGE_PATH", str(tmp_path / wallet_storage_name))
+    return create_app()
+
+
+def _setup_user_and_session(
+    client: TestClient, tenant_id: str, external_id: str, display_name: str
+) -> tuple[dict, dict]:
+    user_resp = client.post(
+        "/foundation/users",
+        json={"tenant_id": tenant_id, "external_id": external_id, "display_name": display_name},
+    )
+    assert user_resp.status_code == 200
+    user = user_resp.json()["user"]
+
+    handoff_resp = client.post(
+        "/auth/handoff",
+        json={
+            "client_type": "telegram",
+            "client_identity_claim": external_id,
+            "tenant_id": user["tenant_id"],
+            "user_id": user["user_id"],
+        },
+    )
+    assert handoff_resp.status_code == 200
+    session = handoff_resp.json()["session"]
+    return user, session
+
+
+def _auth_headers(session: dict, user: dict) -> dict[str, str]:
+    return {
+        "X-Session-Id": session["session_id"],
+        "X-Auth-Tenant-Id": user["tenant_id"],
+        "X-Auth-User-Id": user["user_id"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — PersistentWalletLinkStore direct behavior
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_store_put_and_get_roundtrip(tmp_path: Path) -> None:
+    store_path = tmp_path / "wallet_links.json"
+    from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord
+    from datetime import datetime, timezone
+
+    store = PersistentWalletLinkStore(storage_path=store_path)
+    record = WalletLinkRecord(
+        link_id="wlink-unit-001",
+        tenant_id="tenant-unit",
+        user_id="user-unit",
+        wallet_address="0xunit001",
+        chain_id="polygon",
+        link_type="user_proxy",
+        linked_at=datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone.utc),
+        status="active",
+    )
+    store.put_link(record)
+
+    assert store_path.exists()
+    result = store.get_link("wlink-unit-001")
+    assert result is not None
+    assert result.wallet_address == "0xunit001"
+    assert result.status == "active"
+
+
+def test_persistent_store_load_from_disk_on_init(tmp_path: Path) -> None:
+    store_path = tmp_path / "wallet_links.json"
+    from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord
+    from datetime import datetime, timezone
+
+    store1 = PersistentWalletLinkStore(storage_path=store_path)
+    record = WalletLinkRecord(
+        link_id="wlink-persist-001",
+        tenant_id="tenant-persist",
+        user_id="user-persist",
+        wallet_address="0xpersist001",
+        chain_id="polygon",
+        link_type="external",
+        linked_at=datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone.utc),
+        status="active",
+    )
+    store1.put_link(record)
+
+    # Second instance reads from same path — simulates restart
+    store2 = PersistentWalletLinkStore(storage_path=store_path)
+    result = store2.get_link("wlink-persist-001")
+    assert result is not None
+    assert result.wallet_address == "0xpersist001"
+    assert result.tenant_id == "tenant-persist"
+    assert result.user_id == "user-persist"
+
+
+def test_persistent_store_set_link_status(tmp_path: Path) -> None:
+    store_path = tmp_path / "wallet_links.json"
+    from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord
+    from datetime import datetime, timezone
+
+    store = PersistentWalletLinkStore(storage_path=store_path)
+    record = WalletLinkRecord(
+        link_id="wlink-status-001",
+        tenant_id="tenant-status",
+        user_id="user-status",
+        wallet_address="0xstatus001",
+        chain_id="polygon",
+        link_type="user_proxy",
+        linked_at=datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone.utc),
+        status="active",
+    )
+    store.put_link(record)
+
+    updated = store.set_link_status("wlink-status-001", "unlinked")
+    assert updated.status == "unlinked"
+
+    # Verify persisted
+    store2 = PersistentWalletLinkStore(storage_path=store_path)
+    reloaded = store2.get_link("wlink-status-001")
+    assert reloaded is not None
+    assert reloaded.status == "unlinked"
+
+
+def test_persistent_store_set_link_status_not_found_raises(tmp_path: Path) -> None:
+    store_path = tmp_path / "wallet_links.json"
+    store = PersistentWalletLinkStore(storage_path=store_path)
+
+    try:
+        store.set_link_status("wlink-does-not-exist", "unlinked")
+        assert False, "expected WalletLinkStorageError"
+    except WalletLinkStorageError as exc:
+        assert "wlink-does-not-exist" in str(exc)
+
+
+def test_persistent_store_list_for_user_scoped(tmp_path: Path) -> None:
+    store_path = tmp_path / "wallet_links.json"
+    from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkRecord
+    from datetime import datetime, timezone
+
+    store = PersistentWalletLinkStore(storage_path=store_path)
+    base_dt = datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone.utc)
+
+    for i in range(3):
+        store.put_link(WalletLinkRecord(
+            link_id=f"wlink-ua-{i:03d}",
+            tenant_id="tenant-list",
+            user_id="user-A",
+            wallet_address=f"0xuserA{i:03d}",
+            chain_id="polygon",
+            link_type="user_proxy",
+            linked_at=base_dt,
+            status="active",
+        ))
+
+    store.put_link(WalletLinkRecord(
+        link_id="wlink-ub-000",
+        tenant_id="tenant-list",
+        user_id="user-B",
+        wallet_address="0xuserB000",
+        chain_id="polygon",
+        link_type="user_proxy",
+        linked_at=base_dt,
+        status="active",
+    ))
+
+    result_a = store.list_links_for_user("tenant-list", "user-A")
+    result_b = store.list_links_for_user("tenant-list", "user-B")
+    assert len(result_a) == 3
+    assert len(result_b) == 1
+    assert all(r.user_id == "user-A" for r in result_a)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — restart-safe readback via HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_wallet_link_persists_across_app_restart(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+
+    session_path = str(tmp_path / "sessions.json")
+    wallet_path = str(tmp_path / "wallet_links.json")
+    monkeypatch.setenv("CRUSADER_SESSION_STORAGE_PATH", session_path)
+    monkeypatch.setenv("CRUSADER_WALLET_LINK_STORAGE_PATH", wallet_path)
+
+    link_id: str | None = None
+
+    # First app instance: create user, get session, create wallet-link
+    app1 = create_app()
+    with TestClient(app1) as client1:
+        user, session = _setup_user_and_session(client1, "tenant-restart", "tg_r001", "restart-user")
+        headers = _auth_headers(session, user)
+
+        create_resp = client1.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xrestart001", "chain_id": "polygon", "link_type": "user_proxy"},
+            headers=headers,
+        )
+        assert create_resp.status_code == 200
+        link_id = create_resp.json()["wallet_link"]["link_id"]
+
+    # Second app instance with same storage paths — simulates server restart
+    app2 = create_app()
+    with TestClient(app2) as client2:
+        # Re-issue session (sessions persist too) — verify wallet-link still present
+        list_resp = client2.get("/auth/wallet-links", headers=headers)
+        assert list_resp.status_code == 200
+        links = list_resp.json()["wallet_links"]
+        assert len(links) == 1
+        assert links[0]["link_id"] == link_id
+        assert links[0]["wallet_address"] == "0xrestart001"
+        assert links[0]["status"] == "active"
+
+
+def test_multiple_users_wallet_links_survive_restart(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+
+    session_path = str(tmp_path / "sessions.json")
+    wallet_path = str(tmp_path / "wallet_links.json")
+    monkeypatch.setenv("CRUSADER_SESSION_STORAGE_PATH", session_path)
+    monkeypatch.setenv("CRUSADER_WALLET_LINK_STORAGE_PATH", wallet_path)
+
+    user_a_data: dict = {}
+    user_b_data: dict = {}
+
+    app1 = create_app()
+    with TestClient(app1) as client1:
+        user_a, session_a = _setup_user_and_session(client1, "tenant-multi", "tg_m001", "alice")
+        user_b, session_b = _setup_user_and_session(client1, "tenant-multi", "tg_m002", "bob")
+
+        client1.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xalice001"},
+            headers=_auth_headers(session_a, user_a),
+        )
+        client1.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xbob001"},
+            headers=_auth_headers(session_b, user_b),
+        )
+
+        user_a_data = {"user": user_a, "session": session_a}
+        user_b_data = {"user": user_b, "session": session_b}
+
+    app2 = create_app()
+    with TestClient(app2) as client2:
+        links_a = client2.get(
+            "/auth/wallet-links",
+            headers=_auth_headers(user_a_data["session"], user_a_data["user"]),
+        ).json()["wallet_links"]
+        links_b = client2.get(
+            "/auth/wallet-links",
+            headers=_auth_headers(user_b_data["session"], user_b_data["user"]),
+        ).json()["wallet_links"]
+
+        assert len(links_a) == 1
+        assert links_a[0]["wallet_address"] == "0xalice001"
+        assert len(links_b) == 1
+        assert links_b[0]["wallet_address"] == "0xbob001"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — unlink lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_unlink_wallet_link_sets_status_unlinked(monkeypatch, tmp_path: Path) -> None:
+    app = _make_app(monkeypatch, tmp_path)
+    with TestClient(app) as client:
+        user, session = _setup_user_and_session(client, "tenant-unlink", "tg_u001", "unlink-user")
+        headers = _auth_headers(session, user)
+
+        create_resp = client.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xunlink001"},
+            headers=headers,
+        )
+        assert create_resp.status_code == 200
+        link_id = create_resp.json()["wallet_link"]["link_id"]
+
+        unlink_resp = client.patch(
+            f"/auth/wallet-links/{link_id}/unlink",
+            headers=headers,
+        )
+        assert unlink_resp.status_code == 200
+        result = unlink_resp.json()["wallet_link"]
+        assert result["status"] == "unlinked"
+        assert result["link_id"] == link_id
+
+
+def test_unlink_status_persists_after_restart(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+
+    session_path = str(tmp_path / "sessions.json")
+    wallet_path = str(tmp_path / "wallet_links.json")
+    monkeypatch.setenv("CRUSADER_SESSION_STORAGE_PATH", session_path)
+    monkeypatch.setenv("CRUSADER_WALLET_LINK_STORAGE_PATH", wallet_path)
+
+    link_id: str = ""
+    headers: dict = {}
+
+    app1 = create_app()
+    with TestClient(app1) as client1:
+        user, session = _setup_user_and_session(client1, "tenant-unlinkpersist", "tg_up001", "up-user")
+        headers = _auth_headers(session, user)
+
+        create_resp = client1.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xunlinkpersist001"},
+            headers=headers,
+        )
+        link_id = create_resp.json()["wallet_link"]["link_id"]
+
+        client1.patch(f"/auth/wallet-links/{link_id}/unlink", headers=headers)
+
+    app2 = create_app()
+    with TestClient(app2) as client2:
+        list_resp = client2.get("/auth/wallet-links", headers=headers)
+        links = list_resp.json()["wallet_links"]
+        assert len(links) == 1
+        assert links[0]["link_id"] == link_id
+        assert links[0]["status"] == "unlinked"
+
+
+def test_unlink_not_found_returns_404(monkeypatch, tmp_path: Path) -> None:
+    app = _make_app(monkeypatch, tmp_path)
+    with TestClient(app) as client:
+        user, session = _setup_user_and_session(client, "tenant-unlink404", "tg_404", "not-found-user")
+        headers = _auth_headers(session, user)
+
+        resp = client.patch("/auth/wallet-links/wlink-does-not-exist/unlink", headers=headers)
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"]
+
+
+def test_unlink_cross_user_denied_returns_403(monkeypatch, tmp_path: Path) -> None:
+    app = _make_app(monkeypatch, tmp_path)
+    with TestClient(app) as client:
+        user_a, session_a = _setup_user_and_session(client, "tenant-crossunlink", "tg_cu001", "owner")
+        user_b, session_b = _setup_user_and_session(client, "tenant-crossunlink", "tg_cu002", "intruder")
+
+        create_resp = client.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xowner001"},
+            headers=_auth_headers(session_a, user_a),
+        )
+        assert create_resp.status_code == 200
+        link_id = create_resp.json()["wallet_link"]["link_id"]
+
+        # user_b attempts to unlink user_a's wallet-link
+        resp = client.patch(
+            f"/auth/wallet-links/{link_id}/unlink",
+            headers=_auth_headers(session_b, user_b),
+        )
+        assert resp.status_code == 403
+
+
+def test_unlink_requires_authenticated_session(monkeypatch, tmp_path: Path) -> None:
+    app = _make_app(monkeypatch, tmp_path)
+    with TestClient(app) as client:
+        resp = client.patch(
+            "/auth/wallet-links/wlink-any/unlink",
+            headers={
+                "X-Session-Id": "sess_missing",
+                "X-Auth-Tenant-Id": "tenant-alpha",
+                "X-Auth-User-Id": "user-xyz",
+            },
+        )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — cross-user isolation on persistent storage
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_cross_user_isolation_via_http(monkeypatch, tmp_path: Path) -> None:
+    app = _make_app(monkeypatch, tmp_path)
+    with TestClient(app) as client:
+        user_a, session_a = _setup_user_and_session(client, "tenant-iso", "tg_iso001", "iso-user-a")
+        user_b, session_b = _setup_user_and_session(client, "tenant-iso", "tg_iso002", "iso-user-b")
+
+        client.post(
+            "/auth/wallet-links",
+            json={"wallet_address": "0xisoA001"},
+            headers=_auth_headers(session_a, user_a),
+        )
+
+        list_b = client.get("/auth/wallet-links", headers=_auth_headers(session_b, user_b))
+        assert list_b.status_code == 200
+        assert list_b.json()["wallet_links"] == []


### PR DESCRIPTION
Part A: Phase 8.4 post-merge truth sync (PROJECT_STATE.md + ROADMAP.md)
Part B: Phase 8.5 build
- PersistentWalletLinkStore (local-file JSON, atomic overwrite, restart-safe)
- WalletLinkStore converted to abstract base (SessionStore pattern)
- WalletLinkService.unlink_link (ownership-enforced active -> unlinked)
- PATCH /auth/wallet-links/{link_id}/unlink authenticated route (404/403/200)
- server/main.py wired to PersistentWalletLinkStore + CRUSADER_WALLET_LINK_STORAGE_PATH env var
- 13 new tests: persistence roundtrip, restart continuity, unlink lifecycle,
  cross-user isolation, 403/404 denial paths
- 0 regressions: 20 prior tests (Phase 8.1 + 8.4) still pass

https://claude.ai/code/session_013jcGEn2BNhhw3geuEG7yDe