### PR TITLE
Integrate Telegram design layer into /start /help /status replies and sync checklist

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 16:09
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics fix lane is now implemented at code level for `/start`-only lifecycle gating and no `/help`/`/status` collapse, with deploy-capable SENTINEL proof still pending for Fly + live Telegram verification.
+Last Updated : 2026-04-21 19:05
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics and `/start` `/help` `/status` presentation-layer integration are now implemented at code level, with deploy-capable Fly + live Telegram verification still pending.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -36,6 +36,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
 - Telegram command-routing semantics fix lane is in progress on `feature/fix-telegram-command-routing-and-sync-work-checklist`: polling-loop start lifecycle is now gated to `/start` only so `/help` and `/status` no longer collapse into `/start` at code level; deploy-capable rerun is still required for live Fly + Telegram proof (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log`).
 - Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
+- Telegram design/presentation integration lane is implemented on `feature/integrate-telegram-design-layer-and-sync-checklist`: live `/start`, `/help`, `/status` replies now use structured presentation helpers with preserved paper-only/public-safe boundaries; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-integration.md`).
 
 
 [NOT STARTED]
@@ -44,7 +45,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Run deploy-capable validation on `feature/fix-telegram-command-routing-and-sync-work-checklist` to collect hard evidence for Fly deploy success, `/health`, `/ready`, and real Telegram command replies (`/start`, `/help`, `/status`) before SENTINEL final gate.
+- Run deploy-capable validation on Telegram command-routing + presentation integration branches to collect hard evidence for Fly deploy success, `/health`, `/ready`, and real Telegram command replies (`/start`, `/help`, `/status`) including improved formatting render proof before final review gate.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -12,6 +12,10 @@ from projects.polymarket.polyquantbot.client.telegram.handlers.auth import (
     TelegramHandoffContext,
     handle_start,
 )
