### PR TITLE
Phase 8.15: scaffold dependency-complete runtime-proof lane and evidence path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 13:55
-Status       : Phase 8.13 remains the active open validation lane; public-paper-beta roadmap realignment is preserved so Phase 8.15 runtime proof is next only after current open validation lanes (8.13 and 8.14), followed by 8.16 operational/public readiness and 8.17 release gate.
+Last Updated : 2026-04-20 14:14
+Status       : Open lanes now include Phase 8.13 re-land audit, Phase 8.14 launch-planning app foundation, and Phase 8.15 dependency-complete runtime-proof implementation for paper-beta FastAPI control surfaces; sequence after completion remains 8.16 operational/public readiness then 8.17 release gate.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,6 +29,7 @@ Status       : Phase 8.13 remains the active open validation lane; public-paper-
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION delivery in progress under projects/app/walker_devops; reports are now tracked under projects/app/walker_devops/reports/forge; local runtime verification is blocked in this environment by npm registry 403 and missing OPENAI_API_KEY.
 - Phase 8.13 Telegram session-issuance gate re-land audit on branch feature/reland-session-issuance-gate-fix-20260420: strict active-only issuance gate already present on current code truth; fresh PR opened for SENTINEL-required MAJOR validation before merge.
+- Phase 8.15 dependency-complete runtime-proof implementation started on branch feature/runtime-proof-dependency-complete-2026-04-20: dedicated runtime-proof runner + stable evidence path added for /health, /ready, /beta/status, and /beta/admin; execution remains blocked in this environment by package proxy 403 during dependency installation.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -36,7 +37,7 @@ Status       : Phase 8.13 remains the active open validation lane; public-paper-
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Phase 8.13 re-land audit validation remains the current open operational lane; after currently open lanes (8.13 and 8.14), the public-paper-beta build path continues at Phase 8.15 runtime proof, then 8.16 operational/public readiness, then 8.17 release gate.
+- Complete dependency-complete runtime proof evidence for Phase 8.15 on the active implementation branch, then route MAJOR lane to SENTINEL on PR head branch while keeping 8.13 and 8.14 open-lane sequencing visible.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-20 13:55
+**Last Updated:** 2026-04-20 14:14
 
 # Board Overview
 
@@ -422,7 +422,7 @@
 
 **Goal:** Add a narrow confirmation/activation lifecycle for Telegram-linked onboarding users so runtime does not stop at record creation and can truthfully report activation outcomes before session handoff dispatch.  
 **Status:** 🚧 In Progress (status promotion to done reverted pending explicit merged-main completion proof; numbering continuity before active/open lanes 8.13 and 8.14 is preserved)
-**Last Updated:** 2026-04-20 13:55
+**Last Updated:** 2026-04-20 14:14
 
 ### Scope Lock
 - [x] Keep scope on Telegram confirmation/activation foundation only
@@ -537,8 +537,8 @@
 ## CrusaderBot — Fastest Path to Public-Ready Paper Beta (Post-8.9 Numbering Realignment)
 
 **Goal:** Keep the same three-lane public-paper-beta finish path (runtime proof -> operational/public readiness -> release gate) while remapping it to truthful next-open numbering after consumed/open lanes through Phase 8.14.  
-**Status:** 🚧 In Progress (planning truth synced; implementation not started)  
-**Last Updated:** 2026-04-20 13:23
+**Status:** 🚧 In Progress (planning truth synced; Phase 8.15 implementation branch is now active with dependency-complete runtime-proof lane scaffolding and stable evidence logging path).  
+**Last Updated:** 2026-04-20 14:14
 
 ### Numbering Truth
 - [x] Preserve consumed historical lanes through Phase 8.12.
@@ -548,13 +548,13 @@
 ### Realigned Remaining Path (product path unchanged)
 | Phase | Milestone | Status | Notes |
 |---|---|---|---|
-| 8.15 | Runtime Proof | ❌ Not Started | Next actionable public-paper-beta milestone. |
+| 8.15 | Runtime Proof | 🚧 In Progress | Implementation branch active; dependency-complete runner + stable evidence log path added for paper-beta control surfaces. |
 | 8.16 | Operational/Public Readiness | ❌ Not Started | Follows runtime-proof completion; scope unchanged. |
 | 8.17 | Release Gate | ❌ Not Started | Final public-paper-beta gate before release decision; scope unchanged. |
 
 ### Paper-Beta Claim Boundary
 - [x] Paper-beta-only claim boundary preserved (no live-trading authority claim introduced).
