### PR TITLE
Phase 9.1: document dependency-capable runner preparation path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 18:30
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; after re-running the canonical Phase 9.1 lane on 2026-04-20 18:00 (Asia/Jakarta), dependency installation still fails in this runner (proxy 403 and direct no-proxy network unreachable), so 9.2/9.3 remain pending closure evidence.
+Last Updated : 2026-04-20 19:21
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; dependency-capable runner preparation requirements are now documented (without rerun), and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 runtime-proof-and-evidence lane remains BLOCKED in this runner after closure follow-up rerun at 2026-04-20 18:00 (Asia/Jakarta): canonical entrypoint executes and refreshes evidence, but dependency installation still fails under both proxy (403 Forbidden) and direct no-proxy path (network unreachable), so py_compile+pytest closure evidence is still pending; evidence/report chain: `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`, `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-and-evidence.md`, `projects/polymarket/polyquantbot/reports/forge/phase9-1_02_runtime-proof-rerun-blocked.md`.
+- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep requirements are now documented in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and in parallel route Phase 9.1 runtime-proof closure rerun to a runner with confirmed package-index reachability so dependency install + py_compile + pytest can pass before Phase 9.2.
+- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and route Phase 9.1 canonical runtime-proof closure to a dependency-capable runner using `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` before Phase 9.2.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md
+++ b/projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md
@@ -1,0 +1,85 @@
+# Phase 9.1 Dependency-Capable Runner Preparation
+
+Last Updated: 2026-04-20 19:21 (Asia/Jakarta)
+
+## Purpose
+Define the exact runner requirements needed to execute the canonical Phase 9.1 runtime-proof command in an environment where dependency installation is possible.
+
+Canonical command (unchanged):
+
+```bash
+python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof
+```
+
+This preparation guide does **not** rerun runtime proof and does **not** refresh canonical evidence artifacts.
+
+## Required environment baseline
+- OS: Linux runner with outbound HTTPS access.
+- Python: 3.10+ with `venv` module available.
+- Locale:
+  - `LANG=C.UTF-8`
+  - `LC_ALL=C.UTF-8`
+  - `PYTHONIOENCODING=utf-8`
+- Working directory: repository root.
+
+## Package index reachability requirements
+Runner must satisfy at least one reachable install path:
+
+1. Default/proxy route works end-to-end for:
+   - `https://pypi.org/simple`
+   - `https://files.pythonhosted.org`
+2. Or direct/no-proxy route works end-to-end for the same endpoints.
+
+Preflight checks (recommended before canonical run):
+
+```bash
+python -m pip --version
+python -m pip index versions fastapi
+python -m pip index versions pytest
+```
+
+Expected outcome: commands return package metadata (no `403 Forbidden`, no DNS/network-unreachable errors).
+
+## Dependency install success requirements
+The canonical runner creates:
+- `projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof`
+
+Install phase must succeed for:
+- `-r projects/polymarket/polyquantbot/requirements.txt`
+- explicit runtime-proof stack: `pytest`, `pytest-asyncio`, `httpx`, `pydantic`, `fastapi`
+
+Install success criteria:
+- zero non-zero exits from pip install step
+- no unresolved dependency conflict
+
+## py_compile success requirements
+The runner compiles every target listed in:
+- `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt`
+
+Success criteria:
+- `python -m py_compile` returns exit code 0 for all listed targets.
+
+## Scoped pytest success requirements
+The runner executes each target from:
+- `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt`
+
+Success criteria:
+- each `python -m pytest -q <target>` returns exit code 0.
+
+## Reproducible execution sequence
+From repo root in capable runner:
+
+```bash
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export PYTHONIOENCODING=utf-8
+python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof
+```
+
+Expected output artifact location (produced only when canonical command is run):
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`
+
+## Out of scope
+- No runtime behavior changes.
+- No evidence-log refresh in this prep task.
+- No Phase 9.2 implementation.

--- a/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
+++ b/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
@@ -128,14 +128,14 @@ These checks are exposed under `exit_criteria.checks` with per-check `pass` and 
 Run this command from repo root to execute the dependency-complete runtime-proof lane:
 
 ```bash
