### PR TITLE
Post-release public-facing launch assets pack for Phase 9.3

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 04:56
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on main with paper-only boundary preserved; Crusader is not live-trading ready and not production-capital ready, while Phase 8.14 launch-planning follow-up remains in progress.
+Last Updated : 2026-04-21 05:34
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on main with paper-only boundary preserved; post-release public-facing launch asset pack is now prepared for COMMANDER review; Crusader remains not live-trading ready and not production-capital ready while Phase 8.14 launch-planning follow-up remains in progress.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -29,6 +29,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on
 - Phase 9.1 dependency-complete runtime-proof closure is completed with refreshed canonical evidence log (`projects/polymarket/polyquantbot/reports/forge/phase9-1_01_runtime-proof-evidence.log`) and closure report (`projects/polymarket/polyquantbot/reports/forge/phase9-1_09_runtime-proof-closure-pass.md`).
 - Phase 9.2 operational/public readiness and ops-hardening truth is now treated as landed for release-gate continuity with FORGE report `projects/polymarket/polyquantbot/reports/forge/phase9-2_01_public-readiness-and-ops-hardening.md` and SENTINEL validation `projects/polymarket/polyquantbot/reports/sentinel/phase9-2_01_public-readiness-and-ops-hardening-validation-pr675.md` as the canonical evidence pair.
 - Phase 9.3 public paper-beta release gate is completed on main with SENTINEL validation recorded in `projects/polymarket/polyquantbot/reports/sentinel/phase9-3_01_public-release-gate-validation-pr677.md`; public-ready paper beta path is now complete with explicit paper-only boundary and no live-trading/production-capital readiness claim.
+- Phase 9.3 post-release public-facing launch assets pack is completed with coherent readiness/posture/boundary/onboarding/announcement docs and wording-audit alignment to paper-only truth under `projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md`.
 
 [IN PROGRESS]
 - Phase 8.14 Walker DevOps launch-planning app FOUNDATION lane is reopened as actionable source truth under feature/reopen-phase-8.14-launch-planning-foundation-2026-04-20; baseline implementation remains in projects/app/walker_devops and dependency-complete runtime verification is still pending package-accessible npm install plus OPENAI_API_KEY in a capable runner.
@@ -39,7 +40,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Prepare post-release readiness summary and launch posture assets (onboarding + announcement package) for the completed public-ready paper beta lane while preserving paper-only claim boundaries.
+- COMMANDER review for post-release public-facing launch assets pack and messaging approval.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/docs/announcement_package_draft.md
+++ b/projects/polymarket/polyquantbot/docs/announcement_package_draft.md
@@ -1,0 +1,25 @@
+# CrusaderBot Announcement Package Draft
+
+## Short Version
+CrusaderBot is now available in a public-ready **paper beta** format with managed operator oversight. This launch is paper-only and does not claim live-trading or production-capital readiness.
+
+## Medium Version
+We are launching CrusaderBot in a public-ready paper beta posture. The current release reflects completion of the 9.1, 9.2, and 9.3 closure path for paper-beta readiness, with Telegram and FastAPI control surfaces operating under managed oversight.
+
+This is intentionally a paper-only boundary: CrusaderBot is not live-trading ready, not production-capital ready, and not positioned for unrestricted production execution at this stage.
+
+## Founder-Facing Launch Copy Draft
+Today we are opening CrusaderBot as a public-ready paper beta after closing the 9.1, 9.2, and 9.3 release path for this stage. We are deliberately launching with managed operator oversight and explicit paper-only boundaries.
+
+This launch is built for transparent beta usage, feedback, and operational discipline. We are not claiming live-trading readiness, production-capital readiness, or unrestricted production execution in this release lane.
+
+## What This Is / What This Is Not
+### What this is
+- A public-ready, operator-managed paper beta launch
+- A controlled onboarding and communication posture
+- A truthful release state aligned with current repository truth
+
+### What this is not
+- Not live-trading ready
+- Not production-capital ready
+- Not unrestricted production execution

