### PR TITLE
feat: Phase 8.11 Telegram onboarding/account-link foundation + Phase 8.10 truth sync

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-19 17:00
-Status       : Phase 8.10 Telegram identity resolution foundation SENTINEL CONDITIONAL gate satisfied (114/114 pass, strict outcome normalization fix applied). PR #610 pending COMMANDER review and merge decision.
+Last Updated : 2026-04-19 20:16
+Status       : Phase 8.10 repo-truth closeout synced as merged reality. Phase 8.11 Telegram onboarding/account-link foundation is implemented with persistent minimal user-link creation for unresolved /start users and targeted MAJOR test coverage.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -22,9 +22,10 @@ Status       : Phase 8.10 Telegram identity resolution foundation SENTINEL CONDI
 - Phase 8.7 Telegram/Web runtime handoff integration foundation merged: CrusaderBackendClient HTTP bridge, handle_start Telegram handler, handle_web_handoff web handler, client/telegram/bot.py backend wiring. SENTINEL CONDITIONAL gate satisfied. Pytest gate: 62/62 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-7_01_telegram-web-runtime-handoff-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-7_02_pytest-evidence-pass.md`. SENTINEL report: `projects/polymarket/polyquantbot/reports/sentinel/phase8-7_01_runtime-handoff-validation-pr604.md`.
 - Phase 8.8 real Telegram dispatch integration foundation merged: TelegramDispatcher command router, /start -> handle_start() dispatch boundary, DispatchResult reply mapping, unknown command safe fallback, bot.py dispatcher wiring. SENTINEL CONDITIONAL gate satisfied via phase8-8_02_pytest-evidence-pass.md. Pytest gate: 77/77 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-8_01_telegram-dispatch-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-8_02_pytest-evidence-pass.md`. SENTINEL: PR #607 (CONDITIONAL gate satisfied).
 - Phase 8.9 real Telegram polling / runtime loop foundation merged: TelegramRuntimeAdapter abstract boundary, HttpTelegramAdapter concrete implementation, extract_command_context staging identity contract, TelegramPollingLoop dispatch + reply routing, run_polling_loop top-level wiring, bot.py adapter/loop wiring. SENTINEL CONDITIONAL gate satisfied via phase8-9_02_pytest-evidence-pass.md. Pytest gate: 94/94 pass. Evidence: `projects/polymarket/polyquantbot/reports/forge/phase8-9_01_telegram-runtime-loop-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-9_02_pytest-evidence-pass.md`. SENTINEL: PR #609 (CONDITIONAL gate satisfied).
+- Phase 8.10 Telegram identity resolution foundation merged truth synced: strict outcome normalization fix retained with 114/114 pytest evidence. References preserved: `projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-10_02_pytest-evidence-pass.md`, `projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md`.
 
 [IN PROGRESS]
-- Phase 8.10 Telegram identity resolution foundation: SENTINEL CONDITIONAL gate satisfied (strict outcome normalization fix + 2 new malformed-resolved tests + 114/114 dependency-complete pass). PR #610 open; pending COMMANDER merge decision.
+- Phase 8.11 Telegram onboarding/account-link foundation: unresolved Telegram /start users now trigger backend onboarding start contract with truthful outcomes (onboarded/already_linked/rejected/error) backed by persistent multi-user storage and runtime reply mapping.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -32,7 +33,7 @@ Status       : Phase 8.10 Telegram identity resolution foundation SENTINEL CONDI
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review and merge decision for PR #610 (Phase 8.10 Telegram identity resolution). SENTINEL CONDITIONAL gate satisfied. Evidence: projects/polymarket/polyquantbot/reports/forge/phase8-10_02_pytest-evidence-pass.md (114/114 pass). PR #611 CONDITIONAL gate satisfied — can be closed after PR #610 merges.
+- SENTINEL validation for Phase 8.11 MAJOR scope (Telegram onboarding/account-link foundation) over backend onboarding contract, runtime not_found onboarding mapping, and persistence/isolation evidence; then return to COMMANDER for merge decision.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-19 15:52
+**Last Updated:** 2026-04-19 20:16
 
 # Board Overview
 
@@ -344,8 +344,8 @@
 ## CrusaderBot — Telegram Identity Resolution Foundation Checklist (Phase 8.10)
 
 **Goal:** Replace staging tenant/user placeholders in the Telegram runtime with a truthful backend-driven identity resolution foundation under `projects/polymarket/polyquantbot/`. Introduces a narrow service/contract that maps inbound Telegram `from_user_id` to backend user scope, updates the polling loop to use resolved identity for command dispatch, and defines safe fallback reply behavior for unlinked/unknown users and backend errors.  
-**Status:** 🚧 In Progress — SENTINEL validation required before merge  
-**Last Updated:** 2026-04-19 15:52
+**Status:** ✅ Done (merged truth sync closed. SENTINEL CONDITIONAL gate satisfied with strict outcome normalization and 114/114 pass evidence. References: `projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-10_02_pytest-evidence-pass.md`, `projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md`)  
+**Last Updated:** 2026-04-19 20:16
 
 ### Scope Lock
 - [x] Keep scope on Telegram identity resolution contract only
@@ -379,6 +379,42 @@
 - [x] Portfolio engine rollout
 - [x] Full web identity rollout
 - [x] Production-grade cross-client identity linking orchestration
