### PR TITLE
Add Phase 9.1 external-runner handoff doc and update PROJECT_STATE.md

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 19:21
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; dependency-capable runner preparation requirements are now documented (without rerun), and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
+Last Updated : 2026-04-20 19:36
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; dependency-capable runner preparation requirements and external-runner handoff instructions are now documented (without rerun), and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep requirements are now documented in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
+- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep requirements are documented in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, external-runner execution handoff is documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md
@@ -1,0 +1,34 @@
+# Phase 9.1 — External Runner Handoff (Dependency-Capable Closure Execution)
+
+**Date:** 2026-04-20 19:36
+**Branch:** feature/phase-9-1-external-runner-handoff
+**Task:** Produce concise execution handoff for real Phase 9.1 closure run in a dependency-capable environment
+
+## 1. What was changed
+
+- Captured the confirmed blocker from the current runner context:
+  - proxy/default path fails with `403 Forbidden`
+  - direct/no-proxy path fails with `Network is unreachable`
+- Pointed closure operators to the merged runner-prep source of truth:
+  - `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`
+- Preserved the exact canonical closure command:
+  - `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`
+- Defined exact closure success checklist for the external capable runner:
+  1. dependency install succeeds
+  2. `py_compile` succeeds
+  3. scoped pytest succeeds
+  4. canonical evidence log is updated at `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`
+- No rerun performed, no evidence log refresh performed, no runtime code changed.
+
+## 2. Files modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md`
+- `PROJECT_STATE.md`
+
+## 3. Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
+
+Validation Tier   : MINOR
+Claim Level       : DOCS / EXECUTION HANDOFF
+Validation Target : concise external-runner instructions for unambiguous Phase 9.1 closure execution over paper-beta runtime-proof boundaries
+Not in Scope      : rerun execution, evidence log refresh, runtime code changes, Phase 9.1 closure claim, Phase 9.2 implementation
+Suggested Next    : COMMANDER runs canonical closure lane in a truly dependency-capable runner and captures successful closure evidence


### PR DESCRIPTION
### Motivation
- Document the necessary handoff for completing Phase 9.1 runtime-proof execution in a dependency-capable external runner so the closure can be performed outside the current runner context. 
- Record observed network/proxy blockers that prevented in-runner execution to make troubleshooting explicit. 
- Preserve the canonical closure command and an unambiguous success checklist so external operators can produce the required evidence log. 

### Description
- Updated `PROJECT_STATE.md` timestamp and status wording to reference external-runner handoff instructions for Phase 9.1 and to note that runner-prep requirements are documented. 
- Added `projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md` containing the handoff narrative, observed blockers, pointer to `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, the canonical closure command `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`, and a concise success checklist. 
- Clarified that no rerun or evidence refresh was performed and that the change is documentation-only. 

### Testing
- No automated tests were run because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61c450ec08325b2750da0e6acb9c9)