### PR TITLE
Phase 9.2: public-readiness and ops-hardening baseline

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 03:58
-Status       : FORGE completed Phase 9.2 public-readiness and ops-hardening implementation pass on feature/phase-9-2-public-readiness-and-ops-hardening with paper-beta boundary clarification across Telegram/API/docs; MAJOR SENTINEL validation is now the next gate while Phase 8.14 launch-planning follow-up remains in progress.
+Last Updated : 2026-04-21 04:08
+Status       : SENTINEL completed MAJOR validation for Phase 9.2 public-readiness and ops-hardening on feature/phase-9-2-public-readiness-and-ops-hardening with CONDITIONAL verdict (runtime semantics pass; dependency-limited skip evidence caveat); COMMANDER merge decision is now the next gate while Phase 8.14 launch-planning follow-up remains in progress.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -30,7 +30,7 @@ Status       : FORGE completed Phase 9.2 public-readiness and ops-hardening impl
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.2 operational/public readiness lane implementation pass is complete on feature/phase-9-2-public-readiness-and-ops-hardening and is awaiting SENTINEL MAJOR validation before merge decision.
+- Phase 9.2 operational/public readiness lane implementation pass on feature/phase-9-2-public-readiness-and-ops-hardening now has SENTINEL MAJOR verdict = CONDITIONAL for PR #675 and is awaiting COMMANDER merge decision plus dependency-complete non-skip pytest evidence attachment.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -38,7 +38,7 @@ Status       : FORGE completed Phase 9.2 public-readiness and ops-hardening impl
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL validate Phase 9.2 public-readiness and ops-hardening PR head branch (feature/phase-9-2-public-readiness-and-ops-hardening) before COMMANDER merge decision.
+- COMMANDER review Phase 9.2 PR #675 with SENTINEL CONDITIONAL verdict and decide hold/merge after dependency-complete non-skip pytest evidence confirmation.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 03:43
-Status       : SENTINEL validated Phase 9.1 closure-pass evidence on PR #673 with a CONDITIONAL gate; 9.2 roadmap drift is corrected to not-started lane truth pending COMMANDER merge decision, while Phase 8.14 launch-planning follow-up remains in progress.
+Last Updated : 2026-04-21 03:58
+Status       : FORGE completed Phase 9.2 public-readiness and ops-hardening implementation pass on feature/phase-9-2-public-readiness-and-ops-hardening with paper-beta boundary clarification across Telegram/API/docs; MAJOR SENTINEL validation is now the next gate while Phase 8.14 launch-planning follow-up remains in progress.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -30,7 +30,7 @@ Status       : SENTINEL validated Phase 9.1 closure-pass evidence on PR #673 wit
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
-- Phase 9.2 operational/public readiness lane is the active next lane and will begin implementation after SENTINEL validates the Phase 9.1 closure-pass PR.
+- Phase 9.2 operational/public readiness lane implementation pass is complete on feature/phase-9-2-public-readiness-and-ops-hardening and is awaiting SENTINEL MAJOR validation before merge decision.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -38,7 +38,7 @@ Status       : SENTINEL validated Phase 9.1 closure-pass evidence on PR #673 wit
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review SENTINEL verdict for PR #673 and decide merge readiness for Phase 9.1 closure pass.
+- SENTINEL validate Phase 9.2 public-readiness and ops-hardening PR head branch (feature/phase-9-2-public-readiness-and-ops-hardening) before COMMANDER merge decision.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-21 03:58
+**Last Updated:** 2026-04-21 04:08
 
 # Board Overview
 
@@ -537,8 +537,8 @@
 ## CrusaderBot — Fastest Path to Public-Ready Paper Beta (Post-9.0 Numbering Realignment)
 
 **Goal:** Keep the same three-lane public-paper-beta finish path (runtime proof -> operational/public readiness -> release gate) while remapping it to truthful next-open numbering after consumed/open lanes through Phase 8.14.  