+
+---
+
+## CrusaderBot — Telegram Onboarding / Account-Link Foundation Checklist (Phase 8.11)
+
+**Goal:** Replace unknown-user Telegram `/start` dead-end with a narrow, truthful onboarding/account-link foundation that can initiate link creation for unresolved users while preserving Phase 8.10 resolved-user behavior.  
+**Status:** 🚧 In Progress (FORGE-X implementation complete; MAJOR lane awaiting SENTINEL validation)  
+**Last Updated:** 2026-04-19 20:16
+
+### Scope Lock
+- [x] Keep scope on minimal Telegram onboarding/account-link foundation only
+- [x] Treat validation as `MAJOR`
+- [x] Avoid false claims of full self-serve account management product
+
+### Foundation Deliverables
+- [x] Add backend onboarding contract for unresolved Telegram users (`POST /auth/telegram-onboarding/start`)
+- [x] Add `TelegramOnboardingService` with truthful outcomes (`onboarded`, `already_linked`, `rejected`, `error`)
+- [x] Persist onboarding linkage via existing persistent multi-user user record boundary (`external_id=tg_{telegram_user_id}`)
+- [x] Extend `CrusaderBackendClient` with `start_telegram_onboarding()` API mapping
+- [x] Extend `TelegramPollingLoop` unresolved-user branch to initiate onboarding and map safe replies by real outcomes
+- [x] Preserve resolved-user Phase 8.10 flow (dispatch with real tenant/user scope unchanged)
+- [x] Update bot runtime wiring to pass onboarding initiator
+- [x] Add targeted Phase 8.11 tests for success, already-linked, rejected, error, and persistence/isolation
+- [x] Preserve Phase 8.10 regression coverage in test execution
+- [x] Update forge report, PROJECT_STATE.md, ROADMAP.md
+
+### Explicit Exclusions
+- [x] Full polished Telegram onboarding UX
+- [x] Full cross-client account-link product
+- [x] OAuth
+- [x] RBAC
+- [x] Delegated signing lifecycle
+- [x] Exchange execution rollout
+- [x] Portfolio engine rollout
+- [x] Full web onboarding rollout
+- [x] Production-grade notification orchestration
 
 ---
 

--- a/projects/polymarket/polyquantbot/client/telegram/backend_client.py
+++ b/projects/polymarket/polyquantbot/client/telegram/backend_client.py
@@ -13,6 +13,7 @@ SUPPORTED_CLIENT_TYPES: frozenset[str] = frozenset({"telegram", "web"})
 
 HandoffOutcome = Literal["issued", "rejected", "error"]
 TelegramIdentityOutcome = Literal["resolved", "not_found", "error"]
+TelegramOnboardingOutcome = Literal["onboarded", "already_linked", "rejected", "error"]
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,14 @@ class TelegramIdentityResolution:
     outcome: TelegramIdentityOutcome
     tenant_id: str | None = None
     user_id: str | None = None
+
+
+@dataclass(frozen=True)
+class TelegramOnboardingResult:
+    outcome: TelegramOnboardingOutcome
+    tenant_id: str | None = None
+    user_id: str | None = None
+    detail: str = ""
 
 
 class CrusaderBackendClient:
@@ -188,3 +197,55 @@ class CrusaderBackendClient:
             status_code=resp.status_code,
         )
         return TelegramIdentityResolution(outcome="error")
+
+    async def start_telegram_onboarding(
+        self, telegram_user_id: str
+    ) -> TelegramOnboardingResult:
+        """Call POST /auth/telegram-onboarding/start for unresolved users."""
+        if not telegram_user_id or not telegram_user_id.strip():
+            return TelegramOnboardingResult(
+                outcome="rejected",
+                detail="telegram_user_id must not be empty",
+            )
+
+        payload = {
+            "telegram_user_id": telegram_user_id,
+            "tenant_id": self._identity_tenant_id,
+        }
+
+        try:
+            async with httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=self._timeout,
+            ) as http_client:
+                resp = await http_client.post("/auth/telegram-onboarding/start", json=payload)
+        except Exception as exc:
+            log.error(
+                "crusaderbot_backend_onboarding_http_error",
+                telegram_user_id=telegram_user_id,
+                error=str(exc),
+            )
+            return TelegramOnboardingResult(outcome="error", detail=str(exc))
+
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+                outcome: TelegramOnboardingOutcome = data.get("outcome", "error")
+                return TelegramOnboardingResult(
+                    outcome=outcome,
+                    tenant_id=data.get("tenant_id"),
+                    user_id=data.get("user_id"),
+                    detail=str(data.get("detail") or ""),
+                )
+            except Exception:
+                return TelegramOnboardingResult(outcome="error", detail="invalid onboarding response")
+
+        detail = ""
+        try:
+            detail = str(resp.json().get("detail", ""))
+        except Exception:
+            detail = resp.text or f"http {resp.status_code}"
+        return TelegramOnboardingResult(
+            outcome="error" if resp.status_code >= 500 else "rejected",
+            detail=detail,
+        )

--- a/projects/polymarket/polyquantbot/client/telegram/bot.py
+++ b/projects/polymarket/polyquantbot/client/telegram/bot.py
@@ -95,7 +95,7 @@ async def run_bot() -> None:
         adapter="client.telegram.runtime.HttpTelegramAdapter",
         identity_resolution="backend",
         registered_commands=["/start"],
