### PR TITLE
Re-land Phase 8.13 Telegram session-issuance gate fix (audit & state sync)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-20 06:29
+Last Updated : 2026-04-20 09:50
 Status       : FORGE-X Phase 8.7 public paper beta completion pass is in progress on branch feature/complete-public-paper-beta-pass-20260420; MAJOR lane requires SENTINEL review before merge.
 
 [COMPLETED]
@@ -26,7 +26,7 @@ Status       : FORGE-X Phase 8.7 public paper beta completion pass is in progres
 - Phase 8.11 Telegram onboarding/account-link foundation merged truth synced on main: unresolved /start onboarding route and persistence evidence preserved in `projects/polymarket/polyquantbot/reports/forge/phase8-11_01_telegram-onboarding-account-link-foundation.md` and `projects/polymarket/polyquantbot/reports/forge/phase8-11_02_pytest-evidence-pass.md`; expected validation reference path remains `projects/polymarket/polyquantbot/reports/sentinel/phase8-11_01_telegram-onboarding-validation-pr612.md`.
 
 [IN PROGRESS]
-- Phase 8.13 Telegram session-issuance gate fix: auto-promotion removed, strict active-only issuance gate enforced, 148/148 pytest pass, awaiting COMMANDER merge decision on PR #616 / branch claude/fix-telegram-session-issuance-zGD86.
+- Phase 8.13 Telegram session-issuance gate re-land audit on branch feature/reland-session-issuance-gate-fix-20260420: strict active-only issuance gate already present on current code truth; fresh PR opened for SENTINEL-required MAJOR validation before merge.
 - Phase 8.7 Public Paper Beta Completion Pass (MAJOR): status/control reply semantics hardening, onboarding control-only disclosure tightening, operator guard visibility completion, and paper-boundary regression expansion in progress on branch feature/complete-public-paper-beta-pass-20260420.
 
 [NOT STARTED]
@@ -36,7 +36,7 @@ Status       : FORGE-X Phase 8.7 public paper beta completion pass is in progres
 
 [NEXT PRIORITY]
 - SENTINEL-required review for Phase 8.7 Public Paper Beta Completion Pass after FORGE-X delivery on branch feature/complete-public-paper-beta-pass-20260420.
-- COMMANDER review and merge decision for Phase 8.13 session-issuance gate fix (branch claude/fix-telegram-session-issuance-zGD86). SENTINEL PR #617 BLOCKED finding is resolved; PR #617 can be closed after merge. Report: projects/polymarket/polyquantbot/reports/forge/phase8-13_02_fix-session-issuance-gate.md.
+- SENTINEL-required validation for Phase 8.13 re-land branch feature/reland-session-issuance-gate-fix-20260420 after FORGE-X audit-only truth sync. Report: projects/polymarket/polyquantbot/reports/forge/phase8-13_03_reland-session-issuance-gate-fix.md.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-13_03_reland-session-issuance-gate-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-13_03_reland-session-issuance-gate-fix.md
@@ -1,0 +1,60 @@
+# Phase 8.13 Re-land — Telegram Session-Issuance Gate Fix (Main Truth Audit)
+
+**Date:** 2026-04-20 09:50
+**Branch:** feature/reland-session-issuance-gate-fix-20260420
+**Task:** Re-land Phase 8.13 Telegram session-issuance gate fix against current main truth
+
+## 1. What was built
+
+Completed a fresh FORGE-X re-audit of the current code truth for Telegram session issuance and confirmed the previously reviewed safety fix is already present on the current baseline.
+
+Result: **no runtime code reapplication was required**. The strict active-only issuance gate is already enforced and no auto-promotion path remains in session issuance.
+
+## 2. Current system architecture (relevant slice)
+
+Telegram `/start` relevant control slice:
+
+1. `TelegramActivationService.confirm()` owns activation transition (`pending_confirmation -> active`).
+2. `TelegramSessionIssuanceService.issue()` only reads activation status and issues sessions strictly for `active` users.
+3. `activation_status != "active"` returns `rejected` with no identity/session mutation.
+4. Runtime reply mapping in polling loop preserves `session_issued`, `already_active_session_issued`, `rejected`, and `error` outcomes.
+
+## 3. Files created / modified (full repo-root paths)
+
+### Created
+- `projects/polymarket/polyquantbot/reports/forge/phase8-13_03_reland-session-issuance-gate-fix.md`
+
+### Modified
+- `PROJECT_STATE.md`
+
+### Audited (no changes required)
+- `projects/polymarket/polyquantbot/server/services/telegram_session_issuance_service.py`
+- `projects/polymarket/polyquantbot/server/services/telegram_activation_service.py`
+- `projects/polymarket/polyquantbot/client/telegram/runtime.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`
+
+## 4. What is working
+
+- No auto-promotion behavior in session issuance: `TelegramSessionIssuanceService` does not mutate activation state.
+- Strict active-only gate is present (`activation_status == "active"` required for issuance).
+- Non-active/unresolved identities are rejected for issuance in service contract and focused Phase 8.13 tests.
+- Active identities continue to receive `session_issued` outcomes.
+
+## 5. Known issues
+
+- Targeted pytest execution in this runner is dependency-blocked (`ModuleNotFoundError: No module named 'pydantic'`) before test collection.
+- Because current repo truth already contains the strict gate fix and focused tests, this re-land task only records audit truth + state synchronization on a fresh branch.
+
+## 6. What is next
+
+- Open fresh PR from `feature/reland-session-issuance-gate-fix-20260420` for COMMANDER review.
+- MAJOR lane requires SENTINEL validation before merge.
+- If SENTINEL confirms no regression, COMMANDER can close stale prior references and proceed with this re-land branch.
+
+---
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : Telegram session issuance safety gate only (no auto-promotion, active-only issuance, non-active rejection)
+Not in Scope      : CrusaderBot paper-beta expansion, live trading, dashboard/Falcon integration, unrelated Telegram UX/auth redesign
+Suggested Next    : SENTINEL-required review after FORGE-X re-land PR


### PR DESCRIPTION
### Motivation
- Re-audit current main and re-land the previously reviewed Phase 8.13 session-issuance safety fix while preserving only the strict session/control behavior and avoiding unrelated drift.
- Ensure session issuance enforces a strict `activation_status == "active"` gate and that no auto-promotion path (`pending_confirmation -> active`) exists in the issuance surface.
- Produce a focused FORGE report and update repo state so the work can proceed to required SENTINEL MAJOR validation.

### Description
- Confirmed by code inspection that `TelegramSessionIssuanceService.issue()` enforces a strict active-only gate and never promotes `pending_confirmation` to `active`, so no runtime reapplication of the fix was required.
- Added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase8-13_03_reland-session-issuance-gate-fix.md` documenting the audit findings and MAJOR/SENTINEL handoff context.
- Updated `PROJECT_STATE.md` `Last Updated` timestamp and replaced in-scope Phase 8.13 entries to reflect the re-land audit and the SENTINEL validation next gate.
- Left existing focused tests in place at `projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` and made no other functional changes to session issuance runtime wiring.

### Testing
- Ran `python3 -m py_compile` on the touched modules and the compilation check passed.
- Attempted `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`, but test collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'pydantic'`), so full pytest verification could not complete in this runner.
- Performed targeted search audits with `rg` to confirm the absence of auto-promotion patterns and the presence of `activation_status == "active"` checks, which returned expected evidence.
- Ran encoding/mojibake checks on edited files and found no non-UTF-8 or mojibake sequences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59438d5d883258eb48f77ce7e3074)