### PR TITLE
sentinel: validate reopened phase 8.13 session issuance gate (pr649)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -28,7 +28,7 @@ Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-pla
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION delivery in progress under projects/app/walker_devops; reports are now tracked under projects/app/walker_devops/reports/forge; local runtime verification is blocked in this environment by npm registry 403 and missing OPENAI_API_KEY.
-- Phase 8.13 Telegram session-issuance gate re-land lane on branch feature/reopen-phase-8.13-session-issuance-reland-2026-04-20 passed SENTINEL scoped code-truth validation with CONDITIONAL verdict (runtime pytest execution limited in this runner due missing pydantic dependency); lane remains pending COMMANDER merge decision on PR #649.
+- Phase 8.13 Telegram session-issuance gate re-land lane on branch feature/reopen-phase-8.13-session-issuance-reland-2026-04-20 passed SENTINEL scoped code-truth validation with CONDITIONAL verdict (runtime pytest execution limited in this runner due to missing pydantic dependency); lane remains pending COMMANDER merge decision on PR #649.
 - Phase 8.15 dependency-complete runtime-proof lane remains BLOCKED after rerun follow-up: deterministic runner/manifest/evidence path are preserved for /health, /ready, /beta/status, and /beta/admin, but dependency installation still fails with package/proxy 403 (including direct no-proxy path failure), so no successful py_compile+pytest closure evidence exists yet; follow-up recorded in `projects/polymarket/polyquantbot/reports/forge/phase8-15_02_blocked-rerun-attempt.md`.
 
 [NOT STARTED]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-20 15:13
+Last Updated : 2026-04-20 15:22
 Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-planning app foundation, and Phase 8.15 dependency-complete runtime-proof evidence closure; 8.15 is still blocked pending package-accessible runner proof before 8.16 operational/public readiness then 8.17 release gate.
 
 [COMPLETED]
@@ -28,7 +28,7 @@ Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-pla
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION delivery in progress under projects/app/walker_devops; reports are now tracked under projects/app/walker_devops/reports/forge; local runtime verification is blocked in this environment by npm registry 403 and missing OPENAI_API_KEY.
-- Phase 8.13 Telegram session-issuance gate re-land audit on branch feature/reland-session-issuance-gate-fix-20260420: strict active-only issuance gate already present on current code truth; fresh PR opened for SENTINEL-required MAJOR validation before merge.
+- Phase 8.13 Telegram session-issuance gate re-land lane reopened on branch feature/reopen-phase-8.13-session-issuance-reland-2026-04-20: strict active-only issuance gate is already present on current code truth; fresh source PR lane is maintained for SENTINEL-required MAJOR validation before merge.
 - Phase 8.15 dependency-complete runtime-proof lane remains BLOCKED after rerun follow-up: deterministic runner/manifest/evidence path are preserved for /health, /ready, /beta/status, and /beta/admin, but dependency installation still fails with package/proxy 403 (including direct no-proxy path failure), so no successful py_compile+pytest closure evidence exists yet; follow-up recorded in `projects/polymarket/polyquantbot/reports/forge/phase8-15_02_blocked-rerun-attempt.md`.
 
 [NOT STARTED]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-20 15:22
+Last Updated : 2026-04-20 15:31
 Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-planning app foundation, and Phase 8.15 dependency-complete runtime-proof evidence closure; 8.15 is still blocked pending package-accessible runner proof before 8.16 operational/public readiness then 8.17 release gate.
 
 [COMPLETED]