-        phase="8.10",
+        phase="8.11",
         staging_tenant_id=settings.staging_tenant_id,
         staging_user_id=settings.staging_user_id,
     )
@@ -104,6 +104,7 @@ async def run_bot() -> None:
         adapter=adapter,
         dispatcher=dispatcher,
         identity_resolver=backend,
+        onboarding_initiator=backend,
         staging_tenant_id=settings.staging_tenant_id,
         staging_user_id=settings.staging_user_id,
     )

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -26,6 +26,7 @@ import structlog
 from projects.polymarket.polyquantbot.client.telegram.backend_client import (
     CrusaderBackendClient,
     TelegramIdentityResolution,
+    TelegramOnboardingResult,
 )
 from projects.polymarket.polyquantbot.client.telegram.dispatcher import (
     DispatchResult,
@@ -39,8 +40,16 @@ _STAGING_TENANT_ID = "staging"
 _STAGING_USER_ID = "staging"
 
 _REPLY_NOT_REGISTERED = (
-    "You are not registered with CrusaderBot. "
-    "Contact the bot administrator to get access."
+    "You are not registered with CrusaderBot."
+)
+_REPLY_ONBOARDED = (
+    "Your onboarding request is ready. Please send /start again to continue."
+)
+_REPLY_ALREADY_LINKED = (
+    "Your account is already linked. Please send /start again."
+)
+_REPLY_ONBOARDING_REJECTED = (
+    "Onboarding could not be started. Please contact the bot administrator."
 )
 _REPLY_IDENTITY_ERROR = "Unable to verify your identity. Please try again later."
 
@@ -87,6 +96,16 @@ class TelegramIdentityResolver(Protocol):
         self, telegram_user_id: str
     ) -> TelegramIdentityResolution:
         """Resolve a Telegram user ID to backend tenant/user scope."""
+        ...
+
+
+class TelegramOnboardingInitiator(Protocol):
+    """Protocol for starting onboarding/account-link flow for unresolved users."""
+
+    async def start_telegram_onboarding(
+        self, telegram_user_id: str
+    ) -> TelegramOnboardingResult:
+        """Start onboarding and return typed outcome."""
         ...
 
 
@@ -215,12 +234,14 @@ class TelegramPollingLoop:
         adapter: TelegramRuntimeAdapter,
         dispatcher: TelegramDispatcher,
         identity_resolver: Optional[TelegramIdentityResolver] = None,
+        onboarding_initiator: Optional[TelegramOnboardingInitiator] = None,
         staging_tenant_id: str = _STAGING_TENANT_ID,
         staging_user_id: str = _STAGING_USER_ID,
     ) -> None:
         self._adapter = adapter
         self._dispatcher = dispatcher
         self._identity_resolver = identity_resolver
+        self._onboarding_initiator = onboarding_initiator
         self._staging_tenant_id = staging_tenant_id
         self._staging_user_id = staging_user_id
         self._offset: int = 0
@@ -274,7 +295,33 @@ class TelegramPollingLoop:
                     update_id=update.update_id,
                     from_user_id=update.from_user_id,
                 )
-                await self._safe_send_reply(update.chat_id, _REPLY_NOT_REGISTERED)
+                if self._onboarding_initiator is None:
+                    await self._safe_send_reply(update.chat_id, _REPLY_NOT_REGISTERED)
+                    return
+                try:
+                    onboarding = await self._onboarding_initiator.start_telegram_onboarding(
+                        update.from_user_id
+                    )
+                except Exception as exc:
+                    log.error(
+                        "crusaderbot_telegram_onboarding_exception",
+                        update_id=update.update_id,
+                        from_user_id=update.from_user_id,
+                        error=str(exc),
+                    )
+                    await self._safe_send_reply(update.chat_id, _REPLY_IDENTITY_ERROR)
+                    return
+
+                if onboarding.outcome == "onboarded":
+                    await self._safe_send_reply(update.chat_id, _REPLY_ONBOARDED)
+                    return
+                if onboarding.outcome == "already_linked":
+                    await self._safe_send_reply(update.chat_id, _REPLY_ALREADY_LINKED)
+                    return
+                if onboarding.outcome == "rejected":
+                    await self._safe_send_reply(update.chat_id, _REPLY_ONBOARDING_REJECTED)
+                    return
+                await self._safe_send_reply(update.chat_id, _REPLY_IDENTITY_ERROR)
                 return
 
             if resolution.outcome == "error":
@@ -338,6 +385,7 @@ async def run_polling_loop(
     adapter: TelegramRuntimeAdapter,
     dispatcher: TelegramDispatcher,
     identity_resolver: Optional[TelegramIdentityResolver] = None,
+    onboarding_initiator: Optional[TelegramOnboardingInitiator] = None,
     staging_tenant_id: str = _STAGING_TENANT_ID,
     staging_user_id: str = _STAGING_USER_ID,
 ) -> None:
