### PR TITLE
Refine Telegram onboarding and public UX copy

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-21 14:17
+Last Updated : 2026-04-21 15:21
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, and SENTINEL PR #690 validation is currently BLOCKED pending deploy-capable external proof for startup logs and Telegram command replies.
 
 [COMPLETED]
@@ -35,6 +35,8 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 [IN PROGRESS]
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
 - Telegram runtime activation on Fly lane remains in progress: SENTINEL validation for PR #690 is BLOCKED in current runner due Fly endpoint proxy 403 + missing flyctl; rerun in deploy-capable environment must verify startup logs and live Telegram replies (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`, `projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md`).
+- Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
+
 
 [NOT STARTED]
 - Full wallet lifecycle implementation including secure rotation, vault integration, and production orchestration.

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -49,11 +49,15 @@ class TelegramDispatcher:
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "📘 CrusaderBot commands (public paper beta)\n"
-                    "• /start — initialize or refresh your session\n"
-                    "• /help — show command list\n"
-                    "• /status — runtime and guard snapshot\n"
-                    "Boundary: paper-only execution, no live trading, no production capital."
+                    "📘 CrusaderBot Help (Public Paper Beta)\n\n"
+                    "Quick commands:\n"
+                    "• /start - open or refresh your Telegram session\n"
+                    "• /help - view this command guide\n"
+                    "• /status - view runtime, guard, and mode snapshot\n\n"
+                    "Safety boundary:\n"
+                    "• Paper-only execution\n"
+                    "• No live trading\n"
+                    "• Not production-capital ready"
                 ),
             )
         if command == "/mode":
@@ -129,17 +133,20 @@ class TelegramDispatcher:
             return DispatchResult(
                 outcome="ok",
                 reply_text=(
-                    "🧭 Runtime status (public paper beta)\n"
+                    "🧭 CrusaderBot Status (Public Paper Beta)\n\n"
+                    f"Runtime\n"
                     f"• Mode: {data.get('mode', 'unknown')}\n"
-                    f"• Autotrade: {data.get('autotrade', False)}\n"
-                    f"• Kill switch: {data.get('kill_switch', False)}\n"
-                    f"• Position count: {data.get('position_count', 0)}\n"
+                    f"• Managed state: {managed_beta_state.get('state', 'unknown')}\n"
+                    f"• Release channel: {data.get('public_readiness_semantics', {}).get('release_channel', 'unknown')}\n\n"
+                    f"Safety\n"
                     f"• Guard allows entry: {execution_guard.get('entry_allowed', False)}\n"
                     f"• Guard reasons: {reason_text}\n"
                     f"• Last risk reason: {data.get('last_risk_reason', 'n/a')}\n"
-                    f"• Managed beta state: {managed_beta_state.get('state', 'unknown')}\n"
-                    f"• Release channel: {data.get('public_readiness_semantics', {}).get('release_channel', 'unknown')}\n"
-                    "• Boundary: paper-only execution; Telegram is control/read surface"
+                    f"• Kill switch: {data.get('kill_switch', False)}\n\n"
+                    f"Paper metrics\n"
+                    f"• Autotrade: {data.get('autotrade', False)}\n"
+                    f"• Position count: {data.get('position_count', 0)}\n\n"
+                    "Boundary: paper-only execution. No live trading or production-capital readiness."
                 ),
             )
         if command == "/markets":
@@ -189,9 +196,13 @@ class TelegramDispatcher:
         return DispatchResult(
             outcome="unknown_command",
             reply_text=(
-                "Unknown command for CrusaderBot public paper beta.\n"
-                "Supported: /start /help /mode /autotrade /positions /pnl /risk /status /markets /market360 /social /kill\n"
-                "Note: no manual trade-entry commands are available in this beta."
+                "⚠️ I do not recognize that command.\n\n"
+                "Try one of these:\n"
+                "• /start\n"
+                "• /help\n"
+                "• /status\n"
+                "• /mode /autotrade /positions /pnl /risk /markets /market360 /social /kill\n\n"
+                "CrusaderBot is currently public paper beta only (no manual trade-entry, no live trading)."
             ),
         )
 

