### PR TITLE
fix: gate Telegram /start lifecycle to /start only and preserve /help /status dispatch; sync checklist

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 15:21
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram runtime activation lane for Fly is implemented in code and readiness truth-synced, and SENTINEL PR #690 validation is currently BLOCKED pending deploy-capable external proof for startup logs and Telegram command replies.
+Last Updated : 2026-04-21 16:09
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics fix lane is now implemented at code level for `/start`-only lifecycle gating and no `/help`/`/status` collapse, with deploy-capable SENTINEL proof still pending for Fly + live Telegram verification.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -34,7 +34,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [IN PROGRESS]
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram runtime activation on Fly lane remains in progress: SENTINEL validation for PR #690 is BLOCKED in current runner due Fly endpoint proxy 403 + missing flyctl; rerun in deploy-capable environment must verify startup logs and live Telegram replies (`/start`, `/help`, `/status`) after code-path activation and `/ready` truth-sync (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_01_public-ready-runtime-activation.md`, `projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_01_public-ready-runtime-validation-pr690.md`).
+- Telegram command-routing semantics fix lane is in progress on `feature/fix-telegram-command-routing-and-sync-work-checklist`: polling-loop start lifecycle is now gated to `/start` only so `/help` and `/status` no longer collapse into `/start` at code level; deploy-capable rerun is still required for live Fly + Telegram proof (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log`).
 - Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
 
 
@@ -44,7 +44,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Re-run SENTINEL validation of `feature/public-ready-telegram-runtime-on-fly` in deploy-capable environment with reachable Fly and Telegram chat to collect hard evidence for startup logs, `/ready` telegram_runtime truth, and real Telegram command replies (`/start`, `/help`, `/status`).
+- Run deploy-capable validation on `feature/fix-telegram-command-routing-and-sync-work-checklist` to collect hard evidence for Fly deploy success, `/health`, `/ready`, and real Telegram command replies (`/start`, `/help`, `/status`) before SENTINEL final gate.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -341,6 +341,8 @@ class TelegramPollingLoop:
             )
             return
 
+        requires_start_lifecycle = ctx.command == "/start"
+
         if self._identity_resolver is not None:
             try:
                 resolution = await self._identity_resolver.resolve_telegram_identity(
@@ -362,6 +364,15 @@ class TelegramPollingLoop:
                     update_id=update.update_id,
                     from_user_id=update.from_user_id,
                 )
+                if not requires_start_lifecycle:
+                    await self._safe_send_reply(
+                        update.chat_id,
+                        (
+                            "⚠️ Your account is not onboarded yet.\n"
+                            "Use /start first to begin onboarding, then retry this command."
+                        ),
+                    )
+                    return
                 if self._onboarding_initiator is None:
                     await self._safe_send_reply(update.chat_id, _REPLY_NOT_REGISTERED)
                     return
@@ -412,7 +423,7 @@ class TelegramPollingLoop:
                 await self._safe_send_reply(update.chat_id, _REPLY_IDENTITY_ERROR)
                 return
 
-            if self._activation_confirmer is not None:
+            if requires_start_lifecycle and self._activation_confirmer is not None:
                 try:
                     activation = await self._activation_confirmer.confirm_telegram_activation(
                         update.from_user_id
@@ -437,7 +448,7 @@ class TelegramPollingLoop:
                     await self._safe_send_reply(update.chat_id, _REPLY_IDENTITY_ERROR)
                     return
 
-            if self._session_issuer is not None:
+            if requires_start_lifecycle and self._session_issuer is not None:
                 try:
                     issuance = await self._session_issuer.issue_telegram_session(
                         update.from_user_id,

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log
@@ -1,0 +1,74 @@
+Telegram Runtime 03 Evidence Log
+
+$ git rev-parse --abbrev-ref HEAD
+work
+[exit_code=0]
+
+$ python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('Asia/Jakarta')).strftime('%Y-%m-%d %H:%M'))"
+2026-04-21 16:08
+[exit_code=0]
+
+$ locale
+LANG=C.UTF-8
+LANGUAGE=
+LC_CTYPE="C.UTF-8"
+LC_NUMERIC="C.UTF-8"
+LC_TIME="C.UTF-8"
+LC_COLLATE="C.UTF-8"
+LC_MONETARY="C.UTF-8"
+LC_MESSAGES="C.UTF-8"
+LC_PAPER="C.UTF-8"
+LC_NAME="C.UTF-8"
+LC_ADDRESS="C.UTF-8"
+LC_TELEPHONE="C.UTF-8"
+LC_MEASUREMENT="C.UTF-8"
+LC_IDENTIFICATION="C.UTF-8"
+LC_ALL=C.UTF-8
+[exit_code=0]
+
+$ python3 -m py_compile projects/polymarket/polyquantbot/client/telegram/runtime.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+
+[exit_code=0]
+
+$ pytest -q projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+...................                                                      [100%]
+19 passed in 0.25s
+[exit_code=0]
+
+$ flyctl version
+/bin/sh: 1: flyctl: not found
+[exit_code=127]
+
+$ curl -i --max-time 20 https://crusaderbot.fly.dev/health
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Tue, 21 Apr 2026 09:08:41 GMT
+server: envoy
+connection: close
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (56) CONNECT tunnel failed, response 403
+[exit_code=56]
+
+$ curl -i --max-time 20 https://crusaderbot.fly.dev/ready
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Tue, 21 Apr 2026 09:08:41 GMT
+server: envoy
+connection: close
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (56) CONNECT tunnel failed, response 403
+[exit_code=56]
+
+Manual Telegram command verification (/start, /help, /status): BLOCKED in this runner (no Telegram bot token/chat interaction channel available).

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md
@@ -1,0 +1,61 @@
+# Telegram Runtime 03 — Command Routing Semantics Fix
+
+Date: 2026-04-21 16:08 (Asia/Jakarta)
+Branch: feature/fix-telegram-command-routing-and-sync-work-checklist
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Fixed Telegram command-routing precedence so start lifecycle hooks (onboarding, activation confirmation, session issuance) execute only for `/start`.
+- Preserved command-specific dispatch for non-`/start` commands (`/help`, `/status`, and other command surfaces) so they no longer collapse into the `/start` session/welcome path.
+- Added runtime regression tests to lock command semantics: non-`/start` commands bypass start lifecycle hooks, and unresolved users on non-`/start` commands receive an explicit “use `/start` first” boundary reply.
+- Synced `work_checklist.md` Priority 1 to current repo/runtime truth with explicit DONE / ACTIVE / NEXT status buckets aligned to observed Fly + Telegram state and this routing-fix lane.
+
+## 2. Current system architecture (relevant slice)
+
+1. Telegram polling loop normalizes inbound command text via `extract_command_context(...)`.
+2. Identity resolution still runs before command dispatch when resolver wiring is enabled.
+3. Start lifecycle hooks are now gated behind command check `ctx.command == "/start"`:
+   - onboarding initiator path,
+   - activation confirmer path,
+   - session issuer path.
+4. Non-`/start` commands:
+   - do not trigger onboarding/activation/session issuance flow,
+   - proceed to dispatcher command handler path on resolved identities,
+   - return explicit guard reply for unresolved identities instructing `/start` first.
+5. Dispatcher remains authoritative for command-specific replies (`/help`, `/status`, unknown fallback, etc.).
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+- projects/polymarket/polyquantbot/work_checklist.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log
+- projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- Local routing semantics are fixed at runtime-code level: non-`/start` commands no longer pass through start lifecycle/session issuance hooks.
+- `/help` and `/status` command paths are preserved for dispatcher handling (no forced `/start` welcome/session reply override in the polling loop).
+- Local regression test suite for runtime loop command routing passes (`19 passed`).
+- `work_checklist.md` now reflects current execution truth for Priority 1 with explicit done/active/next separation.
+
+## 5. Known issues
+
+- Deploy/redeploy execution to Fly is blocked in this runner because `flyctl` is not installed.
+- External `/health` and `/ready` probes to `https://crusaderbot.fly.dev` are blocked by proxy 403 from this runner.
+- Real Telegram chat verification for `/start`, `/help`, `/status` cannot be executed in this runner (no Telegram bot token/chat interaction channel here).
+- Because external verification is blocked, this task closes code-level semantics and checklist truth-sync, but keeps deployed verification as the next gate.
+
+## 6. What is next
+
+- Redeploy `feature/fix-telegram-command-routing-and-sync-work-checklist` in a Fly-capable environment.
+- Validate real deployed Telegram behavior for `/start`, `/help`, `/status` against this branch head.
+- Capture startup/deploy evidence (`fly logs`, `/health`, `/ready`, live Telegram replies) and hand off to SENTINEL for MAJOR validation verdict.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : Telegram polling-loop command precedence (`/start` lifecycle gating) + command-specific dispatch continuity (`/help`, `/status`) + checklist truth-sync in `work_checklist.md`
+Not in Scope      : webhook redesign, live-trading enablement, production-capital readiness, wallet lifecycle work, broad docs cleanup outside `work_checklist.md`
+Suggested Next    : SENTINEL validation on this PR head branch in deploy-capable environment with real Telegram command proof

--- a/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_02_command-routing-validation-pr694.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/telegram_runtime_02_command-routing-validation-pr694.md
@@ -1,0 +1,91 @@
+# SENTINEL Validation — Telegram Command Routing Semantics on Fly (PR #694)
+
+Environment
+- Timestamp (Asia/Jakarta): 2026-04-21 17:37
+- Repo: walker-ai-team
+- Branch requested: feature/fix-telegram-command-routing-semantics-and-sync-checklist-2026-04-21
+- Runtime branch observed in this runner: detached `work` (Codex worktree)
+- Validation tier: MAJOR
+- Claim level: USER-FACING TELEGRAM COMMAND CORRECTNESS
+- Source report: `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md`
+
+Validation Context
+- Objective: validate deployed Telegram command-routing semantics for `/start`, `/help`, `/status`; verify non-`/start` no longer collapses into `/start`; verify unresolved non-`/start` guidance and `work_checklist.md` truth-sync.
+- Not in scope respected: runtime activation redesign, webhook redesign, live-trading enablement, production-capital readiness, wallet/portfolio expansion, broad docs cleanup outside work_checklist sync.
+
+Phase 0 Checks
+- Forge report exists at required path: PASS.
+- Forge report structure includes six required sections: PASS.
+- `PROJECT_STATE.md` includes full timestamp and reflects pending deploy-capable validation: PASS.
+- `python -m py_compile` on touched runtime/test files: PASS.
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py`: PASS (19 passed).
+
+Findings
+1) Runtime code semantics are correctly gated to `/start` for lifecycle hooks.
+   - `requires_start_lifecycle = ctx.command == "/start"` gates onboarding/activation/session issuance in `TelegramPollingLoop`.
+   - Non-`/start` + unresolved identity now returns explicit `/start first` guidance reply and exits before lifecycle hooks.
+   - Result: local code-level claim for non-collapse behavior is supported.
+
+2) Regression tests explicitly enforce required command-routing semantics.
+   - Non-`/start` command bypasses activation/session hooks.
+   - Non-`/start` unresolved identity returns `Use /start first` guidance.
+   - `/help` path test confirms dispatcher-based help reply path remains reachable.
+
+3) Deploy-capable proof could not be completed in this environment.
+   - `flyctl` is not installed (`command not found`), so branch deploy/redeploy to Fly could not be executed.
+   - External probes to `https://crusaderbot.fly.dev/health` and `/ready` returned proxy tunnel `403`, preventing endpoint verification from this runner.
+   - Real Telegram interaction for `/start`, `/help`, `/status` cannot be exercised in this runner (no Telegram bot/chat execution channel).
+
+4) `work_checklist.md` sync is directionally consistent with code state.
+   - Priority 1 marks command-routing fix as active and deploy/live-verification as next.
+   - This is truthful given local semantics fix evidence and unresolved deploy/live proof gate.
+
+Score Breakdown
+- Code-path semantic validation: 35/35
+- Regression test evidence: 25/25
+- Deploy to Fly evidence: 0/15
+- `/health` + `/ready` external verification: 0/10
+- Live Telegram `/start` `/help` `/status` verification: 0/10
+- work_checklist truth-sync verification: 5/5
+- Total: 65/100
+
+Critical Issues
+1. Missing deploy-capable evidence for this branch on Fly (required check not satisfied).
+2. Missing live Telegram command proof on deployed runtime for `/start`, `/help`, `/status` (required checks not satisfied).
+
+Status
+- Verdict: BLOCKED
+- Rationale: Mandatory deploy/runtime checks from task objective are not completed in this execution environment; only local code/test validation is complete.
+
+PR Gate Result
+- BLOCKED for merge gate under requested MAJOR validation objective.
+- Unblock conditions:
+  1) Deploy branch `feature/fix-telegram-command-routing-semantics-and-sync-checklist-2026-04-21` (or exact PR #694 head) to Fly from deploy-capable runner.
+  2) Capture successful `/health` and `/ready` responses from deployed app.
+  3) Execute real Telegram chat checks for `/start`, `/help`, `/status` and capture replies proving no non-`/start` collapse.
+
+Broader Audit Finding
+- No contradictory code behavior found locally against the FORGE claim on routing semantics.
+- Risk remains operational (deployment/runtime proof gap), not implementation logic in inspected files.
+
+Reasoning
+- For MAJOR validation, proof must include behavior at deployed boundary, not only local tests.
+- Since deploy/runtime checks are explicitly required by COMMANDER task and are incomplete, approval cannot be issued.
+
+Fix Recommendations
+1. Re-run SENTINEL from a Fly-capable environment with `flyctl` available and authenticated.
+2. Collect evidence bundle:
+   - deploy output
+   - `fly logs` around startup
+   - `/health` and `/ready` responses
+   - Telegram transcript/screenshots for `/start`, `/help`, `/status` and unresolved-user non-`/start` guidance
+3. Append evidence references in a follow-up SENTINEL report and re-issue verdict.
+
+Out-of-scope Advisory
+- None.
+
+Deferred Minor Backlog
+- None introduced by this validation run.
+
+Telegram Visual Preview
+- BLOCKED: local code semantics pass; deploy/live Telegram proof pending.

