### PR TITLE
fix: align Phase 9.1 Falcon readiness with runtime-surface contract

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 02:31
-Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; diagnostics mirroring is now added to the canonical runtime-proof command so external GitHub Actions reruns expose actionable root-cause detail without false closure claims, and 9.2/9.3 remain pending canonical closure evidence from a capable environment.
+Last Updated : 2026-04-21 02:56
+Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; Falcon readiness contract now keeps /ready evaluable when FALCON is enabled without API key, but closure evidence remains pending an external GitHub Actions rerun in a package-accessible runner.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 external capable-runner path now includes diagnostics-mirrored canonical execution in `projects/polymarket/polyquantbot/scripts/run_phase9_1_runtime_proof.py` plus the existing mobile-triggerable GitHub Actions lane (`.github/workflows/phase9_1_runtime_proof.yml`); runtime-proof closure evidence remains pending successful rerun/review in GitHub with newly surfaced failure detail.
+- Phase 9.1 Falcon readiness/runtime contract fix is applied in `projects/polymarket/polyquantbot/configs/falcon.py` so missing `FALCON_API_KEY` under `FALCON_ENABLED=true` is surfaced as readiness-invalid instead of app-creation failure; full closure evidence remains pending external GitHub Actions rerun in a package-accessible runner.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review Phase 9.1 diagnostics lane (`projects/polymarket/polyquantbot/reports/forge/phase9-1_08_runtime-proof-diagnostics.md`), then rerun GitHub workflow to capture actionable root-cause output before any closure-pass claim.
+- COMMANDER review Falcon readiness fix (`projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md`) and trigger external `.github/workflows/phase9_1_runtime_proof.yml`; only produce closure-pass artifacts if full workflow is green.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/configs/falcon.py
+++ b/projects/polymarket/polyquantbot/configs/falcon.py
@@ -25,8 +25,6 @@ class FalconSettings:
 
         if timeout_seconds <= 0:
             raise RuntimeError("FALCON_TIMEOUT must be > 0")
-        if enabled and not api_key:
-            raise RuntimeError("FALCON_API_KEY is required when FALCON_ENABLED=true")
         if enabled and not base_url:
             raise RuntimeError("FALCON_BASE_URL is required when FALCON_ENABLED=true")
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md
@@ -1,0 +1,46 @@
+# Phase 9.1 — Falcon Readiness Contract Fix (Runtime-Surface)
+
+**Date:** 2026-04-21 02:56
+**Branch:** feature/fix-phase-9-1-falcon-readiness-contract
+**Task:** Fix Falcon readiness/runtime contract mismatch so missing `FALCON_API_KEY` under `FALCON_ENABLED=true` is represented as readiness-invalid state instead of failing app creation.
+
+## 1. What was built
+
+- Updated Falcon env parsing contract so `FALCON_ENABLED=true` without `FALCON_API_KEY` no longer raises during app construction.
+- Preserved readiness-surface invalid semantics through existing `/ready` and `/beta/admin` payload fields (`enabled_without_api_key=true`, `config_valid_for_enabled_mode=false`) by allowing app boot to complete and readiness evaluation to run.
+- Kept strict validation for `FALCON_TIMEOUT <= 0` and missing enabled-mode base URL unchanged.
+
+## 2. Current system architecture (relevant slice)
+
+1. `projects/polymarket/polyquantbot/server/main.py` constructs `FalconSettings` during app creation.
+2. `projects/polymarket/polyquantbot/server/api/routes.py:/ready` computes Falcon readiness booleans from `FalconSettings`.
+3. With this fix, missing key in enabled mode is surfaced by readiness payload booleans (invalid config) instead of aborting app creation with runtime exception.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/configs/falcon.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- Falcon readiness contract for the targeted runtime path now matches the runtime-surface expectation: app creation remains evaluable when Falcon is enabled without API key.
+- Local py_compile check passes for touched Python config module.
+- Canonical runtime-proof command still executes and now proceeds to dependency install stage before blocking on package-index reachability in this runner.
+
+## 5. Known issues
+
+- Full runtime-proof closure remains blocked in this environment by dependency installation failures (proxy 403 / direct network unreachable), so closure-pass artifacts were not produced.
+- GitHub Actions rerun could not be triggered from this environment because GitHub CLI/auth tooling is unavailable here.
+
+## 6. What is next
+
+- COMMANDER review this MAJOR/NARROW readiness-contract fix.
+- Trigger `.github/workflows/phase9_1_runtime_proof.yml` on GitHub and verify end-to-end pass in the external capable runner.
+- If and only if full workflow passes, refresh `projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`, write `projects/polymarket/polyquantbot/reports/forge/phase9-1_09_runtime-proof-closure-pass.md`, then sync `PROJECT_STATE.md` and `ROADMAP.md` to close 9.1 and move to 9.2.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : Falcon readiness/runtime contract only for `/ready` evaluability when `FALCON_ENABLED=true` and API key missing
+Not in Scope      : live trading, strategy logic, wallet lifecycle expansion, dashboard expansion, broad Falcon feature work, Phase 9.2/9.3
+Suggested Next    : SENTINEL on PR head branch after external workflow proof is green


### PR DESCRIPTION
### Motivation
- The Phase 9.1 runtime-proof tests expect the `/ready` surface to be evaluable even when `FALCON_ENABLED=true` but no `FALCON_API_KEY` is present, so app creation must not raise on that missing key. 
- The change makes runtime readiness semantics surface invalid Falcon config state via readiness payload booleans rather than causing an unhandled runtime exception that blocks the Phase 9.1 proof lane.

### Description
- Removed the hard-fail requirement for `FALCON_API_KEY` in `projects/polymarket/polyquantbot/configs/falcon.py` so `FalconSettings.from_env()` does not raise when `FALCON_ENABLED=true` and the API key is absent, while keeping strict checks for `FALCON_TIMEOUT` and `FALCON_BASE_URL`.
- Kept readiness signaling behavior intact so `/ready` and `/beta/admin` still report `enabled_without_api_key=true` and `config_valid_for_enabled_mode=false` as the invalid-readiness indicators.
- Added a FORGE report documenting the change at `projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md` and updated `PROJECT_STATE.md` to reflect the applied fix and the next gate (external Phase 9.1 rerun in a package-capable runner).

### Testing
- Ran `python -m py_compile` on `projects/polymarket/polyquantbot/configs/falcon.py`, `projects/polymarket/polyquantbot/server/main.py`, and `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`; compilation passed for the touched modules.
- Executed `pytest` against the runtime-surface tests; the FastAPI-based suite was skipped/guarded by `pytest.importorskip('fastapi')` in this environment so the runtime-surface assertions did not run here (skipped due to missing FastAPI dependency).
- Ran the canonical runtime-proof command `python3 -m projects.polymarket.polyquantbot.scripts.run_phase9_1_runtime_proof` to exercise end-to-end proof flow; the script progressed to venv creation but dependency installation failed in this environment due to proxy `403 Forbidden` and direct network `Network is unreachable` errors, so full proof/pytest closure could not be completed.
- Attempted to trigger the external GitHub Actions rerun from this environment but `gh` CLI was not available (`gh: command not found`), so the external capable-runner verification must be run on GitHub Actions to complete validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e683ecff8c8325a8acfe08e8c731b6)