### PR TITLE
SENTINEL: Validate PR #618 — Strict active-only Telegram session issuance gate (CONDITIONAL)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-19 23:28
+Last Updated : 2026-04-19 23:33
 Status       : Phase 8.13 session-issuance gate fix committed on branch claude/fix-telegram-session-issuance-zGD86. Auto-promotion removed from TelegramSessionIssuanceService; strict active-only gate enforced. 148/148 pytest pass. SENTINEL PR #617 BLOCKED finding is resolved pending COMMANDER merge decision.
 
 [COMPLETED]
@@ -26,7 +26,7 @@ Status       : Phase 8.13 session-issuance gate fix committed on branch claude/f
 - Phase 8.11 Telegram onboarding/account-link foundation merged truth synced on main: unresolved /start onboarding route and persistence evidence preserved in `projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md` and `projects/polymarket/polyquantbot/reports/forge/phase8-11_02_pytest-evidence-pass.md`; expected validation reference path remains `projects/polymarket/polyquantbot/reports/sentinel/phase8-11_01_telegram-onboarding-validation-pr612.md`.
 
 [IN PROGRESS]
-- Phase 8.13 Telegram session-issuance gate fix: auto-promotion removed, strict active-only issuance gate enforced, 148/148 pytest pass, awaiting COMMANDER merge decision on PR #616 / branch claude/fix-telegram-session-issuance-zGD86.
+- Phase 8.13 Telegram session-issuance gate fix validated by SENTINEL for PR #618 on branch claude/fix-telegram-session-issuance-zGD86 with CONDITIONAL verdict (contract checks PASS; 148/148 claim environment-gated on this runner).
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -34,7 +34,7 @@ Status       : Phase 8.13 session-issuance gate fix committed on branch claude/f
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review and merge decision for Phase 8.13 session-issuance gate fix (branch claude/fix-telegram-session-issuance-zGD86). SENTINEL PR #617 BLOCKED finding is resolved; PR #617 can be closed after merge. Report: projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md.
+- COMMANDER final decision for PR #618 after dependency-complete pytest evidence confirms claimed 148/148 gate; SENTINEL contract validation is CONDITIONAL PASS. Reports: projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md and projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_session-issuance-gate-validation-pr618.md.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_session-issuance-gate-validation-pr618.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_session-issuance-gate-validation-pr618.md
@@ -1,0 +1,106 @@
+Environment
+- Date (Asia/Jakarta): 2026-04-19 23:33
+- Validation role: SENTINEL
+- Validation tier: MAJOR
+- Target PR: #618
+- Target branch (declared): claude/fix-telegram-session-issuance-zGD86
+- Working branch observed by git: work (Codex detached/worktree normalization)
+
+Validation Context
+- Objective: re-validate the blocked contract from PR #616 and confirm PR #618 enforces strict active-only session issuance.
+- Required checks:
+  1) auto-promotion fully removed
+  2) pending_confirmation -> rejected
+  3) no activation-state mutation side effect during issuance
+  4) active user still receives session issuance
+  5) tenant isolation preserved
+  6) runtime/client reply mapping matches backend behavior
+  7) claimed 148/148 pytest evidence truthful OR conditionally gated when non-reproducible
+
+Phase 0 Checks
+- Forge report present: PASS (`projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md`).
+- PROJECT_STATE.md present with full timestamp format: PASS.
+- py_compile rerun by SENTINEL on key touched files: PASS.
+- pytest reproducibility on this runner: FAIL (dependency/environment gate; `pydantic` missing in Python 3.10 runner).
+
+Findings
+1) Auto-promotion removed: PASS
+- `TelegramSessionIssuanceService.issue()` rejects any non-active activation status and contains no activation mutation call.
+- No `set_activation_status` invocation exists in issuance service.
+
+2) pending_confirmation returns rejected: PASS
+- Service gate: `if settings.activation_status != "active": return rejected`.
+- Unit/integration test coverage explicitly asserts pending -> rejected.
+
+3) No activation-state mutation side effect in issuance: PASS
+- Issuance service only reads user/settings and calls `AuthSessionService.issue_session()` for active users.
+- Activation mutation remains in `TelegramActivationService.confirm()` via `set_activation_status(..., "active")`.
+
+4) Active users still receive session issuance: PASS
+- Service returns `session_issued` with a session_id for active users.
+- Tests cover active issuance and repeated active issuance.
+
+5) Tenant isolation preserved: PASS
+- Service lookup is tenant-scoped (`get_user_by_external_id(tenant_id=..., external_id=...)`).
+- Dedicated test verifies same telegram_user_id across t1/t2 remains isolated.
+
+6) Runtime/client reply mapping truthful: PASS
+- Backend client maps `/auth/telegram-onboarding/session-issue` response outcome to typed `TelegramSessionIssuanceResult`.
+- Runtime maps:
+  - `session_issued` -> success reply
+  - `already_active_session_issued` -> welcome-back reply
+  - `rejected` -> activation rejected reply
+  - other/error -> identity error reply
+- Mapping remains aligned with backend contract for rejected/issued/error outcomes.
+
+7) Claimed 148/148 pytest evidence: CONDITIONAL
+- Could not fully reproduce in this runner because required runtime deps are missing (`ModuleNotFoundError: pydantic`) when collecting tests.
+- Claim is conditionally accepted pending dependency-complete rerun evidence in COMMANDER/CI environment.
+
+Score Breakdown
+- Contract correctness: 35/35
+- Safety/no hidden mutation: 25/25
+- Tenant isolation: 10/10
+- Runtime/client mapping truthfulness: 15/15
+- Reproducible test evidence in current runner: 0/15 (environment-gated)
+- Report/traceability completeness: 10/10
+- Total: 95/100
+
+Critical Issues
+- None in code-path contract checks.
+- One gate item remains: local reproducibility of 148/148 pytest claim on dependency-complete environment.
+
+Status
+- Verdict: CONDITIONAL
+
+PR Gate Result
+- PR #618 may proceed only with conditional gate: COMMANDER must require one reproducible dependency-complete pytest rerun (or CI artifact) for the claimed 148/148 before final merge decision.
+
+Broader Audit Finding
+- The blocked behavior from PR #616 (issuance-time auto-promotion) is not present in the current issuance service implementation.
+- Activation authority is correctly centralized in `TelegramActivationService.confirm()`.
+
+Reasoning
+- Core safety contract (active-only issuance with no silent activation mutation) is implemented and test-targeted.
+- Only unresolved item is environment reproducibility of total-suite count claim on this runner.
+
+Fix Recommendations
+- Run and attach dependency-complete evidence for:
+  - `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests`
+- Ensure environment includes at minimum: `pydantic`, `fastapi`, and test stack versions used in forge evidence.
+
+Out-of-scope Advisory
+- `already_active_session_issued` remains mapped in runtime/client contract while service currently always returns `session_issued` for active path; distinction can be added later without affecting this gate.
+
+Deferred Minor Backlog
+- [DEFERRED] Resolve pytest warning: `Unknown config option: asyncio_mode` in environment where pytest plugin/config alignment is expected.
+
+Telegram Visual Preview
+- PASS summary:
+  - active-only issuance enforced
+  - pending_confirmation rejected
+  - no issuance-side activation mutation
+  - tenant isolation preserved
+  - runtime reply mapping aligned
+- CONDITIONAL gate:
+  - 148/148 claim not reproducible on this runner due to missing dependencies


