### PR TITLE
fix(polyquantbot): correct Fly startup entrypoint path wiring

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 05:41
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main with paper-only boundary preserved; independent external deploy/runtime revalidation is currently blocked in this runner by outbound Fly endpoint access limits and requires Fly-accessible validation evidence.
+Last Updated : 2026-04-21 09:57
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main with paper-only boundary preserved; Fly startup-path source fix is applied on the active Phase 9.3 lane, while deploy/runtime revalidation remains blocked in this runner by Fly CLI/network access limits.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -34,7 +34,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [IN PROGRESS]
 - Post-release readiness summary and launch posture assets packaging is in progress for public-ready paper beta continuity (paper-only claim boundary preserved).
-- Phase 9.3 deploy/runtime truth revalidation lane is in progress with evidence captured, but external verification of live Fly `/health` and `/ready` is blocked in this runner by CONNECT-tunnel 403 and requires Fly-accessible validation.
+- Phase 9.3 Fly startup-path fix lane is in progress with corrected Docker/Fly entrypoint wiring, but actual redeploy and live `/health` + `/ready` verification remain blocked in this runner (`flyctl` unavailable and CONNECT-tunnel 403).
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -42,7 +42,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review for post-release public-facing launch assets pack and messaging approval.
+- SENTINEL gate on PR head branch after Fly-accessible redeploy evidence confirms machine stability and live `/health` + `/ready`.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/Dockerfile
+++ b/projects/polymarket/polyquantbot/Dockerfile
@@ -17,7 +17,8 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY --from=builder /install /usr/local
-COPY . .
+RUN mkdir -p /app/projects/polymarket/polyquantbot
+COPY . /app/projects/polymarket/polyquantbot
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
@@ -28,4 +29,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:${PORT}/health || exit 1
 
-CMD ["python", "projects/polymarket/polyquantbot/scripts/run_api.py"]
+CMD ["python", "-m", "projects.polymarket.polyquantbot.scripts.run_api"]

--- a/projects/polymarket/polyquantbot/fly.toml
+++ b/projects/polymarket/polyquantbot/fly.toml
@@ -8,6 +8,9 @@ primary_region = 'iad'
 
 [build]
 
