### PR TITLE
feat: complete phase 8.7 public paper beta surfaces

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 05:55
-Status       : FORGE-X Phase 8.6 public paper beta confidence pass is in progress on branch harden/public-paper-beta-confidence-pass-20260420; MAJOR lane requires SENTINEL review before merge.
+Last Updated : 2026-04-20 06:29
+Status       : FORGE-X Phase 8.7 public paper beta completion pass is in progress on branch feature/complete-public-paper-beta-pass-20260420; MAJOR lane requires SENTINEL review before merge.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -27,7 +27,7 @@ Status       : FORGE-X Phase 8.6 public paper beta confidence pass is in progres
 
 [IN PROGRESS]
 - Phase 8.13 Telegram session-issuance gate fix: auto-promotion removed, strict active-only issuance gate enforced, 148/148 pytest pass, awaiting COMMANDER merge decision on PR #616 / branch claude/fix-telegram-session-issuance-zGD86.
-- Phase 8.6 Public Paper Beta Confidence Pass (MAJOR): readiness semantics hardening, deeper API/runtime contract tests, control-plane safety regression checks, and operator confidence polish in progress on branch harden/public-paper-beta-confidence-pass-20260420.
+- Phase 8.7 Public Paper Beta Completion Pass (MAJOR): status/control reply semantics hardening, onboarding control-only disclosure tightening, operator guard visibility completion, and paper-boundary regression expansion in progress on branch feature/complete-public-paper-beta-pass-20260420.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -35,7 +35,7 @@ Status       : FORGE-X Phase 8.6 public paper beta confidence pass is in progres
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL-required review for Phase 8.6 Public Paper Beta Confidence Pass after FORGE-X delivery on branch harden/public-paper-beta-confidence-pass-20260420.
+- SENTINEL-required review for Phase 8.7 Public Paper Beta Completion Pass after FORGE-X delivery on branch feature/complete-public-paper-beta-pass-20260420.
 - COMMANDER review and merge decision for Phase 8.13 session-issuance gate fix (branch claude/fix-telegram-session-issuance-zGD86). SENTINEL PR #617 BLOCKED finding is resolved; PR #617 can be closed after merge. Report: projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md.
 
 [KNOWN ISSUES]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-20 05:55
+**Last Updated:** 2026-04-20 06:29
 
 # Board Overview
 
@@ -455,11 +455,11 @@
 ---
 
 
-## CrusaderBot — Public Paper Beta Confidence Pass (Phase 8.6 Runtime Slice)
+## CrusaderBot — Public Paper Beta Completion Pass (Phase 8.7 Runtime Slice)
 
 **Goal:** Build the fastest safe public-ready paper-trading beta slice with FastAPI control plane, Telegram control shell, backend-managed Falcon read integration, and paper-only worker execution spine.  
-**Status:** 🚧 In Progress (FORGE-X confidence hardening pass in progress on branch `harden/public-paper-beta-confidence-pass-20260420`; SENTINEL required before merge)  
-**Last Updated:** 2026-04-20 05:55
+**Status:** 🚧 In Progress (FORGE-X completion pass in progress on branch `feature/complete-public-paper-beta-pass-20260420`; SENTINEL required before merge)  
+**Last Updated:** 2026-04-20 06:29
 
 ### Scope Lock
 - [x] Preserve Phase 8.3 runtime entrypoints for API, bot, and worker

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -54,7 +54,7 @@ class TelegramDispatcher:
                     "✅ Mode updated\n"
                     f"• Current mode: {data.get('mode', 'unknown')}\n"
                     "• Execution boundary: paper-only\n"
-                    "• Note: live mode is state-only in this beta lane."
+                    "• Operator meaning: mode=live does not enable live order entry in this beta."
                 ),
             )
         if command == "/autotrade":
