### PR TITLE
Phase 9.1: document environment unblock and reproducible dependency-capable runner path

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-20 19:36
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; dependency-capable runner preparation requirements and external-runner handoff instructions are now documented (without rerun), and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
+Last Updated : 2026-04-20 23:08
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; root-cause diagnostics now confirm current Codex runner egress incapability (proxy 403 + no-proxy network unreachable), with one reproducible dependency-capable external-runner path documented and 9.2/9.3 still pending canonical closure evidence from that capable environment.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep requirements are documented in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, external-runner execution handoff is documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_05_external-runner-handoff.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
+- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep guide now includes route-level root cause and reproducible capable-environment path in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, unblock evidence is documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and route Phase 9.1 canonical runtime-proof closure to a dependency-capable runner using `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` before Phase 9.2.
+- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and route Phase 9.1 canonical runtime-proof closure to the confirmed capable external runner path documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md` and `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` before Phase 9.2.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md
+++ b/projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md
@@ -1,6 +1,6 @@
 # Phase 9.1 Dependency-Capable Runner Preparation
 
-Last Updated: 2026-04-20 19:21 (Asia/Jakarta)
+Last Updated: 2026-04-20 23:08 (Asia/Jakarta)
 
 ## Purpose
 Define the exact runner requirements needed to execute the canonical Phase 9.1 runtime-proof command in an environment where dependency installation is possible.
@@ -21,6 +21,27 @@ This preparation guide does **not** rerun runtime proof and does **not** refresh
   - `LC_ALL=C.UTF-8`
   - `PYTHONIOENCODING=utf-8`
 - Working directory: repository root.
+
+## Current Codex runner diagnosis (2026-04-20)
+- Proxy/default route (`HTTP_PROXY=http://proxy:8080`) to PyPI fails at CONNECT with `403 Forbidden`.
+- Direct/no-proxy route fails with outbound network block (`[Errno 101] Network is unreachable`).
+- DNS lookup for `pypi.org` and `files.pythonhosted.org` succeeds, so failure is egress-policy/entitlement, not DNS.
+
+Implication: this runner cannot satisfy dependency-complete preconditions; use a separate capable environment path below.
+
+## Reproducible capable environment path
+1. Use an external Linux runner (VM or CI host) with outbound HTTPS allowed to:
+   - `pypi.org:443`
+   - `files.pythonhosted.org:443`
+2. Set locale/env baseline:
+   - `LANG=C.UTF-8`
+   - `LC_ALL=C.UTF-8`
+   - `PYTHONIOENCODING=utf-8`
+3. From repo root, verify preflight succeeds:
+   - `python -m pip index versions fastapi`
+   - `python -m pip index versions pytest`
+4. Run canonical command unchanged:
+   - `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`
 
 ## Package index reachability requirements
 Runner must satisfy at least one reachable install path:

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md
@@ -1,0 +1,60 @@
+# Phase 9.1 — Dependency-Capable Environment Unblock
+
+**Date:** 2026-04-20 23:08
+**Branch:** feature/unblock-phase-9-1-capable-environment
+**Task:** Identify root cause of package-index reachability failure in current runner and define one reproducible dependency-capable environment path for canonical Phase 9.1 runtime-proof closure lane
+
+## 1. What was built
+
+- Reproduced current-runner package-index failure in both required checks:
+  - `python -m pip index versions fastapi`
+  - `python -m pip index versions pytest`
+- Isolated failure mode by route:
+  - proxy/default route fails with `CONNECT tunnel failed, response 403` (`proxy:8080` policy rejection)
+  - direct/no-proxy route fails with `[Errno 101] Network is unreachable` / `Couldn't connect to server`
+- Verified DNS resolution works for `pypi.org` and `files.pythonhosted.org`, so the blocker is not DNS lookup.
+- Classified the current runner as **subscription/entitlement or isolation-policy constrained** for outbound package-index HTTPS, with proxy and direct paths both unusable.
+- Defined one reproducible capable-environment path for the canonical closure lane:
+  1. run in an external Linux runner (VM/CI host) with unrestricted outbound HTTPS to `pypi.org:443` and `files.pythonhosted.org:443`
+  2. preflight with `python -m pip index versions fastapi` and `python -m pip index versions pytest` (both must return package metadata)
+  3. only then execute canonical command unchanged:
+     - `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`
+
+## 2. Current system architecture (relevant slice)
+
+Environment capability gate for Phase 9.1 closure now has explicit route-level truth:
+
+1. Codex runner default path -> forced proxy (`http://proxy:8080`) -> HTTPS CONNECT to PyPI denied (`403`).
+2. Codex runner no-proxy path -> direct outbound HTTPS blocked (`Errno 101` network unreachable).
+3. Result: dependency installation cannot begin, so canonical runtime-proof command must be executed in a separately capable environment.
+4. Canonical command/path is preserved exactly; this task only unblocks the environment prerequisite.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md`
+- `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Root cause is explicitly documented with reproducible command evidence for proxy and no-proxy routes.
+- A single reproducible dependency-capable environment path is defined and aligned with the unchanged canonical closure command.
+- No canonical Phase 9.1 closure run was performed in this task.
+- No canonical evidence-log refresh was produced.
+- No blocked-rerun continuity artifact was produced.
+
+## 5. Known issues
+
+- Current Codex runner remains incapable of package-index access under both available egress paths (proxy denied, direct blocked).
+- Phase 9.1 closure evidence remains pending execution in a verified dependency-capable external runner.
+
+## 6. What is next
+
+- COMMANDER review this environment-unblock lane.
+- After merge, execute the unchanged canonical command in the confirmed capable environment and capture closure evidence on the canonical log path.
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : root-cause isolation and reproducible dependency-capable execution path prerequisites for Phase 9.1 canonical runtime-proof lane
+Not in Scope      : canonical runtime-proof execution, evidence-log refresh, blocked-rerun continuity PR, runtime behavior changes, Phase 9.2 work
+Suggested Next    : COMMANDER review


