### PR TITLE
[SENTINEL] Validate Telegram runtime activation on Fly (PR #690) — BLOCKED

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 13:59
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, while external deploy verification is currently blocked in this runner environment.
+Last Updated : 2026-04-21 14:17
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, and SENTINEL PR #690 validation is currently BLOCKED pending deploy-capable external proof for startup logs and Telegram command replies.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -34,7 +34,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [IN PROGRESS]
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram runtime activation on Fly lane is in progress for external deploy verification (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync landed in `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`.
+- Telegram runtime activation on Fly lane remains in progress: SENTINEL validation for PR #690 is BLOCKED in current runner due Fly endpoint proxy 403 + missing flyctl; rerun in deploy-capable environment must verify startup logs and live Telegram replies (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`, `projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md`).
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.
@@ -42,7 +42,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` with deploy-capable environment to verify real Fly startup logs and real Telegram command replies (`/start`, `/help`, `/status`).
+- Re-run SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` in deploy-capable environment with reachable Fly and Telegram chat to collect hard evidence for startup logs, `/ready` telegram_runtime truth, and real Telegram command replies (`/start`, `/help`, `/status`).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md
@@ -1,0 +1,96 @@
+# Telegram Runtime 01 — Public-Ready Runtime Validation (PR #690)
+
+Environment
+- Date (Asia/Jakarta): 2026-04-21 14:17
+- Repo: https://github.com/bayuewalker/walker-ai-team
+- PR: #690
+- Source branch validated: feature/public-ready-telegram-runtime-on-fly
+- Validation tier: MAJOR
+- Claim level (declared): FULL RUNTIME INTEGRATION (runtime + user-facing integration)
+- Source forge report: projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md
+- Validator runtime notes:
+  - flyctl: unavailable in this runner (`command not found`)
+  - outbound probe to crusaderbot.fly.dev: blocked by CONNECT tunnel 403
+
+Validation Context
+- Objective evaluated: deployed Telegram runtime activation, truthful `/ready`, and baseline Telegram command replies (`/start`, `/help`, `/status`) on Fly.
+- In-scope checks:
+  - startup includes Telegram runtime activation
+  - startup lifecycle signal visibility
+  - truthful required-mode behavior for `CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true`
+  - truthful `/ready` Telegram runtime fields
+  - deployed Telegram replies for `/start`, `/help`, `/status`
+  - public-safe and paper-only truthful response wording
+  - no silent disabled mode
+- Out of scope enforced: live trading enablement, production-capital readiness, wallet lifecycle expansion, strategy changes, unrelated docs cleanup.
+
+Phase 0 Checks
+1. Forge handoff artifact exists at expected path: PASS.
+2. Forge report includes MAJOR structure and explicit validation target: PASS.
+3. PROJECT_STATE has full timestamp and active lane context for this task: PASS.
+4. Code-path sanity checks rerun by SENTINEL:
+   - `PYTHONIOENCODING=utf-8 python -m py_compile ...`: PASS
+   - `PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py`: PASS (32 passed, 1 skipped)
+5. External runtime validation prerequisites in this runner:
+   - `flyctl`: FAIL (unavailable)
+   - `curl https://crusaderbot.fly.dev/{/,/health,/ready}`: FAIL (CONNECT tunnel failed, 403)
+
+Findings
+1. Deploy startup path includes Telegram runtime bootstrap in API lifespan: PASS.
+   - Evidence: `server/main.py` startup invokes `_start_telegram_runtime(state)` right after API startup validation and before serving runtime; task cancellation and shutdown paths are wired.
+2. Telegram lifecycle signals are instrumented in runtime observer: PASS (code-level).
+   - Evidence: `crusaderbot_telegram_runtime_started`, `crusaderbot_telegram_reply_sent`, `crusaderbot_telegram_runtime_error`, and `crusaderbot_telegram_runtime_stopped` are emitted from observer callbacks.
+3. Required-mode behavior is fail-loud when Telegram runtime is mandatory and invalid: PASS (code-level + test-level).
+   - Evidence: `CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true` is read through `telegram_runtime_required_from_env()`. Missing/invalid bot env causes `_start_telegram_runtime` to raise `RuntimeError` when required.
+4. `/ready` truth surface reflects Telegram runtime state and required gate behavior: PASS (code-level + test-level).
+   - Evidence: `/ready` computes `telegram_readiness_ok` based on required-mode semantics and returns 503 `not_ready` when required runtime is not active.
+5. `/help` and `/status` command handlers are present with explicit public paper-only boundary wording: PASS (code-level + tests).
+6. Deployed runtime lifecycle logs and real Telegram reply behavior (`/start`, `/help`, `/status`) on Fly: NOT VERIFIED (BLOCKED).
+   - Blocking reason: runner cannot reach Fly endpoint (proxy 403) and cannot run `flyctl`.
+
+Score Breakdown
+- Startup activation wiring: 20/20
+- Runtime lifecycle signal wiring: 15/15
+- Required-mode truthfulness (`CRUSADER_TELEGRAM_RUNTIME_REQUIRED=true`): 15/15
+- `/ready` runtime-truth semantics: 15/15
+- Telegram command public-safe wording contract: 10/10
+- Live Fly proof (`/start`, `/help`, `/status` + startup logs): 0/25 (blocked by environment)
+- Total: 75/100
+
+Critical Issues
+1. Missing live Fly verification evidence for required deploy checks (`/start`, `/help`, `/status` reply proof and startup log proof) due environment network/tooling blockers.
+
+Status
+- Verdict: BLOCKED
+- Risk posture: Safe-by-default retained (no false approval without external runtime proof).
+
+PR Gate Result
+- Gate decision for PR #690: BLOCKED pending live Fly-capable validation evidence.
+- Merge recommendation: hold until deploy-capable SENTINEL rerun confirms all required external checks.
+
+Broader Audit Finding
+- No contradiction detected between code-path behavior and forge claim for activation/readiness semantics.
+- Residual gap is strictly external runtime evidence, not local contract regression.
+
+Reasoning
+- The declared claim is FULL RUNTIME INTEGRATION on deployed path. Local code/tests prove integration intent and readiness semantics, but REQUIRED CHECKS include deployed bot command replies and startup logs on Fly.
+- Without direct Fly observability and Telegram chat confirmation in this run, approving would over-claim runtime authority.
+
+Fix Recommendations
+1. Re-run SENTINEL in environment with:
+   - reachable `https://crusaderbot.fly.dev`
+   - `flyctl` installed/authenticated
+   - access to Telegram bot chat for controlled `/start`, `/help`, `/status` probes
+2. Attach hard evidence bundle in rerun report:
+   - `flyctl logs` startup snippet with Telegram lifecycle markers,
+   - `/ready` payload showing truthful `readiness.telegram_runtime` fields,
+   - Telegram message/reply transcript for `/start`, `/help`, `/status` with paper-only wording.
+
+Out-of-scope Advisory
+- No live-trading or production-capital readiness claim should be introduced during this lane closure; keep public-paper-beta boundary unchanged.
+
+Deferred Minor Backlog
+- None added in this run.
+
+Telegram Visual Preview
+- N/A (deployed Telegram chat probe blocked in current runner due external connectivity/tooling limits).


### PR DESCRIPTION
### Motivation
- Verify that the Fly-deployed API bootstraps the Telegram polling runtime, that `/ready` reflects truthful Telegram runtime state, and that baseline Telegram commands (`/start`, `/help`, `/status`) reply correctly for PR #690. 
- This is a MAJOR / FULL RUNTIME INTEGRATION validation required before merge to avoid over-claiming deployed runtime authority.

### Description
- Added SENTINEL validation report at `projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md` with findings, score (75/100), and verdict **BLOCKED** due to missing external proof. 
- Updated `PROJECT_STATE.md` timestamp and status to record the blocked SENTINEL outcome and next-priority instructions to re-run in a deploy-capable environment. 
- Code-level inspection and tests confirm Telegram runtime is wired into the API lifespan (`server/main.py`), readiness fields were added to `/ready`, and `/help`/`/status` command handlers exist in the dispatcher. 
- External deploy verification (Fly startup logs and live Telegram replies) could not be completed in this runner because `flyctl` is unavailable and outbound probes to `crusaderbot.fly.dev` are blocked.

### Testing
- `python -m py_compile` on the runtime/readiness/dispatcher files: PASS. 
- Targeted pytest suite `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` and Telegram dispatch/runtime tests: PASS (32 passed, 1 skipped). 
- External Fly runtime probes (`curl https://crusaderbot.fly.dev{/,/health,/ready}`) were attempted and BLOCKED by a CONNECT tunnel 403. 
- `flyctl` availability check failed (`command not found`) and full `pytest -q` collection warned/failed in this runner due to missing optional environment dependencies, so external deploy proof remains outstanding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e724593fb08325b1aa9b04c25804f1)