### PR TITLE
Phase 9.1: emit actionable diagnostics for canonical runtime-proof failures

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 02:05
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; root-cause diagnostics now confirm current Codex runner egress incapability (proxy 403 + no-proxy network unreachable), with one reproducible dependency-capable external-runner path documented and 9.2/9.3 still pending canonical closure evidence from that capable environment.
+Last Updated : 2026-04-21 02:31
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; diagnostics mirroring is now added to the canonical runtime-proof command so external GitHub Actions reruns expose actionable root-cause detail without false closure claims, and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 external capable-runner path now includes a mobile-triggerable GitHub Actions lane (`.github/workflows/phase9_1_runtime_proof.yml`) with package-index preflight gating and canonical command handoff docs in `projects/polymarket/polyquantbot/docs/phase9_1_github_actions_mobile_run.md`; runtime-proof closure evidence remains pending successful GitHub run and review.
+- Phase 9.1 external capable-runner path now includes diagnostics-mirrored canonical execution in `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` plus the existing mobile-triggerable GitHub Actions lane (`.github/workflows/phase9_1_runtime_proof.yml`); runtime-proof closure evidence remains pending successful rerun/review in GitHub with newly surfaced failure detail.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review Phase 9.1 GitHub Actions runner lane (`projects/polymarket/polyquantbot/reports/forge/phase9-1_07_github-actions-runner.md`), then trigger workflow from GitHub mobile/web and collect canonical runtime-proof evidence before any closure-pass claim.
+- COMMANDER review Phase 9.1 diagnostics lane (`projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md`), then rerun GitHub workflow to capture actionable root-cause output before any closure-pass claim.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md
@@ -1,0 +1,49 @@
+# Phase 9.1 — Runtime-Proof Command Failure Diagnostics
+
+**Date:** 2026-04-21 02:31
+**Branch:** feature/fix-phase-9-1-runtime-proof-diagnostics
+**Task:** Improve canonical Phase 9.1 runtime-proof diagnostics so external-runner exit-code-1 failures expose actionable cause evidence
+
+## 1. What was built
+
+- Added diagnostics mirroring in `run_phase9_1_runtime_proof.py` so every logged step is emitted to stdout/stderr in real time while still being persisted to the canonical evidence log file.
+- Moved runtime-proof target loading inside the evidence-log context and wrapped it with explicit failure handling so missing/invalid target-file errors now emit a traceback and clear failure reason instead of opaque exit-only behavior.
+- Added explicit guard for empty target lists to fail with a direct message.
+- Routed subprocess stderr output and failure sentinel lines to stderr for clearer GitHub Actions log visibility while preserving canonical command and execution flow.
+
+## 2. Current system architecture (relevant slice)
+
+1. GitHub Actions runs the unchanged canonical command: `python -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof`.
+2. The script writes to `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`.
+3. Diagnostic mirroring now duplicates each log line to runner stdout/stderr (flushed immediately), so action logs show the exact failing phase and subprocess stderr details.
+4. Existing workflow artifact collection remains valid because the canonical evidence file path is unchanged.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Canonical command remains unchanged.
+- Exit-code failures now emit concrete diagnostics into GitHub Actions console logs and the persisted evidence log.
+- Target-file load failures and empty-target conditions now produce direct actionable output.
+- No runtime closure-pass claim was introduced for Phase 9.1.
+
+## 5. Known issues
+
+- This lane only improves diagnostics; it does not itself prove a successful external Phase 9.1 runtime-proof execution.
+- External runner rerun is still required to capture the newly surfaced root cause from the real failing environment.
+
+## 6. What is next
+
+- COMMANDER review this STANDARD/FOUNDATION diagnostics patch.
+- After merge, rerun `.github/workflows/phase9_1_runtime_proof.yml` and inspect the improved log output/artifacts.
+- If rerun fully succeeds, open the dedicated closure-pass PR for Phase 9.1.
+
+Validation Tier   : STANDARD
+Claim Level       : FOUNDATION
+Validation Target : Canonical Phase 9.1 runtime-proof command diagnostics visibility in external GitHub Actions logs/artifacts
+Not in Scope      : claiming Phase 9.1 closure, SENTINEL validation, risk/execution logic changes, Phase 9.2/9.3 work
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py
+++ b/projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py
@@ -4,7 +4,9 @@ import os
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
+from typing import TextIO
 
 ROOT = Path(__file__).resolve().parents[4]
 PROJECT_ROOT = ROOT / "projects/polymarket/polyquantbot"
