### PR TITLE
[SENTINEL] Validate PR #620 — Phase 8.3 Public Paper Beta Spine

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 00:15
-Status       : Phase 8.3 public paper beta spine fix pass for PR #620 is in progress on branch refactor/public-paper-beta-spine-20260419 with autotrade/kill execution gating, truthful Telegram command mapping, and narrowed placeholder disclosure awaiting SENTINEL validation.
+Last Updated : 2026-04-20 00:26
+Status       : SENTINEL PASS WITH NOTES completed for Phase 8.3 public paper beta spine (PR #620) on branch refactor/public-paper-beta-spine-20260419; runtime slice and claim discipline validated for COMMANDER merge decision.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -27,7 +27,7 @@ Status       : Phase 8.3 public paper beta spine fix pass for PR #620 is in prog
 
 [IN PROGRESS]
 - Phase 8.13 Telegram session-issuance gate fix: auto-promotion removed, strict active-only issuance gate enforced, 148/148 pytest pass, awaiting COMMANDER merge decision on PR #616 / branch claude/fix-telegram-session-issuance-zGD86.
-- Phase 8.3 Public Paper Beta Spine (MAJOR) fix pass: autotrade off and kill switch now both block new paper entries, /connect_wallet stub removed, /positions /pnl /risk /status mapped to truthful backend surfaces, and Fly/docs claim wording aligned with narrow placeholder behavior; pending SENTINEL review before merge.
+- Phase 8.3 Public Paper Beta Spine (MAJOR) SENTINEL review completed with PASS WITH NOTES for PR #620: worker autotrade/kill/risk gating, truthful Telegram command routing, Fly /health deploy contract, and narrow Falcon placeholder disclosure validated.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -35,7 +35,7 @@ Status       : Phase 8.3 public paper beta spine fix pass for PR #620 is in prog
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL review for Phase 8.3 Public Paper Beta Spine on branch refactor/public-paper-beta-spine-20260419 is required before merge. Report: projects/polymarket/polyquantbot/reports/forge/phase8-3_04_public-paper-beta-spine.md.
+- COMMANDER merge decision for PR #620 (Phase 8.3 Public Paper Beta Spine) with SENTINEL PASS WITH NOTES. Validation report: projects/polymarket/polyquantbot/reports/sentinel/phase8-3_01_public-paper-beta-spine-validation-pr620.md.
 - COMMANDER review and merge decision for Phase 8.13 session-issuance gate fix (branch claude/fix-telegram-session-issuance-zGD86). SENTINEL PR #617 BLOCKED finding is resolved; PR #617 can be closed after merge. Report: projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md.
 
 [KNOWN ISSUES]

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-3_01_public-paper-beta-spine-validation-pr620.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-3_01_public-paper-beta-spine-validation-pr620.md
@@ -1,0 +1,93 @@
+# SENTINEL Validation Report — PR #620 Phase 8.3 Public Paper Beta Spine
+
+## Environment
+- Timestamp (Asia/Jakarta): 2026-04-20 00:26
+- Repository: `walker-ai-team`
+- Project root: `projects/polymarket/polyquantbot`
+- Validation target branch: `refactor/public-paper-beta-spine-20260419`
+- Runtime branch probe (`git rev-parse --abbrev-ref HEAD`): `work` (Codex normalization)
+- Validation tier: `MAJOR`
+- Claim level: `NARROW INTEGRATION`
+
+## Validation Context
+- Scope: runtime/deploy/control-surface slice validation for public paper beta spine; not full production readiness.
+- Contracts validated:
+  - Telegram as control surface only (no manual trade-entry path).
+  - Falcon backend-managed read-side contract (no user key onboarding, no `/setkey`).
+  - Paper-beta worker gating (`autotrade`, `kill_switch`, risk gate before execution).
+  - FastAPI/Fly deploy truth (`/health`, `/ready`, realistic deployment wording).
+  - Claim discipline across report/docs/state.
+
+## Phase 0 Checks
+- Forge report present: `projects/polymarket/polyquantbot/reports/forge/phase8-3_04_public-paper-beta-spine.md`.
+- PROJECT_STATE present and updated before validation handoff.
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` -> collection failed in default env due `ModuleNotFoundError: projects`.
+- `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` -> `5 passed`.
+- UTF-8 locale verified (`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`).
+
+## Findings
+### Runtime correctness
+1. Worker gating is correctly enforced before execution:
+   - `autotrade_enabled=false` causes explicit skip with reason `autotrade_disabled`.
+   - `kill_switch=true` causes explicit skip with reason `kill_switch_enabled`.
+   - Risk gate evaluates before execution (`evaluate(...)` then `if not allowed: continue` before engine execute).
+   - Monitoring/update stages (`position_monitor`, `price_updater`) still run after candidate loop.
+2. No hidden entry path was found inside this worker slice that bypasses autotrade/kill/risk checks.
+3. Execution engine remains paper-only (`{"mode": "paper"}` and paper portfolio path).
+
+### Control-surface truthfulness
+1. Telegram command routing matches declared shell:
+   - `/positions` -> `/beta/positions`
+   - `/pnl` -> `/beta/pnl`
+   - `/risk` -> `/beta/risk`
+   - `/status` -> `/beta/status`
+2. `/connect_wallet` is removed from dispatcher shell and resolves to unknown command fallback.
+3. No manual buy/sell trade-entry command path exists in inspected public shell runtime slice.
+
+### Deploy/runtime truth
+1. FastAPI boot surface is real in `server/main.py`; `/health` and `/ready` are implemented through base router wiring.
+2. Fly health check targets `/health` consistently.
+3. Fly env defaults remain paper-safe (`TRADING_MODE=PAPER`) and Falcon runtime wording is constrained by required secrets when enabled.
+
+### Claim/report truthfulness
+1. Falcon contract is backend-managed in env config and does not expose user key onboarding flow.
+2. Falcon gateway behavior is partially placeholder/sample; this is explicitly disclosed in docs and forge report.
+3. Scope remains narrow and does not claim broad public production readiness.
+
+## Score Breakdown
+- Runtime correctness: 35/35
+- Control-surface truthfulness: 25/25
+- Deploy/runtime truth: 20/20
+- Claim discipline: 18/20
+- Test sufficiency: 8/10
+- **Total: 106/110 (normalized 96/100)**
+
+## Critical Issues
+- None.
+
+## Status
+- **PASS WITH NOTES**
+
+## PR Gate Result
+- Gate recommendation: **Ready for COMMANDER merge decision**.
+- Validation interpretation: MAJOR gate satisfied for declared NARROW INTEGRATION slice.
+
+## Broader Audit Finding
+- The API exposes `POST /beta/mode` accepting `live`, while risk gate blocks non-paper execution (`mode_not_paper_default`). This is acceptable for current narrow scope but should remain explicitly documented as non-live-authoritative until a later phase.
+
+## Reasoning
+- The reviewed code path consistently enforces safety gating (autotrade/kill/risk) before paper execution and does not reveal a Telegram bypass path. Deploy and docs wording are aligned with placeholder Falcon behavior and paper-beta limitations.
+
+## Fix Recommendations
+1. Add one API-level test asserting `/beta/mode=live` cannot produce execution events (defensive regression coverage).
+2. Add a worker test that confirms monitoring/update calls still run when autotrade is off for all candidates.
+3. Standardize pytest invocation environment (set PYTHONPATH in CI/test runner contract) to avoid collection drift.
+
+## Out-of-scope Advisory
+- This review does not assert production Falcon signal quality, live trading readiness, or end-to-end operational SLOs beyond the declared paper-beta runtime slice.
+
+## Deferred Minor Backlog
+- [DEFERRED] Pytest import path ergonomics (`ModuleNotFoundError: projects` without `PYTHONPATH=.`) should be normalized in shared test runner config.
+
+## Telegram Visual Preview
+- Public shell reflects control-only commands and unknown-command fallback for removed stubs; no manual trade-entry pathway detected.


### PR DESCRIPTION
### Motivation
- Provide a narrow public paper-beta runtime slice that exposes a FastAPI control plane, Telegram control surface, backend-managed Falcon read-side integration, and a paper-only worker execution spine while enforcing execution gating and truthful documentation. 
- Remove control-shell stubs and overclaims so the deployed surface and docs match the actual paper-only, placeholder-backed Falcon behavior.

### Description
- Enforced worker gating and paper-only execution by adding/updating `projects/polymarket/polyquantbot/server/workers/paper_beta_worker.py`, `server/risk/paper_risk_gate.py`, and `server/execution/paper_execution.py` so `autotrade` and `kill_switch` block new entries and the risk gate runs before execution. 
- Added a backend-managed Falcon contract and read-side placeholder gateway in `projects/polymarket/polyquantbot/configs/falcon.py` and `server/integrations/falcon_gateway.py` with explicit placeholder/sample behavior and environment-driven enablement. 
- Truthful control-plane and Telegram mapping changes including `projects/polymarket/polyquantbot/server/api/public_beta_routes.py`, `client/telegram/dispatcher.py`, `client/telegram/runtime.py`, and `client/telegram/bot.py` to map `/positions`, `/pnl`, `/risk`, `/status` to `/beta/*`, remove the `/connect_wallet` stub, and ensure no manual trade-entry commands exist. 
- Documentation, deploy config, and state updates including `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`, `projects/polymarket/polyquantbot/fly.toml`, `PROJECT_STATE.md` changes, and new tests and a SENTINEL report at `projects/polymarket/polyquantbot/reports/sentinel/phase8-3_01_public-paper-beta-spine-validation-pr620.md`.

### Testing
- Ran focused unit tests with `PYTHONPATH=. pytest -q projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` which passed `5 passed` and validated autotrade/kill gating and Telegram command-to-endpoint mapping. 
- Noted and recorded an environment collection quirk where `pytest -q` without `PYTHONPATH=.` raised `ModuleNotFoundError: No module named 'projects'`, and recommended normalizing test runner `PYTHONPATH` in CI. 
- Verified runtime probes and deploy wiring via inspection of `server/main.py`, `server/api/routes.py` (`/health` and `/ready`), and `fly.toml` health-check configuration; no critical issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50fe1bc5c8325ac274d16e6a956cc)