--- a/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
@@ -259,3 +259,48 @@ def test_polling_loop_uses_staging_contract() -> None:
     dispatched_ctx: TelegramCommandContext = dispatcher.dispatch.call_args[0][0]
     assert dispatched_ctx.tenant_id == "t-stage"
     assert dispatched_ctx.user_id == "u-stage"
+
+
+def test_polling_loop_non_start_command_bypasses_start_lifecycle_hooks() -> None:
+    update = _make_update(update_id=60, chat_id="c60", from_user_id="tg60", text="/help")
+    adapter = MockTelegramAdapter([update])
+    dispatcher = _mock_dispatcher(reply_text="Help text")
+    resolver = AsyncMock(
+        resolve_telegram_identity=AsyncMock(
+            return_value=MagicMock(outcome="resolved", tenant_id="t1", user_id="u1")
+        )
+    )
+    activation_confirmer = AsyncMock()
+    session_issuer = AsyncMock()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=resolver,
+        activation_confirmer=activation_confirmer,
+        session_issuer=session_issuer,
+    )
+    asyncio.run(loop.run_once())
+    dispatcher.dispatch.assert_called_once()
+    activation_confirmer.confirm_telegram_activation.assert_not_awaited()
+    session_issuer.issue_telegram_session.assert_not_awaited()
+    assert adapter.replies[0] == ("c60", "Help text")
+
+
+def test_polling_loop_non_start_not_found_requires_start_first() -> None:
+    update = _make_update(update_id=61, chat_id="c61", from_user_id="tg61", text="/status")
+    adapter = MockTelegramAdapter([update])
+    dispatcher = _mock_dispatcher(reply_text="Status text")
+    resolver = AsyncMock(
+        resolve_telegram_identity=AsyncMock(return_value=MagicMock(outcome="not_found"))
+    )
+    onboarding_initiator = AsyncMock()
+    loop = TelegramPollingLoop(
+        adapter=adapter,
+        dispatcher=dispatcher,
+        identity_resolver=resolver,
+        onboarding_initiator=onboarding_initiator,
+    )
+    asyncio.run(loop.run_once())
+    dispatcher.dispatch.assert_not_called()
+    onboarding_initiator.start_telegram_onboarding.assert_not_awaited()
+    assert "Use /start first" in adapter.replies[0][1]

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -8,32 +8,44 @@ PRIORITY 1 — Bot Public-Ready Baseline
 
 This must be finished first.
 
