### PR TITLE
SENTINEL: Phase 8.7 closeout + Phase 8.8 Telegram dispatch foundation (dispatcher, tests, bot wiring)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-19 14:01
+Last Updated : 2026-04-19 14:21
 Status       : Phase 8.7 Telegram/Web runtime handoff integration foundation merged (SENTINEL CONDITIONAL gate satisfied via phase8-7_02_pytest-evidence-pass.md, 62/62 pass). Phase 8.8 real Telegram dispatch integration foundation in progress on branch claude/phase-8-7-8-telegram-dispatch-TAE9c.
 
 [COMPLETED]
@@ -22,7 +22,7 @@ Status       : Phase 8.7 Telegram/Web runtime handoff integration foundation mer
 - Phase 8.7 Telegram/Web runtime handoff integration foundation merged: CrusaderBackendClient HTTP bridge, handle_start Telegram handler, handle_web_handoff web handler, client/telegram/bot.py backend wiring. SENTINEL CONDITIONAL gate satisfied. Pytest gate: 62/62 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-7_01_telegram-web-runtime-handoff-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-7_02_pytest-evidence-pass.md`. SENTINEL report: `projects/polymarket/polyquantbot/reports/sentinel/phase8-7_01_runtime-handoff-validation-pr604.md`.
 
 [IN PROGRESS]
-- Phase 8.8 real Telegram dispatch integration foundation: TelegramDispatcher command router, /start → handle_start() dispatch boundary, reply mapping adapter contract, targeted tests. Branch: claude/phase-8-7-8-telegram-dispatch-TAE9c.
+- Phase 8.8 real Telegram dispatch integration foundation validated by SENTINEL for PR #606 with CONDITIONAL verdict (runtime path validated; traceability drift fix pending for missing historical Sentinel report references). Branch: claude/phase-8-7-8-telegram-dispatch-TAE9c.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -30,7 +30,7 @@ Status       : Phase 8.7 Telegram/Web runtime handoff integration foundation mer
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL validation required for Phase 8.8 real Telegram dispatch integration foundation before merge. Source: projects/polymarket/polyquantbot/reports/forge/phase8-8_01_telegram-dispatch-foundation.md. Tier: MAJOR.
+- COMMANDER decision gate for PR #606 (SENTINEL verdict: CONDITIONAL). Resolve traceability drift on missing Sentinel report references before merge. Validation report: projects/polymarket/polyquantbot/reports/sentinel/phase8-8_01_telegram-dispatch-validation-pr606.md.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-8_01_telegram-dispatch-validation-pr606.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-8_01_telegram-dispatch-validation-pr606.md
@@ -1,0 +1,96 @@
+# SENTINEL Validation Report — PR #606 (Phase 8.7 Closeout + Phase 8.8 Telegram Dispatch Foundation)
+
+## Environment
+- Date (Asia/Jakarta): 2026-04-19 14:21
+- Repo: `walker-ai-team`
+- Project root: `projects/polymarket/polyquantbot`
+- Target PR: #606
+- Target branch (declared): `claude/phase-8-7-8-telegram-dispatch-TAE9c`
+- Validation Tier: MAJOR
+- Claim Levels:
+  - Phase 8.7 closeout: REPO TRUTH SYNC ONLY
+  - Phase 8.8 implementation: FOUNDATION
+
+## Validation Context
+- Blueprint source reviewed: `docs/crusader_multi_user_architecture_blueprint.md`
+- Primary scope reviewed:
+  - `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`
+  - `projects/polymarket/polyquantbot/client/telegram/bot.py`
+  - `projects/polymarket/polyquantbot/client/telegram/handlers/auth.py`
+  - `projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py`
+  - `projects/polymarket/polyquantbot/reports/forge/phase8-8_01_telegram-dispatch-foundation.md`
+  - `PROJECT_STATE.md`
+  - `ROADMAP.md`
+- Secondary comparison reviewed:
+  - `projects/polymarket/polyquantbot/client/telegram/backend_client.py`
+  - `projects/polymarket/polyquantbot/tests/test_phase8_7_runtime_handoff_foundation_20260419.py`
+  - `projects/polymarket/polyquantbot/server/api/client_auth_routes.py`
+
+## Phase 0 Checks
+- ✅ UTF-8 locale verified (`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`)
+- ✅ Python syntax compilation passed for touched Phase 8.8 files (`python3 -m py_compile ...`)
+- ⚠️ Requested pytest re-run could not be completed in this runner because required runtime dependencies are missing:
+  - `fastapi` not installed
+  - import root `projects` not on interpreter path in current shell context
+- ✅ No mojibake sequences detected in reviewed Phase 8.8 files
+
+## Findings
+1. **Routing contract is implemented truthfully at FOUNDATION level.**
+   - `/start` routes to `_dispatch_start()` then `handle_start()`.
+   - Unknown commands return `outcome="unknown_command"` with non-empty reply.
+   - Command routing is case-insensitive (`strip().lower()`).
+2. **Context and outcome mapping is coherent.**
+   - `from_user_id` is mapped to `TelegramHandoffContext.telegram_user_id`.
+   - `DispatchResult` forwards `outcome`, `reply_text`, and `session_id` from `HandleStartResult`.
+   - Empty/whitespace `from_user_id` is rejected in `handle_start()` before backend call.
+3. **Runtime wiring is truthful as FOUNDATION only.**
+   - `client/telegram/bot.py` wires `TelegramDispatcher` and logs registered commands (`/start`) and phase `8.8`.
+   - No false code claim of completed Telegram polling loop was found.
+4. **Documentation/report drift detected (non-runtime but material for traceability).**
+   - `PROJECT_STATE.md`, `ROADMAP.md`, and forge report reference Sentinel report files that are not present in repository paths:
+     - `projects/polymarket/polyquantbot/reports/sentinel/phase8-7_01_runtime-handoff-validation-pr604.md`
+     - `projects/polymarket/polyquantbot/reports/sentinel/phase8-5_01_wallet-link-persistence-validation.md`
+     - `projects/polymarket/polyquantbot/reports/sentinel/phase8-6_01_persistent-multi-user-store-validation.md`
+   - This is a repo-truth traceability drift.
+
+## Score Breakdown
+- Scope coverage: 30/30
+- Routing contract safety: 20/20
+- Context mapping and rejection behavior: 20/20
+- Runtime wiring truthfulness: 15/15
+- Evidence reproducibility in this runner: 5/15 (dependency-limited)
+- Traceability consistency: 5/10 (missing referenced Sentinel files)
+
+**Total: 95/110 (normalized 86/100)**
+
+## Critical Issues
+- None in Phase 8.8 runtime implementation path.
+
+## Status
+**CONDITIONAL**
+
+## PR Gate Result
+- Gate decision: **CONDITIONAL PASS**
+- Rationale:
+  - Implementation-level MAJOR validation targets for Phase 8.8 FOUNDATION are satisfied by code and tests design.
+  - Merge should wait for traceability cleanup on missing referenced Sentinel report paths and (ideally) dependency-complete pytest confirmation artifact on the source branch.
+
+## Broader Audit Finding
+- No evidence of overclaiming a full Telegram bot product in runtime code.
+- Scope exclusions remain truthful: no broad command suite, no OAuth, no RBAC, no delegated signing lifecycle, no exchange execution rollout, no portfolio engine rollout.
+
+## Reasoning
+The dispatch boundary is narrow, explicit, and test-covered for `/start` and unknown-command fallback. The main residual risk is governance/traceability drift from references to non-existent Sentinel report files, not runtime behavior regression in this PR scope.
+
+## Fix Recommendations
+1. Update stale/missing Sentinel report references in `PROJECT_STATE.md`, `ROADMAP.md`, and forge reports to valid existing paths (or add archival note if intentionally moved).
+2. Attach dependency-complete pytest evidence (Phase 8.8 + declared regression set) from the source branch environment to close reproducibility gap.
+
+## Out-of-scope Advisory
+- Real Telegram framework polling loop integration remains a future lane and should be validated separately once introduced.
+
+## Deferred Minor Backlog
+- `[DEFERRED] pytest warning: Unknown config option: asyncio_mode` remains hygiene-only backlog.
+
+## Telegram Visual Preview
+- N/A (SENTINEL validation artifact only)


### PR DESCRIPTION
### Motivation
- Close out Phase 8.7 repo-truth and introduce Phase 8.8 foundation: a narrow Telegram dispatch boundary that routes `/start` to the existing `handle_start()` handoff flow without claiming a full Telegram bot product.
- Provide a testable, non-networked dispatch contract and bootstrap wiring so future lanes can add a real Telegram polling loop and richer command surface.

### Description
- Added a `TelegramDispatcher` command router implementing case-insensitive routing for `/start`, unknown-command safe fallback, context mapping (`from_user_id` → `telegram_user_id`), and `DispatchResult` mapping from `HandleStartResult` (`projects/polymarket/polyquantbot/client/telegram/dispatcher.py`).
- Updated Telegram bootstrap to instantiate the dispatcher and log registered commands/phase without introducing a polling loop (`projects/polymarket/polyquantbot/client/telegram/bot.py`).
- Added thin `/start` handler layer (already present) usage is preserved and validated in `client/telegram/handlers/auth.py`; added targeted Phase 8.8 unit tests (`projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py`).
- Updated repo state and planning artifacts to reflect Phase 8.7 closeout and Phase 8.8 in-progress status (`PROJECT_STATE.md`, `ROADMAP.md`) and added a SENTINEL validation report for PR #606 (`projects/polymarket/polyquantbot/reports/sentinel/phase8-8_01_telegram-dispatch-validation-pr606.md`).

### Testing
- `python3 -m py_compile` was run against the touched Phase 8.8 files and succeeded (syntax checked).
- `pytest -q` was attempted for the Phase 8.8 and Phase 8.7 test modules in this runner but collection failed due to missing runtime dependencies (`fastapi` not installed) and interpreter import-path setup (`ModuleNotFoundError: No module named 'projects'`), so full test execution could not be reproduced here.
- The branch contains 15 targeted Phase 8.8 unit tests for dispatcher behavior and a declared regression suite (total referenced 77 tests in the forge report) which are expected to pass in a dependency-complete CI environment; attach CI pytest evidence from the source branch to close reproducibility gap before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4822ac55483259fcc84f9c7b13695)