+[processes]
+  app = "python -m projects.polymarket.polyquantbot.scripts.run_api"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-runtime-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-runtime-evidence.log
@@ -1,0 +1,57 @@
+[phase9-3_05 fly startup-path fix evidence]
+UTC 2026-04-21 02:57:58
+
+## Git branch
+feature/fix-fly-startup-path-and-redeploy
+
+## Runtime entrypoint fixes
+20:RUN mkdir -p /app/projects/polymarket/polyquantbot
+21:COPY . /app/projects/polymarket/polyquantbot
+32:CMD ["python", "-m", "projects.polymarket.polyquantbot.scripts.run_api"]
+11:[processes]
+12:  app = "python -m projects.polymarket.polyquantbot.scripts.run_api"
+
+## Python module startup sanity
+exit_code=1
+-- stderr (first 30 lines) --
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.10.19/lib/python3.10/runpy.py", line 196, in _run_module_as_main
+    return _run_code(code, main_globals, None,
+  File "/root/.pyenv/versions/3.10.19/lib/python3.10/runpy.py", line 86, in _run_code
+    exec(code, run_globals)
+  File "/workspace/walker-ai-team/projects/polymarket/polyquantbot/scripts/run_api.py", line 2, in <module>
+    from projects.polymarket.polyquantbot.server.main import main
+  File "/workspace/walker-ai-team/projects/polymarket/polyquantbot/server/main.py", line 9, in <module>
+    import uvicorn
+ModuleNotFoundError: No module named 'uvicorn'
+
+## Fly deploy attempt
+/bin/bash: line 18: flyctl: command not found
+
+## External runtime probes
+### GET /health
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (56) CONNECT tunnel failed, response 403
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Tue, 21 Apr 2026 02:57:59 GMT
+server: envoy
+connection: close
+
+
+### GET /ready
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (56) CONNECT tunnel failed, response 403
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Tue, 21 Apr 2026 02:57:59 GMT
+server: envoy
+connection: close
+
+

--- a/projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-startup-path-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-startup-path-fix.md
@@ -1,0 +1,50 @@
+# Phase 9.3 — Fly Startup Path Fix and Redeploy Attempt (Blocked by Environment Access)
+
+**Date:** 2026-04-21 09:57
+**Branch:** feature/fix-fly-startup-path-and-redeploy
+**Task:** Fix Fly startup crash from invalid runtime entry path, redeploy, and verify runtime health (`/health`, `/ready`, machine stability).
+
+## 1. What was built
+
+- Fixed container runtime path mismatch by copying project files into `/app/projects/polymarket/polyquantbot` in the image so the `projects.polymarket...` import tree and path expectations are valid at runtime.
+- Switched runtime entry invocation to module form (`python -m projects.polymarket.polyquantbot.scripts.run_api`) to avoid script-path `sys.path` import failure mode.
+- Added explicit Fly process command in `fly.toml` so process startup is pinned to the corrected module entrypoint.
+- Captured fresh runtime/deploy evidence in `projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-runtime-evidence.log`.
+
+## 2. Current system architecture (relevant slice)
+
+1. Fly app `crusaderbot` runs process `app` from `projects/polymarket/polyquantbot/fly.toml`.
+2. Container image now materializes project code under `/app/projects/polymarket/polyquantbot`.
+3. Runtime process command is module-based (`python -m projects.polymarket.polyquantbot.scripts.run_api`) and resolves through the existing `projects.polymarket.polyquantbot.server.main` runtime entry.
+4. Health endpoints remain defined in API route surface (`/health`, `/ready`) and are expected to be validated externally after deploy.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/Dockerfile`
+- `projects/polymarket/polyquantbot/fly.toml`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-startup-path-fix.md`
+- `projects/polymarket/polyquantbot/reports/forge/phase9-3_05_fly-runtime-evidence.log`
+
+## 4. What is working
+
+- Startup command/path mismatch is corrected in source for both Docker default command and Fly `processes.app` command.
+- Module execution now advances past previous missing-file failure mode; local sanity now fails later at missing dependency (`uvicorn`) in this runner, indicating path/module resolution is fixed and failure moved beyond original crash class.
+- Evidence artifact captures branch identity, changed startup directives, local module-launch output, deploy attempt output, and live endpoint probe outputs.
+
+## 5. Known issues
+
+- **Blocker:** this runner cannot execute Fly redeploy because `flyctl` is not available and cannot be installed here (install endpoint access fails with HTTP 403 in this environment).
+- **Blocker:** external probes to `https://crusaderbot.fly.dev/health` and `/ready` remain blocked by CONNECT tunnel `403 Forbidden (envoy)`, so live post-fix runtime status cannot be verified from this runner.
+- Because deploy + live health checks are externally blocked, this task is closed as **NEXT BLOCKER** rather than PASS.
+
+## 6. What is next
+
+- Run deploy from a Fly-accessible environment with authenticated `flyctl` on this branch head, using `projects/polymarket/polyquantbot/fly.toml`.
+- Validate machine stability (no restart loop) and confirm `GET /health` + `GET /ready` from Fly-visible network.
+- Send this branch to SENTINEL for MAJOR-tier verification after deploy evidence is produced.
+
+Validation Tier   : MAJOR
+Claim Level       : RUNTIME DEPLOY FIX
+Validation Target : Fix runtime startup path/entrypoint mismatch and re-verify deployed machine health (`/health`, `/ready`, restart-loop status)
+Not in Scope      : strategy logic, risk constants, wallet lifecycle expansion, release copy/docs refresh, live-trading enablement
+Suggested Next    : SENTINEL validation on actual PR head branch after Fly-accessible deploy evidence capture


### PR DESCRIPTION
### Motivation
- Fix a Fly startup crash caused by the container/runtime attempting to execute an invalid script path and failing to import the `projects` package tree at runtime.
- Ensure the deployed image's filesystem layout and process invocation match the code's `projects.polymarket.polyquantbot` import expectations so the service can start reliably.

### Description
- Adjusted the container image to materialize source under `/app/projects/polymarket/polyquantbot` and restored a module-style invocation by updating `projects/polymarket/polyquantbot/Dockerfile` (`COPY` + `CMD [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e70fc6a8832599b6cc37f246a79c)