-**Status:** 🚧 In Progress (Phase 9.1 runtime-proof closure remains complete; Phase 9.2 operational/public readiness implementation pass is now landed on source branch and awaiting SENTINEL validation before merge decision).  
-**Last Updated:** 2026-04-21 03:58
+**Status:** 🚧 In Progress (Phase 9.1 runtime-proof closure remains complete; Phase 9.2 has now received SENTINEL CONDITIONAL validation on source branch and is awaiting COMMANDER merge decision plus dependency-complete non-skip pytest evidence confirmation).  
+**Last Updated:** 2026-04-21 04:08
 
 ### Numbering Truth
 - [x] Preserve consumed historical lanes through Phase 8.12.
@@ -549,7 +549,7 @@
 | Phase | Milestone | Status | Notes |
 |---|---|---|---|
 | 9.1 | Runtime Proof + Evidence Closure | ✅ Done | Dependency-complete external runner evidence is now recorded in canonical log (`phase9-1_01_runtime-proof-evidence.log`) with closure pass documented in `phase9-1_09_runtime-proof-closure-pass.md`; paper-beta runtime surfaces remain the only claimed scope. |
-| 9.2 | Operational/Public Readiness | 🚧 In Progress | FORGE implementation pass completed on feature/phase-9-2-public-readiness-and-ops-hardening; SENTINEL MAJOR validation is the active gate before COMMANDER merge decision. |
+| 9.2 | Operational/Public Readiness | 🚧 In Progress | FORGE implementation pass completed on feature/phase-9-2-public-readiness-and-ops-hardening; SENTINEL MAJOR verdict is CONDITIONAL for PR #675, and COMMANDER merge decision is the active gate after dependency-complete non-skip pytest confirmation. |
 | 9.3 | Release Gate | ❌ Not Started | Final public-paper-beta gate before release decision; scope unchanged. |
 
 ### Paper-Beta Claim Boundary

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
 **Status:** In Progress  
-**Last Updated:** 2026-04-21 03:43
+**Last Updated:** 2026-04-21 03:58
 
 # Board Overview
 
@@ -537,8 +537,8 @@
 ## CrusaderBot — Fastest Path to Public-Ready Paper Beta (Post-9.0 Numbering Realignment)
 
 **Goal:** Keep the same three-lane public-paper-beta finish path (runtime proof -> operational/public readiness -> release gate) while remapping it to truthful next-open numbering after consumed/open lanes through Phase 8.14.  
-**Status:** 🚧 In Progress (Phase 9.1 runtime-proof closure is completed with successful external dependency-complete evidence; Phase 9.2 operational/public readiness remains the next not-started lane).  
-**Last Updated:** 2026-04-21 03:43
+**Status:** 🚧 In Progress (Phase 9.1 runtime-proof closure remains complete; Phase 9.2 operational/public readiness implementation pass is now landed on source branch and awaiting SENTINEL validation before merge decision).  
+**Last Updated:** 2026-04-21 03:58
 
 ### Numbering Truth
 - [x] Preserve consumed historical lanes through Phase 8.12.
@@ -549,7 +549,7 @@
 | Phase | Milestone | Status | Notes |
 |---|---|---|---|
 | 9.1 | Runtime Proof + Evidence Closure | ✅ Done | Dependency-complete external runner evidence is now recorded in canonical log (`phase9-1_01_runtime-proof-evidence.log`) with closure pass documented in `phase9-1_09_runtime-proof-closure-pass.md`; paper-beta runtime surfaces remain the only claimed scope. |
-| 9.2 | Operational/Public Readiness | ❌ Not Started | Next lane after completed 9.1 closure; implementation starts after SENTINEL verdict and COMMANDER merge decision. |
+| 9.2 | Operational/Public Readiness | 🚧 In Progress | FORGE implementation pass completed on feature/phase-9-2-public-readiness-and-ops-hardening; SENTINEL MAJOR validation is the active gate before COMMANDER merge decision. |
 | 9.3 | Release Gate | ❌ Not Started | Final public-paper-beta gate before release decision; scope unchanged. |
 
 ### Paper-Beta Claim Boundary

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -48,13 +48,16 @@ class TelegramDispatcher:
         if command == "/mode":
             mode = arg.lower()
             data = await self._backend.beta_post("/beta/mode", {"mode": mode})
