### PR TITLE
sentinel: validate phase 9.1 falcon readiness contract (PR #671)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-21 02:56
+Last Updated : 2026-04-21 03:04
 Status       : Open lanes remain Phase 8.14 launch-planning foundation actionable-source follow-up and Phase 9.1 dependency-complete runtime-proof evidence closure; Falcon readiness contract now keeps /ready evaluable when FALCON is enabled without API key, but closure evidence remains pending an external GitHub Actions rerun in a package-accessible runner.
 
 [COMPLETED]
@@ -29,7 +29,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.1 Falcon readiness/runtime contract fix is applied in `projects/polymarket/polyquantbot/configs/falcon.py` so missing `FALCON_API_KEY` under `FALCON_ENABLED=true` is surfaced as readiness-invalid instead of app-creation failure; full closure evidence remains pending external GitHub Actions rerun in a package-accessible runner.
+- Phase 9.1 Falcon readiness/runtime contract fix is validated by SENTINEL as CONDITIONAL for scoped contract behavior (PR #671); closure remains pending dependency-complete external runtime proof to upgrade evidence from conditional to full closure.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -37,7 +37,7 @@ Status       : Open lanes remain Phase 8.14 launch-planning foundation actionabl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review Falcon readiness fix (`projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md`) and trigger external `.github/workflows/phase9_1_runtime_proof.yml`; only produce closure-pass artifacts if full workflow is green.
+- COMMANDER review SENTINEL validation (`projects/polymarket/polyquantbot/reports/sentinel/phase9-1_02_falcon-readiness-contract-validation-pr671.md`) and trigger dependency-complete external runtime proof before Phase 9.1 closure.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase9-1_02_falcon-readiness-contract-validation-pr671.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase9-1_02_falcon-readiness-contract-validation-pr671.md
@@ -1,0 +1,108 @@
+# SENTINEL Validation — Phase 9.1 Falcon Readiness Contract Fix (PR #671)
+
+**Date:** 2026-04-21 03:04
+**Env:** dev
+**Tier:** MAJOR
+**Claim Level:** NARROW INTEGRATION
+**Source report:** `projects/polymarket/polyquantbot/reports/forge/phase9-1_09_falcon-readiness-contract-fix.md`
+**Validated branch:** `feature/fix-phase-9-1-falcon-readiness-contract`
+
+## Environment
+
+- Runner locale: `C.UTF-8` (`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`).
+- Working ref in Codex worktree: detached `work` ref at commit `40f0e6fb7d0ac7eb0a9d2d7743899b6bdf906d28`.
+- Python runtime missing FastAPI dependency in this runner (`ModuleNotFoundError: No module named 'fastapi'`), preventing live API instantiation checks.
+
+## Validation Context
+
+- Validation Target: Falcon readiness/runtime contract only for `/ready` evaluability when `FALCON_ENABLED=true` and API key missing.
+- Not in Scope: live trading, strategy logic, wallet lifecycle expansion, dashboard expansion, broad Falcon feature work, Phase 9.2/9.3.
+- Method: patch-diff verification + targeted static/runtime-safe checks executable in this environment.
+
+## Phase 0 Checks
+
+- Forge report exists at expected path and includes MAJOR-format sections.
+- `PROJECT_STATE.md` existed with full timestamp format before validation.
+- Confirmed patch scope from commit diff: only removed required API-key raise in `configs/falcon.py`; no additional runtime-domain code changed.
+- `python -m py_compile` on touched runtime files passed.
+- `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` produced `1 skipped` and non-zero exit due environment dependency constraints.
+
+## Findings
+
+1. **Scope containment — PASS**
+   - Code delta is narrowly scoped to Falcon settings constructor contract.
+   - Removed guard: `if enabled and not api_key: raise RuntimeError(...)`.
+   - Timeout and base URL validation guards remain intact.
+
+2. **Missing API key under enabled mode no longer aborts app construction — PASS (code-path evidence)**
+   - `FalconSettings.from_env()` now returns object with empty `api_key` allowed when enabled mode is true.
+   - This unblocks `create_app()` call path from failing at config parse layer for this exact condition.
+
+3. **/ready semantics truthfulness retained — PASS (contract evidence)**
+   - `/ready` computes:
+     - `enabled_without_api_key = falcon_settings.enabled and not falcon_api_key_configured`
+     - `config_valid_for_enabled_mode = (not falcon_settings.enabled) or falcon_api_key_configured`
+   - Therefore under enabled mode with missing key, expected semantics remain:
+     - `enabled_without_api_key=true`
+     - `config_valid_for_enabled_mode=false`
+
+4. **Broader Falcon/runtime safety regression — NO NEW CRITICAL REGRESSION FOUND**
+   - Existing safety checks for invalid timeout and missing base URL in enabled mode are preserved.
+   - No strategy/risk/execution pipeline code was modified by this patch.
+
+## Score Breakdown
+
+- Scope adherence: 30/30
+- Contract correctness (config + readiness booleans): 30/30
+- Regression safety (targeted): 25/25
+- Runtime proof evidence completeness in current runner: 5/15
+
+**Total: 90/100**
+
+## Critical Issues
+
+- None found in scoped Falcon readiness contract implementation.
+
+## Status
+
+**CONDITIONAL**
+
+## PR Gate Result
+
+- Gate recommendation: **CONDITIONAL PASS** for scoped contract logic.
+- Condition to close fully as APPROVED-equivalent evidence chain: execute dependency-complete runtime test/CI run that instantiates app and hits `/ready` with `FALCON_ENABLED=true` and missing `FALCON_API_KEY`.
+
+## Broader Audit Finding
+
+- No out-of-scope runtime or safety surface changes were introduced by PR #671.
+
+## Reasoning
+
+The patch is tightly constrained and directly addresses the stated mismatch between app-construction behavior and `/ready` readiness semantics. Inability to execute FastAPI runtime surface in this environment is an evidence-depth limitation, not a contradiction in code-path logic.
+
+## Fix Recommendations
+
+1. Run external dependency-complete validation (GitHub Actions or equivalent) for:
+   - app construction with `FALCON_ENABLED=true` and missing API key,
+   - `/ready` response contract booleans,
+   - existing timeout/base-url negative guards.
+2. If external run passes, archive evidence and promote gate to final closure for Phase 9.1 readiness contract.
+
+## Out-of-scope Advisory
+
+- None.
+
+## Deferred Minor Backlog
+
+- Environment packaging baseline for local SENTINEL runtime checks remains incomplete (`fastapi` missing in this runner).
+
+## Telegram Visual Preview
+
+- N/A (SENTINEL validation artifact only).
+
+Done ✅ — GO-LIVE: CONDITIONAL. Score: 90/100. Critical: 0.
+Branch: feature/fix-phase-9-1-falcon-readiness-contract
+PR target: main (COMMANDER-requested SENTINEL delivery branch)
+Report: projects/polymarket/polyquantbot/reports/sentinel/phase9-1_02_falcon-readiness-contract-validation-pr671.md
+State: PROJECT_STATE.md updated
+NEXT GATE: Return to COMMANDER for final decision.


### PR DESCRIPTION
### Motivation
- Align Falcon config parsing with the runtime `/ready` surface so `FALCON_ENABLED=true` without `FALCON_API_KEY` does not abort app creation and is instead reported as an invalid readiness state. 
- Keep the change narrowly scoped to readiness/runtime contract behavior and avoid touching execution, trading, or risk surfaces. 
- Produce SENTINEL evidence and update project state to record the validation verdict and next gate.

### Description
- Removed the hard-fail guard for missing API key in `FalconSettings.from_env()` so app construction is allowed when `FALCON_ENABLED=true` and the API key is empty. 
- Verified `/ready` readiness booleans remain unchanged and still compute `enabled_without_api_key` and `config_valid_for_enabled_mode` as intended. 
- Added the SENTINEL report at `projects/polymarket/polyquantbot/reports/sentinel/phase9-1_02_falcon-readiness-contract-validation-pr671.md`. 
- Updated `PROJECT_STATE.md` timestamp and in-progress/next-priority wording to reflect the SENTINEL conditional validation and required external runtime proof.

### Testing
- Ran `python -m py_compile` on touched files which passed. 
- Executed `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` which resulted in `1 skipped` and did not produce full runtime proof due to environment dependency constraints. 
- Attempted FastAPI `TestClient` instantiation which failed in this runner with `ModuleNotFoundError: No module named 'fastapi'`. 
- Performed a direct runtime check by calling `FalconSettings.from_env()` in-process which confirmed `enabled == True` and `api_key_configured() == False`, and that `FALCON_TIMEOUT` and missing `FALCON_BASE_URL` guards still raise as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6868512988325b4e4e67a0bd064a0)