### PR TITLE
Phase 9.3: capture deploy/runtime truth blocker evidence

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 05:29
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on main with paper-only boundary preserved; Crusader is not live-trading ready and not production-capital ready, and Phase 8.14 launch-planning foundation is now historical-complete truth.
+Last Updated : 2026-04-21 05:41
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main with paper-only boundary preserved; independent external deploy/runtime revalidation is currently blocked in this runner by outbound Fly endpoint access limits and requires Fly-accessible validation evidence.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -33,6 +33,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on
 
 [IN PROGRESS]
 - Post-release readiness summary and launch posture assets packaging is in progress for public-ready paper beta continuity (paper-only claim boundary preserved).
+- Phase 9.3 deploy/runtime truth revalidation lane is in progress with evidence captured, but external verification of live Fly `/health` and `/ready` is blocked in this runner by CONNECT-tunnel 403 and requires Fly-accessible validation.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -40,6 +41,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path is complete on
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
+- Run SENTINEL deploy/runtime validation from a Fly-accessible environment on the Phase 9.3 deploy-runtime-truth source branch to verify live `/health`, live `/ready`, startup stability, and machine crash-loop status against captured blocker evidence.
 - Prepare post-release readiness summary and launch posture assets (onboarding + announcement package) for the completed public-ready paper beta lane while preserving paper-only claim boundaries.
 
 [KNOWN ISSUES]

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log
@@ -1,0 +1,149 @@
+Phase 9.3 Deploy/Runtime Evidence Log
+Generated (Asia/Jakarta): 2026-04-21 05:40
+Branch Context: feature/phase-9-3-deploy-runtime-truth (Codex worktree may show work)
+
+$ which flyctl
+[exit_code=1]
+
+$ which fly
+[exit_code=1]
+
+$ curl -sS -D - https://crusaderbot.fly.dev/health
+[exit_code=56]
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Mon, 20 Apr 2026 22:40:54 GMT
+server: envoy
+connection: close
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+$ curl -sS -D - https://crusaderbot.fly.dev/ready
+[exit_code=56]
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Mon, 20 Apr 2026 22:40:54 GMT
+server: envoy
+connection: close
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+# health probe 1 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_health_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/health
+[exit_code=56]
+http_code=000 total_time=0.005757
+
+
+# health probe 2 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_health_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/health
+[exit_code=56]
+http_code=000 total_time=0.005422
+
+
+# health probe 3 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_health_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/health
+[exit_code=56]
+http_code=000 total_time=0.005111
+
+
+# health probe 4 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_health_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/health
+[exit_code=56]
+http_code=000 total_time=0.005306
+
+
+# health probe 5 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_health_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/health
+[exit_code=56]
+http_code=000 total_time=0.004675
+
+
+# ready probe 1 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_ready_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/ready
+[exit_code=56]
+http_code=000 total_time=0.004254
+
+
+# ready probe 2 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_ready_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/ready
+[exit_code=56]
+http_code=000 total_time=0.004667
+
+
+# ready probe 3 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_ready_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/ready
+[exit_code=56]
+http_code=000 total_time=0.005213
+
+
+# ready probe 4 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_ready_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/ready
+[exit_code=56]
+http_code=000 total_time=0.004602
+
+
+# ready probe 5 at 2026-04-21 05:40:54
+$ curl -sS -o /tmp/crusader_ready_body.json -w 'http_code=%{http_code} total_time=%{time_total}\n' https://crusaderbot.fly.dev/ready
+[exit_code=56]
+http_code=000 total_time=0.005335
+
+
+# header probe 1
+$ curl -sSI https://crusaderbot.fly.dev/health | tr -d '\r' | rg -n 'fly-request-id|via|server|date|HTTP/'
+[exit_code=0]
+1:HTTP/1.1 403 Forbidden
+4:date: Mon, 20 Apr 2026 22:40:54 GMT
+5:server: envoy
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+# header probe 2
+$ curl -sSI https://crusaderbot.fly.dev/health | tr -d '\r' | rg -n 'fly-request-id|via|server|date|HTTP/'
+[exit_code=0]
+1:HTTP/1.1 403 Forbidden
+4:date: Mon, 20 Apr 2026 22:40:54 GMT
+5:server: envoy
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+# header probe 3
+$ curl -sSI https://crusaderbot.fly.dev/health | tr -d '\r' | rg -n 'fly-request-id|via|server|date|HTTP/'
+[exit_code=0]
+1:HTTP/1.1 403 Forbidden
+4:date: Mon, 20 Apr 2026 22:40:54 GMT
+5:server: envoy
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+# header probe 4
+$ curl -sSI https://crusaderbot.fly.dev/health | tr -d '\r' | rg -n 'fly-request-id|via|server|date|HTTP/'
+[exit_code=0]
+1:HTTP/1.1 403 Forbidden
+4:date: Mon, 20 Apr 2026 22:40:54 GMT
+5:server: envoy
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+# header probe 5
+$ curl -sSI https://crusaderbot.fly.dev/health | tr -d '\r' | rg -n 'fly-request-id|via|server|date|HTTP/'
+[exit_code=0]
+1:HTTP/1.1 403 Forbidden
+4:date: Mon, 20 Apr 2026 22:40:54 GMT
+5:server: envoy
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403
+
+
+# proxy bypass attempt
+$ HTTPS_PROXY= HTTP_PROXY= ALL_PROXY= NO_PROXY='*' curl -sS -D - https://crusaderbot.fly.dev/health
+[exit_code=56]
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Mon, 20 Apr 2026 22:41:04 GMT
+server: envoy
+connection: close
+[stderr]
+curl: (56) CONNECT tunnel failed, response 403

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-truth.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-truth.md
@@ -1,0 +1,46 @@
+# Phase 9.3 — Deploy / Runtime Truth Validation (Blocked by External Access Gate)
+
+**Date:** 2026-04-21 05:41
+**Branch:** feature/phase-9-3-deploy-runtime-truth
+**Task:** Validate real Fly deploy/runtime truth for CrusaderBot (`/health`, `/ready`, startup stability, crash-loop risk) and sync repo truth only if evidence proves weaker runtime posture.
+
+## 1. What was built
+
+- Captured a fresh deploy/runtime evidence bundle at `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log` with direct probe attempts against `https://crusaderbot.fly.dev/health` and `https://crusaderbot.fly.dev/ready`.
+- Executed repeated health and readiness probes (5x each), repeated header probes (5x), and one explicit proxy-bypass attempt to verify whether runner networking caused false negatives.
+- Confirmed this runner does not have `flyctl` / `fly` binaries available, so machine-level state (`fly status`, `fly machine list`, restart/crash-loop counters) cannot be inspected from this environment.
+
+## 2. Current system architecture (relevant slice)
+
+1. Deploy target in repo remains `projects/polymarket/polyquantbot/fly.toml` with `app = 'crusaderbot'` and HTTP service internal port `8080`.
+2. Runtime route implementation still declares `/health` and `/ready` in `projects/polymarket/polyquantbot/server/api/routes.py`.
+3. This lane required live external verification; however, all external probes from this runner were blocked upstream by an Envoy CONNECT-tunnel `403 Forbidden` before reaching the app surface.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-truth.md`
+
+## 4. What is working
+
+- Evidence capture is complete and reviewable for this attempt lane, including raw command outputs, timestamps, and repeated probe results.
+- Negative-path validation was performed (repeated probes + proxy-bypass attempt) to reduce false attribution risk.
+- Repo truth for deploy target and route surfaces remains internally consistent (`fly.toml`, `/health`, `/ready` route definitions).
+
+## 5. Known issues
+
+- **Blocker:** live deploy/runtime truth could not be verified from this execution environment because outbound Fly endpoint access is blocked at CONNECT-tunnel stage (`403 Forbidden`, `server: envoy`) for both `/health` and `/ready`.
+- **Blocker:** machine stability/crash-loop truth cannot be proven without Fly control-plane access (`flyctl` absent; no authenticated machine inspection path available in this runner).
+- Because live runtime proof is blocked externally, this pass cannot truthfully re-assert stronger deploy-health closure than prior merged wording.
+
+## 6. What is next
+
+- COMMANDER should run SENTINEL/ops validation from an environment with Fly control-plane access (or provide a Fly evidence artifact) against this same source branch.
+- If external validation confirms degradation, downgrade ROADMAP/PROJECT_STATE wording in a scoped truth-sync follow-up.
+- If external validation confirms healthy deploy + stable machine + truthful `/health` + truthful `/ready`, preserve current paper-beta wording and close this lane.
+
+Validation Tier   : MAJOR
+Claim Level       : RUNTIME DEPLOY TRUTH
+Validation Target : deployed Fly/runtime truth for healthy startup path, machine stability, `/health`, and `/ready` under current public paper-beta posture
+Not in Scope      : live trading, production capital readiness, strategy changes, wallet lifecycle expansion, dashboard expansion, launch-asset copywriting, broad docs cleanup
+Suggested Next    : SENTINEL/ops runtime validation from Fly-accessible environment, then COMMANDER decision

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase9-3_02_deploy-runtime-truth-validation-pr682.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase9-3_02_deploy-runtime-truth-validation-pr682.md
@@ -1,0 +1,77 @@
+# Phase 9.3 — Deploy / Runtime Truth Validation (PR #682)
+
+## Environment
+- Timestamp (Asia/Jakarta): 2026-04-21 05:50
+- Repo: `walker-ai-team`
+- Source branch under validation: `feature/phase-9-3-deploy-runtime-truth`
+- PR: #682
+- Runner profile: Codex worktree (`git rev-parse --abbrev-ref HEAD` => `work`), outbound traffic constrained by proxy policy
+- Fly control-plane tools: `flyctl` / `fly` not present in runner
+
+## Validation Context
+- Validation Tier: MAJOR
+- Claim Level: RUNTIME DEPLOY TRUTH
+- Validation target: live Fly deploy/runtime truth for machine stability, startup stability, `/health`, and `/ready` under public paper-beta posture
+- Not in Scope: live trading, production capital readiness, strategy changes, wallet lifecycle expansion, dashboard expansion, launch-copy work, broad docs cleanup
+- Source evidence reviewed:
+  - `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-truth.md`
+  - `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log`
+
+## Phase 0 Checks
+- Forge report exists at required path and includes 6 required sections.
+- PROJECT_STATE.md has full timestamp format and includes in-progress wording for this validation lane.
+- Source evidence logs include repeated `/health` and `/ready` probes and blocked-runner details.
+- Reproduction checks executed from this runner:
+  - `curl -v https://crusaderbot.fly.dev/health` -> CONNECT tunnel `403 Forbidden` via envoy
+  - `curl -v https://crusaderbot.fly.dev/ready` -> CONNECT tunnel `403 Forbidden` via envoy
+  - `curl -v --noproxy '*' https://crusaderbot.fly.dev/health` -> direct network route unavailable (`curl: (7)`)
+  - `curl -v --noproxy '*' https://crusaderbot.fly.dev/ready` -> direct network route unavailable (`curl: (7)`)
+- Fly control-plane inspection unavailable (`flyctl_absent`), so machine health/crash-loop counters cannot be independently queried in this runner.
+
+## Findings
+1. **Live Fly runtime endpoints are not reachable from this runner.**
+   - Both `/health` and `/ready` remain externally blocked in current environment, preventing endpoint truth verification against the deployed app.
+2. **Startup stability and crash-loop status cannot be proven from this environment.**
+   - Without Fly control-plane access (`flyctl`) and without successful endpoint reachability, SENTINEL cannot confirm machine steady state or crash-loop absence.
+3. **PR #682 blocked-runner evidence is materially accurate.**
+   - Source evidence and independent reruns both show upstream access blocking before app-layer response is observed.
+
+## Score Breakdown
+- Required checks passed: 1/5 (blocked-runner evidence accuracy)
+- Required checks unverified/blocked: 4/5 (`/health`, `/ready`, crash-loop state, startup stability)
+- Confidence score: **42/100**
+
+## Critical Issues
+1. **Critical:** Cannot verify deployed `/health` truth response from Fly-accessible path in this runner.
+2. **Critical:** Cannot verify deployed `/ready` truth response from Fly-accessible path in this runner.
+3. **Critical:** Cannot validate machine crash-loop absence or startup stability without Fly control-plane visibility.
+
+## Status
+- Verdict: **BLOCKED**
+- Rationale: MAJOR validation objective requires direct runtime proof. Current environment cannot produce runtime proof due network/control-plane access constraints.
+
+## PR Gate Result
+- **PR #682 gate: BLOCKED**
+- Merge recommendation: hold until validation is re-run from a Fly-accessible environment with endpoint reachability and machine-level inspection evidence.
+
+## Broader Audit Finding
+- No contradiction found between repo route definitions (`/health`, `/ready`) and forge report narrative.
+- The blocker is environmental verification reachability, not an observed app-runtime defect from this runner.
+
+## Reasoning
+- SENTINEL must validate actual behavior on claimed runtime path for MAJOR scope.
+- Because endpoint and machine checks cannot be completed, safe-default policy applies: unresolved runtime truth => BLOCKED.
+
+## Fix Recommendations
+1. Re-run SENTINEL from a runner with confirmed Fly endpoint reachability and no forced CONNECT tunnel denial.
+2. Add Fly control-plane evidence (`fly status`, `fly machine list`, recent restart/crash indicators) to prove startup and non-crash-loop state.
+3. Capture timestamped `/health` and `/ready` responses (status, payload, headers) from that accessible environment and attach to follow-up sentinel report.
+
+## Out-of-scope Advisory
+- No assessment made for live-trading readiness, production-capital safety, strategy behavior, wallet lifecycle expansion, or dashboard scope.
+
+## Deferred Minor Backlog
+- None added.
+
+## Telegram Visual Preview
+- N/A (validation-only deliverable; no BRIEFER artifact requested in this lane).


