### PR TITLE
docs: correct public-paper-beta repo-truth realignment

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 13:23
-Status       : Public-paper-beta roadmap numbering is realigned to consumed/open phase truth; the next beta lane is Phase 8.15 runtime proof, with operational/public readiness and release gate queued as Phases 8.16 and 8.17.
+Last Updated : 2026-04-20 13:55
+Status       : Phase 8.13 remains the active open validation lane; public-paper-beta roadmap realignment is preserved so Phase 8.15 runtime proof is next only after current open validation lanes (8.13 and 8.14), followed by 8.16 operational/public readiness and 8.17 release gate.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -36,7 +36,7 @@ Status       : Public-paper-beta roadmap numbering is realigned to consumed/open
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Phase 8.15 runtime proof is the next public-paper-beta lane after consumed/open truth through Phase 8.14; Phase 8.16 operational/public readiness and Phase 8.17 release gate remain queued as the unchanged downstream path.
+- Phase 8.13 re-land audit validation remains the current open operational lane; after currently open lanes (8.13 and 8.14), the public-paper-beta build path continues at Phase 8.15 runtime proof, then 8.16 operational/public readiness, then 8.17 release gate.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-20 13:23
+**Last Updated:** 2026-04-20 13:55
 
 # Board Overview
 
@@ -421,8 +421,8 @@
 ## CrusaderBot — Telegram Confirmation / Activation Foundation Checklist (Phase 8.12)
 
 **Goal:** Add a narrow confirmation/activation lifecycle for Telegram-linked onboarding users so runtime does not stop at record creation and can truthfully report activation outcomes before session handoff dispatch.  
-**Status:** ✅ Done (historical lane consumed on main; preserved as numbering continuity before active/open lanes 8.13 and 8.14)  
-**Last Updated:** 2026-04-20 13:23
+**Status:** 🚧 In Progress (status promotion to done reverted pending explicit merged-main completion proof; numbering continuity before active/open lanes 8.13 and 8.14 is preserved)
+**Last Updated:** 2026-04-20 13:55
 
 ### Scope Lock
 - [x] Keep scope on Telegram confirmation/activation foundation only

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-9_05_public-paper-beta-roadmap-realignment.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-9_05_public-paper-beta-roadmap-realignment.md
@@ -1,6 +1,6 @@
 # Phase 8.9 — Public-Paper-Beta Roadmap Realignment After Consumed 8.10/8.11 Truth
 
-**Date:** 2026-04-20 13:23
+**Date:** 2026-04-20 13:55
 **Branch:** feature/public-paper-beta-roadmap-realignment-2026-04-20
 
 ## 1. What was changed
@@ -10,7 +10,8 @@
   - Phase 8.15 = runtime proof
   - Phase 8.16 = operational/public readiness
   - Phase 8.17 = release gate
-- Updated `PROJECT_STATE.md` next-priority wording so runtime proof is explicitly the next public-paper-beta milestone.
+- Corrected `PROJECT_STATE.md` status/next-priority wording so Phase 8.13 remains the current open validation lane, while Phase 8.15 is clearly positioned as the next public-paper-beta lane only after currently open lanes (8.13 and 8.14).
+- Reverted unproven Phase 8.12 roadmap status promotion from done to in-progress until explicit merged-main completion proof is available, while preserving numbering continuity and the 8.15 -> 8.16 -> 8.17 realigned public-paper-beta path.
 
 ## 2. Files modified (full repo-root paths)
 - PROJECT_STATE.md
@@ -20,6 +21,6 @@
 ## 3. Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
 Validation Tier   : MINOR
 Claim Level       : FOUNDATION (DOCS / STATE TRUTH SYNC)
-Validation Target : repo-root phase numbering truth sync between PROJECT_STATE.md and ROADMAP.md for post-8.9 public-paper-beta planning lanes
+Validation Target : repo-root truth sync ensuring PROJECT_STATE.md keeps Phase 8.13 as current open lane while ROADMAP.md preserves 8.15 -> 8.16 -> 8.17 public-paper-beta path without unproven completion claims
 Not in Scope      : runtime code changes, strategy/risk/execution behavior, SENTINEL validation, roadmap content unrelated to phase-numbering drift
 Suggested Next    : COMMANDER review


### PR DESCRIPTION
### Motivation
- Fix repo-truth drift introduced by the public-paper-beta realignment so planning numbering does not overwrite actual open validation lanes. 
- Preserve the intended downstream public-paper-beta path (8.15 → 8.16 → 8.17) while keeping active open lane truth intact. 

### Description
- Updated `PROJECT_STATE.md` to keep Phase 8.13 as the active open validation lane and to reword `NEXT PRIORITY` so Phase 8.15 is explicitly the next public-paper-beta lane only after 8.13/8.14. 
- Reverted the unproven Phase 8.12 status promotion in `ROADMAP.md` from `✅ Done` back to `🚧 In Progress` and refreshed the roadmap `Last Updated` timestamp. 
- Edited the forge report `projects/polymarket/polyquantbot/reports/forge/phase8-9_05_public-paper-beta-roadmap-realignment.md` to reflect the corrected truth and updated `Date` and `Validation Target`. 

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and the check passed. 
- Performed mojibake pattern scans for `â€`, `â†`, `ðŸ`, `\udc`, and `�` across touched files and found no matches. 
- Verified `PYTHONIOENCODING=utf-8` environment probe returned `utf-8` and all file writes used UTF-8 encoding. 
- Changes were committed on branch `feature/public-paper-beta-roadmap-realignment-2026-04-20` and are ready for COMMANDER review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cd8e456083259c4b5eee76281437)