-python -m projects.polymarket.polyquantbot.scripts.run_phase8_15_runtime_proof
+python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof
 ```
 
 The runner:
-- creates a dedicated virtualenv at `projects/polymarket/polyquantbot/.venv-phase8-15-runtime-proof`
+- creates a dedicated virtualenv at `projects/polymarket/polyquantbot/.venv-phase9-1-runtime-proof`
 - installs runtime/test dependencies (`requirements.txt` + pytest stack)
-- executes `py_compile` and runtime-surface pytest targets listed in `projects/polymarket/polyquantbot/tests/runtime_proof_phase8_15_targets.txt`
-- writes stable evidence output to `projects/polymarket/polyquantbot/reports/forge/phase8-15_01_runtime-proof-evidence.log`
+- executes `py_compile` and runtime-surface pytest targets listed in `projects/polymarket/polyquantbot/tests/runtime_proof_phase9_1_targets.txt`
+- writes stable evidence output to `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`
 
 ## Explicit non-goals and live-readiness block
 - No live trading rollout or privileged live execution controls

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_04_dependency-capable-runner-prep.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_04_dependency-capable-runner-prep.md
@@ -1,0 +1,57 @@
+# Phase 9.1 — Dependency-Capable Runner Preparation
+
+**Date:** 2026-04-20 19:21
+**Branch:** feature/prepare-phase-9-1-dependency-capable-runner
+**Task:** Prepare reproducible dependency-capable runner requirements for Phase 9.1 canonical runtime-proof closure lane
+
+## 1. What was built
+
+- Added a dedicated runner-preparation guide at `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` documenting exact requirements for package-index reachability, dependency install success, `py_compile` success, and scoped pytest success.
+- Updated `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md` so dependency-complete runtime-proof command/path references align with the canonical Phase 9.1 lane.
+- Preserved canonical runtime-proof command unchanged:
+  - `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`
+- Did not rerun canonical runtime proof and did not refresh canonical evidence artifacts.
+
+## 2. Current system architecture (relevant slice)
+
+Phase 9.1 closure flow remains:
+1. operator executes canonical package command from repo root
+2. runner creates isolated venv and installs dependency-complete runtime/test stack
+3. runner executes `py_compile` against scoped target manifest
+4. runner executes scoped pytest targets
+5. runner writes canonical evidence log
+
+This task adds explicit environment/runner prerequisites so the same unchanged command can be rerun in a dependency-capable environment.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`
+- `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_04_dependency-capable-runner-prep.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Reproducible runner prerequisites are now explicitly documented for:
+  - package-index reachability
+  - dependency install success
+  - `py_compile` success
+  - scoped pytest success
+- Canonical Phase 9.1 runtime-proof command remains unchanged and is clearly called out as the authoritative execution path.
+- No new rerun evidence artifact and no blocked-rerun continuity artifact were produced in this task.
+
+## 5. Known issues
+
+- Current Codex runner still cannot prove dependency-complete closure because package-index access constraints remain environment-dependent.
+- Phase 9.1 closure status therefore remains pending real execution in a dependency-capable runner.
+
+## 6. What is next
+
+- COMMANDER review this preparation lane.
+- After merge, execute the canonical command in a dependency-capable runner to capture successful install + `py_compile` + scoped pytest evidence in the canonical log.
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : reproducible dependency-capable runner requirements and documentation for canonical Phase 9.1 runtime-proof lane
+Not in Scope      : canonical rerun execution, evidence log refresh, blocked-rerun continuity artifacts, runtime behavior changes, Phase 9.2 implementation
+Suggested Next    : COMMANDER review


### PR DESCRIPTION
### Motivation
- Provide an explicit, reproducible runner-preparation path so the canonical Phase 9.1 runtime-proof command can be rerun in an environment with package-index reachability and dependency-install success. 
- Keep the canonical execution command and evidence artifacts unchanged while removing ambiguity about the environment prerequisites that blocked the previous rerun attempt. 

### Description
- Added a runner-prep document at `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` that specifies OS, Python, locale, package-index reachability, pip preflight checks, dependency install criteria, `py_compile` criteria, and scoped `pytest` criteria. 
- Updated `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md` to point dependency-complete runtime-proof instructions to the canonical Phase 9.1 lane (`python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`) and to use the Phase 9.1 venv/targets/evidence paths. 
- Added a FORGE-X report `projects/polymarket/polyquantbot/reports/forge/phase9-1_04_dependency-capable-runner-prep.md` documenting the change, scope, and next steps (STANDARD / FOUNDATION). 
- Updated `PROJECT_STATE.md` scoped lines and `Last Updated` timestamp to record that runner-prep requirements are documented while preserving the blocked/ pending closure status until execution in a dependency-capable runner. 

### Testing
- Ran `python3 -m py_compile projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` and it completed successfully (PASS). 
- Verified runner locale environment variables (`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`) via `locale` and ensured `PYTHONIOENCODING` is set in the execution environment (PASS). 
- Performed mojibake scans for patterns `â€`, `â†`, `ðŸ`, `\udc`, and `�` across touched files and found no matches (PASS). 
- Executed a timezone check using `zoneinfo` to derive Asia/Jakarta timestamp and it completed successfully, while an alternative `pytz`-based check failed because `pytz` is not installed in this environment (not required for the runner-prep doc; WARNING).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61a2482908325b820ece31ce36530)