-1. Telegram Runtime Activation
+Status Snapshot (2026-04-21)
 
-[ ] Make sure the Telegram listener/worker is truly active on Fly
+DONE / Mostly Done
 
-[ ] Confirm the runtime mode: polling or webhook
+[x] Fly app is alive
 
-[ ] Make sure the bot starts automatically when the app boots
+[x] Telegram runtime is active on Fly
 
-[ ] Make sure /ready truthfully reflects Telegram runtime state
+[x] Telegram startup is automatic in the deploy path
 
-[ ] Make sure worker_runtime.active is truthful
+[x] /ready includes Telegram runtime truth
 
-[ ] Make sure worker_runtime.startup_complete is truthful
+[x] /start replies on deployed environment
 
-[ ] Add clear Telegram startup logs
+[x] Onboarding/public-safe/paper-only copy refined
 
-[ ] Remove any silent disabled mode
+[x] Fallback/error copy refined
+
+
+ACTIVE (Current lane)
+
+[ ] Fix /help command semantics so it reaches real help handler (no /start collapse)
+
+[ ] Fix /status command semantics so it reaches real status handler (no /start collapse)
+
+[ ] Ensure command routing precedence no longer collapses non-/start commands into /start lifecycle/session path
+
+
+NEXT (immediately after code fix)
+
+[ ] Redeploy latest command-routing fix to Fly
+
+[ ] Verify live Telegram behavior for /start, /help, and /status
+
+[ ] Save fresh deploy evidence (logs + /health + /ready + command replies)
 
 
 2. Baseline Public Commands