@@ -354,14 +402,16 @@ async def run_polling_loop(
         adapter=adapter,
         dispatcher=dispatcher,
         identity_resolver=identity_resolver,
+        onboarding_initiator=onboarding_initiator,
         staging_tenant_id=staging_tenant_id,
         staging_user_id=staging_user_id,
     )
     log.info(
         "crusaderbot_telegram_polling_started",
-        phase="8.10",
+        phase="8.11",
         registered_commands=["/start"],
         identity_resolution="enabled" if identity_resolver is not None else "staging_fallback",
+        onboarding="enabled" if onboarding_initiator is not None else "disabled",
         staging_tenant_id=staging_tenant_id,
         staging_user_id=staging_user_id,
     )

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md
@@ -1,0 +1,88 @@
+# Phase 8.10 Post-Merge Truth Sync + Phase 8.11 Telegram Onboarding / Account-Link Foundation
+
+**Date:** 2026-04-19 20:16  
+**Branch:** feature/phase8-11-telegram-onboarding-account-link-foundation-2026-04-19
+
+## 1. What was built
+
+### Part A — Phase 8.10 closeout (truth sync)
+- Synced `PROJECT_STATE.md` and `ROADMAP.md` to close stale "pending merge/validation" wording for Phase 8.10 and reflect merged-truth status.
+- Preserved Phase 8.10 reference continuity:
+  - `projects/polymarket/polyquantbot/reports/forge/phase8-10_01_telegram-identity-resolution-foundation.md`
+  - `projects/polymarket/polyquantbot/reports/forge/phase8-10_02_pytest-evidence-pass.md`
+  - `projects/polymarket/polyquantbot/reports/sentinel/phase8-10_01_telegram-identity-validation-pr610.md`
+
+### Part B — Phase 8.11 onboarding/account-link foundation
+- Added `TelegramOnboardingService` with narrow outcomes:
+  - `onboarded` -> creates minimal user record with `external_id=tg_{telegram_user_id}`
+  - `already_linked` -> existing user matched by `(tenant_id, external_id)`
+  - `rejected` -> invalid input boundary
+  - `error` -> storage/service exception boundary
+- Added backend route:
+  - `POST /auth/telegram-onboarding/start`
+- Added client contract:
+  - `CrusaderBackendClient.start_telegram_onboarding()`
+- Extended Telegram runtime:
+  - unresolved identity (`not_found`) now invokes onboarding initiator and maps safe reply outcomes (`onboarded`, `already_linked`, `rejected`, `error`)
+  - resolved identity flow from Phase 8.10 remains unchanged
+
+## 2. Current system architecture (relevant slice)
+
+`TelegramPollingLoop` now follows:
+1. resolve identity via `resolve_telegram_identity()`
+2. if `resolved` -> dispatch unchanged over real tenant/user scope
+3. if `not_found` -> call `start_telegram_onboarding()`
+4. map onboarding result to safe Telegram reply and stop dispatch for that update
+
+Backend onboarding path:
+1. `POST /auth/telegram-onboarding/start`
+2. `TelegramOnboardingService.start(telegram_user_id, tenant_id)`
+3. lookup existing user by `external_id=tg_{telegram_user_id}`
+4. if missing -> create `UserRecord` (persistent via existing `PersistentMultiUserStore`)
+5. return typed onboarding outcome
+
+## 3. Files created / modified (full repo-root paths)
+
+### Created
+- `projects/polymarket/polyquantbot/server/services/telegram_onboarding_service.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_11_telegram_onboarding_20260419.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md`
+
+### Modified
+- `projects/polymarket/polyquantbot/server/api/client_auth_routes.py`
+- `projects/polymarket/polyquantbot/server/main.py`
+- `projects/polymarket/polyquantbot/client/telegram/backend_client.py`
+- `projects/polymarket/polyquantbot/client/telegram/runtime.py`
+- `projects/polymarket/polyquantbot/client/telegram/bot.py`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4. What is working
+
+- Unresolved Telegram users no longer receive only dead-end rejection; onboarding foundation now starts from runtime not_found branch.
+- Onboarding create path persists created user mapping in multi-user store.
+- Already-linked users are detected deterministically by `(tenant_id, external_id)`.
+- Rejected and error paths return safe reply behavior without runtime crash.
+- Phase 8.10 resolver/dispatch behavior remains preserved.
+
+## 5. Known issues
+
+- This lane is intentionally not full account-link productization (no OAuth/RBAC/multi-client UX).
+- Onboarding currently creates minimal user-only linkage foundation; account/wallet lifecycle remains follow-up.
+- Pre-auth onboarding route currently has no rate limiting in this lane.
+
+## 6. What is next
+
+- MAJOR validation handoff to SENTINEL for:
+  - onboarding route/service behavior
+  - runtime not_found onboarding reply mapping
+  - persistence/isolation proof
+  - Phase 8.10 regression continuity
+
+Validation declaration:
+
+Validation Tier   : MAJOR (with included MINOR truth sync)  
+Claim Level       : FOUNDATION  
+Validation Target : Phase 8.11 Telegram onboarding/account-link foundation only (unresolved `/start` path, backend onboarding contract, persistence boundary, outcome mapping, tests)  
+Not in Scope      : full Telegram onboarding UX, OAuth, RBAC, delegated signing lifecycle, exchange execution rollout, portfolio rollout, full web onboarding  
+Suggested Next    : SENTINEL validation, then COMMANDER review

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md
@@ -1,7 +1,7 @@
 # Phase 8.10 Post-Merge Truth Sync + Phase 8.11 Telegram Onboarding / Account-Link Foundation
 
 **Date:** 2026-04-19 20:16  
