### PR TITLE
Activate Telegram runtime in Fly API path and expose truthful `/ready` Telegram state

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 13:24
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; live Fly runtime surface is now externally verified responding (`/`, `/health`, `/ready`) with paper-only boundary preserved and no live-trading/production-capital readiness claim.
+Last Updated : 2026-04-21 13:59
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, while external deploy verification is currently blocked in this runner environment.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -34,7 +34,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [IN PROGRESS]
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Phase 9.3 final truth-sync lane is in progress to land verified live Fly runtime observations (`/`, `/health`, `/ready`) as canonical repo truth while preserving explicit paper-only execution boundaries.
+- Telegram runtime activation on Fly lane is in progress for external deploy verification (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync landed in `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -42,7 +42,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER review of post-launch cleanup/readme/announcement polish PR for final wording alignment against paper-only public-beta truth.
+- SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` with deploy-capable environment to verify real Fly startup logs and real Telegram command replies (`/start`, `/help`, `/status`).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 13:59
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, while external deploy verification is currently blocked in this runner environment.
+Last Updated : 2026-04-21 14:17
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, and SENTINEL PR #690 validation is currently BLOCKED pending deploy-capable external proof for startup logs and Telegram command replies.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -34,7 +34,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [IN PROGRESS]
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram runtime activation on Fly lane is in progress for external deploy verification (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync landed in `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`.
+- Telegram runtime activation on Fly lane remains in progress: SENTINEL validation for PR #690 is BLOCKED in current runner due Fly endpoint proxy 403 + missing flyctl; rerun in deploy-capable environment must verify startup logs and live Telegram replies (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`, `projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md`).
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -42,7 +42,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` with deploy-capable environment to verify real Fly startup logs and real Telegram command replies (`/start`, `/help`, `/status`).
+- Re-run SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` in deploy-capable environment with reachable Fly and Telegram chat to collect hard evidence for startup logs, `/ready` telegram_runtime truth, and real Telegram command replies (`/start`, `/help`, `/status`).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -45,6 +45,17 @@ class TelegramDispatcher:
         arg = ctx.argument.strip()
         if command == "/start":
             return await self._dispatch_start(ctx)
+        if command == "/help":
+            return DispatchResult(
+                outcome="ok",
+                reply_text=(
+                    "📘 CrusaderBot commands (public paper beta)\n"
+                    "• /start — initialize or refresh your session\n"
+                    "• /help — show command list\n"
+                    "• /status — runtime and guard snapshot\n"
+                    "Boundary: paper-only execution, no live trading, no production capital."
+                ),
+            )
         if command == "/mode":
             mode = arg.lower()
             data = await self._backend.beta_post("/beta/mode", {"mode": mode})
@@ -179,7 +190,7 @@ class TelegramDispatcher:
             outcome="unknown_command",
             reply_text=(
                 "Unknown command for CrusaderBot public paper beta.\n"
-                "Supported: /start /mode /autotrade /positions /pnl /risk /status /markets /market360 /social /kill\n"
+                "Supported: /start /help /mode /autotrade /positions /pnl /risk /status /markets /market360 /social /kill\n"
                 "Note: no manual trade-entry commands are available in this beta."
             ),
         )

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -141,6 +141,18 @@ class TelegramSessionIssuer(Protocol):
         ...
 
 
+class TelegramRuntimeObserver(Protocol):
+    def on_startup(self) -> None: ...
+
+    def on_iteration(self, processed_count: int) -> None: ...
+
+    def on_reply_sent(self) -> None: ...
+
+    def on_error(self, error: str) -> None: ...
+
+    def on_shutdown(self) -> None: ...
+
+
 class HttpTelegramAdapter(TelegramRuntimeAdapter):
     """Concrete Telegram adapter that calls the Telegram Bot API via httpx.
 
@@ -273,6 +285,7 @@ class TelegramPollingLoop:
         session_issuer: Optional[TelegramSessionIssuer] = None,
         staging_tenant_id: str = _STAGING_TENANT_ID,
         staging_user_id: str = _STAGING_USER_ID,
+        observer: Optional[TelegramRuntimeObserver] = None,
     ) -> None:
         self._adapter = adapter
         self._dispatcher = dispatcher
@@ -282,6 +295,7 @@ class TelegramPollingLoop:
         self._session_issuer = session_issuer
         self._staging_tenant_id = staging_tenant_id
         self._staging_user_id = staging_user_id
+        self._observer = observer
         self._offset: int = 0
 
     async def run_once(self) -> int:
@@ -466,12 +480,16 @@ class TelegramPollingLoop:
     async def _safe_send_reply(self, chat_id: str, text: str) -> None:
         try:
             await self._adapter.send_reply(chat_id, text)
+            if self._observer is not None:
+                self._observer.on_reply_sent()
         except Exception as exc:
             log.error(
                 "crusaderbot_telegram_runtime_send_reply_error",
                 chat_id=chat_id,
                 error=str(exc),
             )
+            if self._observer is not None:
+                self._observer.on_error(str(exc))
 
 
 async def run_polling_loop(
@@ -483,6 +501,7 @@ async def run_polling_loop(
     session_issuer: Optional[TelegramSessionIssuer] = None,
     staging_tenant_id: str = _STAGING_TENANT_ID,
     staging_user_id: str = _STAGING_USER_ID,
+    observer: Optional[TelegramRuntimeObserver] = None,
 ) -> None:
     """Top-level async polling function. Runs until cancelled.
 
@@ -502,6 +521,7 @@ async def run_polling_loop(
         session_issuer=session_issuer,
         staging_tenant_id=staging_tenant_id,
         staging_user_id=staging_user_id,
+        observer=observer,
     )
     log.info(
         "crusaderbot_telegram_polling_started",
@@ -514,14 +534,22 @@ async def run_polling_loop(
         staging_tenant_id=staging_tenant_id,
         staging_user_id=staging_user_id,
     )
+    if observer is not None:
+        observer.on_startup()
     while True:
         try:
             count = await loop.run_once()
+            if observer is not None:
+                observer.on_iteration(count)
             if count == 0:
                 await asyncio.sleep(1.0)
         except asyncio.CancelledError:
             log.info("crusaderbot_telegram_polling_cancelled")
+            if observer is not None:
+                observer.on_shutdown()
             return
         except Exception as exc:
             log.error("crusaderbot_telegram_polling_error", error=str(exc))
+            if observer is not None:
+                observer.on_error(str(exc))
             await asyncio.sleep(5.0)

--- a/projects/polymarket/polyquantbot/fly.toml
+++ b/projects/polymarket/polyquantbot/fly.toml
@@ -8,6 +8,9 @@ primary_region = 'iad'
 
 [build]
 
+[env]
+  CRUSADER_TELEGRAM_RUNTIME_REQUIRED = "true"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md
@@ -1,0 +1,67 @@
+# Telegram Runtime 01 — Public-Ready Runtime Activation
+
+Date: 2026-04-21 13:59 (Asia/Jakarta)
+Branch: feature/public-ready-telegram-runtime-on-fly
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Activated Telegram polling runtime from the Fly API process lane by bootstrapping Telegram runtime in `server/main.py` lifespan startup using `run_polling_loop(...)` as an in-process async task.
+- Added explicit Telegram runtime readiness state in `RuntimeState` and wired `/ready` to reflect true Telegram runtime status (required/enabled/startup_complete/active/iterations/last_error).
+- Added fail-loud Telegram requirement control (`CRUSADER_TELEGRAM_RUNTIME_REQUIRED`) and mapped Fly config to require Telegram runtime on deploy (`fly.toml`).
+- Added public baseline `/help` command support in Telegram dispatcher and updated unknown-command help text accordingly.
+- Added runtime observability hooks for startup, iteration, reply sent, error, and shutdown events via observer callbacks from Telegram polling loop to server runtime state.
+
+## 2. Current system architecture (relevant slice)
+
+1. Fly runtime still serves FastAPI from `server/main.py`.
+2. During FastAPI lifespan startup:
+   - API startup validation runs.
+   - Telegram runtime bootstrap validation runs (`TELEGRAM_BOT_TOKEN` required).
+   - If valid, polling loop starts as a background asyncio task and reports lifecycle state through runtime observer.
+   - If invalid and Telegram runtime is marked required, startup fails loudly.
+3. `/ready` now reports Telegram runtime truth in `readiness.telegram_runtime` and returns `503 not_ready` when Telegram runtime is required but not active.
+4. Telegram command baseline now includes `/help` as a first-class dispatcher command with paper-only boundary messaging.
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/server/core/runtime.py
+- projects/polymarket/polyquantbot/server/main.py
+- projects/polymarket/polyquantbot/server/api/routes.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+- projects/polymarket/polyquantbot/fly.toml
+- projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+- projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+- projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+- projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-evidence.log
+- projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- Telegram runtime is now wired into deploy entrypoint path (API process) rather than isolated script-only path.
+- `/ready` now includes explicit Telegram runtime truth fields and can gate readiness when runtime is required.
+- Missing Telegram token no longer silently degrades when required mode is enabled.
+- `/help` is now implemented as a real command response.
+- Targeted runtime + dispatcher + readiness tests pass (32 passed, 1 skipped).
+
+## 5. Known issues
+
+- Deployed Fly verification and real Telegram chat command confirmation (`/start`, `/help`, `/status`) are blocked in this runner due missing `flyctl` and outbound proxy 403 on `crusaderbot.fly.dev`.
+- Because deploy verification is blocked here, this lane is outcome-labeled as **blocked for external verification** while code/runtime truth changes are landed.
+- No live-trading or production-capital readiness is claimed.
+
+## 6. What is next
+
+- SENTINEL must validate this PR head branch as MAJOR lane and verify deployed behavior using a Fly-capable environment:
+  - startup logs include Telegram runtime lifecycle signals,
+  - `/ready` reflects truthful Telegram runtime state,
+  - deployed bot replies to `/start`, `/help`, `/status`.
+- If external verification succeeds, close blocker and advance COMMANDER decision.
+
+Validation Tier   : MAJOR
+Claim Level       : FULL RUNTIME INTEGRATION
+Validation Target : Fly startup path + Telegram polling runtime activation + `/ready` truth surface + baseline Telegram commands (`/start`, `/help`, `/status`) in deployed environment
+Not in Scope      : live-trading enablement, production-capital readiness, wallet lifecycle expansion, strategy upgrades, unrelated dashboard/doc cleanup
+Suggested Next    : SENTINEL validation on actual PR head branch in deploy-capable environment

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-evidence.log
@@ -1,0 +1,39 @@
+Date (Asia/Jakarta): 2026-04-21 13:59
+Branch: feature/public-ready-telegram-runtime-on-fly
+Validation Tier: MAJOR
+
+[local-check] py_compile
+Command:
+PYTHONIOENCODING=utf-8 python -m py_compile projects/polymarket/polyquantbot/server/core/runtime.py projects/polymarket/polyquantbot/server/main.py projects/polymarket/polyquantbot/server/api/routes.py projects/polymarket/polyquantbot/client/telegram/runtime.py projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+Result: PASS
+
+[local-check] targeted pytest
+Command:
+PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+Result: PASS
+Output summary: 32 passed, 1 skipped
+
+[deploy-check] external fly surface probe
+Command:
+for p in / /health /ready; do echo "=== $p ==="; curl -sS -m 20 "https://crusaderbot.fly.dev$p"; echo; echo; done
+Result: BLOCKED (environment network/proxy)
+Output:
+=== / ===
+curl: (56) CONNECT tunnel failed, response 403
+
+=== /health ===
+curl: (56) CONNECT tunnel failed, response 403
+
+=== /ready ===
+curl: (56) CONNECT tunnel failed, response 403
+
+[deploy-check] flyctl availability
+Command:
+which flyctl && flyctl version
+Result: BLOCKED (flyctl unavailable in runner)
+
+[repo-check] full pytest collection
+Command:
+PYTHONIOENCODING=utf-8 pytest -q
+Result: WARNING (environment dependency limitation)
+Summary: collection failed with missing optional dependencies (fastapi, pydantic) in current runner.

--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md
@@ -1,0 +1,96 @@
+# Telegram Runtime 01 — Public-Ready Runtime Validation (PR #690)
+
+Environment
+- Date (Asia/Jakarta): 2026-04-21 14:17
+- Repo: https://github.com/bayuewalker/walker-ai-team
+- PR: #690
+- Source branch validated: feature/public-ready-telegram-runtime-on-fly
+- Validation tier: MAJOR
+- Claim level (declared): FULL RUNTIME INTEGRATION (runtime + user-facing integration)
+- Source forge report: projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md
+- Validator runtime notes:
+  - flyctl: unavailable in this runner (`command not found`)
+  - outbound probe to crusaderbot.fly.dev: blocked by CONNECT tunnel 403
+
+Validation Context
+- Objective evaluated: deployed Telegram runtime activation, truthful `/ready`, and baseline Telegram command replies (`/start`, `/help`, `/status`) on Fly.
+- In-scope checks:
+  - startup includes Telegram runtime activation
+  - startup lifecycle signal visibility
+  - truthful required-mode behavior for `CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true`
+  - truthful `/ready` Telegram runtime fields
+  - deployed Telegram replies for `/start`, `/help`, `/status`
+  - public-safe and paper-only truthful response wording
+  - no silent disabled mode
+- Out of scope enforced: live trading enablement, production-capital readiness, wallet lifecycle expansion, strategy changes, unrelated docs cleanup.
+
+Phase 0 Checks
+1. Forge handoff artifact exists at expected path: PASS.
+2. Forge report includes MAJOR structure and explicit validation target: PASS.
+3. PROJECT_STATE has full timestamp and active lane context for this task: PASS.
+4. Code-path sanity checks rerun by SENTINEL:
+   - `PYTHONIOENCODING=utf-8 python -m py_compile ...`: PASS
+   - `PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py`: PASS (32 passed, 1 skipped)
+5. External runtime validation prerequisites in this runner:
+   - `flyctl`: FAIL (unavailable)
+   - `curl https://crusaderbot.fly.dev/{/,/health,/ready}`: FAIL (CONNECT tunnel failed, 403)
+
+Findings
+1. Deploy startup path includes Telegram runtime bootstrap in API lifespan: PASS.
+   - Evidence: `server/main.py` startup invokes `_start_telegram_runtime(state)` right after API startup validation and before serving runtime; task cancellation and shutdown paths are wired.
+2. Telegram lifecycle signals are instrumented in runtime observer: PASS (code-level).
+   - Evidence: `crusaderbot_telegram_runtime_started`, `crusaderbot_telegram_reply_sent`, `crusaderbot_telegram_runtime_error`, and `crusaderbot_telegram_runtime_stopped` are emitted from observer callbacks.
+3. Required-mode behavior is fail-loud when Telegram runtime is mandatory and invalid: PASS (code-level + test-level).
+   - Evidence: `CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true` is read through `telegram_runtime_required_from_env()`. Missing/invalid bot env causes `_start_telegram_runtime` to raise `RuntimeError` when required.
+4. `/ready` truth surface reflects Telegram runtime state and required gate behavior: PASS (code-level + test-level).
+   - Evidence: `/ready` computes `telegram_readiness_ok` based on required-mode semantics and returns 503 `not_ready` when required runtime is not active.
+5. `/help` and `/status` command handlers are present with explicit public paper-only boundary wording: PASS (code-level + tests).
+6. Deployed runtime lifecycle logs and real Telegram reply behavior (`/start`, `/help`, `/status`) on Fly: NOT VERIFIED (BLOCKED).
+   - Blocking reason: runner cannot reach Fly endpoint (proxy 403) and cannot run `flyctl`.
+
+Score Breakdown
+- Startup activation wiring: 20/20
+- Runtime lifecycle signal wiring: 15/15
+- Required-mode truthfulness (`CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true`): 15/15
+- `/ready` runtime-truth semantics: 15/15
+- Telegram command public-safe wording contract: 10/10
+- Live Fly proof (`/start`, `/help`, `/status` + startup logs): 0/25 (blocked by environment)
+- Total: 75/100
+
+Critical Issues
+1. Missing live Fly verification evidence for required deploy checks (`/start`, `/help`, `/status` reply proof and startup log proof) due environment network/tooling blockers.
+
+Status
+- Verdict: BLOCKED
+- Risk posture: Safe-by-default retained (no false approval without external runtime proof).
+
+PR Gate Result
+- Gate decision for PR #690: BLOCKED pending live Fly-capable validation evidence.
+- Merge recommendation: hold until deploy-capable SENTINEL rerun confirms all required external checks.
+
+Broader Audit Finding
+- No contradiction detected between code-path behavior and forge claim for activation/readiness semantics.
+- Residual gap is strictly external runtime evidence, not local contract regression.
+
+Reasoning
+- The declared claim is FULL RUNTIME INTEGRATION on deployed path. Local code/tests prove integration intent and readiness semantics, but REQUIRED CHECKS include deployed bot command replies and startup logs on Fly.
+- Without direct Fly observability and Telegram chat confirmation in this run, approving would over-claim runtime authority.
+
+Fix Recommendations
+1. Re-run SENTINEL in environment with:
+   - reachable `https://crusaderbot.fly.dev`
+   - `flyctl` installed/authenticated
+   - access to Telegram bot chat for controlled `/start`, `/help`, `/status` probes
+2. Attach hard evidence bundle in rerun report:
+   - `flyctl logs` startup snippet with Telegram lifecycle markers,
+   - `/ready` payload showing truthful `readiness.telegram_runtime` fields,
+   - Telegram message/reply transcript for `/start`, `/help`, `/status` with paper-only wording.
+
+Out-of-scope Advisory
+- No live-trading or production-capital readiness claim should be introduced during this lane closure; keep public-paper-beta boundary unchanged.
+
+Deferred Minor Backlog
+- None added in this run.
+
+Telegram Visual Preview
+- N/A (deployed Telegram chat probe blocked in current runner due external connectivity/tooling limits).

--- a/projects/polymarket/polyquantbot/server/api/routes.py
+++ b/projects/polymarket/polyquantbot/server/api/routes.py
@@ -40,6 +40,10 @@ def build_router(
             "kill_switch_enabled": beta_state.kill_switch,
             "execution_ready_for_paper_entries": execution_ready_for_paper_entries,
         }
+        telegram_runtime_ready = (
+            state.telegram_runtime_startup_complete and state.telegram_runtime_active
+        )
+        telegram_readiness_ok = telegram_runtime_ready if state.telegram_runtime_required else True
         ready_dimensions = {
             "scope": {
                 "contract_version": "phase8-6-public-paper-beta-confidence-pass",
@@ -56,6 +60,16 @@ def build_router(
                 "iterations_total": beta_state.worker_runtime.iterations_total,
                 "last_iteration_visible": beta_state.worker_runtime.iterations_total > 0,
                 "last_error": beta_state.worker_runtime.last_error,
+            },
+            "telegram_runtime": {
+                "required": state.telegram_runtime_required,
+                "enabled": state.telegram_runtime_enabled,
+                "startup_complete": state.telegram_runtime_startup_complete,
+                "active": state.telegram_runtime_active,
+                "shutdown_complete": state.telegram_runtime_shutdown_complete,
+                "iterations_total": state.telegram_runtime_iterations_total,
+                "last_iteration_visible": state.telegram_runtime_iterations_total > 0,
+                "last_error": state.telegram_runtime_last_error,
             },
             "worker_prerequisites": worker_prerequisites,
             "falcon_config_state": {
@@ -77,12 +91,12 @@ def build_router(
         }
         return JSONResponse(
             {
-                "status": "ready" if state.ready else "not_ready",
+                "status": "ready" if state.ready and telegram_readiness_ok else "not_ready",
                 "service": settings.app_name,
                 "validation_errors": state.validation_errors,
                 "readiness": ready_dimensions,
             },
-            status_code=200 if state.ready else 503,
+            status_code=200 if state.ready and telegram_readiness_ok else 503,
         )
 
     return router

--- a/projects/polymarket/polyquantbot/server/core/runtime.py
+++ b/projects/polymarket/polyquantbot/server/core/runtime.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Optional
 
 import structlog
 
@@ -59,6 +60,14 @@ class RuntimeState:
     shutdown_at: datetime | None = None
     validation_errors: list[str] = field(default_factory=list)
     ready: bool = False
+    telegram_runtime_required: bool = False
+    telegram_runtime_enabled: bool = False
+    telegram_runtime_startup_complete: bool = False
+    telegram_runtime_active: bool = False
+    telegram_runtime_shutdown_complete: bool = False
+    telegram_runtime_iterations_total: int = 0
+    telegram_runtime_last_error: str = ""
+    telegram_runtime_task: Optional[asyncio.Task[None]] = None
 
     def mark_started(self) -> None:
         self.started_at = datetime.now(timezone.utc)
@@ -76,6 +85,11 @@ def validate_api_environment(settings: ApiSettings) -> list[str]:
         errors.append("CRUSADER_STARTUP_MODE must remain 'strict' at runtime.")
 
     return errors
+
+
+def telegram_runtime_required_from_env() -> bool:
+    raw = os.getenv("CRUSADER_TELEGRAM_RUNTIME_REQUIRED", "false").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 async def run_startup_validation(settings: ApiSettings, state: RuntimeState) -> None:

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -20,7 +21,12 @@ from projects.polymarket.polyquantbot.server.core.runtime import (
     RuntimeState,
     run_shutdown,
     run_startup_validation,
+    telegram_runtime_required_from_env,
 )
+from projects.polymarket.polyquantbot.client.telegram.backend_client import CrusaderBackendClient
+from projects.polymarket.polyquantbot.client.telegram.bot import TelegramBotSettings, validate_bot_environment
+from projects.polymarket.polyquantbot.client.telegram.dispatcher import TelegramDispatcher
+from projects.polymarket.polyquantbot.client.telegram.runtime import HttpTelegramAdapter, run_polling_loop
 from projects.polymarket.polyquantbot.server.services.account_service import AccountService
 from projects.polymarket.polyquantbot.server.services.auth_session_service import AuthSessionService
 from projects.polymarket.polyquantbot.server.services.telegram_activation_service import TelegramActivationService
@@ -40,6 +46,77 @@ from projects.polymarket.polyquantbot.server.storage.wallet_link_store import Pe
 log = structlog.get_logger(__name__)
 
 
+class RuntimeTelegramObserver:
+    def __init__(self, state: RuntimeState) -> None:
+        self._state = state
+
+    def on_startup(self) -> None:
+        self._state.telegram_runtime_startup_complete = True
+        self._state.telegram_runtime_active = True
+        self._state.telegram_runtime_shutdown_complete = False
+        self._state.telegram_runtime_last_error = ""
+        log.info("crusaderbot_telegram_runtime_started")
+
+    def on_iteration(self, processed_count: int) -> None:
+        self._state.telegram_runtime_iterations_total += processed_count
+
+    def on_reply_sent(self) -> None:
+        log.info("crusaderbot_telegram_reply_sent")
+
+    def on_error(self, error: str) -> None:
+        self._state.telegram_runtime_last_error = error
+        log.error("crusaderbot_telegram_runtime_error", error=error)
+
+    def on_shutdown(self) -> None:
+        self._state.telegram_runtime_active = False
+        self._state.telegram_runtime_shutdown_complete = True
+        log.info("crusaderbot_telegram_runtime_stopped")
+
+
+async def _start_telegram_runtime(state: RuntimeState) -> None:
+    settings = TelegramBotSettings.from_env()
+    validation_errors = validate_bot_environment(settings)
+    state.telegram_runtime_required = telegram_runtime_required_from_env()
+    state.telegram_runtime_enabled = not validation_errors
+    if validation_errors:
+        state.telegram_runtime_last_error = "; ".join(validation_errors)
+        log.error(
+            "crusaderbot_telegram_runtime_disabled",
+            required=state.telegram_runtime_required,
+            errors=validation_errors,
+        )
+        if state.telegram_runtime_required:
+            raise RuntimeError(state.telegram_runtime_last_error)
+        return
+
+    backend = CrusaderBackendClient(
+        base_url=settings.backend_base_url,
+        identity_tenant_id=settings.staging_tenant_id,
+    )
+    dispatcher = TelegramDispatcher(backend=backend)
+    adapter = HttpTelegramAdapter(token=settings.telegram_token)
+    observer = RuntimeTelegramObserver(state=state)
+    state.telegram_runtime_task = asyncio.create_task(
+        run_polling_loop(
+            adapter=adapter,
+            dispatcher=dispatcher,
+            identity_resolver=backend,
+            onboarding_initiator=backend,
+            activation_confirmer=backend,
+            session_issuer=backend,
+            staging_tenant_id=settings.staging_tenant_id,
+            staging_user_id=settings.staging_user_id,
+            observer=observer,
+        )
+    )
+    log.info(
+        "crusaderbot_telegram_runtime_bootstrap_ready",
+        backend_base_url=settings.backend_base_url,
+        chat_id_configured=bool(settings.telegram_chat_id),
+        required=state.telegram_runtime_required,
+    )
+
+
 def create_app() -> FastAPI:
     settings = ApiSettings.from_env()
     falcon_settings = FalconSettings.from_env()
@@ -48,9 +125,16 @@ def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         await run_startup_validation(settings=settings, state=state)
+        await _start_telegram_runtime(state=state)
         try:
             yield
         finally:
+            if state.telegram_runtime_task is not None:
+                state.telegram_runtime_task.cancel()
+                try:
+                    await state.telegram_runtime_task
+                except asyncio.CancelledError:
+                    pass
             await run_shutdown(state=state)
 
     app = FastAPI(

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -93,6 +93,7 @@ def test_ready_route_reports_readiness_dimensions(monkeypatch) -> None:
 
     assert "scope" in readiness
     assert "worker_runtime" in readiness
+    assert "telegram_runtime" in readiness
     assert "worker_prerequisites" in readiness
     assert "falcon_config_state" in readiness
     assert "control_plane" in readiness
@@ -131,6 +132,20 @@ def test_ready_route_reports_readiness_semantics(monkeypatch) -> None:
     assert readiness["falcon_config_state"]["enabled"] is False
     assert readiness["falcon_config_state"]["config_valid_for_enabled_mode"] is True
     assert readiness["control_plane"]["live_mode_execution_allowed"] is False
+
+
+def test_ready_route_not_ready_when_telegram_required_without_token(monkeypatch) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("CRUSADER_TELEGRAM_RUNTIME_REQUIRED", "true")
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/ready")
+    assert response.status_code == 503
+    readiness = response.json()["readiness"]
+    assert readiness["telegram_runtime"]["required"] is True
+    assert readiness["telegram_runtime"]["enabled"] is False
 
 
 def test_ready_route_falcon_enabled_without_key_is_not_valid(monkeypatch) -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
@@ -132,11 +132,12 @@ def test_dispatch_unknown_command() -> None:
     backend.request_handoff.assert_not_awaited()
 
 
-def test_dispatch_unknown_command_help() -> None:
+def test_dispatch_help_command() -> None:
     backend = _make_mock_backend(outcome="issued")
     dispatcher = TelegramDispatcher(backend=backend)
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/help")))
-    assert result.outcome == "unknown_command"
+    assert result.outcome == "ok"
+    assert "CrusaderBot commands" in result.reply_text
     backend.request_handoff.assert_not_awaited()
 
 

--- a/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
@@ -159,8 +159,8 @@ def test_polling_loop_run_once_sends_reply() -> None:
     assert adapter.replies[0][1] == "Welcome to CrusaderBot!"
 
 
-def test_polling_loop_run_once_unknown_command_fallback() -> None:
-    """Unknown command routes through real TelegramDispatcher and returns unknown_command reply."""
+def test_polling_loop_run_once_help_command_reply() -> None:
+    """Help command routes through real TelegramDispatcher and returns command list reply."""
     update = _make_update(update_id=12, chat_id="c2", from_user_id="tg2", text="/help")
     adapter = MockTelegramAdapter([update])
     backend = MagicMock()
@@ -168,7 +168,7 @@ def test_polling_loop_run_once_unknown_command_fallback() -> None:
     loop = TelegramPollingLoop(adapter=adapter, dispatcher=dispatcher)
     asyncio.run(loop.run_once())
     assert len(adapter.replies) == 1
-    assert "Unknown command" in adapter.replies[0][1]
+    assert "CrusaderBot commands" in adapter.replies[0][1]
 
 
 def test_polling_loop_run_once_non_command_no_dispatch() -> None:


### PR DESCRIPTION
### Motivation

- Ensure the Fly-deployed API process boots a real Telegram polling runtime (not just FastAPI) so deployed public paper-beta is truly responsive to Telegram commands and the readiness surface reflects actual Telegram activity.
- Fail loud when Telegram is declared required but misconfigured, and preserve the explicit paper-only execution boundary so no live-trading claims are introduced.

### Description

- Start Telegram polling from the FastAPI lifespan in `server/main.py` using `run_polling_loop(...)` as a background task and cancel it cleanly on shutdown.  
- Add explicit Telegram runtime truth fields to `RuntimeState` (`required`, `enabled`, `startup_complete`, `active`, `shutdown_complete`, `iterations_total`, `last_error`, task handle) and an env helper `telegram_runtime_required_from_env()`.  
- Wire an observer from the polling loop to update runtime state and add lifecycle logs for startup/iteration/reply/error/shutdown.  
- Gate `/ready` on Telegram truth by adding `readiness.telegram_runtime` and returning `503` when Telegram is required but not active.  
- Add `CRUSADER_TELEGRAM_RUNTIME_REQUIRED` to `fly.toml` to make the deploy-required contract explicit.  
- Implement a real `/help` reply in the Telegram dispatcher and update unknown-command messaging to include `/help`.  
- Update targeted tests to assert readiness telegram fields and `/help` behavior, and add a FORGE report + evidence artifact; update `PROJECT_STATE.md` to reflect implemented lane with external verification blocked in this runner.

### Testing

- `py_compile` on touched modules: `PYTHONIOENCODING=utf-8 python -m py_compile ...` — PASS.  
- Targeted pytest run: `PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` — PASS (summary: `32 passed, 1 skipped`).  
- Full-test collection: `pytest -q` — BLOCKED in this runner due to missing environment deps (`fastapi`, `pydantic`) (collection errors).  
- External deploy verification (probe `https://crusaderbot.fly.dev/`, `/health`, `/ready`) — BLOCKED by outbound proxy/connect 403 in this environment; `flyctl` is unavailable in the runner.  

Report: `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`
State: `PROJECT_STATE.md` updated
Validation Tier: MAJOR
Claim Level: FULL RUNTIME INTEGRATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71f5c2c50832587286104a397d05d)