@@ -28,7 +28,7 @@ Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-pla
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION delivery in progress under projects/app/walker_devops; reports are now tracked under projects/app/walker_devops/reports/forge; local runtime verification is blocked in this environment by npm registry 403 and missing OPENAI_API_KEY.
-- Phase 8.13 Telegram session-issuance gate re-land lane reopened on branch feature/reopen-phase-8.13-session-issuance-reland-2026-04-20: strict active-only issuance gate is already present on current code truth; fresh source PR lane is maintained for SENTINEL-required MAJOR validation before merge.
+- Phase 8.13 Telegram session-issuance gate re-land lane on branch feature/reopen-phase-8.13-session-issuance-reland-2026-04-20 passed SENTINEL scoped code-truth validation with CONDITIONAL verdict (runtime pytest execution limited in this runner due missing pydantic dependency); lane remains pending COMMANDER merge decision on PR #649.
 - Phase 8.15 dependency-complete runtime-proof lane remains BLOCKED after rerun follow-up: deterministic runner/manifest/evidence path are preserved for /health, /ready, /beta/status, and /beta/admin, but dependency installation still fails with package/proxy 403 (including direct no-proxy path failure), so no successful py_compile+pytest closure evidence exists yet; follow-up recorded in `projects/polymarket/polyquantbot/reports/forge/phase8-15_02_blocked-rerun-attempt.md`.
 
 [NOT STARTED]
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.13 re-land audit, Phase 8.14 launch-pla
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Keep Phase 8.15 pending package-accessible runner access, then rerun dependency-complete runtime proof to produce successful py_compile+pytest evidence before reopening SENTINEL revalidation, while preserving visible 8.13/8.14/8.15 lane ordering truth.
+- COMMANDER decision gate: review Phase 8.13 SENTINEL CONDITIONAL verdict on PR #649, and in parallel keep Phase 8.15 pending package-accessible runner access for dependency-complete runtime-proof rerun evidence.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/forge/phase8-13_04_reopen-session-issuance-reland.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase8-13_04_reopen-session-issuance-reland.md
@@ -1,0 +1,58 @@
+# Phase 8.13 Reopen — Session-Issuance Gate Re-Land (Fresh Source PR)
+
+**Date:** 2026-04-20 15:22
+**Branch:** feature/reopen-phase-8.13-session-issuance-reland-2026-04-20
+**Task:** Reopen Phase 8.13 as a fresh source PR lane from current main truth for clean SENTINEL validation
+
+## 1. What was built
+
+Performed a fresh FORGE-X audit for the Phase 8.13 Telegram session-issuance safety gate against current repository truth and prepared a new source branch/report lane for review continuity.
+
+Result: **no runtime code delta is required** in the 8.13 gate slice. The active-only issuance gate is already present in code truth, and non-active identities are rejected without auto-promotion.
+
+## 2. Current system architecture (relevant slice)
+
+1. `TelegramActivationService.confirm()` remains the only owner of activation-state promotion (`pending_confirmation -> active`).
+2. `TelegramSessionIssuanceService.issue()` is an issuance-only gate: it reads activation state and issues a backend session only for active users.
+3. Non-active activation states return `rejected` and do not mutate onboarding/activation/session-state ownership records.
+4. Runtime reply mapping for Phase 8.13 outcomes remains wired for `session_issued`, `already_active_session_issued`, `rejected`, and `error`.
+
+## 3. Files created / modified (full repo-root paths)
+
+### Created
+- `projects/polymarket/polyquantbot/reports/forge/phase8-13_04_reopen-session-issuance-reland.md`
+
+### Modified
+- `PROJECT_STATE.md`
+
+### Audited (no change required)
+- `projects/polymarket/polyquantbot/server/services/telegram_session_issuance_service.py`
+- `projects/polymarket/polyquantbot/server/services/telegram_activation_service.py`
+- `projects/polymarket/polyquantbot/client/telegram/runtime.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`
+
+## 4. What is working
+
+- Active-only issuance gate is preserved in current code truth (`activation_status == "active"` required).
+- No auto-promotion behavior exists in session issuance path.
+- Non-active users remain rejected in issuance path and focused 8.13 tests encode the non-mutation contract.
+- A fresh Phase 8.13 source branch/report lane now exists for SENTINEL-required MAJOR validation continuity.
+
+## 5. Known issues
+
+- This environment does not include full dependency-complete runtime packages for end-to-end pytest proof in this lane.
+- This task intentionally does not alter 8.15 dependency-complete runtime-proof lane or unrelated Telegram UX/auth scope.
+
+## 6. What is next
+
+- Open/maintain source PR from `feature/reopen-phase-8.13-session-issuance-reland-2026-04-20` for COMMANDER review.
+- Route this MAJOR lane to SENTINEL on this exact PR head branch before merge decision.
+- Keep 8.13 scope constrained to session issuance safety gate truth only.
+
+---
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : Telegram session issuance safety gate only (no auto-promotion, active-only issuance, non-active rejection)
+Not in Scope      : public paper beta expansion, live trading, dashboard work, unrelated Telegram UX/auth redesign, 8.15 runtime proof
+Suggested Next    : SENTINEL-required review on the Phase 8.13 PR head branch

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
@@ -77,7 +77,7 @@
 
 ## PR Gate Result
 - **Merge gate outcome:** CONDITIONAL
-- **Reason:** Scoped code truth and contract tests are aligned with the 8.13 safety gate, but this runner could not execute the focused pytest module due missing `pydantic` dependency.
+- **Reason:** Scoped code truth and contract tests are aligned with the 8.13 safety gate, but this runner could not execute the focused pytest module due to missing pydantic dependency.
 
 ## Broader Audit Finding
 - No scoped drift detected between forge report claims and code behavior for the 8.13 issuance gate.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