-- [x] This realignment is numbering/state truth only (no runtime code changes).
+- [x] Realignment truth is preserved while Phase 8.15 runtime-proof infrastructure is now in progress without live-trading or product-scope expansion.
 
 ---
 

--- a/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
+++ b/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
@@ -125,18 +125,17 @@ These checks are exposed under `exit_criteria.checks` with per-check `pass` and 
 - Runtime claims must be tied to dependency-complete evidence from an environment where `fastapi` and test dependencies are installed.
 
 ### Dependency-complete validation commands
-Run these commands from repo root in a dependency-complete environment:
+Run this command from repo root to execute the dependency-complete runtime-proof lane:
 
 ```bash
-python -m py_compile \
-  projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py \
-  projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py \
-  projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py
-
-pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
-pytest -q projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
-pytest -q projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py
+PYTHONPATH=. python projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py
 ```
+
+The runner:
+- creates a dedicated virtualenv at `projects/polymarket/polyquantbot/.venv-phase8-15-runtime-proof`
+- installs runtime/test dependencies (`requirements.txt` + pytest stack)
+- executes `py_compile` and runtime-surface pytest targets listed in `projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt`
+- writes stable evidence output to `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`
 
 ## Explicit non-goals and live-readiness block
 - No live trading rollout or privileged live execution controls

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-15_01_dependency-complete-runtime-proof.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-15_01_dependency-complete-runtime-proof.md
@@ -1,0 +1,70 @@
+# Phase 8.15 — Dependency-Complete Runtime Proof (Paper-Beta Control Surfaces)
+
+**Date:** 2026-04-20 14:14
+**Branch:** feature/runtime-proof-dependency-complete-2026-04-20
+**Task:** Establish repeatable dependency-complete runtime-proof lane and stable evidence path for `/health`, `/ready`, `/beta/status`, `/beta/admin`
+
+## 1. What was built
+
+Built a dedicated runtime-proof runner and target manifest for the paper-beta FastAPI control-surface slice:
+
+- Added `run_phase8_15_runtime_proof.py` runner that:
+  - creates a dedicated venv (`.venv-phase8-15-runtime-proof`)
+  - installs runtime/test dependencies with retry/backoff
+  - executes `py_compile` + targeted pytest modules for the four named surfaces
+  - writes stable evidence output to a deterministic log path
+- Added explicit target manifest for runtime-proof modules so the lane is repeatable and scope-locked.
+- Updated public paper-beta docs to point to the new runtime-proof lane command and stable evidence location.
+
+## 2. Current system architecture (relevant slice)
+
+`Phase 8.15 runtime-proof lane`
+
+1. `projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt`
+   - authoritative runtime-proof target list
+2. `projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py`
+   - dependency-complete lane runner (venv + install + py_compile + pytest)
+3. `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`
+   - stable evidence sink for review and SENTINEL handoff
+4. existing runtime-surface tests remain the validation target surface:
+   - `test_crusader_runtime_surface.py`
+   - `test_phase8_7_public_paper_beta_completion_20260420.py`
+   - `test_phase8_8_public_paper_beta_exit_criteria_20260420.py`
+
+## 3. Files created / modified (full repo-root paths)
+
+### Created
+- `projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py`
+- `projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt`
+- `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`
+- `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_dependency-complete-runtime-proof.md`
+
+### Modified
+- `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4. What is working
+
+- Runtime-proof lane is now deterministic and repeatable by command (`PYTHONPATH=. python ...run_phase8_15_runtime_proof.py`).
+- Validation scope is explicitly constrained to paper-beta control surfaces (`/health`, `/ready`, `/beta/status`, `/beta/admin`) via target manifest and existing test modules.
+- Stable evidence path exists and captures command attempts, dependency install behavior, and pass/fail outcomes for review.
+- No live-trading expansion or boundary broadening introduced.
+
+## 5. Known issues
+
+- In this runner, dependency installation is blocked by proxy-level `403 Forbidden` responses for both pip and apt sources, so the lane cannot complete executed pytest proof here.
+- Current evidence log records the blocked dependency-complete run attempt and exact failure output.
+- This branch therefore establishes the runtime-proof infrastructure and evidence path, but does **not** claim successful dependency-complete execution in this environment.
+
+## 6. What is next
+
+- Run the same lane in an environment with reachable package sources so FastAPI/runtime deps can install.
+- Re-run the runtime-proof command and update evidence log with successful `py_compile` and pytest pass outputs for the three scoped modules.
+- Route to SENTINEL MAJOR validation on the active PR head branch with refreshed evidence.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : dependency-complete runtime-proof execution evidence for `/health`, `/ready`, `/beta/status`, and `/beta/admin` under paper-beta boundaries
+Not in Scope      : live trading, strategy changes, wallet lifecycle expansion, dashboard expansion, broad UX overhaul, release-gate decisioning
+Suggested Next    : SENTINEL-required review after dependency-complete evidence is re-run in a package-accessible runner

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log
@@ -1,0 +1,25 @@
+Phase 8.15 Dependency-Complete Runtime Proof
+Python executable: /root/.pyenv/versions/3.10.19/bin/python3
+Repo root: /workspace/walker-ai-team
+Project root: /workspace/walker-ai-team/projects/polymarket/polyquantbot
+Targets file: /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt
+
+[1/5] create venv: /workspace/walker-ai-team/projects/polymarket/polyquantbot/.venv-phase8-15-runtime-proof
+
+
+venv python: /workspace/walker-ai-team/projects/polymarket/polyquantbot/.venv-phase8-15-runtime-proof/bin/python
+[2/5] install dependency-complete runtime/test stack
+Requirement already satisfied: pip in ./projects/polymarket/polyquantbot/.venv-phase8-15-runtime-proof/lib/python3.10/site-packages (23.0.1)
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+ERROR: Could not find a version that satisfies the requirement pytest (from versions: none)
+ERROR: No matching distribution found for pytest
+FAIL: dependency install exit=1

--- a/projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py
+++ b/projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PROJECT_ROOT = ROOT / "projects/polymarket/polyquantbot"
+VENV_DIR = PROJECT_ROOT / ".venv-phase8-15-runtime-proof"
+TARGETS_FILE = PROJECT_ROOT / "tests/runtime_proof_phase8_15_targets.txt"
+EVIDENCE_LOG = PROJECT_ROOT / "reports/forge/phase8-15_01_runtime-proof-evidence.log"
+
+
+def _run(cmd: list[str], *, env: dict[str, str], timeout_s: int = 300) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout_s,
+        check=False,
+    )
+
+
+def _run_with_retry(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    timeout_s: int = 300,
+    retries: int = 3,
+    base_backoff_s: float = 2.0,
+) -> subprocess.CompletedProcess[str]:
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, retries + 1):
+        result = _run(cmd, env=env, timeout_s=timeout_s)
+        last_result = result
+        if result.returncode == 0:
+            return result
+        if attempt < retries:
+            time.sleep(base_backoff_s * (2 ** (attempt - 1)))
+    assert last_result is not None
+    return last_result
+
+
+def _write_line(handle, line: str = "") -> None:
+    handle.write(f"{line}\n")
+
+
+def main() -> int:
+    env = os.environ.copy()
+    env["LANG"] = "C.UTF-8"
+    env["LC_ALL"] = "C.UTF-8"
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    targets = [
+        line.strip()
+        for line in TARGETS_FILE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    EVIDENCE_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+    with EVIDENCE_LOG.open("w", encoding="utf-8") as log:
+        _write_line(log, "Phase 8.15 Dependency-Complete Runtime Proof")
+        _write_line(log, f"Python executable: {sys.executable}")
+        _write_line(log, f"Repo root: {ROOT}")
+        _write_line(log, f"Project root: {PROJECT_ROOT}")
+        _write_line(log, f"Targets file: {TARGETS_FILE}")
+        _write_line(log)
+
+        _write_line(log, f"[1/5] create venv: {VENV_DIR}")
+        create_venv = _run([sys.executable, "-m", "venv", str(VENV_DIR)], env=env)
+        _write_line(log, create_venv.stdout.rstrip())
+        _write_line(log, create_venv.stderr.rstrip())
+        if create_venv.returncode != 0:
+            _write_line(log, f"FAIL: venv creation exit={create_venv.returncode}")
+            return create_venv.returncode
+
+        venv_python = VENV_DIR / "bin/python"
+        _write_line(log, f"venv python: {venv_python}")
+
+        _write_line(log, "[2/5] install dependency-complete runtime/test stack")
+        install_cmd = [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "-r",
+            "projects/polymarket/polyquantbot/requirements.txt",
+            "pytest",
+            "pytest-asyncio",
+            "httpx",
+            "pydantic",
+        ]
+        install_result = _run_with_retry(install_cmd, env=env, timeout_s=900)
+        _write_line(log, install_result.stdout.rstrip())
+        _write_line(log, install_result.stderr.rstrip())
+        if install_result.returncode != 0:
+            _write_line(log, f"FAIL: dependency install exit={install_result.returncode}")
+            return install_result.returncode
+
+        _write_line(log, "[3/5] runtime-surface py_compile")
+        py_compile_cmd = [str(venv_python), "-m", "py_compile", *targets]
+        py_compile_result = _run(py_compile_cmd, env=env)
+        _write_line(log, py_compile_result.stdout.rstrip())
+        _write_line(log, py_compile_result.stderr.rstrip())
+        if py_compile_result.returncode != 0:
+            _write_line(log, f"FAIL: py_compile exit={py_compile_result.returncode}")
+            return py_compile_result.returncode
+        _write_line(log, "PASS: py_compile")
+
+        _write_line(log, "[4/5] execute runtime-surface pytest targets")
+        for target in targets:
+            pytest_cmd = [str(venv_python), "-m", "pytest", "-q", target]
+            _write_line(log, f"command: {' '.join(pytest_cmd)}")
+            pytest_result = _run(pytest_cmd, env=env, timeout_s=600)
+            _write_line(log, pytest_result.stdout.rstrip())
+            _write_line(log, pytest_result.stderr.rstrip())
+            if pytest_result.returncode != 0:
+                _write_line(log, f"FAIL: pytest target {target} exit={pytest_result.returncode}")
+                return pytest_result.returncode
+
+        _write_line(log, "PASS: all runtime-surface pytest targets")
+        _write_line(log)
+        _write_line(log, "[5/5] runtime proof completed")
+
+    print(f"Evidence written: {EVIDENCE_LOG}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt
+++ b/projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt
@@ -1,0 +1,4 @@
+# Phase 8.15 dependency-complete runtime proof targets (paper-beta control surfaces)
+projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
+projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py


### PR DESCRIPTION
### Motivation
- Provide a repeatable, dependency-complete runtime-proof lane for the paper-beta FastAPI control surfaces (`/health`, `/ready`, `/beta/status`, `/beta/admin`) so SENTINEL can validate real execution evidence rather than skipped dependency guards. 
- Preserve narrow-scope paper-beta boundaries while adding a stable evidence sink and a deterministic runner to remove ambiguity between skip-only tests and real runtime proof. 

### Description
- Added a deterministic runtime-proof runner `projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py` that creates an isolated venv, installs runtime/test deps (with retry/backoff), runs `py_compile` and the scoped pytest targets, and writes stable evidence to `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`.
- Added a scope-locked target manifest `projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt` enumerating the validation test modules for the four named surfaces.
- Updated documentation `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md` to point at the new runner command (`PYTHONPATH=. python projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py`) and describe the evidence path.
- Added a FORGE report `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_dependency-complete-runtime-proof.md` and updated repo truth files `PROJECT_STATE.md` and `ROADMAP.md` to reflect Phase 8.15 as in-progress on the implementation branch; no live-trading or scope-expanding changes were introduced.

### Testing
- `python3 -m py_compile projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py` → PASS.
- Executing the runner (`PYTHONIOENCODING=utf-8 PYTHONPATH=. python3 projects/polymarket/polyquantbot/scripts/run_phase8_15_runtime_proof.py`) was attempted and produced deterministic evidence in `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`, but dependency installation failed due to environment package proxy `403 Forbidden` (recorded in the evidence log); outcome: `FAIL: dependency install exit=1`.
- Targeted runtime-surface pytest modules remain the validation targets but are blocked in this execution environment; re-run of the runner in a package-accessible environment is required to produce passing pytest evidence for SENTINEL validation.

Report: `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_dependency-complete-runtime-proof.md`
State: `PROJECT_STATE.md` updated
Validation Tier: MAJOR
Claim Level: NARROW INTEGRATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d1f2f1d48325aed7c4e7fdf5120d)