### PR DESCRIPTION
### Motivation
- Re-validate PR #618 (branch `claude/fix-telegram-session-issuance-zGD86`) to confirm the blocked behavior from PR #616 (issuance-time auto-promotion) was removed and that only `activation_status == "active"` users receive backend sessions. 

### Description
- Added SENTINEL MAJOR-tier validation report at `projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_session-issuance-gate-validation-pr618.md` recording findings and the `CONDITIONAL` verdict. 
- Updated `PROJECT_STATE.md` timestamp and Phase 8.13 entry to reflect SENTINEL validation and NEXT PRIORITY handoff to COMMANDER. 
- Validated implementation evidence showing `TelegramSessionIssuanceService.issue()` enforces a strict gate (`if settings.activation_status != "active": return rejected`) and contains no activation mutation calls, while `TelegramActivationService.confirm()` remains the sole owner of `pending_confirmation -> active`. 
- Confirmed runtime client mapping and backend client surface remain aligned for `session_issued`, `already_active_session_issued`, `rejected`, and error outcomes.

### Testing
- Ran `python3 -m py_compile` on the touched files which completed successfully for the inspected files. 
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` and it failed during collection with `ModuleNotFoundError: No module named 'projects'` when `PYTHONPATH` was not set. 
- Re-ran with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` and collection failed with `ModuleNotFoundError: No module named 'pydantic'`, so the claimed `148/148` pytest pass could not be reproduced in this runner and is conditionally gated pending a dependency-complete CI/local rerun. 
- Resulting SENTINEL verdict: `CONDITIONAL` (contract and safety checks PASS; full-suite pytest evidence is environment-gated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5039a18308325a3e50d71f2593112)