### PR TITLE
Phase 9.1: normalize runtime-proof lane and capture dependency failure evidence

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 16:50
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 8.15 dependency-complete runtime-proof evidence closure; 8.15 is still blocked pending package-accessible runner proof before 8.16 operational/public readiness then 8.17 release gate.
+Last Updated : 2026-04-20 17:32
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; 9.1 remains blocked in current runner after proxy and direct no-proxy dependency install failures before 9.2 operational/public readiness then 9.3 release gate.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 8.15 dependency-complete runtime-proof lane remains BLOCKED after rerun follow-up: deterministic runner/manifest/evidence path are preserved for /health, /ready, /beta/status, and /beta/admin, but dependency installation still fails with package/proxy 403 (including direct no-proxy path failure), so no successful py_compile+pytest closure evidence exists yet; follow-up recorded in `projects/polymarket/polyquantbot/reports/forge/phase8-15_02_blocked-rerun-attempt.md`.
+- Phase 9.1 runtime-proof-and-evidence lane is active but still BLOCKED in this environment: normalized runner+targets and canonical evidence path are preserved for /health, /ready, /beta/status, and /beta/admin, yet dependency installation fails under both proxy (403 Forbidden) and direct no-proxy path (network unreachable), so py_compile+pytest closure evidence is still pending; evidence captured in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` and report `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md`.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and in parallel keep Phase 8.15 pending package-accessible runner access for dependency-complete runtime-proof rerun evidence.
+- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and in parallel keep Phase 9.1 pending a dependency-capable runner so runtime-proof py_compile+pytest evidence can close before Phase 9.2.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-20 15:27
+**Last Updated:** 2026-04-20 17:32
 
 # Board Overview
 
@@ -534,27 +534,27 @@
 
 ---
 
-## CrusaderBot — Fastest Path to Public-Ready Paper Beta (Post-8.9 Numbering Realignment)
+## CrusaderBot — Fastest Path to Public-Ready Paper Beta (Post-9.0 Numbering Realignment)
 
 **Goal:** Keep the same three-lane public-paper-beta finish path (runtime proof -> operational/public readiness -> release gate) while remapping it to truthful next-open numbering after consumed/open lanes through Phase 8.14.  
-**Status:** 🚧 In Progress (Phase 8.15 now has a package-accessible runner entrypoint, but rerun evidence closure remains blocked in this runner because dependency installation still fails; dependency-complete closure proof is still pending successful package resolution).  
-**Last Updated:** 2026-04-20 15:27
+**Status:** 🚧 In Progress (Phase 9.1 now has a normalized package-accessible runner + target manifest + canonical evidence path, but dependency-complete closure remains blocked in this runner because dependency installation still fails under both proxy and direct no-proxy attempts).  
+**Last Updated:** 2026-04-20 17:32
 
 ### Numbering Truth
 - [x] Preserve consumed historical lanes through Phase 8.12.
 - [x] Preserve currently active/open lanes Phase 8.13 and Phase 8.14 as already consumed numbering.
-- [x] Set next truthful available public-paper-beta lane to Phase 8.15.
+- [x] Normalize next public-paper-beta runtime-proof lane naming to Phase 9.1 while preserving the same product path semantics.
 
 ### Realigned Remaining Path (product path unchanged)
 | Phase | Milestone | Status | Notes |
 |---|---|---|---|
-| 8.15 | Runtime Proof | 🚧 In Progress | Package-accessible runner path is now in place and rerun is documented, but dependency install still fails in runner environment, so py_compile+pytest closure evidence remains blocked pending successful dependency resolution. |
-| 8.16 | Operational/Public Readiness | ❌ Not Started | Follows runtime-proof completion; scope unchanged. |
-| 8.17 | Release Gate | ❌ Not Started | Final public-paper-beta gate before release decision; scope unchanged. |
+| 9.1 | Runtime Proof + Evidence Closure | 🚧 In Progress | Normalized runtime-proof lane exists (`run_phase9_1_runtime_proof.py`, `runtime_proof_phase9_1_targets.txt`, canonical log path), but dependency installation still fails in this runner under proxy 403 and direct no-proxy network-unreachable conditions; py_compile+pytest closure evidence remains blocked pending dependency-capable environment access. |
+| 9.2 | Operational/Public Readiness | ❌ Not Started | Follows 9.1 runtime-proof closure; scope unchanged. |
+| 9.3 | Release Gate | ❌ Not Started | Final public-paper-beta gate before release decision; scope unchanged. |
 
 ### Paper-Beta Claim Boundary
 - [x] Paper-beta-only claim boundary preserved (no live-trading authority claim introduced).
-- [x] Realignment truth is preserved while Phase 8.15 runtime-proof infrastructure is now in progress without live-trading or product-scope expansion.
+- [x] Realignment truth is preserved while Phase 9.1 runtime-proof infrastructure remains paper-beta only with no live-trading or product-scope expansion.
 
 ---
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md
@@ -1,0 +1,64 @@
+# Phase 9.1 — Runtime Proof + Evidence Closure
+
+**Date:** 2026-04-20 17:32
+**Branch:** feature/phase-9-1-runtime-proof-and-evidence
+**Task:** Phase 9.1 runtime proof + evidence closure lane with dependency-complete install and paper-beta surface execution
+
+## 1. What was built
+
+- Added normalized Phase 9.1 runtime-proof runner at `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` as the package-style successor to the 8.15 lane.
+- Added normalized target manifest at `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt` preserving the required paper-beta runtime control-surface test contract.
+- Executed dependency-complete runtime-proof runner and captured canonical evidence to `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`.
+- Captured exact failure evidence for both dependency install attempts:
+  - proxy/default path -> `403 Forbidden`
+  - direct no-proxy path -> network unreachable
+- Synced repo truth language from the old 8.15/8.16/8.17 naming into the normalized 9.1/9.2/9.3 lane representation in `PROJECT_STATE.md` and `ROADMAP.md`.
+
+## 2. Current system architecture (relevant slice)
+
+`python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof` performs:
+
+1. create isolated venv (`.venv-phase9-1-runtime-proof`)
+2. install dependency-complete runtime stack (requirements + pytest/httpx/pydantic/fastapi) with retry
+3. fallback reattempt under no-proxy env when proxy path fails
+4. run `py_compile` for all manifest targets
+5. run scoped pytest targets and append deterministic output to canonical evidence log
+
+Paper-beta boundaries are unchanged: only runtime proof of `/health`, `/ready`, `/beta/status`, and `/beta/admin` test surfaces is targeted.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py`
+- `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4. What is working
+
+- Phase 9.1 normalized runtime-proof lane is now codified and runnable.
+- Canonical evidence path is stable and deterministic.
+- Failure mode evidence is explicit and reproducible across both install paths (proxy and direct no-proxy).
+- Repo state/roadmap truth now reflects 9.1/9.2/9.3 language normalization for active runtime-proof follow-up.
+
+## 5. Known issues
+
+- Dependency-complete install remains blocked in this environment:
+  - proxy path returns `403 Forbidden`
+  - no-proxy path cannot reach package index (network unreachable)
+- Because dependency installation does not complete, `py_compile` and scoped pytest execution for runtime-proof closure cannot be completed in this runner.
+
+## 6. What is next
+
+- Re-run `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof` in a dependency-capable runner and confirm:
+  - install success
+  - py_compile success
+  - scoped pytest success for runtime-proof target manifest
+- Keep claims narrow until those checks pass: paper-beta runtime-proof lane only, not release gate, not live-trading readiness.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : executed dependency-complete runtime proof for /health, /ready, /beta/status, and /beta/admin under paper-beta boundaries
+Not in Scope      : live trading, strategy changes, wallet lifecycle expansion, dashboard expansion, broad UX overhaul, release-gate decisioning
+Suggested Next    : SENTINEL validation on this source branch after dependency-capable runner evidence closure is available

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log
@@ -1,0 +1,41 @@
+Phase 9.1 Dependency-Complete Runtime Proof
+Python executable: /root/.pyenv/versions/3.10.19/bin/python3
+Repo root: /workspace/walker-ai-team
+Project root: /workspace/walker-ai-team/projects/polymarket/polyquantbot
+Targets file: /workspace/walker-ai-team/projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt
+
+[1/5] create venv: /workspace/walker-ai-team/projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof
+
+
+venv python: /workspace/walker-ai-team/projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof/bin/python
+[2/5] install dependency-complete runtime/test stack
+package entrypoint: python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof
+install attempt A (proxy/default env)
+Requirement already satisfied: pip in ./projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof/lib/python3.10/site-packages (23.0.1)
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pip/
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/pytest/
+ERROR: Could not find a version that satisfies the requirement pytest (from versions: none)
+ERROR: No matching distribution found for pytest
+install attempt B (direct/no-proxy env)
+Requirement already satisfied: pip in ./projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof/lib/python3.10/site-packages (23.0.1)
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f3036556ce0>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pip/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f3036557010>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pip/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f3036557370>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pip/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f3036557520>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pip/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365576d0>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pip/
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365e1270>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365e1720>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365e18d0>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365e1a80>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f30365e1c30>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
+ERROR: Could not find a version that satisfies the requirement pytest (from versions: none)
+ERROR: No matching distribution found for pytest
+FAIL: dependency install exit=1

--- a/projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py
+++ b/projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PROJECT_ROOT = ROOT / "projects/polymarket/polyquantbot"
+VENV_DIR = PROJECT_ROOT / ".venv-phase9-1-runtime-proof"
+TARGETS_FILE = PROJECT_ROOT / "tests/runtime_proof_phase9_1_targets.txt"
+EVIDENCE_LOG = PROJECT_ROOT / "reports/forge/phase9-1_01_runtime-proof-evidence.log"
+
+REQUIRED_PACKAGES = ["pytest", "pytest-asyncio", "httpx", "pydantic", "fastapi"]
+
+
+def _run(cmd: list[str], *, env: dict[str, str], timeout_s: int = 300) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout_s,
+        check=False,
+    )
+
+
+def _run_with_retry(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    timeout_s: int = 300,
+    retries: int = 3,
+    base_backoff_s: float = 2.0,
+) -> subprocess.CompletedProcess[str]:
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, retries + 1):
+        result = _run(cmd, env=env, timeout_s=timeout_s)
+        last_result = result
+        if result.returncode == 0:
+            return result
+        if attempt < retries:
+            time.sleep(base_backoff_s * (2 ** (attempt - 1)))
+    assert last_result is not None
+    return last_result
+
+
+def _write_line(handle, line: str = "") -> None:
+    handle.write(f"{line}\n")
+
+
+def _base_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["LANG"] = "C.UTF-8"
+    env["LC_ALL"] = "C.UTF-8"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _without_proxy(env: dict[str, str]) -> dict[str, str]:
+    no_proxy_env = env.copy()
+    for key in (
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "all_proxy",
+        "no_proxy",
+        "NO_PROXY",
+    ):
+        no_proxy_env.pop(key, None)
+    return no_proxy_env
+
+
+def main() -> int:
+    env = _base_env()
+
+    targets = [
+        line.strip()
+        for line in TARGETS_FILE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    EVIDENCE_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+    with EVIDENCE_LOG.open("w", encoding="utf-8") as log:
+        _write_line(log, "Phase 9.1 Dependency-Complete Runtime Proof")
+        _write_line(log, f"Python executable: {sys.executable}")
+        _write_line(log, f"Repo root: {ROOT}")
+        _write_line(log, f"Project root: {PROJECT_ROOT}")
+        _write_line(log, f"Targets file: {TARGETS_FILE}")
+        _write_line(log)
+
+        _write_line(log, f"[1/5] create venv: {VENV_DIR}")
+        create_venv = _run([sys.executable, "-m", "venv", str(VENV_DIR)], env=env)
+        _write_line(log, create_venv.stdout.rstrip())
+        _write_line(log, create_venv.stderr.rstrip())
+        if create_venv.returncode != 0:
+            _write_line(log, f"FAIL: venv creation exit={create_venv.returncode}")
+            return create_venv.returncode
+
+        venv_python = VENV_DIR / "bin/python"
+        _write_line(log, f"venv python: {venv_python}")
+
+        _write_line(log, "[2/5] install dependency-complete runtime/test stack")
+        _write_line(log, "package entrypoint: python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof")
+
+        install_cmd = [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "-r",
+            "projects/polymarket/polyquantbot/requirements.txt",
+            *REQUIRED_PACKAGES,
+        ]
+
+        _write_line(log, "install attempt A (proxy/default env)")
+        install_result = _run_with_retry(install_cmd, env=env, timeout_s=900)
+        _write_line(log, install_result.stdout.rstrip())
+        _write_line(log, install_result.stderr.rstrip())
+
+        if install_result.returncode != 0:
+            no_proxy_env = _without_proxy(env)
+            _write_line(log, "install attempt B (direct/no-proxy env)")
+            install_result_no_proxy = _run_with_retry(install_cmd, env=no_proxy_env, timeout_s=900)
+            _write_line(log, install_result_no_proxy.stdout.rstrip())
+            _write_line(log, install_result_no_proxy.stderr.rstrip())
+            if install_result_no_proxy.returncode != 0:
+                _write_line(log, f"FAIL: dependency install exit={install_result_no_proxy.returncode}")
+                return install_result_no_proxy.returncode
+            install_result = install_result_no_proxy
+
+        _write_line(log, "PASS: dependency install")
+        _write_line(log, "[3/5] runtime-surface py_compile")
+        py_compile_cmd = [str(venv_python), "-m", "py_compile", *targets]
+        py_compile_result = _run(py_compile_cmd, env=env)
+        _write_line(log, py_compile_result.stdout.rstrip())
+        _write_line(log, py_compile_result.stderr.rstrip())
+        if py_compile_result.returncode != 0:
+            _write_line(log, f"FAIL: py_compile exit={py_compile_result.returncode}")
+            return py_compile_result.returncode
+        _write_line(log, "PASS: py_compile")
+
+        _write_line(log, "[4/5] execute runtime-surface pytest targets")
+        for target in targets:
+            pytest_cmd = [str(venv_python), "-m", "pytest", "-q", target]
+            _write_line(log, f"command: {' '.join(pytest_cmd)}")
+            pytest_result = _run(pytest_cmd, env=env, timeout_s=600)
+            _write_line(log, pytest_result.stdout.rstrip())
+            _write_line(log, pytest_result.stderr.rstrip())
+            if pytest_result.returncode != 0:
+                _write_line(log, f"FAIL: pytest target {target} exit={pytest_result.returncode}")
+                return pytest_result.returncode
+
+        _write_line(log, "PASS: all runtime-surface pytest targets")
+        _write_line(log)
+        _write_line(log, "[5/5] runtime proof completed")
+
+    print(f"Evidence written: {EVIDENCE_LOG}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt
+++ b/projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt
@@ -1,0 +1,4 @@
+# Phase 9.1 dependency-complete runtime proof targets (paper-beta control surfaces)
+projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
+projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py


### PR DESCRIPTION
### Motivation
- Normalize and advance the runtime-proof lane into a coherent Phase 9.1 lane that provides a package-style runner, deterministic target manifest, and a canonical evidence path for dependency-complete proof of the paper-beta control surfaces (`/health`, `/ready`, `/beta/status`, `/beta/admin`).
- Capture exact failure evidence when dependency installation cannot complete in the current runner so SENTINEL and COMMANDER have verifiable, reproducible blocker information while preserving paper-beta-only claim boundaries.

### Description
- Added a package-style runtime-proof runner `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` that creates an isolated venv, attempts dependency installation with retry and a no-proxy fallback, runs `py_compile` over manifest targets, and executes scoped `pytest` targets while writing deterministic output to a canonical evidence log at `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`.
- Added the runtime-proof target manifest `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt` and a FORGE report `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md` documenting the lane, evidence, known issues, and next steps.
- Updated repository truth in `PROJECT_STATE.md` and `ROADMAP.md` to normalize the lane numbering to `9.1/9.2/9.3` (runtime-proof → operational/public readiness → release gate) while explicitly preserving the paper-beta-only claim boundary.

### Testing
- Ran the Phase 9.1 runner (`python3 -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`) and captured canonical evidence in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`, but the run failed at dependency installation due to proxy `403 Forbidden` on the proxy path and `Network is unreachable` on direct/no-proxy attempts. (FAIL)
- Executed `python3 -m py_compile` on the new `run_phase9_1_runtime_proof.py` and the existing `run_phase8_15_runtime_proof.py`, both of which compiled successfully. (PASS)
- Attempted scoped pytest (`python3 -m pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`) which produced a single skipped test and did not close the runtime-proof gate; full pytest closure remains blocked until dependencies can be installed in a dependency-capable runner. (INCOMPLETE)
- Evidence of the dependency-install failure and the exact stderr/stdout are recorded in the canonical evidence log at `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ff4288448325a2e69b5483956e43)