--- a/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+++ b/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
@@ -57,7 +57,10 @@ async def handle_start(
         )
         return HandleStartResult(
             outcome="rejected",
-            reply_text="Could not identify your Telegram account. Please try again.",
+            reply_text=(
+                "I couldn't verify your Telegram identity yet. "
+                "Please send /start again in a moment."
+            ),
         )
 
     request = BackendHandoffRequest(
@@ -80,7 +83,10 @@ async def handle_start(
         return HandleStartResult(
             outcome="session_issued",
             session_id=result.session_id,
-            reply_text="Welcome to CrusaderBot. Your session is ready.",
+            reply_text=(
+                "✅ Welcome to CrusaderBot public paper beta.\n"
+                "Your session is ready. Use /help for commands and /status for runtime info."
+            ),
         )
 
     if result.outcome == "rejected":
@@ -91,7 +97,11 @@ async def handle_start(
         )
         return HandleStartResult(
             outcome="rejected",
-            reply_text=f"Session could not be issued: {result.detail}",
+            reply_text=(
+                "⚠️ Session could not be opened right now.\n"
+                f"Reason: {result.detail or 'not available'}\n"
+                "Please try /start again shortly."
+            ),
         )
 
     log.error(
@@ -101,5 +111,8 @@ async def handle_start(
     )
     return HandleStartResult(
         outcome="error",
-        reply_text="A backend error occurred. Please try again later.",
+        reply_text=(
+            "⚠️ Temporary backend issue while starting your session. "
+            "Please try again shortly."
+        ),
     )

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -42,28 +42,43 @@ _STAGING_TENANT_ID = "staging"
 _STAGING_USER_ID = "staging"
 
 _REPLY_NOT_REGISTERED = (
-    "You are not registered with CrusaderBot yet. This public paper beta supports control/read commands only after onboarding; manual trade-entry is unavailable."
+    "Welcome - your account is not onboarded yet.\n\n"
+    "CrusaderBot is currently public paper beta (paper-only).\n"
+    "We'll start your onboarding first; then send /start again."
 )
 _REPLY_ONBOARDED = (
-    "Your onboarding request is ready. Send /start again to continue into the paper-beta control surface."
+    "✅ Onboarding started successfully.\n"
+    "Send /start again to continue into the paper-beta control surface."
 )
 _REPLY_ALREADY_LINKED = (
-    "Your account is already linked. Please send /start again."
+    "ℹ️ Your account is already linked.\n"
+    "Send /start to continue."
 )
 _REPLY_ACTIVATED = (
-    "Your account is now activated. Please send /start again to continue."
+    "✅ Your account is activated.\n"
+    "Send /start again to open your session."
 )
-_REPLY_SESSION_ISSUED = "Welcome to CrusaderBot public paper beta. Your control session is ready (paper-only execution boundary)."
+_REPLY_SESSION_ISSUED = (
+    "✅ Session ready. Welcome to CrusaderBot public paper beta.\n"
+    "Use /help for commands or /status for runtime + guard status.\n"
+    "Boundary: paper-only execution."
+)
 _REPLY_ALREADY_ACTIVE_SESSION_ISSUED = (
-    "Welcome back. Your account is already active and your control session is ready (paper-only boundary)."
+    "✅ Welcome back. Your session is ready.\n"
+    "Boundary: paper-only execution."
 )
 _REPLY_ACTIVATION_REJECTED = (
-    "Activation was rejected. Please contact the bot administrator."
+    "⚠️ Activation is not available for this account yet.\n"
+    "Please contact support if this seems unexpected."
 )
 _REPLY_ONBOARDING_REJECTED = (
-    "Onboarding could not be started. Please contact the bot administrator."
+    "⚠️ Onboarding could not be started right now.\n"
+    "Please try again later or contact support."
 )
-_REPLY_IDENTITY_ERROR = "Unable to verify your identity. Please try again later."
+_REPLY_IDENTITY_ERROR = (
+    "⚠️ We couldn't verify your identity right now.\n"
+    "Please try again shortly."
+)
 
 
 @dataclass(frozen=True)
@@ -471,7 +486,7 @@ class TelegramPollingLoop:
             )
             await self._safe_send_reply(
                 update.chat_id,
-                "A runtime error occurred. Please try again.",
+                "⚠️ Temporary runtime error. Please try your command again.",
             )
             return
 

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ux_01_refine-onboarding-command-copy.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ux_01_refine-onboarding-command-copy.md
@@ -1,0 +1,29 @@
+# Telegram UX 01 — Refine Onboarding and Command Copy
+
+Date: 2026-04-21 15:21 (Asia/Jakarta)
+Branch: feature/refine-telegram-onboarding-and-public-ux-copy
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was changed
+
+- Refined `/help` copy to be scan-first in Telegram with clearer command intent and explicit public paper-beta safety boundaries.
+- Refined `/status` copy into structured sections (Runtime, Safety, Paper metrics) to reduce wall-of-text behavior while preserving truthful paper-only posture.
+- Refined `/start` session-success, session-rejected, and temporary backend-error replies to be clearer, calmer, and next-step oriented.
+- Refined onboarding/session lifecycle fallback replies for not-onboarded, onboarded, already-linked, activated, activation-rejected, onboarding-rejected, and identity/runtime temporary errors.
+- Refined unknown-command reply formatting to be friendlier and action-oriented, while preserving no live trading / no manual trade-entry constraints.
+
+## 2. Files modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+- projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/reports/forge/telegram_ux_01_refine-onboarding-command-copy.md
+- PROJECT_STATE.md
+
+## 3. Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
+
+Validation Tier   : MINOR
+Claim Level       : FOUNDATION
+Validation Target : Telegram onboarding and command UX copy surfaces for `/start`, `/help`, `/status`, unknown-command, and user-facing fallback/error responses
+Not in Scope      : runtime activation/deploy/webhook changes, command-routing logic changes, live-trading enablement, production-capital readiness, wallet lifecycle expansion
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
@@ -137,7 +137,7 @@ def test_dispatch_help_command() -> None:
     dispatcher = TelegramDispatcher(backend=backend)
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/help")))
     assert result.outcome == "ok"
-    assert "CrusaderBot commands" in result.reply_text
+    assert "CrusaderBot Help" in result.reply_text
     backend.request_handoff.assert_not_awaited()
 
 

--- a/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
@@ -168,7 +168,7 @@ def test_polling_loop_run_once_help_command_reply() -> None:
     loop = TelegramPollingLoop(adapter=adapter, dispatcher=dispatcher)
     asyncio.run(loop.run_once())
     assert len(adapter.replies) == 1
-    assert "CrusaderBot commands" in adapter.replies[0][1]
+    assert "CrusaderBot Help" in adapter.replies[0][1]
 
 
 def test_polling_loop_run_once_non_command_no_dispatch() -> None:


### PR DESCRIPTION
### Motivation
- Improve the Telegram onboarding and command UX so first-contact and in-chat experiences are clearer, more scannable on mobile, and feel trustworthy while preserving the paper-only public beta boundary. 
- This is a wording/UX polish only and must not change runtime activation, deploy, or trading behavior.

### Description
- Reworked the `/help` message to be scan-first and explicitly state the public paper-beta safety boundary in `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`.
- Restructured `/status` output into short sections (Runtime / Safety / Paper metrics) for readability and to avoid walls of text in `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`.
- Improved `/start` lifecycle replies and backend-error/retry guidance in `projects/polymarket/polyquantbot/client/telegram/handlers/auth.py` and refined onboarding/fallback replies (not-onboarded, onboarded, already-linked, activated, activation-rejected, identity/runtime errors) in `projects/polymarket/polyquantbot/client/telegram/runtime.py`.
- Aligned unit tests for the new copy and added a MINOR FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_ux_01_refine-onboarding-command-copy.md` and a scoped `PROJECT_STATE.md` entry.
- Report: `projects/polymarket/polyquantbot/reports/forge/telegram_ux_01_refine-onboarding-command-copy.md`; State: `PROJECT_STATE.md`; Validation Tier: `MINOR`; Claim Level: `FOUNDATION`.

### Testing
- Ran `PYTHONIOENCODING=utf-8 python3 -m py_compile` on the touched modules (`client/telegram/dispatcher.py`, `client/telegram/handlers/auth.py`, `client/telegram/runtime.py`) and compilation passed.
- Ran `PYTHONIOENCODING=utf-8 pytest -q projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` and the selected suites passed (`32 passed` across the run).
- Attempted the broader Telegram onboarding/activation/session test collection, but collection failed in this environment due to missing dependency `pydantic` (external-environment limitation); this is unrelated to the copy changes and can be re-run in a dependency-complete runner.
- Performed a mojibake/encoding scan on touched files (no invalid sequences found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e732f3b2c083259d848c1f0322c7d1)