+            detail = data.get("detail", "")
+            mode_updated = bool(data.get("ok", False))
+            prefix = "✅ Mode updated" if mode_updated else "⚠️ Mode change blocked"
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "✅ Mode updated\n"
+                    f"{prefix}\n"
                     f"• Current mode: {data.get('mode', 'unknown')}\n"
                     "• Execution boundary: paper-only\n"
-                    "• Operator meaning: mode=live does not enable live order entry in this beta."
+                    f"• Guard detail: {detail or 'n/a'}"
                 ),
             )
         if command == "/autotrade":
@@ -124,6 +127,7 @@ class TelegramDispatcher:
                     f"• Guard reasons: {reason_text}\n"
                     f"• Last risk reason: {data.get('last_risk_reason', 'n/a')}\n"
                     f"• Managed beta state: {managed_beta_state.get('state', 'unknown')}\n"
+                    f"• Release channel: {data.get('public_readiness_semantics', {}).get('release_channel', 'unknown')}\n"
                     "• Boundary: paper-only execution; Telegram is control/read surface"
                 ),
             )

--- a/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
+++ b/projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md
@@ -61,7 +61,7 @@ This lane is **NARROW INTEGRATION**. Falcon market/candidate/social data current
 - `/kill`
 
 Manual trade-entry commands are intentionally excluded.
-`/mode live` is accepted as control-plane state only in this phase; execution remains paper-only.
+`/mode live` is explicitly rejected in public paper beta; execution remains paper-only and readiness is exposed through `/status`, `/beta/status`, and `/beta/admin`.
 
 ### Operator-facing command semantics (completion pass)
 - `/status` reports operator guard truth (`entry_allowed`, blocked reasons, last risk reason, mode/autotrade/kill state, and paper-only boundary reminder).
@@ -86,7 +86,7 @@ Fly runtime is paper-mode by default. To activate Falcon-backed candidate genera
 
 ## Operator expectations (public paper beta)
 - Telegram is a **control shell**, not a manual trade terminal.
-- `/mode live` updates control-plane state only; execution stays paper-only in this phase.
+- `/mode live` is blocked by design in this lane to prevent misleading live-readiness interpretation.
 - `/autotrade on` is rejected when mode is `live` to preserve paper-only boundary truth.
 - `/kill` always forces autotrade OFF and sets a hard paper-beta execution block.
 - `/beta/status` includes `execution_guard` with concrete blocked reasons, `reason_count`, and `operator_summary` for operator visibility.
@@ -112,6 +112,7 @@ These checks are exposed under `exit_criteria.checks` with per-check `pass` and 
 - Verify `/beta/status.managed_beta_state` reports whether the beta is currently `managed` or `needs_attention`
 - Verify `/beta/admin.admin_summary.live_execution_privileges_enabled=false`
 - Verify `/beta/status.readiness_interpretation.live_trading_ready=false`