--- a/projects/polymarket/polyquantbot/docs/launch_posture_summary.md
+++ b/projects/polymarket/polyquantbot/docs/launch_posture_summary.md
@@ -1,0 +1,28 @@
+# CrusaderBot Launch Posture Summary
+
+## What Can Be Launched Now
+CrusaderBot can be launched publicly as a **managed paper beta** with controlled onboarding, operator oversight, and transparent boundary messaging.
+
+## What Should Be Communicated Publicly
+Public communication should consistently state that CrusaderBot:
+- is available as a public-ready paper beta
+- operates under an operator-managed model
+- has explicit paper-only execution boundaries
+- is intentionally constrained for safe beta learning
+
+## What Remains Intentionally Out of Scope
+The current launch posture does not include claims for:
+- live-trading readiness
+- production-capital readiness
+- unrestricted production execution
+
+## Operator Posture During Public Beta
+Operators should maintain:
+- active oversight of beta usage and runtime status
+- strict adherence to paper-only constraints
+- clear user communication on capability boundaries
+- conservative escalation and incident response discipline
+
+## Truth Framing
+- **What is true now:** public-ready paper beta with managed controls.
+- **What is not claimed:** production/live trading readiness.

--- a/projects/polymarket/polyquantbot/docs/onboarding_summary_user_operator.md
+++ b/projects/polymarket/polyquantbot/docs/onboarding_summary_user_operator.md
@@ -1,0 +1,30 @@
+# CrusaderBot Onboarding Summary (User + Operator)
+
+## Who This Beta Is For
+This beta is for users and operators who want to evaluate CrusaderBot behavior, workflow, and controls in a paper-only environment.
+
+## What Users Can Do
+Users can:
+- interact with the beta experience through the published control surfaces
+- review status and behavior within the paper-beta boundary
+- provide product and usability feedback for future hardening
+
+## What Operators Should Watch
+Operators should monitor:
+- boundary adherence (paper-only execution)
+- user expectation alignment (no overclaim to live/production behavior)
+- runtime status continuity and operational clarity
+- issue reporting and response discipline during public beta
+
+## Limitations Users Must Understand
+Before use, users must understand:
+- this is not live-trading deployment
+- this is not production-capital deployment
+- execution posture is intentionally constrained for beta safety
+- operator oversight remains a core part of the beta model
+
+## How to Interpret Readiness/Status Boundaries
+At a high level:
+- readiness = public-ready for paper beta
+- boundary = paper-only, managed, intentionally limited
+- non-claim = no live-trading/production-capital readiness implied

--- a/projects/polymarket/polyquantbot/docs/paper_only_boundary_statement.md
+++ b/projects/polymarket/polyquantbot/docs/paper_only_boundary_statement.md
@@ -1,0 +1,13 @@
+# CrusaderBot Paper-Only Boundary Statement
+
+CrusaderBot is released in a **paper-beta only** posture.
+
+## Boundary Declaration
+- Paper beta only
+- Not live-trading ready
+- Not production-capital ready
+- Not approved for unrestricted production execution
+- Operator-managed beta posture is required
+
+## Reusable External Statement
+"CrusaderBot is currently offered as a managed public paper beta. It is not live-trading ready, not production-capital ready, and is intentionally limited to paper-only execution boundaries."