@@ -47,8 +49,12 @@ def _run_with_retry(
     return last_result
 
 
-def _write_line(handle, line: str = "") -> None:
+def _write_line(handle: TextIO, line: str = "", *, stream: TextIO | None = None) -> None:
     handle.write(f"{line}\n")
+    handle.flush()
+    if stream is None:
+        stream = sys.stdout
+    print(line, file=stream, flush=True)
 
 
 def _base_env() -> dict[str, str]:
@@ -78,28 +84,43 @@ def _without_proxy(env: dict[str, str]) -> dict[str, str]:
 def main() -> int:
     env = _base_env()
 
-    targets = [
-        line.strip()
-        for line in TARGETS_FILE.read_text(encoding="utf-8").splitlines()
-        if line.strip() and not line.strip().startswith("#")
-    ]
-
     EVIDENCE_LOG.parent.mkdir(parents=True, exist_ok=True)
 
     with EVIDENCE_LOG.open("w", encoding="utf-8") as log:
         _write_line(log, "Phase 9.1 Dependency-Complete Runtime Proof")
+        _write_line(log, "Diagnostics mode: enabled (stdout/stderr mirrored)")
         _write_line(log, f"Python executable: {sys.executable}")
         _write_line(log, f"Repo root: {ROOT}")
         _write_line(log, f"Project root: {PROJECT_ROOT}")
         _write_line(log, f"Targets file: {TARGETS_FILE}")
         _write_line(log)
 
+        try:
+            targets = [
+                line.strip()
+                for line in TARGETS_FILE.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ]
+        except Exception:
+            _write_line(log, "FAIL: unable to load runtime proof targets", stream=sys.stderr)
+            _write_line(log, traceback.format_exc().rstrip(), stream=sys.stderr)
+            return 1
+
+        if not targets:
+            _write_line(log, "FAIL: no runtime proof targets were loaded", stream=sys.stderr)
+            return 1
+
+        _write_line(log, f"Loaded targets ({len(targets)}):")
+        for target in targets:
+            _write_line(log, f"- {target}")
+        _write_line(log)
+
         _write_line(log, f"[1/5] create venv: {VENV_DIR}")
         create_venv = _run([sys.executable, "-m", "venv", str(VENV_DIR)], env=env)
         _write_line(log, create_venv.stdout.rstrip())
-        _write_line(log, create_venv.stderr.rstrip())
+        _write_line(log, create_venv.stderr.rstrip(), stream=sys.stderr)
         if create_venv.returncode != 0:
-            _write_line(log, f"FAIL: venv creation exit={create_venv.returncode}")
+            _write_line(log, f"FAIL: venv creation exit={create_venv.returncode}", stream=sys.stderr)
             return create_venv.returncode
 
         venv_python = VENV_DIR / "bin/python"
@@ -123,16 +144,16 @@ def main() -> int:
         _write_line(log, "install attempt A (proxy/default env)")
         install_result = _run_with_retry(install_cmd, env=env, timeout_s=900)
         _write_line(log, install_result.stdout.rstrip())
-        _write_line(log, install_result.stderr.rstrip())
+        _write_line(log, install_result.stderr.rstrip(), stream=sys.stderr)
 
         if install_result.returncode != 0:
             no_proxy_env = _without_proxy(env)
             _write_line(log, "install attempt B (direct/no-proxy env)")
             install_result_no_proxy = _run_with_retry(install_cmd, env=no_proxy_env, timeout_s=900)
             _write_line(log, install_result_no_proxy.stdout.rstrip())
-            _write_line(log, install_result_no_proxy.stderr.rstrip())
+            _write_line(log, install_result_no_proxy.stderr.rstrip(), stream=sys.stderr)
             if install_result_no_proxy.returncode != 0:
-                _write_line(log, f"FAIL: dependency install exit={install_result_no_proxy.returncode}")
+                _write_line(log, f"FAIL: dependency install exit={install_result_no_proxy.returncode}", stream=sys.stderr)
                 return install_result_no_proxy.returncode
             install_result = install_result_no_proxy
 
@@ -141,9 +162,9 @@ def main() -> int:
         py_compile_cmd = [str(venv_python), "-m", "py_compile", *targets]
         py_compile_result = _run(py_compile_cmd, env=env)
         _write_line(log, py_compile_result.stdout.rstrip())
-        _write_line(log, py_compile_result.stderr.rstrip())
+        _write_line(log, py_compile_result.stderr.rstrip(), stream=sys.stderr)
         if py_compile_result.returncode != 0:
-            _write_line(log, f"FAIL: py_compile exit={py_compile_result.returncode}")
+            _write_line(log, f"FAIL: py_compile exit={py_compile_result.returncode}", stream=sys.stderr)
             return py_compile_result.returncode
         _write_line(log, "PASS: py_compile")
 
@@ -153,9 +174,9 @@ def main() -> int:
             _write_line(log, f"command: {' '.join(pytest_cmd)}")
             pytest_result = _run(pytest_cmd, env=env, timeout_s=600)
             _write_line(log, pytest_result.stdout.rstrip())
-            _write_line(log, pytest_result.stderr.rstrip())
+            _write_line(log, pytest_result.stderr.rstrip(), stream=sys.stderr)
             if pytest_result.returncode != 0:
-                _write_line(log, f"FAIL: pytest target {target} exit={pytest_result.returncode}")
+                _write_line(log, f"FAIL: pytest target {target} exit={pytest_result.returncode}", stream=sys.stderr)
                 return pytest_result.returncode
 
         _write_line(log, "PASS: all runtime-surface pytest targets")


### PR DESCRIPTION
### Motivation

- The canonical Phase 9.1 runtime-proof command was failing in an external GitHub Actions runner with exit code 1 while emitting insufficient detail to identify the root cause. 
- Improve diagnostics so GitHub Actions logs/artifacts show the precise failing step and any subprocess stderr output without changing the canonical command or claiming Phase 9.1 closure.

### Description

- Instrumented `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` to mirror every logged evidence line to live stdout/stderr (flushed) so runner logs show step-by-step progress. 
- Moved runtime-proof target loading into the evidence-log context and added `try/except` with `traceback` output plus an explicit empty-target guard so target-file errors now emit a clear failure reason. 
- Routed subprocess `stderr` and failure sentinel lines to `stderr` (while still writing the canonical evidence log file) to improve visibility of root-cause details in GitHub Actions. 
- Added the FORGE report `projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md` and updated `PROJECT_STATE.md` to reflect the diagnostics lane status and next gate while preserving the unchanged canonical command and existing workflow artifact paths.

### Testing

- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` and it succeeded with no syntax errors. 
- Scanned changed files for mojibake sequences using `rg -n -F -e 'â€' -e 'â†' -e 'ðŸ' -e '\\udc' -e '�'` and found no matches. 
- Verified Git config values with `git config --global --get core.quotepath` and `git config --global --get core.autocrlf` which returned `false` and `input` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67ec8a44883258145394354c4f1d4)