-**Branch:** feature/phase8-11-telegram-onboarding-account-link-foundation-2026-04-19
+**Branch:** feature/task-title-2026-04-19-u33jkr
 
 ## 1. What was built
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-11_02_pytest-evidence-pass.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-11_02_pytest-evidence-pass.md
@@ -1,0 +1,60 @@
+# Phase 8.11 Pytest Evidence — Dependency-Complete Pass
+
+**Date:** 2026-04-19  
+**Branch:** feature/task-title-2026-04-19-u33jkr  
+**PR:** #612  
+**Environment:** Python 3.11.15, pytest 9.0.3, pydantic, fastapi, httpx, uvicorn, structlog installed
+
+## Purpose
+
+Closes the SENTINEL CONDITIONAL gate from PR #613 which cited missing dependency-complete pytest reproduction evidence as a required follow-up item.
+
+## Command
+
+```
+python -m pytest -q \
+  projects/polymarket/polyquantbot/tests/test_phase8_11_telegram_onboarding_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_7_runtime_handoff_foundation_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_6_persistent_multi_user_store_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_5_persistent_wallet_link_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_4_client_auth_wallet_link_20260419.py \
+  projects/polymarket/polyquantbot/tests/test_phase8_1_multi_user_foundation_20260419.py
+```
+
+## Result
+
+```
+124 passed in 3.17s
+```
+
+**Status: PASS — all 124 tests passed with zero failures, zero errors, zero warnings.**
+
+## Test breakdown by module
+
+| Module | Tests | Result |
+|---|---|---|
+| test_phase8_11_telegram_onboarding_20260419 | 10 | PASS |
+| test_phase8_10_telegram_identity_20260419 | 20 | PASS |
+| test_phase8_9_telegram_runtime_20260419 | 18 | PASS |
+| test_phase8_8_telegram_dispatch_20260419 | 12 | PASS |
+| test_phase8_7_runtime_handoff_foundation_20260419 | 14 | PASS |
+| test_phase8_6_persistent_multi_user_store_20260419 | 13 | PASS |
+| test_phase8_5_persistent_wallet_link_20260419 | 13 | PASS |
+| test_phase8_4_client_auth_wallet_link_20260419 | 12 | PASS |
+| test_phase8_1_multi_user_foundation_20260419 | 8 | PASS |
+| **Total** | **124** | **PASS** |
+
+## SENTINEL CONDITIONAL gate satisfaction
+
+SENTINEL PR #613 identified two required follow-up items:
+
+1. **Traceability cleanup** — forge report branch metadata mismatched actual PR #612 source branch.
+   - Fixed: `projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md` branch field updated from `feature/phase8-11-telegram-onboarding-account-link-foundation-2026-04-19` to `feature/task-title-2026-04-19-u33jkr`.
+
+2. **Dependency-complete pytest evidence** — pytest collection had been blocked by missing `pydantic` in the SENTINEL runner.
+   - Resolved: this file documents the full dependency-complete run confirming 124 tests pass.
+
+Both CONDITIONAL gate items are now satisfied. PR #612 is ready for COMMANDER merge review.

--- a/projects/polymarket/polyquantbot/server/api/client_auth_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/client_auth_routes.py
@@ -12,6 +12,7 @@ from projects.polymarket.polyquantbot.server.schemas.auth_session import AuthMet
 from projects.polymarket.polyquantbot.server.schemas.wallet_link import WalletLinkCreateRequest
 from projects.polymarket.polyquantbot.server.services.auth_session_service import AuthSessionService
 from projects.polymarket.polyquantbot.server.services.telegram_identity_service import TelegramIdentityService