### PR DESCRIPTION
### Motivation
- Validate the real Fly deploy/runtime truth for CrusaderBot (`/health`, `/ready`, startup stability, crash-loop risk) and capture reproducible evidence for SENTINEL when external verification from this runner is blocked.
- Avoid claiming a healthy deploy when external probes or Fly control-plane inspection cannot be performed from this environment.

### Description
- Added a FORGE report `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-truth.md` documenting the deploy/runtime validation attempt and blocker findings. 
- Added an evidence log `projects/polymarket/polyquantbot/reports/forge/phase9-3_04_deploy-runtime-evidence.log` containing raw probe outputs (`curl`), header probes, a proxy-bypass attempt, and tool availability checks.
- Updated `PROJECT_STATE.md` `Last Updated` and `Status` to record that external deploy/runtime revalidation is blocked in this runner and added a `NEXT PRIORITY` asking for SENTINEL/ops validation from a Fly-accessible environment.
- Commit recorded on the current worktree branch (commit `9310adf...`) and PR metadata created with title matching this change.

### Testing
- Ran `python3 -m py_compile projects/polymarket/polyquantbot/server/main.py projects/polymarket/polyquantbot/server/api/routes.py`, which completed with no syntax errors (pass).
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`, which reported `1 skipped` and exited non-zero (exit code 5), so the full test gate did not complete successfully in this environment.
- Performed runtime probes recorded in the evidence log showing `which flyctl` / `which fly` returned not found and repeated `curl` probes to `https://crusaderbot.fly.dev/health` and `/ready` returned `HTTP/1.1 403 Forbidden` with `curl: (56) CONNECT tunnel failed, response 403`, demonstrating outbound CONNECT-tunnel blocking from this runner.
- Verified locale (`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`) and ran mojibake checks on the new files (no mojibake detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ab22b0108325b1826c48da2513b4)