### PR TITLE
Phase 8.10 — Telegram identity resolution foundation: backend lookup, route, client & runtime integration

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 15:52
-Status       : Phase 8.9 real Telegram polling / runtime loop foundation merged (SENTINEL CONDITIONAL gate satisfied via phase8-9_02_pytest-evidence-pass.md, 94/94 pass). Phase 8.10 Telegram identity resolution foundation in progress on branch claude/phase8-10-telegram-identity-ePWJP.
+Last Updated : 2026-04-19 16:09
+Status       : Phase 8.9 real Telegram polling / runtime loop foundation merged (SENTINEL CONDITIONAL gate satisfied via phase8-9_02_pytest-evidence-pass.md, 94/94 pass). Phase 8.10 Telegram identity resolution foundation received SENTINEL CONDITIONAL for PR #610 (contract hardening + reproducible pytest evidence pending).
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -24,7 +24,7 @@ Status       : Phase 8.9 real Telegram polling / runtime loop foundation merged 
 - Phase 8.9 real Telegram polling / runtime loop foundation merged: TelegramRuntimeAdapter abstract boundary, HttpTelegramAdapter concrete implementation, extract_command_context staging identity contract, TelegramPollingLoop dispatch + reply routing, run_polling_loop top-level wiring, bot.py adapter/loop wiring. SENTINEL CONDITIONAL gate satisfied via phase8-9_02_pytest-evidence-pass.md. Pytest gate: 94/94 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-9_01_telegram-runtime-loop-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-9_02_pytest-evidence-pass.md`. SENTINEL: PR #609 (CONDITIONAL gate satisfied).
 
 [IN PROGRESS]
-- Phase 8.10 Telegram identity resolution foundation: replacing CRUSADER_STAGING_TENANT_ID / CRUSADER_STAGING_USER_ID placeholders with real backend-driven lookup; TelegramIdentityService server-side resolver; GET /auth/telegram-identity/{telegram_user_id} backend route; TelegramIdentityResolver Protocol + updated TelegramPollingLoop; safe not_found/error reply behavior. Branch: claude/phase8-10-telegram-identity-ePWJP.
+- Phase 8.10 Telegram identity resolution foundation: SENTINEL CONDITIONAL on PR #610. Required before merge: strict unknown-outcome normalization in backend client/runtime identity contract and dependency-complete rerun evidence for claimed 112/112 pytest scope. Branch: claude/phase8-10-telegram-identity-ePWJP.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -32,7 +32,7 @@ Status       : Phase 8.9 real Telegram polling / runtime loop foundation merged 
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL validation required for Phase 8.10 Telegram identity resolution foundation before merge. Source: projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md. Tier: MAJOR.
+- FORGE-X follow-up required on branch claude/phase8-10-telegram-identity-ePWJP for PR #610: close identity-outcome normalization gap and attach dependency-complete pytest evidence (claimed 112/112) before SENTINEL re-run. Source: projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md. Tier: MAJOR.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 15:52
+**Last Updated:** 2026-04-19 16:09
 
 # Board Overview
 
@@ -344,8 +344,8 @@
 ## CrusaderBot — Telegram Identity Resolution Foundation Checklist (Phase 8.10)
 
 **Goal:** Replace staging tenant/user placeholders in the Telegram runtime with a truthful backend-driven identity resolution foundation under `projects/polymarket/polyquantbot/`. Introduces a narrow service/contract that maps inbound Telegram `from_user_id` to backend user scope, updates the polling loop to use resolved identity for command dispatch, and defines safe fallback reply behavior for unlinked/unknown users and backend errors.  
-**Status:** 🚧 In Progress — SENTINEL validation required before merge  
-**Last Updated:** 2026-04-19 15:52
+**Status:** 🚧 In Progress — SENTINEL CONDITIONAL for PR #610; FORGE-X follow-up required (identity-outcome normalization + dependency-complete pytest evidence) before revalidation  
+**Last Updated:** 2026-04-19 16:09
 
 ### Scope Lock
 - [x] Keep scope on Telegram identity resolution contract only

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md
@@ -1,0 +1,124 @@
+# SENTINEL Validation Report — PR #610 (Phase 8.9 Closeout + Phase 8.10 Telegram Identity Resolution Foundation)
+
+## Environment
+- Date (Asia/Jakarta): 2026-04-19 16:09
+- Validator role: SENTINEL
+- Source PR: #610
+- Source branch: claude/phase8-10-telegram-identity-ePWJP
+- Project root: projects/polymarket/polyquantbot
+- Validation Tier: MAJOR
+- Claim levels reviewed:
+  - Phase 8.9 closeout: REPO TRUTH SYNC ONLY
+  - Phase 8.10 implementation: FOUNDATION
+
+## Validation Context
+Blueprint reviewed:
+- docs/crusader_multi_user_architecture_blueprint.md
+
+Primary scope validated:
+1. Identity-resolution truth and scope boundaries
+2. Backend lookup boundary (`get_user_by_external_id`) and tenant isolation
+3. TelegramIdentityService contract (`resolved` / `not_found` / `error`)
+4. Backend route integrity (`GET /auth/telegram-identity/{telegram_user_id}`)
+5. Client/runtime integration (`CrusaderBackendClient`, `TelegramIdentityResolver`, `TelegramPollingLoop`)
+6. Tests/docs/report/state alignment
+
+## Phase 0 Checks
+- Forge report exists and naming is valid:
+  - projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md
+- PROJECT_STATE.md present with full timestamp format.
+- ROADMAP.md updated with Phase 8.9 closeout + Phase 8.10 checklist.
+- Mojibake quick scan on inspected files: no corruption signatures found.
+- Pre-flight command evidence gathered:
+  - `locale` => `C.UTF-8` / `LC_ALL=C.UTF-8`
+  - `python3 -m py_compile ...` => pass (targeted files)
+  - `pytest -q ...` (8-file regression set) => environment-limited failure due missing dependencies (`fastapi`, unresolved `projects` import path in current runner)
+
+## Findings
+1. **Identity foundation scope claims are truthful (PASS).**
+   - No code path introduces OAuth, RBAC, delegated signing lifecycle, exchange execution rollout, portfolio engine rollout, or production cross-client orchestration in this PR slice.
+   - Runtime remains command-limited (`/start` + unknown fallback), consistent with foundation claim.
+
+2. **Backend lookup boundary and tenant isolation are correct (PASS).**
+   - `MultiUserStore`, `PersistentMultiUserStore`, and `InMemoryMultiUserStore` all implement tenant-scoped `get_user_by_external_id(tenant_id, external_id)` logic.
+   - `UserService.get_user_by_external_id` is a thin boundary delegation with no ownership widening.
+
+3. **TelegramIdentityService contract is coherent for expected paths (PASS).**
+   - `resolve()` enforces empty-input error behavior, maps `external_id = "tg_{telegram_user_id}"`, handles store exceptions as `error`, and cleanly distinguishes `resolved` vs `not_found`.
+
+4. **Backend identity route contract is minimal and pre-auth by design (PASS).**
+   - `GET /auth/telegram-identity/{telegram_user_id}` is sessionless and returns only outcome + scope fields.
+   - Route does not issue sessions and does not invoke handoff/session issuance logic.
+
+5. **Client/runtime integration behavior is largely correct (PASS with one contract gap).**
+   - `CrusaderBackendClient.resolve_telegram_identity()` correctly maps HTTP failures/exceptions to `error`.
+   - `TelegramIdentityResolver` protocol is real and used by polling loop.
+   - `TelegramPollingLoop` behavior matches intended matrix:
+     - resolved -> dispatch with backend tenant/user
+     - not_found -> unregistered reply, no dispatch
+     - error -> identity-error reply, no dispatch
+     - resolver exception -> identity-error reply, no dispatch
+     - no resolver -> staging fallback preserved
+     - non-command text -> resolution not triggered
+
+6. **Contract hardening gap: unknown outcome is not normalized (NEEDS FIX).**
+   - `CrusaderBackendClient.resolve_telegram_identity()` accepts arbitrary `outcome` strings from JSON and returns them through typed field without runtime normalization.
+   - `TelegramPollingLoop` treats any non-`not_found`/non-`error` outcome as resolved branch, risking dispatch with null tenant/user on malformed backend payload.
+   - This is a correctness/safety contract gap for MAJOR lane validation (foundation contract should be explicit and closed).
+
+7. **112/112 claim cannot be independently reproduced in this runner (CONSTRAINED).**
+   - Attempted full 8-phase regression command.
+   - Blocked by missing dependencies (`fastapi`) and unresolved package import path in current environment.
+   - Therefore, pass-count claim remains unverified in this environment.
+
+## Score Breakdown
+- Scope adherence: 24/25
+- Backend boundary safety: 24/25
+- Runtime integration correctness: 20/25
+- Evidence reproducibility in current runner: 14/25
+
+**Total: 82/100**
+
+## Critical Issues
+- Critical: 0
+- High: 1
+  - Unknown outcome normalization gap in backend client/runtime contract.
+- Medium: 1
+  - Claimed 112/112 pass not reproducible in this runner due dependency/env constraints.
+
+## Status
+**CONDITIONAL**
+
+## PR Gate Result
+- Merge is **not blocked for architectural scope drift**.
+- Merge is **conditionally held** pending one required contract hardening fix and one reproducible test-evidence rerun in dependency-complete environment.
+
+## Broader Audit Finding
+- Foundation boundary is clean and intentionally narrow.
+- Tenant isolation is preserved at lookup boundary.
+- No evidence of hidden scope expansion into auth productization/execution domains.
+
+## Reasoning
+Given declared claim level (FOUNDATION), broad product omissions are acceptable and truthful. However, the identity outcome contract is a core safety boundary for dispatch routing. Accepting unexpected outcomes and implicitly routing toward dispatch without strict normalization is a material integration gap for this lane and must be fixed prior to approval.
+
+## Fix Recommendations
+1. In `CrusaderBackendClient.resolve_telegram_identity()`, normalize response outcome strictly:
+   - Allowed: `resolved`, `not_found`, `error`
+   - Any unknown value -> `error`
+2. In `TelegramPollingLoop`, only enter resolved dispatch branch when:
+   - `resolution.outcome == "resolved"` AND
+   - `resolution.tenant_id` and `resolution.user_id` are non-empty strings
+   - Otherwise send `_REPLY_IDENTITY_ERROR` and skip dispatch.
+3. Re-run the claimed 112-test regression suite in dependency-complete environment and attach exact command output artifact.
+
+## Out-of-scope Advisory
+- Pre-auth identity route rate limiting / abuse controls remain a follow-up hardening lane (not blocker for declared foundation claim).
+
+## Deferred Minor Backlog
+- None deferred in this validation pass.
+
+## Telegram Visual Preview
+- Registered Telegram user issuing `/start`: identity resolved via backend, command dispatched under real tenant/user, reply sent.
+- Unregistered Telegram user issuing `/start`: receives explicit not-registered reply, dispatch skipped.
+- Identity backend error/exception: receives identity-error reply, dispatch skipped.
+- Non-command Telegram message: ignored (no identity lookup, no dispatch).


### PR DESCRIPTION
### Motivation
- Replace the Phase 8.9 staging identity placeholders with a narrow backend-driven identity lookup foundation so Telegram runtime can dispatch under real tenant/user scope while keeping full account-link UX, OAuth, RBAC, and production orchestration out of scope. 
- Provide a single, testable contract for identity resolution (`resolved` / `not_found` / `error`) that preserves tenant isolation and safe fallback behavior in the polling loop.

### Description
- Added a backend identity resolution service: `projects/polymarket/polyquantbot/server/services/telegram_identity_service.py` with `TelegramIdentityResolution` and `TELEGRAM_EXTERNAL_ID_PREFIX = "tg_"`, implementing `resolve(telegram_user_id, tenant_id)` that returns `resolved/not_found/error` outcomes.
- Extended storage/service boundaries to support external-id lookups: added `get_user_by_external_id(tenant_id, external_id)` to `MultiUserStore` (abstract), implemented in `PersistentMultiUserStore` (`server/storage/multi_user_store.py`) and `InMemoryMultiUserStore` (`server/storage/in_memory_store.py`), and delegated via `UserService.get_user_by_external_id` (`server/services/user_service.py`).
- Exposed pre-auth backend route: `GET /auth/telegram-identity/{telegram_user_id}` in `projects/polymarket/polyquantbot/server/api/client_auth_routes.py` that returns `{outcome, tenant_id, user_id}` and does not issue sessions.
- Client and runtime integration:
  - Added `CrusaderBackendClient.resolve_telegram_identity()` and `identity_tenant_id` parameter in `projects/polymarket/polyquantbot/client/telegram/backend_client.py` to call the new route and map responses to a typed `TelegramIdentityResolution`.
  - Introduced `TelegramIdentityResolver` Protocol and integrated identity-resolution into `TelegramPollingLoop` in `projects/polymarket/polyquantbot/client/telegram/runtime.py` so the loop: (a) calls resolver for command messages, (b) sends safe replies for `not_found` / `error` / resolver exceptions, and (c) when `resolved` replaces staging tenant/user in the `TelegramCommandContext` before dispatching.
  - Wired backend identity resolver into bot bootstrap in `projects/polymarket/polyquantbot/client/telegram/bot.py` (passes `backend` as `identity_resolver`).
- Tests and reports: added targeted tests `projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` (18 targeted tests), updated forge report `projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md`, and added a SENTINEL validation report `projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md` while updating `PROJECT_STATE.md` and `ROADMAP.md` to reflect SENTINEL CONDITIONAL state.

### Testing
- Static compile checks: ran `python3 -m py_compile` against touched modules (passed for the modified files).
- Unit/test run attempt: attempted `pytest -q` across the Phase 8 regression set but execution in this runner failed during collection due to missing environment deps (`fastapi`) and import-path constraints, so the claimed `112/112` regression pass recorded in the forge report could not be independently reproduced here.
- Local/CI evidence: the forge report attached to the change claims full regression preservation and `112/112` pass; SENTINEL report documents a conditional verdict and requests two follow-ups (strict outcome normalization in client/runtime and a dependency-complete re-run of the test suite) before final approval.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49b4bcd108325a0a387e80980194c)