+from projects.polymarket.polyquantbot.server.services.telegram_onboarding_service import TelegramOnboardingService
 from projects.polymarket.polyquantbot.server.services.wallet_link_service import (
     WalletLinkNotFoundError,
     WalletLinkOwnershipError,
@@ -27,10 +28,16 @@ class ClientHandoffRequestBody(BaseModel):
     ttl_seconds: int = Field(default=1800, ge=60, le=86400)
 
 
+class TelegramOnboardingStartBody(BaseModel):
+    telegram_user_id: str = Field(min_length=1)
+    tenant_id: str = Field(min_length=1)
+
+
 def build_client_auth_router(
     auth_session_service: AuthSessionService,
     wallet_link_service: WalletLinkService,
     telegram_identity_service: TelegramIdentityService,
+    telegram_onboarding_service: TelegramOnboardingService,
 ) -> APIRouter:
     router = APIRouter(prefix="/auth", tags=["client-auth"])
 
@@ -54,6 +61,22 @@ def build_client_auth_router(
             "outcome": resolution.outcome,
             "tenant_id": resolution.tenant_id,
             "user_id": resolution.user_id,
+        }
+
+    @router.post("/telegram-onboarding/start")
+    async def start_telegram_onboarding(
+        body: TelegramOnboardingStartBody,
+    ) -> dict[str, object]:
+        """Start minimal Telegram onboarding/account-link foundation."""
+        result = telegram_onboarding_service.start(
+            telegram_user_id=body.telegram_user_id,
+            tenant_id=body.tenant_id,
+        )
+        return {
+            "outcome": result.outcome,
+            "tenant_id": result.tenant_id,
+            "user_id": result.user_id,
+            "detail": result.detail,
         }
 
     @router.post("/handoff")

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -22,6 +22,7 @@ from projects.polymarket.polyquantbot.server.core.runtime import (
 from projects.polymarket.polyquantbot.server.services.account_service import AccountService
 from projects.polymarket.polyquantbot.server.services.auth_session_service import AuthSessionService
 from projects.polymarket.polyquantbot.server.services.telegram_identity_service import TelegramIdentityService
+from projects.polymarket.polyquantbot.server.services.telegram_onboarding_service import TelegramOnboardingService
 from projects.polymarket.polyquantbot.server.services.user_service import UserService
 from projects.polymarket.polyquantbot.server.services.wallet_link_service import WalletLinkService
 from projects.polymarket.polyquantbot.server.services.wallet_service import WalletService
@@ -63,6 +64,7 @@ def create_app() -> FastAPI:
     account_service = AccountService(store=store)
     wallet_service = WalletService(store=store)
     telegram_identity_service = TelegramIdentityService(user_service=user_service)
+    telegram_onboarding_service = TelegramOnboardingService(user_service=user_service)
 
     session_storage_path = Path(
         os.getenv(
@@ -85,6 +87,7 @@ def create_app() -> FastAPI:
     app.state.multi_user_storage_path = multi_user_storage_path
     app.state.multi_user_store = store
     app.state.telegram_identity_service = telegram_identity_service
+    app.state.telegram_onboarding_service = telegram_onboarding_service
     app.state.persistent_session_store = persistent_session_store
     app.state.user_service = user_service
     app.state.account_service = account_service
@@ -109,6 +112,7 @@ def create_app() -> FastAPI:
             auth_session_service=auth_session_service,
             wallet_link_service=wallet_link_service,
             telegram_identity_service=telegram_identity_service,
+            telegram_onboarding_service=telegram_onboarding_service,
         )
     )
 
@@ -130,7 +134,7 @@ def create_app() -> FastAPI:
         multi_user_storage_path=str(multi_user_storage_path),
         session_storage_path=str(session_storage_path),
         wallet_link_storage_path=str(wallet_link_storage_path),
-        phase="8.10",
+        phase="8.11",
     )
     return app
 

--- a/projects/polymarket/polyquantbot/server/services/telegram_onboarding_service.py
+++ b/projects/polymarket/polyquantbot/server/services/telegram_onboarding_service.py
@@ -1,0 +1,90 @@
+"""Telegram onboarding/account-link foundation service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import structlog
+
+from projects.polymarket.polyquantbot.server.schemas.multi_user import UserCreate
+from projects.polymarket.polyquantbot.server.services.user_service import UserService
+
+log = structlog.get_logger(__name__)
+
+TelegramOnboardingOutcome = Literal["onboarded", "already_linked", "rejected", "error"]
+TELEGRAM_EXTERNAL_ID_PREFIX = "tg_"
+
+
+@dataclass(frozen=True)
+class TelegramOnboardingResult:
+    outcome: TelegramOnboardingOutcome
+    tenant_id: str | None = None
+    user_id: str | None = None
+    detail: str | None = None
+
+
+class TelegramOnboardingService:
+    """Narrow onboarding/account-link foundation for unresolved Telegram users.
+
+    This service intentionally performs only a minimal, truthful action:
+    - if Telegram external identity already exists under tenant => already_linked
+    - else create a minimal user record bound to tg_{telegram_user_id} => onboarded
+    """
+
+    def __init__(self, user_service: UserService) -> None:
+        self._user_service = user_service
+
+    def start(self, telegram_user_id: str, tenant_id: str) -> TelegramOnboardingResult:
+        if not telegram_user_id or not telegram_user_id.strip():
+            return TelegramOnboardingResult(
+                outcome="rejected",
+                detail="telegram_user_id must not be empty",
+            )
+        if not tenant_id or not tenant_id.strip():
+            return TelegramOnboardingResult(
+                outcome="rejected",
+                detail="tenant_id must not be empty",
+            )
+
+        external_id = f"{TELEGRAM_EXTERNAL_ID_PREFIX}{telegram_user_id}"
+        try:
+            existing = self._user_service.get_user_by_external_id(
+                tenant_id=tenant_id,
+                external_id=external_id,
+            )
+            if existing is not None:
+                return TelegramOnboardingResult(
+                    outcome="already_linked",
+                    tenant_id=existing.tenant_id,
+                    user_id=existing.user_id,
+                )
+
+            created_user, _ = self._user_service.create_user(
+                UserCreate(
+                    tenant_id=tenant_id,
+                    external_id=external_id,
+                    display_name=f"tg:{telegram_user_id}",
+                )
+            )
+            log.info(
+                "crusaderbot_telegram_onboarding_user_created",
+                tenant_id=tenant_id,
+                user_id=created_user.user_id,
+                telegram_user_id=telegram_user_id,
+            )
+            return TelegramOnboardingResult(
+                outcome="onboarded",
+                tenant_id=created_user.tenant_id,
+                user_id=created_user.user_id,
+            )
+        except Exception as exc:
+            log.error(
+                "crusaderbot_telegram_onboarding_error",
+                tenant_id=tenant_id,
+                telegram_user_id=telegram_user_id,
+                error=str(exc),
+            )
+            return TelegramOnboardingResult(
+                outcome="error",
+                detail=str(exc),
+            )

--- a/projects/polymarket/polyquantbot/tests/test_phase8_11_telegram_onboarding_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_11_telegram_onboarding_20260419.py
@@ -1,0 +1,232 @@
+"""Phase 8.11 — Telegram onboarding/account-link foundation tests."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from projects.polymarket.polyquantbot.client.telegram.backend_client import (
+    CrusaderBackendClient,
+    TelegramIdentityResolution,
+    TelegramOnboardingResult,
+)
+from projects.polymarket.polyquantbot.client.telegram.dispatcher import DispatchResult, TelegramDispatcher
+from projects.polymarket.polyquantbot.client.telegram.runtime import (
+    TelegramInboundUpdate,
+    TelegramPollingLoop,
+    TelegramRuntimeAdapter,
+    _REPLY_ALREADY_LINKED,
+    _REPLY_IDENTITY_ERROR,
+    _REPLY_ONBOARDED,
+    _REPLY_ONBOARDING_REJECTED,
+)
+from projects.polymarket.polyquantbot.server.services.telegram_onboarding_service import (
+    TELEGRAM_EXTERNAL_ID_PREFIX,
+    TelegramOnboardingService,
+)
+from projects.polymarket.polyquantbot.server.services.user_service import UserService
+from projects.polymarket.polyquantbot.server.storage.in_memory_store import InMemoryMultiUserStore
+from projects.polymarket.polyquantbot.server.storage.multi_user_store import PersistentMultiUserStore
+
+
+class MockTelegramAdapter(TelegramRuntimeAdapter):
+    def __init__(self, updates: list[TelegramInboundUpdate]) -> None:
+        self._updates = updates
+        self.replies: list[tuple[str, str]] = []
+
+    async def get_updates(self, offset: int = 0, limit: int = 100) -> list[TelegramInboundUpdate]:
+        return [u for u in self._updates if u.update_id >= offset]
+
+    async def send_reply(self, chat_id: str, text: str) -> None:
+        self.replies.append((chat_id, text))
+
+
+class MockIdentityResolver:
+    async def resolve_telegram_identity(self, telegram_user_id: str) -> TelegramIdentityResolution:
+        return TelegramIdentityResolution(outcome="not_found")
+
+
+class MockOnboardingInitiator:
+    def __init__(self, result: TelegramOnboardingResult) -> None:
+        self._result = result
+
+    async def start_telegram_onboarding(self, telegram_user_id: str) -> TelegramOnboardingResult:
+        return self._result
+
+
+def _make_update() -> TelegramInboundUpdate:
+    return TelegramInboundUpdate(
+        update_id=1,
+        chat_id="chat_001",
+        from_user_id="12345678",
+        text="/start",
+    )
+
+
+def _make_dispatcher() -> TelegramDispatcher:
+    dispatcher = MagicMock(spec=TelegramDispatcher)
+    dispatcher.dispatch = AsyncMock(
+        return_value=DispatchResult(
+            outcome="session_issued",
+            reply_text="Welcome!",
+            session_id="sess_1",
+        )
+    )
+    return dispatcher
+
+
+def test_onboarding_service_success_creates_user() -> None:
+    store = InMemoryMultiUserStore()
+    service = TelegramOnboardingService(user_service=UserService(store=store))
+
+    result = service.start(telegram_user_id="12345678", tenant_id="t1")
+
+    assert result.outcome == "onboarded"
+    assert result.user_id is not None
+    created = store.get_user(result.user_id)
+    assert created is not None
+    assert created.tenant_id == "t1"
+    assert created.external_id == f"{TELEGRAM_EXTERNAL_ID_PREFIX}12345678"
+
+
+def test_onboarding_service_already_linked_path() -> None:
+    store = InMemoryMultiUserStore()
+    service = TelegramOnboardingService(user_service=UserService(store=store))
+
+    first = service.start(telegram_user_id="12345678", tenant_id="t1")
+    second = service.start(telegram_user_id="12345678", tenant_id="t1")
+
+    assert first.outcome == "onboarded"
+    assert second.outcome == "already_linked"
+    assert second.user_id == first.user_id
+
+
+def test_onboarding_service_rejected_path_empty_id() -> None:
+    service = TelegramOnboardingService(user_service=UserService(store=InMemoryMultiUserStore()))
+    result = service.start(telegram_user_id="", tenant_id="t1")
+    assert result.outcome == "rejected"
+
+
+def test_onboarding_service_error_path_store_exception() -> None:
+    user_service = UserService(store=InMemoryMultiUserStore())
+
+    def raise_error(tenant_id: str, external_id: str) -> None:
+        raise RuntimeError("forced failure")
+
+    user_service.get_user_by_external_id = raise_error  # type: ignore[method-assign]
+    service = TelegramOnboardingService(user_service=user_service)
+    result = service.start(telegram_user_id="12345678", tenant_id="t1")
+    assert result.outcome == "error"
+
+
+def test_onboarding_service_persistence_and_tenant_isolation(tmp_path: Path) -> None:
+    storage_path = tmp_path / "multi_user.json"
+    service_a = TelegramOnboardingService(
+        user_service=UserService(store=PersistentMultiUserStore(storage_path=storage_path))
+    )
+    result_t1 = service_a.start(telegram_user_id="12345678", tenant_id="t1")
+    assert result_t1.outcome == "onboarded"
+
+    service_b = TelegramOnboardingService(
+        user_service=UserService(store=PersistentMultiUserStore(storage_path=storage_path))
+    )
+    result_t2 = service_b.start(telegram_user_id="12345678", tenant_id="t2")
+    assert result_t2.outcome == "onboarded"
+    assert result_t2.user_id != result_t1.user_id
+
+    store_verify = PersistentMultiUserStore(storage_path=storage_path)
+    assert store_verify.get_user(result_t1.user_id or "") is not None
+    assert store_verify.get_user(result_t2.user_id or "") is not None
+
+
+def test_backend_client_start_onboarding_http_success() -> None:
+    client = CrusaderBackendClient(base_url="http://localhost:8080", identity_tenant_id="t1")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "outcome": "onboarded",
+        "tenant_id": "t1",
+        "user_id": "usr_abc",
+        "detail": "",
+    }
+
+    async def run() -> TelegramOnboardingResult:
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_http
+            return await client.start_telegram_onboarding("12345678")
+
+    result = asyncio.get_event_loop().run_until_complete(run())
+    assert result.outcome == "onboarded"
+    assert result.user_id == "usr_abc"
+
+
+def test_polling_loop_not_found_onboarded_reply() -> None:
+    adapter = MockTelegramAdapter(updates=[_make_update()])
+    dispatcher = _make_dispatcher()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=MockIdentityResolver(),
+        onboarding_initiator=MockOnboardingInitiator(
+            TelegramOnboardingResult(outcome="onboarded", tenant_id="t1", user_id="usr_1")
+        ),
+    )
+
+    asyncio.get_event_loop().run_until_complete(loop.run_once())
+    assert adapter.replies[0][1] == _REPLY_ONBOARDED
+    dispatcher.dispatch.assert_not_awaited()
+
+
+def test_polling_loop_not_found_already_linked_reply() -> None:
+    adapter = MockTelegramAdapter(updates=[_make_update()])
+    dispatcher = _make_dispatcher()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=MockIdentityResolver(),
+        onboarding_initiator=MockOnboardingInitiator(
+            TelegramOnboardingResult(outcome="already_linked", tenant_id="t1", user_id="usr_1")
+        ),
+    )
+
+    asyncio.get_event_loop().run_until_complete(loop.run_once())
+    assert adapter.replies[0][1] == _REPLY_ALREADY_LINKED
+    dispatcher.dispatch.assert_not_awaited()
+
+
+def test_polling_loop_not_found_rejected_reply() -> None:
+    adapter = MockTelegramAdapter(updates=[_make_update()])
+    dispatcher = _make_dispatcher()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=MockIdentityResolver(),
+        onboarding_initiator=MockOnboardingInitiator(
+            TelegramOnboardingResult(outcome="rejected", detail="denied")
+        ),
+    )
+
+    asyncio.get_event_loop().run_until_complete(loop.run_once())
+    assert adapter.replies[0][1] == _REPLY_ONBOARDING_REJECTED
+    dispatcher.dispatch.assert_not_awaited()
+
+
+def test_polling_loop_not_found_onboarding_error_reply() -> None:
+    adapter = MockTelegramAdapter(updates=[_make_update()])
+    dispatcher = _make_dispatcher()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=MockIdentityResolver(),
+        onboarding_initiator=MockOnboardingInitiator(
+            TelegramOnboardingResult(outcome="error", detail="backend error")
+        ),
+    )
+
+    asyncio.get_event_loop().run_until_complete(loop.run_once())
+    assert adapter.replies[0][1] == _REPLY_IDENTITY_ERROR
+    dispatcher.dispatch.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Close out Phase 8.10 repo-truth (remove stale "pending" wording and preserve Phase 8.10 evidence references) and advance the roadmap/state to reflect merged reality. 
- Replace the current unknown-Telegram-user dead-end with a minimal, truthful onboarding / account-link foundation that is small, testable, and preserves tenant isolation. 
- Keep the scope narrow (FOUNDATION claim) and prepare the MAJOR validation handoff to SENTINEL.

