### PR TITLE
fix: add status code assertion in runtime surface contract test

### DIFF
--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -29,8 +29,10 @@ def test_runtime_surface_contract_keys_exist(monkeypatch, path: str, required_ke
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     app = create_app()
     with TestClient(app) as client:
-        payload = client.get(path).json()
-    assert required_keys.issubset(payload.keys())
+        response = client.get(path)
+        assert response.status_code == 200
+        payload = response.json()
+        assert required_keys.issubset(payload.keys())
 
 
 def test_api_settings_uses_fly_port(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Harden runtime-surface contract test per Gemini suggestion by asserting HTTP status before JSON parsing to avoid false positives and clearer failures.
- Also intended to prepare PR #636 branch for merge by applying the requested test fix while the merge-conflict resolution for `PROJECT_STATE.md` and `ROADMAP.md` was part of the original task scope.

### Description
- Updated `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` to call `response = client.get(path)` and `assert response.status_code == 200` before `payload = response.json()` and the contract-key assertion.
- No other files were modified in this change and no runtime logic was altered.
- Commit created on the current local branch with message `fix: assert runtime surface status before json parse` (local commit `aec42d4`).

### Testing
- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` and it succeeded. 
- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py` and it succeeded. 
- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py` and it succeeded.
- Could not perform the requested `git fetch`/`rebase`/`push` or verify PR #636 mergeability because the local environment has no configured `origin` remote, so conflict resolution on `PROJECT_STATE.md` and `ROADMAP.md` was not applied in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b39357f8832587903eb7d9d19bea)