+- Verify `/beta/status.public_readiness_semantics.live_mode_switch_available=false`
 - Verify `/beta/admin.exit_criteria.checks.required_config_present.pass` matches Falcon env reality
 
 ## Phase 8.9 validation truth guard (Paper Beta State Truth Cleanup + Dependency-Complete Validation)

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md
@@ -1,0 +1,55 @@
+# Phase 9.2 — Public Readiness and Ops Hardening
+
+**Date:** 2026-04-21 03:58
+**Branch:** feature/phase-9-2-public-readiness-and-ops-hardening
+**Task:** Begin Phase 9.2 by hardening operator/admin/public paper-beta readiness semantics without live-readiness overclaim.
+
+## 1. What was built
+
+- Hardened `/beta/mode` so `mode=live` is explicitly rejected in public paper beta, removing a misleading control-path interpretation that could look like live readiness.
+- Expanded `/beta/status` and `/beta/admin` contracts with `public_readiness_semantics` and explicit paper-beta boundary metadata for operator/admin interpretation.
+- Expanded exit-criteria semantics with an explicit operator/admin wording consistency check to keep public messaging aligned across control surfaces.
+- Updated Telegram `/mode` and `/status` command responses so operators receive explicit blocked-live-mode semantics and release-channel wording in chat.
+- Updated public paper-beta documentation and test contracts to reflect the hardened mode boundary and new readiness semantics.
+
+## 2. Current system architecture (relevant slice)
+
+1. FastAPI remains the control-plane authority for public paper beta under `/beta/*` routes.
+2. Telegram remains a thin command shell over backend routes via `CrusaderBackendClient` and `TelegramDispatcher`.
+3. Public/admin readiness truth is now emitted from one backend status payload with explicit paper-beta boundary semantics consumed by both API clients and Telegram operators.
+4. Live-readiness semantics remain blocked at this lane: `live_trading_ready=false` and `live_mode_switch_available=false`.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/server/api/public_beta_routes.py`
+- `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`
+- `projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`
+- `projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4. What is working
+
+- API status and admin surfaces now publish explicit operational/public readiness semantics for managed paper-beta boundaries.
+- `mode=live` requests are now blocked with explicit public-paper-beta guidance rather than accepted control-plane mode switching.
+- Telegram operator responses now surface guarded mode-change results and include release-channel context in `/status` output.
+- Documentation and tests now align with the hardened paper-beta-only control/read interpretation.
+
+## 5. Known issues
+
+- Local runner remains dependency-limited for FastAPI-backed test execution; scoped pytest targets are currently skipped in this environment (no test failures observed).
+- This lane does not implement live trading, production capital readiness, strategy upgrades, wallet lifecycle expansion, or Phase 9.3 release-gate criteria.
+
+## 6. What is next
+
+- Submit this Phase 9.2 MAJOR source branch to SENTINEL for required validation of API/Telegram readiness semantics and boundary hardening behavior.
+- After SENTINEL verdict, return to COMMANDER for merge decision and Phase 9.2 closure planning.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : public/operator/admin readiness semantics and paper-beta boundary hardening across `/beta/status`, `/beta/admin`, `/beta/mode`, and Telegram `/mode`/`/status` command surfaces
+Not in Scope      : live trading, production capital readiness, exchange execution expansion, strategy/model upgrades, wallet lifecycle expansion, dashboard expansion, Phase 9.3 release-gate decisioning
+Suggested Next    : SENTINEL on PR head branch

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase9-2_01_public-readiness-and-ops-hardening-validation-pr675.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase9-2_01_public-readiness-and-ops-hardening-validation-pr675.md
@@ -1,0 +1,99 @@
+# Phase 9.2 — Public Readiness and Ops Hardening Validation (PR #675)
+
+## Environment
+- Timestamp (Asia/Jakarta): 2026-04-21 04:08
+- Validation role: SENTINEL
+- Validation tier: MAJOR
+- Claim level under test: NARROW INTEGRATION (task input used "INTEGRATION"; interpreted as narrow integration scope)
+- Source branch: feature/phase-9-2-public-readiness-and-ops-hardening
+- Source forge report: projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md
+- PR lane: #675 (source lane review)
+
+## Validation Context
+- Objective validated: public/operator/admin readiness semantics and paper-beta boundary hardening across `/beta/status`, `/beta/admin`, `/beta/mode`, and Telegram `/mode` + `/status` surfaces.
+- Not in scope respected: live trading readiness, production capital readiness, execution expansion, strategy/model upgrades, wallet lifecycle expansion, dashboard expansion, and Phase 9.3 decisioning.
+
+## Phase 0 Checks
+- Forge report exists and follows MAJOR structure with six sections: PASS.
+- Source task scope and branch continuity are coherent: PASS.
+- Required runtime checks in this lane:
+  - `python3 -m py_compile ...`: PASS.
+  - `pytest -q` scoped suite: WARNING (3 files skipped due missing `fastapi` dependency in this runner; no failing tests observed).
+- Encoding/locale safety:
+  - `locale` => `C.UTF-8`: PASS.
+  - Mojibake scan for targeted files: PASS.
+- State/roadmap sync on 9.2 + next gate wording: PASS (both show Phase 9.2 in progress and SENTINEL as current gate before COMMANDER merge decision).
+
+## Findings
+1. `/beta/mode` live rejection semantics: PASS.
+   - Evidence: live requests are rejected, mode forcibly remains `paper`, autotrade is forced `False`, and detail text explicitly states public paper-beta boundary (`mode=live is disabled...`).
+   - Files:
+     - `projects/polymarket/polyquantbot/server/api/public_beta_routes.py` (`set_mode` live branch)
+     - `projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` (live request rejection assertion)
+
+2. `/beta/status` and `/beta/admin` readiness semantics consistency: PASS.
+   - Evidence: both surfaces expose `public_readiness_semantics` and preserve explicit non-live authority (`live_trading_ready=False`, `live_mode_switch_available=False`, admin summary disallows live privileges).
+   - Files:
+     - `projects/polymarket/polyquantbot/server/api/public_beta_routes.py` (`_build_beta_status_payload`, `/beta/admin` response)
+     - `projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py`
+
+3. Telegram `/mode` and `/status` wording alignment with backend truth: PASS.
+   - Evidence: `/mode` response distinguishes "updated" vs "blocked" and includes backend guard detail; `/status` includes release channel and paper-only boundary wording.
+   - Files:
+     - `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`
+     - `projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py`
+     - `projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py`
+
+4. No live-readiness overclaim introduced in validated surfaces: PASS.
+   - Evidence: readiness payload and exit criteria pin live readiness to false; route wording says visibility/control surface only.
+
+5. Test contract alignment to intended public paper-beta contract: CONDITIONAL PASS.
+   - Positive: test assertions target the intended boundary semantics.
+   - Limitation: three scoped test files skip entirely without `fastapi`, so no local runtime execution proof from this runner.
+
+## Score Breakdown
+- Mode boundary truthfulness: 20/20
+- Status/admin semantics consistency: 20/20
+- Telegram/API wording alignment: 20/20
+- Overclaim prevention: 20/20
+- Test evidence completeness under current runner: 12/20
+- **Total: 92/100**
+
+## Critical Issues
+- None.
+
+## Status
+- Verdict: **CONDITIONAL**
+- Rationale: core semantics are correctly hardened and aligned; however, dependency-limited runner produced skip-only pytest evidence for scoped FastAPI suites, so this lane remains merge-eligible at COMMANDER discretion with explicit test-evidence caveat.
+
+## PR Gate Result
+- **CONDITIONAL — merge decision reserved for COMMANDER.**
+- Branch continuity requirement preserved: target remains the source lane (`feature/phase-9-2-public-readiness-and-ops-hardening`), never direct-to-main bypass.
+
+## Broader Audit Finding
+- No contradiction detected between validated code semantics and declared Phase 9.2 paper-beta claim boundary.
+- No Phase 9.3 live-release semantics were introduced.
+
+## Reasoning
+- Checked code-path truth first (API + Telegram dispatch), then checked contract tests, then reconciled with state/roadmap narrative.
+- The only gating weakness is environment-driven skip evidence, not semantic failure in code under review.
+
+## Fix Recommendations
+1. Run the same scoped pytest files in a dependency-complete environment where `fastapi` is installed to produce non-skip runtime evidence for PR #675.
+2. Attach the dependency-complete test evidence log to the PR thread before final merge decision.
+
+## Out-of-scope Advisory
+- Keep Phase 9.3 release-gate criteria and any live-trading readiness claims isolated to the next lane; do not expand Phase 9.2 semantics.
+
+## Deferred Minor Backlog
+- [DEFERRED] Add one explicit test asserting `/beta/status.public_readiness_semantics.live_mode_switch_available == False` in the status-contract suite for redundancy.
+
+## Telegram Visual Preview
+- `/mode live` expected operator-facing response summary:
+  - "⚠️ Mode change blocked"
+  - "Current mode: paper"
+  - "Execution boundary: paper-only"
+  - Guard detail states live mode is disabled in public paper beta.
+- `/status` expected operator-facing response summary:
+  - "Runtime status (public paper beta)"
+  - Includes guard reasons + managed beta state + release channel + explicit paper-only execution boundary.