@@ -65,10 +65,10 @@ class TelegramDispatcher:
             message = (
                 "🤖 Autotrade updated\n"
                 f"• Status: {status}\n"
-                "• Mode: paper beta control plane"
+                "• Scope: control-plane toggle for paper execution only"
             )
             if detail:
-                message += f"\n• Note: {detail}"
+                message += f"\n• Guard: {detail}"
             return DispatchResult(outcome="ok", reply_text=message)
         if command == "/positions":
             data = await self._backend.beta_get("/beta/positions")
@@ -76,8 +76,9 @@ class TelegramDispatcher:
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "📌 Positions (paper)\n"
+                    "📌 Positions (paper beta)\n"
                     f"• Open positions: {len(items)}\n"
+                    "• Boundary: read-only surface (no manual order entry commands)\n"
                     f"• Detail: {items}"
                 ),
             )
@@ -86,8 +87,9 @@ class TelegramDispatcher:
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "📊 PnL (paper)\n"
-                    f"• Unrealized + realized: {data.get('pnl', 0.0)}"
+                    "📊 PnL (paper beta)\n"
+                    f"• Unrealized + realized: {data.get('pnl', 0.0)}\n"
+                    "• Interpretation: informational metric; no live settlement path in this lane"
                 ),
             )
         if command == "/risk":
@@ -100,20 +102,27 @@ class TelegramDispatcher:
                     f"• Exposure: {data.get('exposure', 0.0)}\n"
                     f"• Last reason: {data.get('last_reason', 'n/a')}\n"
                     f"• Kill switch: {data.get('kill_switch', False)}\n"
-                    f"• Autotrade enabled: {data.get('autotrade_enabled', False)}"
+                    f"• Autotrade enabled: {data.get('autotrade_enabled', False)}\n"
+                    "• Boundary: risk state governs paper execution only"
                 ),
             )
         if command == "/status":
             data = await self._backend.beta_get("/beta/status")
+            execution_guard = data.get("execution_guard", {})
+            blocked_reasons = execution_guard.get("blocked_reasons", [])
+            reason_text = ", ".join(blocked_reasons) if blocked_reasons else "none"
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "🧭 Runtime status (paper beta)\n"
+                    "🧭 Runtime status (public paper beta)\n"
                     f"• Mode: {data.get('mode', 'unknown')}\n"
                     f"• Autotrade: {data.get('autotrade', False)}\n"
                     f"• Kill switch: {data.get('kill_switch', False)}\n"
                     f"• Position count: {data.get('position_count', 0)}\n"
-                    f"• Last risk reason: {data.get('last_risk_reason', 'n/a')}"
+                    f"• Guard allows entry: {execution_guard.get('entry_allowed', False)}\n"
+                    f"• Guard reasons: {reason_text}\n"
+                    f"• Last risk reason: {data.get('last_risk_reason', 'n/a')}\n"
+                    "• Boundary: paper-only execution; Telegram is control/read surface"
                 ),
             )
         if command == "/markets":