@@ -1,0 +1,104 @@
+# SENTINEL Validation Report — Phase 8.13 Reopened Session-Issuance Gate Re-Land (PR #649)
+
+## Environment
+- Timestamp (Asia/Jakarta): 2026-04-20 15:31
+- Repo: `bayuewalker/walker-ai-team`
+- Validation role: SENTINEL
+- Validation tier: MAJOR
+- Claim level: NARROW INTEGRATION
+- Target branch (task-declared): `feature/reopen-phase-8.13-session-issuance-reland-2026-04-20`
+- Workspace HEAD branch (Codex worktree): `work`
+
+## Validation Context
+- Source forge report: `projects/polymarket/polyquantbot/reports/forge/phase8-13_04_reopen-session-issuance-reland.md`
+- Validation target:
+  - Telegram session issuance safety gate only
+  - no auto-promotion
+  - active-only issuance
+  - non-active rejection without state mutation
+- Not in scope honored:
+  - public paper beta expansion
+  - live trading
+  - dashboard work
+  - unrelated Telegram UX/auth redesign
+  - 8.15 runtime proof
+
+## Phase 0 Checks
+- Forge report exists at the expected path with 6-section MAJOR structure.
+- Reopened 8.13 lane exists as a true source-lane continuation: prior runtime implementation commit for strict issuance gate remains in repository history (`b844eef`), while reopen commit (`04f9f95`) intentionally reopens validation/state lane only.
+- PROJECT_STATE.md reflects 8.13 as an open validation lane before this SENTINEL pass.
+- Target code and tests for the 8.13 gate are present at declared paths.
+- Executed check:
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` -> collection failed in this runner due missing dependency `pydantic` (`ModuleNotFoundError`).
+
+## Findings
+1. **Reopened PR lane integrity (not relabel-only deception): PASS**
+   - Runtime gate logic for 8.13 is present in code truth (`telegram_session_issuance_service.py`) and was introduced by earlier source implementation commit (`b844eef`).
+   - Reopen commit (`04f9f95`) does not claim new runtime behavior; it reopens traceable validation continuity for the same safety gate.
+
+2. **Active-only issuance enforcement: PASS**
+   - `TelegramSessionIssuanceService.issue()` enforces strict gate: any `activation_status != "active"` returns `rejected` and does not proceed to session issuance.
+   - Session issuance is reached only after active-state check succeeds.
+
+3. **No auto-promotion inside issuance path: PASS**
+   - Session issuance service has no activation-state mutation call and documents that promotion is out of scope.
+   - Activation mutation remains isolated in `TelegramActivationService.confirm()` via explicit `set_activation_status(..., "active")`.
+
+4. **Non-active rejection without activation/session-ownership mutation: PASS (code + contract tests)**
+   - Rejection path returns before session creation and does not call activation mutation.
+   - Focused tests explicitly assert pending user remains `pending_confirmation` after issuance attempt and that unlinked/non-active paths return `rejected`.
+
+5. **Runtime reply mapping consistency (`session_issued`, `already_active_session_issued`, `rejected`, `error`): PASS**
+   - Polling loop maps:
+     - `session_issued` -> `_REPLY_SESSION_ISSUED`
+     - `already_active_session_issued` -> `_REPLY_ALREADY_ACTIVE_SESSION_ISSUED`
+     - `rejected` -> `_REPLY_ACTIVATION_REJECTED`
+     - fallback/error -> `_REPLY_IDENTITY_ERROR`
+   - Focused tests assert each mapping outcome path.
+
+6. **Focused 8.13 gate contract test encoding: PASS (static) / RUNTIME EVIDENCE LIMITED**
+   - Contract coverage exists for active issuance, non-active rejection, no side-effect activation mutation, tenant isolation, and runtime reply mapping.
+   - Runner cannot execute full pytest in current environment due missing `pydantic`; runtime confirmation is therefore limited by environment.
+
+## Score Breakdown
+- Reopened lane traceability integrity: 20/20
+- Active-only issuance enforcement: 20/20
+- No auto-promotion segregation: 20/20
+- Non-active non-mutation safety: 20/20
+- Executed runtime evidence sufficiency on this runner: 10/20
+
+**Total: 90/100**
+
+## Critical Issues
+- None in scoped code logic.
+
+## Status
+**CONDITIONAL**
+
+## PR Gate Result
+- **Merge gate outcome:** CONDITIONAL
+- **Reason:** Scoped code truth and contract tests are aligned with the 8.13 safety gate, but this runner could not execute the focused pytest module due missing `pydantic` dependency.
+
+## Broader Audit Finding
+- No scoped drift detected between forge report claims and code behavior for the 8.13 issuance gate.
+- No evidence of session-issuance auto-promotion coupling.
+
+## Reasoning
+Within the declared NARROW INTEGRATION target, the source lane is truthful and safety semantics are preserved: active-only issuance, explicit non-active rejection, no issuance-path promotion, and consistent runtime reply mapping. The only limitation is environment-level test execution failure due missing dependency in this runner, which prevents a fully executed local re-proof.
+
+## Fix Recommendations
+1. Re-run focused 8.13 tests in a dependency-complete runner:
+   - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`
+2. Attach pass output to PR #649 discussion for closure-grade evidence.
+3. Keep scope constrained to 8.13 gate semantics; do not mix with 8.15 runtime-proof lane.
+
+## Out-of-scope Advisory
+- 8.15 dependency-complete runtime-proof remains a separate blocked lane and is not part of this validation verdict.
+
+## Deferred Minor Backlog
+- None added by this validation.
+
+## Telegram Visual Preview
+- Phase 8.13 reopened lane validated as truthful continuation of strict issuance gate semantics.
+- Active-only issuance and non-active rejection safety contract remains intact.
+- Verdict is CONDITIONAL only because local runner cannot execute focused pytest due missing dependency.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
@@ -84,7 +84,7 @@
 - No evidence of session-issuance auto-promotion coupling.
 
 ## Reasoning
