### PR TITLE
Hotfix: prevent stdlib `platform` shadowing to fix Fly.io startup crash

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-20 23:08
+Last Updated : 2026-04-21 00:11
 Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; root-cause diagnostics now confirm current Codex runner egress incapability (proxy 403 + no-proxy network unreachable), with one reproducible dependency-capable external-runner path documented and 9.2/9.3 still pending canonical closure evidence from that capable environment.
 
 [COMPLETED]
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 runtime-proof-and-evidence lane remains pending dependency-capable closure execution: canonical command remains unchanged, runner-prep guide now includes route-level root cause and reproducible capable-environment path in `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md`, unblock evidence is documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md`, and closure evidence is still pending in `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log` until run in a package-index-capable environment.
+- Phase 9.1 Fly startup crash hotfix lane is now implemented in `projects/polymarket/polyquantbot/platform/__init__.py` with stdlib delegation guard for `platform.system()` shadowing; forge evidence is captured in `projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md`, and Fly deploy/runtime smoke confirmation remains pending SENTINEL + capable deploy environment execution.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER decision gate: review Phase 8.14 actionable-source assessment for launch-planning foundation follow-up scope, and route Phase 9.1 canonical runtime-proof closure to the confirmed capable external runner path documented in `projects/polymarket/polyquantbot/reports/forge/phase9-1_06_capable-environment-unblock.md` and `projects/polymarket/polyquantbot/docs/phase9_1_dependency_capable_runner_prep.md` before Phase 9.2.
+- SENTINEL gate required for Phase 9.1 Fly startup crash hotfix (`projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md`), then re-run Fly deploy smoke/runtime proof before Phase 9.2 closure decisions.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/platform/__init__.py
+++ b/projects/polymarket/polyquantbot/platform/__init__.py
@@ -1,1 +1,55 @@
-"""Phase 2 platform shell namespace."""
+"""Phase 2 platform shell namespace.
+
+This package intentionally lives under
+`projects.polymarket.polyquantbot.platform`.
+
+When runtime working directory is set to this project root,
+third-party imports like `import platform` can accidentally resolve to this
+package instead of Python's stdlib `platform.py`. To prevent startup crashes
+(e.g. missing `platform.system()`), unknown top-level attributes are delegated
+to the stdlib platform module.
+"""
+from __future__ import annotations
+
+from importlib import util
+from pathlib import Path
+import sysconfig
+from types import ModuleType
+from typing import Any
+
+_STDLIB_PLATFORM: ModuleType | None = None
+
+
+def _load_stdlib_platform() -> ModuleType:
+    """Load stdlib `platform.py` directly from the Python stdlib path."""
+    global _STDLIB_PLATFORM
+    if _STDLIB_PLATFORM is not None:
+        return _STDLIB_PLATFORM
+
+    stdlib_path = Path(sysconfig.get_paths()["stdlib"]) / "platform.py"
+    spec = util.spec_from_file_location("_polyquant_stdlib_platform", stdlib_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load stdlib platform module from {stdlib_path}")
+
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _STDLIB_PLATFORM = module
+    return module
+
+
+# Commonly used by dependencies during startup validation.
+def system() -> str:
+    return _load_stdlib_platform().system()
+
+
+def __getattr__(name: str) -> Any:
+    """Delegate unresolved top-level attributes to stdlib `platform` module."""
+    try:
+        return globals()[name]
+    except KeyError:
+        return getattr(_load_stdlib_platform(), name)
+
+
+__all__ = [
+    "system",
+]

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md
@@ -1,0 +1,55 @@
+# Phase 9.1 — Fly Startup Crash Hotfix (platform shadow guard)
+
+**Date:** 2026-04-21 00:11
+**Task:** Phase 9.1 Fly.io startup crash hotfix + runtime proof unblock
+
+## 1. What was built
+
+- Isolated the startup-crash root cause as Python stdlib shadowing of `platform` when runtime executes from `projects/polymarket/polyquantbot`.
+- Reproduced the exact failure signature locally:
+  - `python -c "import platform; print(platform.__file__); print(platform.system())"`
+  - output before fix resolved to `projects/polymarket/polyquantbot/platform/__init__.py` and raised `AttributeError: module 'platform' has no attribute 'system'`.
+- Implemented a narrow hotfix in `projects/polymarket/polyquantbot/platform/__init__.py`:
+  - adds a stdlib delegation bridge that loads Python stdlib `platform.py` directly from the interpreter stdlib path via `importlib.util.spec_from_file_location`
+  - exposes `system()` explicitly and routes unresolved attributes via `__getattr__` to stdlib `platform`
+  - preserves existing package namespace behavior for `projects.polymarket.polyquantbot.platform.*` imports.
+- Cleared generated `__pycache__` artifacts under `projects/polymarket/polyquantbot/` after validation runs.
+
+## 2. Current system architecture (relevant slice)
+
+Startup/import boundary relevant to Fly crash:
+
+1. Deploy startup enters app runtime from project surface.
+2. Python import resolution may pick local package `platform` when CWD is `projects/polymarket/polyquantbot`.
+3. Third-party startup libraries (e.g., ASGI/server stack) call `platform.system()` during bootstrap.
+4. Before hotfix: crash at bootstrap because local `platform` package had no `system` attribute.
+5. After hotfix: local package delegates stdlib `platform` API, so `platform.system()` and related calls resolve successfully while project internal package paths remain valid.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/platform/__init__.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Shadowing root cause is now proven and reproducible with before/after import-resolution evidence.
+- In project-root CWD, `import platform; platform.system()` now returns normal stdlib-backed output (`Linux`) instead of startup-fatal `AttributeError`.
+- Existing project package path remains usable (`projects.polymarket.polyquantbot.platform.execution...` import path still resolves).
+- Python compile check passes for touched runtime hotfix module.
+
+## 5. Known issues
+
+- Full HTTP startup smoke proof (`/health`, `/ready`) cannot be executed in this runner because runtime dependency `uvicorn` is not installed in the local environment.
+- Fly remote machine smoke-check pass is not directly executable from this environment; must be confirmed by deployment run in Fly-capable/dependency-complete lane.
+
+## 6. What is next
+
+- SENTINEL validation is required for this MAJOR hotfix lane.
+- After COMMANDER review + SENTINEL gate, re-run Fly deploy smoke checks and capture runtime evidence (`/health`, `/ready`, startup logs) for Phase 9.1 closure continuity.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : Fly startup crash path caused by `platform` stdlib shadowing during runtime bootstrap
+Not in Scope      : strategy behavior, live trading rollout, Telegram UX expansion, broad architecture changes
+Suggested Next    : SENTINEL validation, then COMMANDER decision


### PR DESCRIPTION
### Motivation
- Fly.io deploys were failing at startup with `AttributeError: module 'platform' has no attribute 'system'`, which points to stdlib `platform` being shadowed by a local package when running from the project root.
- A narrow, deploy-oriented hotfix is required to restore expected startup behavior and unblock Phase 9.1 runtime proof without changing the project package layout.
- This is a MAJOR validation-tier change that requires SENTINEL validation before merge.

### Description
- Implemented a stdlib delegation bridge in `projects/polymarket/polyquantbot/platform/__init__.py` that loads the interpreter's `platform.py` via `importlib.util.spec_from_file_location`, exposes `system()`, and delegates unresolved top-level attributes to the stdlib module via `__getattr__`.
- Cleared generated `__pycache__` artifacts under `projects/polymarket/polyquantbot/`, updated `PROJECT_STATE.md` with the Phase 9.1 hotfix status, and added the FORGE continuity report at `projects/polymarket/polyquantbot/reports/forge/phase9-1_07_fly-startup-platform-shadow-hotfix.md` documenting the change and next steps.
- The fix is intentionally narrow and preserves the existing `projects.polymarket.polyquantbot.platform.*` package namespace while restoring expected stdlib API compatibility used by startup dependencies.

### Testing
- Ran `python -m py_compile projects/polymarket/polyquantbot/platform/__init__.py` and the file compiled successfully.
- Verified import resolution with `python -c "import platform; print(platform.__file__); print(platform.system())"` from the project CWD and confirmed it now returns the stdlib-backed output (`Linux`) without `AttributeError`.
- Confirmed project imports still work by importing `ExecutionIntent` (`from projects.polymarket.polyquantbot.platform.execution.execution_intent import ExecutionIntent`) which succeeded.
- Attempted full FastAPI app creation/startup checks but this runner lacks `uvicorn`, so `create_app`/HTTP smoke tests are blocked by the environment and are documented as requiring SENTINEL validation in a dependency-capable deploy environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d7ef2788325b74e97995e15e309)