@@ -163,8 +172,9 @@ class TelegramDispatcher:
         return DispatchResult(
             outcome="unknown_command",
             reply_text=(
-                "Unknown command for CrusaderBot paper beta.\n"
-                "Try: /start /mode /autotrade /positions /pnl /risk /status /markets /market360 /social /kill"
+                "Unknown command for CrusaderBot public paper beta.\n"
+                "Supported: /start /mode /autotrade /positions /pnl /risk /status /markets /market360 /social /kill\n"
+                "Note: no manual trade-entry commands are available in this beta."
             ),
         )
 

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -42,10 +42,10 @@ _STAGING_TENANT_ID = "staging"
 _STAGING_USER_ID = "staging"
 
 _REPLY_NOT_REGISTERED = (
-    "You are not registered with CrusaderBot yet. Public beta currently supports control commands only after onboarding."
+    "You are not registered with CrusaderBot yet. This public paper beta supports control/read commands only after onboarding; manual trade-entry is unavailable."
 )
 _REPLY_ONBOARDED = (
-    "Your onboarding request is ready. Please send /start again to continue."
+    "Your onboarding request is ready. Send /start again to continue into the paper-beta control surface."
 )
 _REPLY_ALREADY_LINKED = (
     "Your account is already linked. Please send /start again."
@@ -53,9 +53,9 @@ _REPLY_ALREADY_LINKED = (
 _REPLY_ACTIVATED = (
     "Your account is now activated. Please send /start again to continue."
 )
-_REPLY_SESSION_ISSUED = "Welcome to CrusaderBot. Your session is ready."
+_REPLY_SESSION_ISSUED = "Welcome to CrusaderBot public paper beta. Your control session is ready (paper-only execution boundary)."
 _REPLY_ALREADY_ACTIVE_SESSION_ISSUED = (
-    "Welcome back. Your account is already active and your session is ready."
+    "Welcome back. Your account is already active and your control session is ready (paper-only boundary)."
 )
 _REPLY_ACTIVATION_REJECTED = (
     "Activation was rejected. Please contact the bot administrator."

--- a/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
+++ b/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
@@ -62,6 +62,11 @@ This lane is **NARROW INTEGRATION**. Falcon market/candidate/social data current
 Manual trade-entry commands are intentionally excluded.
 `/mode live` is accepted as control-plane state only in this phase; execution remains paper-only.
 
+### Operator-facing command semantics (completion pass)
+- `/status` reports operator guard truth (`entry_allowed`, blocked reasons, last risk reason, mode/autotrade/kill state, and paper-only boundary reminder).
+- `/positions`, `/pnl`, and `/risk` are explicitly informational control/read surfaces and do not grant execution authority.
+- `/start` and unresolved-user onboarding replies explicitly state this is a public **paper** beta control surface with no manual trade-entry path.
+
 ## Paper worker flow
 `market_sync -> signal_runner -> risk_monitor -> position_monitor -> price_updater`
 
@@ -83,8 +88,9 @@ Fly runtime is paper-mode by default. To activate Falcon-backed candidate genera
 - `/mode live` updates control-plane state only; execution stays paper-only in this phase.
 - `/autotrade on` is rejected when mode is `live` to preserve paper-only boundary truth.
 - `/kill` always forces autotrade OFF and sets a hard paper-beta execution block.
-- `/beta/status` includes `execution_guard` with concrete blocked reasons for operator visibility.
-- Unknown Telegram commands should fall back to a concise supported-command hint.
+- `/beta/status` includes `execution_guard` with concrete blocked reasons, `reason_count`, and `operator_summary` for operator visibility.
+- `/beta/status` includes `readiness_interpretation` (`control_surface`, `execution_authority`, `live_trading_ready=false`) to prevent overclaiming readiness.
+- Unknown Telegram commands fall back to a concise supported-command hint and restate that manual trade-entry commands are not available in this beta.
 
 ## Known limitations
 - Falcon data surfaces remain narrow/placeholder-bounded outside `market_360`; signal quality is not a production claim.

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-7_03_public-paper-beta-completion-pass.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-7_03_public-paper-beta-completion-pass.md
@@ -1,0 +1,48 @@
+# Phase 8.7 — Public Paper Beta Completion Pass
+
+**Date:** 2026-04-20 06:29
+**Branch:** feature/complete-public-paper-beta-pass-20260420
+
+## 1. What was built
+Completed a MAJOR narrow-integration hardening pass over the existing public paper-beta runtime slice by tightening operator-facing status semantics, improving Telegram control-command clarity (`/status`, `/positions`, `/pnl`, `/risk`), strengthening onboarding/not-registered boundary disclosure, and expanding focused regression coverage for control/read truth boundaries.
+
+## 2. Current system architecture (relevant slice)
+`Telegram command/control lane` -> `client/telegram/runtime.py` -> identity resolution and onboarding fallback semantics -> `client/telegram/dispatcher.py` command replies with explicit paper-only guard wording.
+
+`FastAPI status/control lane` -> `server/api/public_beta_routes.py` -> `/beta/status` operator state snapshot (mode/autotrade/kill/guard/position_count/last_risk_reason) plus readiness interpretation fields for truthful paper-beta scope.
+
+`Validation lane` -> `tests/test_phase8_3_public_paper_beta_spine_20260419.py` + `tests/test_phase8_7_public_paper_beta_completion_20260420.py` + `tests/test_crusader_runtime_surface.py` targeted checks for status payload semantics, command reply boundaries, onboarding fallback wording, and paper-only execution guard visibility.
+
+## 3. Files created / modified (full repo-root paths)
+### Modified
+- projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/server/api/public_beta_routes.py
+- projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+- projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
+- PROJECT_STATE.md
+- ROADMAP.md
+
+### Created
+- projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
+- projects/polymarket/polyquantbot/reports/forge/phase8-7_03_public-paper-beta-completion-pass.md
+
+## 4. What is working
+- `/beta/status` now exposes richer operator truth without expanding execution authority: mode/autotrade/kill-switch, paper-only boundary, execution guard summary + reason count, last risk reason, position count, and readiness interpretation (`live_trading_ready=false`).
+- Telegram `/status`, `/positions`, `/pnl`, and `/risk` replies now provide clearer operator interpretation text while preserving explicit paper-only boundaries and no-manual-trade-entry truth.
+- Onboarding/not-registered runtime fallback messaging now clearly states control/read-only access after onboarding and reiterates no manual trade-entry availability in this public paper beta lane.
+- Regression checks were expanded to validate command reply semantics, status payload interpretation contract, onboarding fallback wording, and guard boundary messaging.
+
+## 5. Known issues
+- In this runner, targeted pytest modules are skipped when `fastapi` is unavailable (`pytest.importorskip("fastapi")`), so full runtime assertion execution requires dependency-complete environment.
+- This pass intentionally does not add live trading authority, dashboard expansion, user-managed Falcon keys, or manual trade-entry commands.
+
+## 6. What is next
+- SENTINEL MAJOR validation required on branch `feature/complete-public-paper-beta-pass-20260420` before merge.
+- COMMANDER merge decision after SENTINEL verdict.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : public paper-beta status/control/onboarding semantics (`/beta/status`, Telegram `/status` `/positions` `/pnl` `/risk` `/start` fallback wording), and regression coverage for paper-only guard truth
+Not in Scope      : live trading rollout, dashboard expansion, user-managed Falcon keys, manual trade-entry commands, wallet lifecycle expansion, broad architecture rewrite
+Suggested Next    : SENTINEL review required

--- a/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
@@ -39,9 +39,16 @@ def build_public_beta_router(falcon: FalconGateway) -> APIRouter:
             "execution_guard": {
                 "entry_allowed": len(execution_blocked_reasons) == 0,
                 "blocked_reasons": execution_blocked_reasons,
+                "reason_count": len(execution_blocked_reasons),
+                "operator_summary": "blocked" if execution_blocked_reasons else "entry_allowed",
             },
             "position_count": len(STATE.positions),
             "last_risk_reason": STATE.last_risk_reason,
+            "readiness_interpretation": {
+                "control_surface": "telegram_and_api_control_only",
+                "execution_authority": "paper_only",
+                "live_trading_ready": False,
+            },
         }
 
     @router.post("/mode")

--- a/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
@@ -69,9 +69,25 @@ class FakeBackend:
         if path == "/beta/pnl":
             return {"pnl": 12.5}
         if path == "/beta/risk":
-            return {"drawdown": 0.0, "exposure": 0.02}
+            return {
+                "drawdown": 0.0,
+                "exposure": 0.02,
+                "last_reason": "autotrade_disabled",
+                "kill_switch": False,
+                "autotrade_enabled": False,
+            }
         if path == "/beta/status":
-            return {"mode": "paper"}
+            return {
+                "mode": "paper",
+                "autotrade": False,
+                "kill_switch": False,
+                "position_count": 0,
+                "last_risk_reason": "autotrade_disabled",
+                "execution_guard": {
+                    "entry_allowed": False,
+                    "blocked_reasons": ["autotrade_disabled"],
+                },
+            }
         return {}
 
     async def beta_post(self, path: str, payload: dict[str, object]):
@@ -272,3 +288,25 @@ def test_status_reports_control_plane_guard_reasons() -> None:
     assert status_payload["paper_only_execution_boundary"] is True
     assert status_payload["execution_guard"]["entry_allowed"] is False
     assert "mode_live_paper_execution_disabled" in status_payload["execution_guard"]["blocked_reasons"]
+
+
+def test_status_command_reply_surfaces_execution_guard_and_boundary() -> None:
+    backend = FakeBackend()
+    dispatcher = TelegramDispatcher(backend=backend)
+    result = asyncio.run(dispatcher.dispatch(_make_ctx("/status")))
+    assert "Guard allows entry" in result.reply_text
+    assert "autotrade_disabled" in result.reply_text
+    assert "paper-only execution" in result.reply_text
+
+
+def test_positions_pnl_risk_replies_keep_paper_beta_boundaries_visible() -> None:
+    backend = FakeBackend()
+    dispatcher = TelegramDispatcher(backend=backend)
+
+    positions_reply = asyncio.run(dispatcher.dispatch(_make_ctx("/positions"))).reply_text
+    pnl_reply = asyncio.run(dispatcher.dispatch(_make_ctx("/pnl"))).reply_text
+    risk_reply = asyncio.run(dispatcher.dispatch(_make_ctx("/risk"))).reply_text
+
+    assert "no manual order entry" in positions_reply
+    assert "no live settlement path" in pnl_reply
+    assert "paper execution only" in risk_reply

--- a/projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from projects.polymarket.polyquantbot.client.telegram.dispatcher import TelegramCommandContext, TelegramDispatcher
+from projects.polymarket.polyquantbot.client.telegram.runtime import TelegramInboundUpdate, TelegramPollingLoop, TelegramRuntimeAdapter
+from projects.polymarket.polyquantbot.server.core.public_beta_state import STATE
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from projects.polymarket.polyquantbot.server.main import create_app
+
+
+class FakeBackend:
+    async def request_handoff(self, request):
+        class _Result:
+            outcome = "issued"
+            session_id = "sess-1"
+            detail = ""
+
+        return _Result()
+
+    async def beta_get(self, path: str, params=None):
+        if path == "/beta/status":
+            return {
+                "mode": "paper",
+                "autotrade": False,
+                "kill_switch": False,
+                "position_count": 0,
+                "last_risk_reason": "autotrade_disabled",
+                "execution_guard": {
+                    "entry_allowed": False,
+                    "blocked_reasons": ["autotrade_disabled"],
+                },
+            }
+        return {}
+
+    async def beta_post(self, path: str, payload: dict[str, object]):
+        return {"ok": True}
+
+
+class _Adapter(TelegramRuntimeAdapter):
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def get_updates(self, offset: int = 0, limit: int = 100) -> list[TelegramInboundUpdate]:
+        return [
+            TelegramInboundUpdate(
+                update_id=offset + 1,
+                chat_id="chat-1",
+                from_user_id="tg-404",
+                text="/status",
+            )
+        ]
+
+    async def send_reply(self, chat_id: str, text: str) -> None:
+        self.replies.append(text)
+
+
+class _IdentityNotFoundResolver:
+    async def resolve_telegram_identity(self, telegram_user_id: str):
+        class _Resolution:
+            outcome = "not_found"
+            tenant_id = None
+            user_id = None
+
+        return _Resolution()
+
+
+def _reset_state() -> None:
+    STATE.mode = "paper"
+    STATE.autotrade_enabled = False
+    STATE.kill_switch = False
+    STATE.last_risk_reason = ""
+    STATE.positions.clear()
+
+
+def test_beta_status_payload_exposes_operator_interpretation_contract() -> None:
+    _reset_state()
+    app = create_app()
+    with TestClient(app) as client:
+        payload = client.get("/beta/status").json()
+
+    assert payload["paper_only_execution_boundary"] is True
+    assert payload["execution_guard"]["reason_count"] >= 1
+    assert payload["readiness_interpretation"]["control_surface"] == "telegram_and_api_control_only"
+    assert payload["readiness_interpretation"]["execution_authority"] == "paper_only"
+    assert payload["readiness_interpretation"]["live_trading_ready"] is False
+
+
+def test_status_command_text_keeps_public_beta_boundary_truth() -> None:
+    backend = FakeBackend()
+    dispatcher = TelegramDispatcher(backend=backend)
+    ctx = TelegramCommandContext(
+        command="/status",
+        from_user_id="tg-1",
+        chat_id="chat-1",
+        tenant_id="tenant-1",
+        user_id="user-1",
+    )
+
+    result = asyncio.run(dispatcher.dispatch(ctx))
+
+    assert "public paper beta" in result.reply_text
+    assert "Guard reasons" in result.reply_text
+    assert "no manual trade-entry commands" not in result.reply_text
+    assert "paper-only execution" in result.reply_text
+
+
+def test_not_registered_runtime_reply_mentions_control_only_boundary() -> None:
+    adapter = _Adapter()
+    backend = FakeBackend()
+    dispatcher = TelegramDispatcher(backend=backend)
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=_IdentityNotFoundResolver(),
+    )
+
+    processed = asyncio.run(loop.run_once())
+
+    assert processed == 1
+    assert len(adapter.replies) == 1
+    assert "control/read commands only after onboarding" in adapter.replies[0]
+    assert "manual trade-entry is unavailable" in adapter.replies[0]


### PR DESCRIPTION
### Motivation
- Complete the public paper-beta completion pass to close operator-surface gaps, tighten onboarding/control messaging, and make status/control responses more actionable while preserving the paper-only, narrow-integration claim (MAJOR → SENTINEL required).

### Description
- Extend `/beta/status` operator payload with `reason_count`, `operator_summary`, and `readiness_interpretation` to surface control-plane interpretation without expanding execution authority (`projects/polymarket/polyquantbot/server/api/public_beta_routes.py`).
- Tighten Telegram control-surface replies for `/mode`, `/autotrade`, `/status`, `/positions`, `/pnl`, `/risk`, and unknown-command handling to explicitly state the paper-only/no-manual-trade-entry boundary and clearer operator interpretation (`projects/polymarket/polyquantbot/client/telegram/dispatcher.py`).
- Harden onboarding and session wording for unresolved users and session issuance so the runtime explicitly communicates control/read-only paper-beta scope (`projects/polymarket/polyquantbot/client/telegram/runtime.py`).
- Add and update focused regression tests that assert status payload semantics, command reply boundaries, and onboarding fallback wording, refresh documentation, update `PROJECT_STATE.md`/`ROADMAP.md`, and add a FORGE report for Phase 8.7 (`projects/polymarket/polyquantbot/tests/...`, `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`, `projects/polymarket/polyquantbot/reports/forge/phase8-7_03_public-paper-beta-completion-pass.md`).

### Testing
- `python3 -m py_compile` on touched files (`dispatcher.py`, `runtime.py`, `public_beta_routes.py`, and modified tests) passed with no syntax errors.
- `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py` was executed but tests were skipped in this runner due to `pytest.importorskip("fastapi")` (environment lacks `fastapi`), resulting in skipped tests; a dependency-complete environment is required for full runtime assertions.
- Automated grep checks were run to verify no manual trade-entry commands or trade-entry paths were introduced in the touched control-surface files and returned no matches, confirming negative-regression on manual-execution paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56455e9488325a77e2dc237280070)