-
-[ ] Make sure /start replies successfully
-
-[ ] Make sure /help replies successfully
-
-[ ] Make sure /status replies successfully
 
 [ ] Make sure responses are not empty or dummy
 


### PR DESCRIPTION
### Motivation
- Restore correct Telegram command routing so onboarding/activation/session issuance run only for `/start` and prevent `/help` and `/status` from being absorbed into the `/start` lifecycle.
- Provide clear user guidance for unresolved identities on non-`/start` commands and lock command semantics with regression tests.
- Sync `projects/polymarket/polyquantbot/work_checklist.md` to reflect current repo/runtime truth and the immediate next gate (deploy-capable verification).

### Description
- Gate the start lifecycle in `TelegramPollingLoop` so onboarding, activation confirmation, and session issuance are executed only when `ctx.command == "/start"` and add an explicit guard reply for unresolved non-`/start` commands.
- Add unit/regression tests to `projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` that verify non-`/start` commands bypass start hooks and that unresolved non-`/start` commands receive the `Use /start first` guidance.
- Sync `projects/polymarket/polyquantbot/work_checklist.md` Priority 1 with DONE / ACTIVE / NEXT buckets and add a FORGE report and an evidence log at `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md` and `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log`.
- Update `PROJECT_STATE.md` timestamp and in-progress wording to reference this branch and the deploy-capable SENTINEL verification gate.

### Testing
- Ran `python3 -m py_compile` on `projects/polymarket/polyquantbot/client/telegram/runtime.py` and the modified test file with no syntax errors reported.
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` and observed `19 passed`.
- Automated deploy/runtime probes (`flyctl version`, `curl https://crusaderbot.fly.dev/health` and `/ready`) were executed and are blocked in this runner (missing `flyctl` and proxy 403), so live Telegram verification (`/start`, `/help`, `/status`) remains pending for SENTINEL in a deploy-capable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73de6d0b08325a11f99cae45d7be4)