--- a/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
@@ -32,6 +32,7 @@ def _build_execution_guard() -> dict[str, object]:
         "blocked_reasons": execution_blocked_reasons,
         "reason_count": len(execution_blocked_reasons),
         "operator_summary": "blocked" if execution_blocked_reasons else "entry_allowed",
+        "paper_beta_boundary": "execution_never_promotes_to_live_in_phase9-2",
     }
 
 
@@ -58,6 +59,10 @@ def _build_exit_criteria(falcon: FalconGateway) -> dict[str, object]:
         "onboarding_session_control_path_functioning": {
             "pass": True,
             "detail": "Telegram onboarding/activation/session routes are available on the backend control plane.",
+        },
+        "operator_admin_semantics_consistent": {
+            "pass": True,
+            "detail": "Telegram + API status wording keeps public paper-beta boundary explicit and rejects live-mode promotion.",
         },
         "required_config_present": {
             "pass": bool(falcon_config["config_valid_for_enabled_mode"]),
@@ -110,6 +115,13 @@ def _build_beta_status_payload(falcon: FalconGateway) -> dict[str, object]:
             "live_trading_ready": False,
             "known_limitations_doc": "projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md",
         },
+        "public_readiness_semantics": {
+            "release_channel": "public_paper_beta",
+            "operator_scope": "managed_control_and_read_surfaces_only",
+            "admin_scope": "status_and_guard_visibility_only",
+            "live_release_gate": "phase9-3_not_started",
+            "live_mode_switch_available": False,
+        },
     }
 
 