### Description
- Added a narrow onboarding service `TelegramOnboardingService` that returns typed outcomes (`onboarded`, `already_linked`, `rejected`, `error`) and creates a minimal `UserRecord` with `external_id = tg_{telegram_user_id}` when appropriate (`projects/polymarket/polyquantbot/server/services/telegram_onboarding_service.py`).
- Exposed a pre-auth onboarding route `POST /auth/telegram-onboarding/start` and wired the service into FastAPI composition (`server/api/client_auth_routes.py`, `server/main.py`).
- Extended the client-side contract with `CrusaderBackendClient.start_telegram_onboarding()` and a typed `TelegramOnboardingResult` (`client/telegram/backend_client.py`).
- Updated `TelegramPollingLoop` to invoke onboarding when a resolver replies `not_found`, mapping onboarding outcomes to safe user replies (`onboarded`, `already_linked`, `rejected`, `error`) while preserving Phase 8.10 resolved dispatch behavior (`client/telegram/runtime.py`, `client/telegram/bot.py`).
- Added targeted Phase 8.11 tests that cover successful onboarding, already-linked, rejected, error, persistence/isolation, and runtime reply mapping (`projects/polymarket/polyquantbot/tests/test_phase8_11_telegram_onboarding_20260419.py`).
- Performed Phase 8.10 post-merge truth sync updates to `PROJECT_STATE.md` and `ROADMAP.md` and added a FORGE report (`projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md`).

### Testing
- `python -m py_compile` was run against the touched Python modules and passed for the modified/added files. 
- `pytest -q` for the Phase 8.10 and Phase 8.11 test suites was attempted but test collection failed in this runner due to a missing environment dependency (`pydantic`), so full automated pytest in this environment was not completed. 
- Unit tests and targeted Phase 8.11 test cases were added in-source and the branch includes the new test files for SENTINEL validation to run in a dependency-complete environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d48f19dc8325b1d9f58dfbc51bb4)