### PR DESCRIPTION
### Motivation

- Identify why package-index reachability fails in the current runner and provide a reproducible environment path so the canonical Phase 9.1 runtime-proof closure can be executed in a dependency-capable runner.
- Preserve the canonical closure command and avoid running the closure or producing evidence in this task.

### Description

- Added a new FORGE-X report `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md` that records reproduced failures, route-level diagnosis, and a single reproducible capable-environment path.
- Updated `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` to include the Codex-runner diagnosis (proxy `403` on CONNECT and direct path `Network is unreachable`), explicit preflight checks, and a step-by-step capable-runner sequence while preserving the canonical command `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof` unchanged.
- Updated `PROJECT_STATE.md` to reflect the root-cause diagnosis, point to the new unblock report and prep doc for next-gate routing, and refresh the `Last Updated` timestamp.

### Testing

- Verified locale baseline with `locale` and environment variables and confirmed `LANG=C.UTF-8` / `LC_ALL=C.UTF-8` are present (success).
- Observed proxy environment variables present (`HTTP_PROXY`, `HTTPS_PROXY`, etc.) via `env` (success).
- Ran `python -m pip index versions fastapi` and `python -m pip index versions pytest` in the current runner and reproduced failures: proxy path fails with `CONNECT tunnel failed: 403 Forbidden` and direct/no-proxy attempts fail with `[Errno 101] Network is unreachable` (fail as diagnosed).
- Confirmed DNS resolution for `pypi.org` and `files.pythonhosted.org` using a small Python `socket.getaddrinfo` check (success), showing the blocker is egress/policy rather than DNS.
- Performed `curl -I` checks that returned `403` through the proxy and immediate failure for direct attempts (evidence of proxy denial and blocked egress).
- Confirmed `python -m pip --version` ran successfully, and ran mojibake checks on touched files (no mojibake detected).

Validation Tier: STANDARD
Claim Level: FOUNDATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64f0e72848325934b2077dc4eb53f)