-Within the declared NARROW INTEGRATION target, the source lane is truthful and safety semantics are preserved: active-only issuance, explicit non-active rejection, no issuance-path promotion, and consistent runtime reply mapping. The only limitation is environment-level test execution failure due missing dependency in this runner, which prevents a fully executed local re-proof.
+Within the declared NARROW INTEGRATION target, the source lane is truthful and safety semantics are preserved: active-only issuance, explicit non-active rejection, no issuance-path promotion, and consistent runtime reply mapping. The only limitation is environment-level test execution failure due to missing dependency in this runner, which prevents a fully executed local re-proof.
 
 ## Fix Recommendations
 1. Re-run focused 8.13 tests in a dependency-complete runner:

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
@@ -101,4 +101,4 @@ Within the declared NARROW INTEGRATION target, the source lane is truthful and s
 ## Telegram Visual Preview
 - Phase 8.13 reopened lane validated as truthful continuation of strict issuance gate semantics.
 - Active-only issuance and non-active rejection safety contract remains intact.
-- Verdict is CONDITIONAL only because local runner cannot execute focused pytest due missing dependency.
+- Verdict is CONDITIONAL only because local runner cannot execute focused pytest due to missing dependency.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md
@@ -29,7 +29,7 @@
 - PROJECT_STATE.md reflects 8.13 as an open validation lane before this SENTINEL pass.
 - Target code and tests for the 8.13 gate are present at declared paths.
 - Executed check:
-  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` -> collection failed in this runner due missing dependency `pydantic` (`ModuleNotFoundError`).
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py` -> collection failed in this runner due to missing dependency `pydantic` (`ModuleNotFoundError`).
 
 ## Findings
 1. **Reopened PR lane integrity (not relabel-only deception): PASS**


### PR DESCRIPTION
### Motivation
- Provide a SENTINEL MAJOR validation pass for the reopened Phase 8.13 source lane to confirm the Telegram session-issuance safety gate (active-only issuance, no auto-promotion, non-active rejection without state mutation).
- Record the validation verdict and update repository state so COMMANDER can decide on merge while preserving 8.13/8.14/8.15 lane continuity.

### Description
- Added a SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/phase8-13_01_reopened-session-issuance-validation-pr649.md` containing findings, score, verdict (`CONDITIONAL`), reasoning, and fix recommendations.
- Updated `PROJECT_STATE.md` `Last Updated` timestamp and the Phase 8.13/Next Priority lines to reflect the SENTINEL `CONDITIONAL` verdict and next-step ownership for COMMANDER review.
- Validation focused on static inspection of the session-issuance slice (including `projects/polymarket/polyquantbot/server/services/telegram_session_issuance_service.py`, `projects/polymarket/polyquantbot/server/services/telegram_activation_service.py`, `projects/polymarket/polyquantbot/client/telegram/runtime.py`, and the focused tests at `projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`).

### Testing
- Attempted `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_13_telegram_session_issuance_20260419.py`, which failed during collection with `ModuleNotFoundError: No module named 'pydantic'` in this runner, so runtime test proof could not be completed here (automated test: FAILED).
- Ran UTF-8 / BOM verification on touched files using a small Python check, and validated both `PROJECT_STATE.md` and the new sentinel report decode as UTF-8 with no BOM (automated check: PASSED).
- Performed static code inspection of the issuance and activation services and runtime reply mappings to confirm enforcement of `activation_status == "active"`, absence of promotion in the issuance path, and correct reply mapping for `session_issued`, `already_active_session_issued`, `rejected`, and `error` (static checks: PASSED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e3fcb98483259332d3f3a085b821)