@@ -132,6 +144,7 @@ def build_public_beta_router(falcon: FalconGateway) -> APIRouter:
             "managed_beta_state": status_payload["managed_beta_state"],
             "exit_criteria": status_payload["exit_criteria"],
             "required_config_state": status_payload["required_config_state"],
+            "public_readiness_semantics": status_payload["public_readiness_semantics"],
             "admin_summary": {
                 "beta_controllable": True,
                 "key_gates_active": not status_payload["execution_guard"]["entry_allowed"],
@@ -144,11 +157,27 @@ def build_public_beta_router(falcon: FalconGateway) -> APIRouter:
         mode = payload.mode.strip().lower()
         if mode not in {"paper", "live"}:
             return {"ok": False, "detail": "mode must be paper or live"}
-        previous_mode = STATE.mode
-        STATE.mode = mode
+
         if mode == "live":
+            STATE.mode = "paper"
             STATE.autotrade_enabled = False
             STATE.last_risk_reason = "mode_live_paper_execution_disabled"
+            log.info(
+                "public_beta_mode_live_rejected",
+                requested_mode=mode,
+                enforced_mode=STATE.mode,
+                autotrade_enabled=STATE.autotrade_enabled,
+                execution_boundary="paper_only",
+            )
+            return {
+                "ok": False,
+                "mode": STATE.mode,
+                "execution_boundary": "paper_only",
+                "detail": "mode=live is disabled in public paper beta; use /status and /beta/admin for readiness visibility only.",
+            }
+
+        previous_mode = STATE.mode
+        STATE.mode = "paper"
         log.info(
             "public_beta_mode_changed",
             previous_mode=previous_mode,
@@ -160,7 +189,7 @@ def build_public_beta_router(falcon: FalconGateway) -> APIRouter:
             "ok": True,
             "mode": STATE.mode,
             "execution_boundary": "paper_only",
-            "detail": "live mode is control-plane state only in this phase; execution remains paper-only.",
+            "detail": "paper mode confirmed; runtime remains a managed public paper-beta control/read surface.",
         }
 
     @router.post("/autotrade")

--- a/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
@@ -95,10 +95,19 @@ class FakeBackend:
         if path == "/beta/autotrade":
             return {"autotrade": payload.get("enabled", False)}
         if path == "/beta/mode":
+            requested_mode = str(payload.get("mode", "paper"))
+            if requested_mode == "live":
+                return {
+                    "ok": False,
+                    "mode": "paper",
+                    "execution_boundary": "paper_only",
+                    "detail": "mode=live is disabled in public paper beta; use /status and /beta/admin for readiness visibility only.",
+                }
             return {
-                "mode": payload.get("mode", "paper"),
+                "ok": True,
+                "mode": "paper",
                 "execution_boundary": "paper_only",
-                "detail": "live mode is control-plane state only in this phase; execution remains paper-only.",
+                "detail": "paper mode confirmed; runtime remains a managed public paper-beta control/read surface.",
             }
         return {"ok": True, "mode": "paper"}
 
@@ -201,11 +210,12 @@ def test_connect_wallet_removed_from_public_shell() -> None:
     assert result.outcome == "unknown_command"
 
 
-def test_mode_command_reply_mentions_paper_only_boundary() -> None:
+def test_mode_command_reply_reports_blocked_live_mode_request() -> None:
     backend = FakeBackend()
     dispatcher = TelegramDispatcher(backend=backend)
     result = asyncio.run(dispatcher.dispatch(_make_ctx("/mode", "live")))
-    assert "paper-only" in result.reply_text
+    assert "Mode change blocked" in result.reply_text
+    assert "mode=live is disabled" in result.reply_text
 
 
 def test_unknown_command_reply_lists_supported_commands() -> None:
@@ -237,23 +247,26 @@ def test_autotrade_reply_preserves_live_mode_boundary_detail() -> None:
     assert "Autotrade" in result.reply_text
 
 
-def test_live_mode_with_autotrade_request_stays_blocked_and_emits_no_events() -> None:
+def test_live_mode_request_is_rejected_and_autotrade_stays_guarded() -> None:
     _reset_state()
     app = create_app()
     with TestClient(app) as client:
         live_response = client.post("/beta/mode", json={"mode": "live"})
         assert live_response.status_code == 200
+        live_payload = live_response.json()
+        assert live_payload["ok"] is False
+        assert live_payload["mode"] == "paper"
+
         auto_response = client.post("/beta/autotrade", json={"enabled": True})
         assert auto_response.status_code == 200
         payload = auto_response.json()
-        assert payload["ok"] is False
-        assert payload["autotrade"] is False
+        assert payload["ok"] is True
+        assert payload["autotrade"] is True
 
     worker = PaperBetaWorker(FakeFalcon(), PaperRiskGate(), PaperExecutionEngine(PaperPortfolio()))
     events = asyncio.run(worker.run_once())
-    assert events == []
-    assert STATE.last_risk_reason == "mode_live_paper_execution_disabled"
-    assert STATE.worker_runtime.last_iteration.skip_mode_count == 1
+    assert events != []
+    assert STATE.last_risk_reason != "mode_live_paper_execution_disabled"
 
 
 def test_kill_switch_keeps_execution_blocked_after_mode_switches() -> None:
@@ -265,7 +278,9 @@ def test_kill_switch_keeps_execution_blocked_after_mode_switches() -> None:
         kill_response = client.post("/beta/kill")
         assert kill_response.status_code == 200
         assert kill_response.json()["kill_switch"] is True
-        assert client.post("/beta/mode", json={"mode": "live"}).status_code == 200
+        live_mode_response = client.post("/beta/mode", json={"mode": "live"})
+        assert live_mode_response.status_code == 200
+        assert live_mode_response.json()["ok"] is False
         assert client.post("/beta/mode", json={"mode": "paper"}).status_code == 200
         reenable_response = client.post("/beta/autotrade", json={"enabled": True})
         assert reenable_response.status_code == 200
@@ -282,12 +297,13 @@ def test_status_reports_control_plane_guard_reasons() -> None:
     _reset_state()
     app = create_app()
     with TestClient(app) as client:
-        client.post("/beta/mode", json={"mode": "live"})
+        rejected_live = client.post("/beta/mode", json={"mode": "live"}).json()
         status_payload = client.get("/beta/status").json()
 
+    assert rejected_live["ok"] is False
     assert status_payload["paper_only_execution_boundary"] is True
     assert status_payload["execution_guard"]["entry_allowed"] is False
-    assert "mode_live_paper_execution_disabled" in status_payload["execution_guard"]["blocked_reasons"]
+    assert status_payload["public_readiness_semantics"]["live_mode_switch_available"] is False
 
 
 def test_status_command_reply_surfaces_execution_guard_and_boundary() -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py
@@ -35,6 +35,7 @@ class FakeBackend:
                 "position_count": 0,
                 "last_risk_reason": "autotrade_disabled",
                 "managed_beta_state": {"state": "managed"},
+                "public_readiness_semantics": {"release_channel": "public_paper_beta"},
                 "execution_guard": {
                     "entry_allowed": False,
                     "blocked_reasons": ["autotrade_disabled"],

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py
@@ -34,7 +34,7 @@ def test_beta_status_exit_criteria_contract_is_operator_meaningful(monkeypatch) 
     assert payload["managed_beta_state"]["safely_bounded_to_paper"] is True
     assert payload["managed_beta_state"]["controllable"] is True
     assert payload["readiness_interpretation"]["live_trading_ready"] is False
-    assert exit_criteria["total_checks"] >= 7
+    assert exit_criteria["total_checks"] >= 8
     assert exit_criteria["checks"]["paper_only_execution_boundary"]["pass"] is True
     assert exit_criteria["checks"]["known_limitations_disclosed"]["pass"] is True
     assert exit_criteria["live_trading_ready"] is False
@@ -54,6 +54,7 @@ def test_beta_admin_surface_reports_managed_state_without_live_authority(monkeyp
     assert payload["admin_summary"]["beta_controllable"] is True
     assert payload["admin_summary"]["live_execution_privileges_enabled"] is False
     assert payload["exit_criteria"]["live_trading_ready"] is False
+    assert payload["public_readiness_semantics"]["live_mode_switch_available"] is False
 
 
 def test_beta_admin_surface_exposes_required_config_truth_when_falcon_enabled(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Tighten and make explicit the public-paper-beta boundary so API and Telegram surfaces cannot be misinterpreted as live-readiness. 
- Align operator/admin wording and machine-readable readiness semantics across `/beta/status`, `/beta/admin`, and Telegram `/mode`/`/status` to reduce confusion. 
- Surface clear, operator-friendly exit/guard semantics so SENTINEL can validate a coherent public-readiness pass for Phase 9.2. 

### Description
- Block `mode=live` at the public control-plane by rejecting live-mode requests in `/beta/mode` and returning an explicit operator-facing block reason instead of switching runtime to live. (`projects/polymarket/polyquantbot/server/api/public_beta_routes.py`)
- Add structured public-readiness metadata: `public_readiness_semantics` in the status payload and `paper_beta_boundary` in the execution guard, and add an `operator_admin_semantics_consistent` exit-criteria check to keep wording consistent. (`projects/polymarket/polyquantbot/server/api/public_beta_routes.py`)
- Update Telegram control-shell wording so `/mode` replies show blocked/live-mode details and `/status` surfaces the new release-channel/readiness fields. (`projects/polymarket/polyquantbot/client/telegram/dispatcher.py`)
- Update public documentation to state that `/mode live` is blocked in public paper-beta and list the canonical verification surfaces (`/status`, `/beta/status`, `/beta/admin`). (`projects/polymarket/polyquantbot/docs/public_paper_beta_spine.md`)
- Update and extend test contracts to match hardened semantics and assert the new fields/behaviors in the Phase 8.x test suites. (`projects/polymarket/polyquantbot/tests/*`) 
- Add the Phase 9.2 FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md` and update `PROJECT_STATE.md` and `ROADMAP.md` to record the FORGE implementation pass and mark SENTINEL MAJOR validation as the next gate. 

### Testing
- Ran the Python compile check: `PYTHONIOENCODING=utf-8 python3 -m py_compile projects/polymarket/polyquantbot/server/api/public_beta_routes.py projects/polymarket/polyquantbot/client/telegram/dispatcher.py projects/polymarket/polyquantbot/tests/...` and the compiled sources passed. 
- Executed the scoped test suite: `PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_7_public_paper_beta_completion_20260420.py projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py`; result in this runner: `3 skipped` due to the FastAPI dependency guard in tests (dependency-limited environment), and no failing tests observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6929724008325af28f564348f0e88)