+from projects.polymarket.polyquantbot.client.telegram.presentation import (
+    format_help_reply,
+    format_status_reply,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -48,17 +52,7 @@ class TelegramDispatcher:
         if command == "/help":
             return DispatchResult(
                 outcome="ok",
-                reply_text=(
-                    "📘 CrusaderBot Help (Public Paper Beta)\n\n"
-                    "Quick commands:\n"
-                    "• /start - open or refresh your Telegram session\n"
-                    "• /help - view this command guide\n"
-                    "• /status - view runtime, guard, and mode snapshot\n\n"
-                    "Safety boundary:\n"
-                    "• Paper-only execution\n"
-                    "• No live trading\n"
-                    "• Not production-capital ready"
-                ),
+                reply_text=format_help_reply(),
             )
         if command == "/mode":
             mode = arg.lower()
@@ -132,21 +126,18 @@ class TelegramDispatcher:
             managed_beta_state = data.get("managed_beta_state", {})
             return DispatchResult(
                 outcome="ok",
-                reply_text=(
-                    "🧭 CrusaderBot Status (Public Paper Beta)\n\n"
-                    f"Runtime\n"
-                    f"• Mode: {data.get('mode', 'unknown')}\n"
-                    f"• Managed state: {managed_beta_state.get('state', 'unknown')}\n"
-                    f"• Release channel: {data.get('public_readiness_semantics', {}).get('release_channel', 'unknown')}\n\n"
-                    f"Safety\n"
-                    f"• Guard allows entry: {execution_guard.get('entry_allowed', False)}\n"
-                    f"• Guard reasons: {reason_text}\n"
-                    f"• Last risk reason: {data.get('last_risk_reason', 'n/a')}\n"
-                    f"• Kill switch: {data.get('kill_switch', False)}\n\n"
-                    f"Paper metrics\n"
-                    f"• Autotrade: {data.get('autotrade', False)}\n"
-                    f"• Position count: {data.get('position_count', 0)}\n\n"
-                    "Boundary: paper-only execution. No live trading or production-capital readiness."
+                reply_text=format_status_reply(
+                    mode=str(data.get("mode", "unknown")),
+                    managed_state=str(managed_beta_state.get("state", "unknown")),
+                    release_channel=str(
+                        data.get("public_readiness_semantics", {}).get("release_channel", "unknown")
+                    ),
+                    entry_allowed=bool(execution_guard.get("entry_allowed", False)),
+                    guard_reasons=reason_text,
+                    last_risk_reason=str(data.get("last_risk_reason", "n/a")),
+                    kill_switch=bool(data.get("kill_switch", False)),
+                    autotrade=bool(data.get("autotrade", False)),
+                    position_count=int(data.get("position_count", 0)),
                 ),
             )
         if command == "/markets":

--- a/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+++ b/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
@@ -11,6 +11,9 @@ from projects.polymarket.polyquantbot.client.telegram.backend_client import (
     BackendHandoffResult,
     CrusaderBackendClient,
 )
+from projects.polymarket.polyquantbot.client.telegram.presentation import (
+    format_start_session_ready_reply,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -83,10 +86,7 @@ async def handle_start(
         return HandleStartResult(
             outcome="session_issued",
             session_id=result.session_id,
-            reply_text=(
-                "✅ Welcome to CrusaderBot public paper beta.\n"
-                "Your session is ready. Use /help for commands and /status for runtime info."
-            ),
+            reply_text=format_start_session_ready_reply(),
         )
 
     if result.outcome == "rejected":

--- a/projects/polymarket/polyquantbot/client/telegram/presentation.py
+++ b/projects/polymarket/polyquantbot/client/telegram/presentation.py
@@ -1,0 +1,89 @@
+"""Telegram presentation helpers for public paper-beta live replies.
+
+Pure formatting only: no I/O, no runtime side effects.
+"""
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.telegram.ui.components import SEP, render_kv_line
+
+
+def format_start_session_ready_reply() -> str:
+    return (
+        "🚀 CrusaderBot — Session Ready\n"
+        f"{SEP}\n"
+        "Your paper-beta session is active.\n\n"
+        "Next steps:\n"
+        "• /help — command guide\n"
+        "• /status — runtime and guard snapshot\n\n"
+        "Boundary:\n"
+        "• Public-ready paper beta\n"
+        "• Paper-only execution\n"
+        "• Not live-trading ready\n"
+        "• Not production-capital ready"
+    )
+
+
+def format_help_reply() -> str:
+    lines = [
+        "📘 CrusaderBot Help — Public Paper Beta",
+        SEP,
+        "Core commands",
+        render_kv_line("/START", "Open or refresh your session"),
+        render_kv_line("/HELP", "View this guide"),
+        render_kv_line("/STATUS", "Runtime + guard snapshot"),
+        SEP,
+        "Paper control surfaces",
+        render_kv_line("/MODE", "Set paper mode only"),
+        render_kv_line("/AUTOTRADE", "Toggle paper autotrade"),
+        render_kv_line("/POSITIONS", "Read open paper positions"),
+        render_kv_line("/PNL", "Read paper PnL"),
+        render_kv_line("/RISK", "Read risk state"),
+        render_kv_line("/MARKETS", "Query market scan"),
+        render_kv_line("/MARKET360", "View market detail"),
+        render_kv_line("/SOCIAL", "View social pulse"),
+        render_kv_line("/KILL", "Force paper kill switch"),
+        SEP,
+        "Boundary",
+        "• Public-ready paper beta",
+        "• Paper-only execution",
+        "• Not live-trading ready",
+        "• Not production-capital ready",
+    ]
+    return "\n".join(lines)
+
+
+def format_status_reply(
+    *,
+    mode: str,
+    managed_state: str,
+    release_channel: str,
+    entry_allowed: bool,
+    guard_reasons: str,
+    last_risk_reason: str,
+    kill_switch: bool,
+    autotrade: bool,
+    position_count: int,
+) -> str:
+    return "\n".join(
+        [
+            "🧭 CrusaderBot Status — Public Paper Beta",
+            SEP,
+            "Runtime",
+            render_kv_line("Mode", mode),
+            render_kv_line("State", managed_state),
+            render_kv_line("Channel", release_channel),
+            SEP,
+            "Safety",
+            render_kv_line("Entry", str(entry_allowed)),
+            render_kv_line("Reasons", guard_reasons),
+            render_kv_line("Last risk", last_risk_reason),
+            render_kv_line("Kill switch", str(kill_switch)),
+            SEP,
+            "Paper metrics",
+            render_kv_line("Autotrade", str(autotrade)),
+            render_kv_line("Positions", str(position_count)),
+            SEP,
+            "Boundary: paper-only execution. Not live-trading ready. Not production-capital ready.",
+        ]
+    )
+

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -35,6 +35,9 @@ from projects.polymarket.polyquantbot.client.telegram.dispatcher import (
     TelegramCommandContext,
     TelegramDispatcher,
 )
+from projects.polymarket.polyquantbot.client.telegram.presentation import (
+    format_start_session_ready_reply,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -58,11 +61,7 @@ _REPLY_ACTIVATED = (
     "✅ Your account is activated.\n"
     "Send /start again to open your session."
 )
-_REPLY_SESSION_ISSUED = (
-    "✅ Session ready. Welcome to CrusaderBot public paper beta.\n"
-    "Use /help for commands or /status for runtime + guard status.\n"
-    "Boundary: paper-only execution."
-)
+_REPLY_SESSION_ISSUED = format_start_session_ready_reply()
 _REPLY_ALREADY_ACTIVE_SESSION_ISSUED = (
     "✅ Welcome back. Your session is ready.\n"
     "Boundary: paper-only execution."

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-evidence.log
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-evidence.log
@@ -1,0 +1,59 @@
+=== /start session-issued reply ===
+🚀 CrusaderBot — Session Ready
+━━━━━━━━━━━━━━━━━━━━━━
+Your paper-beta session is active.
+
+Next steps:
+• /help — command guide
+• /status — runtime and guard snapshot
+
+Boundary:
+• Public-ready paper beta
+• Paper-only execution
+• Not live-trading ready
+• Not production-capital ready
+
+=== /help reply ===
+📘 CrusaderBot Help — Public Paper Beta
+━━━━━━━━━━━━━━━━━━━━━━
+Core commands
+/START       ● Open or refresh your session
+/HELP        ● View this guide
+/STATUS      ● Runtime + guard snapshot
+━━━━━━━━━━━━━━━━━━━━━━
+Paper control surfaces
+/MODE        ● Set paper mode only
+/AUTOTRADE   ● Toggle paper autotrade
+/POSITIONS   ● Read open paper positions
+/PNL         ● Read paper PnL
+/RISK        ● Read risk state
+/MARKETS     ● Query market scan
+/MARKET360   ● View market detail
+/SOCIAL      ● View social pulse
+/KILL        ● Force paper kill switch
+━━━━━━━━━━━━━━━━━━━━━━
+Boundary
+• Public-ready paper beta
+• Paper-only execution
+• Not live-trading ready
+• Not production-capital ready
+
+=== /status reply (representative payload mapping) ===
+🧭 CrusaderBot Status — Public Paper Beta
+━━━━━━━━━━━━━━━━━━━━━━
+Runtime
+MODE         ● paper
+STATE        ● running
+CHANNEL      ● public_paper_beta
+━━━━━━━━━━━━━━━━━━━━━━
+Safety
+ENTRY        ● False
+REASONS      ● autotrade_disabled
+LAST RISK    ● kill_switch_enabled
+KILL SWITCH  ● True
+━━━━━━━━━━━━━━━━━━━━━━
+Paper metrics
+AUTOTRADE    ● False
+POSITIONS    ● 2
+━━━━━━━━━━━━━━━━━━━━━━
+Boundary: paper-only execution. Not live-trading ready. Not production-capital ready.

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-integration.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-integration.md
@@ -1,0 +1,57 @@
+# Telegram UX 02 — Design Layer Integration into Live Replies
+
+Date: 2026-04-21 19:05 (Asia/Jakarta)
+Branch: feature/integrate-telegram-design-layer-and-sync-checklist
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Integrated a dedicated Telegram presentation helper layer into the live command reply path used by the polling runtime and dispatcher.
+- Wired `/help` live reply generation to the new presentation layer with structured sections, visual separators, and readable command grouping suitable for mobile Telegram chats.
+- Wired `/status` live reply generation to the presentation layer while preserving command semantics and status truth boundaries from backend payloads.
+- Wired `/start` session-issued reply text (both dispatcher auth handler path and polling-loop session issuance path) to the same presentation style for consistent onboarding UX.
+- Synced `projects/polymarket/polyquantbot/work_checklist.md` so command-routing fix is marked landed and design-layer integration is reflected as completed in repo code truth, with deploy verification still pending.
+
+## 2. Current system architecture (relevant slice)
+
+1. `TelegramPollingLoop` resolves command context and keeps `/start` lifecycle gating logic unchanged.
+2. Dispatcher command semantics remain unchanged (`/start`, `/help`, `/status` still route to their own handlers).
+3. Reply text for `/help` and `/status` now comes from `client/telegram/presentation.py` formatter functions.
+4. `/start` session-issued success reply in both auth handler and runtime session-issuance path now uses the same presentation formatter.
+5. Backend status truth remains source-of-data for runtime/safety/metrics values; presentation layer only controls output structure and readability.
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/presentation.py
+- projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+- projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+- projects/polymarket/polyquantbot/work_checklist.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-integration.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-evidence.log
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- `/start`, `/help`, and `/status` semantics remain command-correct (no collapse into a single behavior path).
+- Live reply bodies for those commands are now visibly structured with hierarchy/separators and improved scan readability.
+- Paper-only/public-safe boundaries are preserved and explicit in the new presentation outputs.
+- Unit tests covering the touched Telegram command/reply surfaces pass locally.
+
+## 5. Known issues
+
+- Real Telegram mobile rendering proof in deployed environment is still pending because this task runs in local CI/container context only.
+- Deploy-capable verification (`fly deploy`, live bot chat capture) remains required before claiming deployed formatting completion.
+
+## 6. What is next
+
+- Redeploy this branch (or merged equivalent) to Fly in a deploy-capable environment.
+- Capture real Telegram `/start`, `/help`, `/status` screenshots/output evidence to confirm mobile rendering quality.
+- Run COMMANDER review for STANDARD lane closure.
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : Live Telegram reply presentation integration for `/start`, `/help`, `/status` without command semantics regression or readiness-overclaim.
+Not in Scope      : runtime activation redesign, webhook/polling redesign, command routing architecture rewrite, live-trading enablement, production-capital readiness.
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
@@ -310,7 +310,7 @@ def test_status_command_reply_surfaces_execution_guard_and_boundary() -> None:
     backend = FakeBackend()
     dispatcher = TelegramDispatcher(backend=backend)
     result = asyncio.run(dispatcher.dispatch(_make_ctx("/status")))
-    assert "Guard allows entry" in result.reply_text
+    assert "Entry" in result.reply_text
     assert "autotrade_disabled" in result.reply_text
     assert "paper-only execution" in result.reply_text
 

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -29,20 +29,22 @@ DONE / Mostly Done
 
 ACTIVE (Current lane)
 
-[ ] Fix /help command semantics so it reaches real help handler (no /start collapse)
+[x] Fix /help command semantics so it reaches real help handler (no /start collapse)
 
-[ ] Fix /status command semantics so it reaches real status handler (no /start collapse)
+[x] Fix /status command semantics so it reaches real status handler (no /start collapse)
 
-[ ] Ensure command routing precedence no longer collapses non-/start commands into /start lifecycle/session path
+[x] Ensure command routing precedence no longer collapses non-/start commands into /start lifecycle/session path
+
+[x] Integrate Telegram design/presentation layer into live `/start`, `/help`, `/status` reply builders (repo code truth)
 
 
-NEXT (immediately after code fix)
+NEXT (immediately after code fix + UX integration)
 
-[ ] Redeploy latest command-routing fix to Fly
+[ ] Redeploy latest command-routing + Telegram UX integration to Fly
 
 [ ] Verify live Telegram behavior for /start, /help, and /status
 
-[ ] Save fresh deploy evidence (logs + /health + /ready + command replies)
+[ ] Save fresh deploy evidence (logs + /health + /ready + command replies, including improved Telegram reply formatting)
 
 
 2. Baseline Public Commands


### PR DESCRIPTION
### Motivation
- Apply the existing Telegram design/presentation layer to live reply surfaces so `/start`, `/help`, and `/status` present a polished, mobile-friendly UX while preserving current command semantics and paper-only safety boundaries.
- Keep presentation logic isolated from routing/behavior so no command-collapse or readiness overclaims are introduced.
- Record repo truth by syncing `work_checklist.md` and updating `PROJECT_STATE.md` to reflect the integration landing in code (deploy verification remains next).

### Description
- Add `projects/polymarket/polyquantbot/client/telegram/presentation.py` containing pure-formatting helpers `format_start_session_ready_reply`, `format_help_reply`, and `format_status_reply` that use the repo UI primitives (e.g. `SEP`, `render_kv_line`).
- Wire presentation formatters into live reply paths by using `format_help_reply` and `format_status_reply` from `client/telegram/dispatcher.py` and `format_start_session_ready_reply` from `client/telegram/handlers/auth.py` and `client/telegram/runtime.py` so `/start`, `/help`, and `/status` use the new style without changing dispatch semantics.
- Update one assertion in `projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` to match the structured `status` output; add a forge report and a representative evidence log under `projects/polymarket/polyquantbot/reports/forge/`.
- Sync `projects/polymarket/polyquantbot/work_checklist.md` to mark the command-routing fixes done and record the UX integration in code truth, and update `PROJECT_STATE.md` timestamp/status to reflect the change.

### Testing
- Ran syntax checks via `python3 -m py_compile` on the touched Telegram modules and they succeeded.
- Ran the focused test set via `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py` which resulted in `34 passed, 1 skipped`.
- Generated a representative formatter output log (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-evidence.log`) to show before/after style and ran a mojibake/encoding scan on touched files with no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76799897c8325a5d0c2f71c3dd8c3)