--- a/projects/polymarket/polyquantbot/docs/post_release_readiness_summary.md
+++ b/projects/polymarket/polyquantbot/docs/post_release_readiness_summary.md
@@ -1,0 +1,23 @@
+# CrusaderBot Post-Release Readiness Summary
+
+## Current Readiness Snapshot
+CrusaderBot is **public-ready for paper beta** with the Phase 9 closure path complete:
+- Phase 9.1 runtime proof closure: complete
+- Phase 9.2 operational/public readiness closure: complete
+- Phase 9.3 public paper-beta release gate closure: complete
+
+## Operating Surfaces Included in This Readiness
+The current paper-beta release posture includes:
+- Telegram control surface for operator/user interaction
+- FastAPI control plane for runtime control and service boundaries
+- Managed operator oversight during beta operation
+
+## Explicit Boundary (Authoritative)
+CrusaderBot is currently positioned as:
+- **Paper-beta ready**
+- **Paper-only execution boundary**
+- **Not live-trading ready**
+- **Not production-capital ready**
+
+## What This Summary Confirms
+This summary confirms launch-facing readiness for a public paper-beta lane only. It does **not** claim unrestricted production execution, live-capital deployment, or production trading readiness.

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md
@@ -1,0 +1,32 @@
+# Phase 9.3 — Post-Release Public-Facing Launch Assets Pack
+
+**Date:** 2026-04-21 05:34
+**Branch:** feature/post-release-public-facing-launch-assets
+**Task:** Build one coherent post-release public-facing launch asset pack for CrusaderBot without introducing live-trading or production-capital overclaim.
+
+## 1. What was changed
+
+- Created a post-release readiness summary documenting public-ready paper beta truth and completed 9.1 / 9.2 / 9.3 closure path.
+- Created a launch posture summary defining what can be launched now, what to communicate publicly, what remains out of scope, and required operator posture.
+- Created a reusable paper-only boundary statement for external/internal communication consistency.
+- Created a combined user/operator onboarding summary with explicit readiness-boundary interpretation guidance.
+- Created an announcement package draft with short, medium, founder-facing, and "what this is / what this is not" sections.
+- Ran wording audit against all new launch-facing assets to enforce no live-readiness, production-capital, or unrestricted production wording.
+
+## 2. Files modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/docs/post_release_readiness_summary.md`
+- `projects/polymarket/polyquantbot/docs/launch_posture_summary.md`
+- `projects/polymarket/polyquantbot/docs/paper_only_boundary_statement.md`
+- `projects/polymarket/polyquantbot/docs/onboarding_summary_user_operator.md`
+- `projects/polymarket/polyquantbot/docs/announcement_package_draft.md`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md`
+- `PROJECT_STATE.md`
+
+## 3. Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
+
+Validation Tier   : MINOR
+Claim Level       : PUBLIC-FACING DOCS / LAUNCH ASSETS
+Validation Target : post-release public launch-facing documentation pack and wording-boundary coherence across all five assets
+Not in Scope      : runtime code, API behavior, Telegram behavior, monitor/dashboard logic, live-trading readiness claims, production-capital readiness claims
+Suggested Next    : COMMANDER review


### PR DESCRIPTION
### Motivation
- Produce a single coherent post-release asset pack that documents launch posture, onboarding, announcement drafts, and a reusable paper-only boundary for CrusaderBot. 
- Preserve the repository truth that the system is a public-ready paper beta and explicitly avoid any live-trading or production-capital claims. 
- Provide founder- and operator-usable messaging and prepare the assets for COMMANDER review without touching runtime code. 

### Description
- Added five public-facing docs under `projects/polymarket/polyquantbot/docs/`: `post_release_readiness_summary.md`, `launch_posture_summary.md`, `paper_only_boundary_statement.md`, `onboarding_summary_user_operator.md`, and `announcement_package_draft.md`. 
- Added FORGE-X report `projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md` which documents the change and validation declaration. 
- Updated `PROJECT_STATE.md` to note the launch-assets pack is prepared for COMMANDER review and set the next gate to COMMANDER review, without altering unrelated state lines. 
- No runtime, API, Telegram, monitoring, or production behavior changes were made. 
- Report: `projects/polymarket/polyquantbot/reports/forge/phase9-3_03_post-release-launch-assets-pack.md`; State: `PROJECT_STATE.md`; Validation Tier: `MINOR`; Claim Level: `PUBLIC-FACING DOCS / LAUNCH ASSETS`. 

### Testing
- Verified branch is `feature/post-release-public-facing-launch-assets` with `git rev-parse --abbrev-ref HEAD` and `git status` showing the staged changes. 
- Verified UTF-8 locale via `locale` and used `TZ=Asia/Jakarta date '+%Y-%m-%d %H:%M'` to derive the required Asia/Jakarta timestamp for `PROJECT_STATE.md`. 
- Performed mojibake checks using fixed-string `rg` patterns for common corruption sequences (no matches). 
- Confirmed the new files exist and the FORGE report lists all modified files and the validation block. 
- Environment note: an attempted `pytz`-based timestamp command failed with `ModuleNotFoundError: No module named 'pytz'`, but the `TZ` fallback produced the correct Jakarta timestamp and did not block the work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a9ca171c8325890b340dae0e8ca2)