### PR TITLE
feat: consolidate Telegram presentation across remaining public reply surfaces

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-21 19:05
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics and `/start` `/help` `/status` presentation-layer integration are now implemented at code level, with deploy-capable Fly + live Telegram verification still pending.
+Last Updated : 2026-04-21 19:32
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics plus expanded public-reply presentation consolidation are implemented at code level, with deploy-capable Fly + live Telegram verification still pending.
 
 [COMPLETED]
 - Phase 6.6.8 public safety hardening merged via PR #565.
@@ -36,7 +36,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
 - Telegram command-routing semantics fix lane is in progress on `feature/fix-telegram-command-routing-and-sync-work-checklist`: polling-loop start lifecycle is now gated to `/start` only so `/help` and `/status` no longer collapse into `/start` at code level; deploy-capable rerun is still required for live Fly + Telegram proof (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log`).
 - Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
-- Telegram design/presentation integration lane is implemented on `feature/integrate-telegram-design-layer-and-sync-checklist`: live `/start`, `/help`, `/status` replies now use structured presentation helpers with preserved paper-only/public-safe boundaries; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_02_design-layer-integration.md`).
+- Telegram presentation consolidation lane is implemented on `feature/extend-telegram-presentation-layer-and-sync-checklist`: `/start` `/help` `/status` plus remaining public onboarding/fallback/error surfaces now use shared structured presentation helpers with preserved paper-only/public-safe boundaries; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`).
 
 
 [NOT STARTED]

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -15,6 +15,7 @@ from projects.polymarket.polyquantbot.client.telegram.handlers.auth import (
 from projects.polymarket.polyquantbot.client.telegram.presentation import (
     format_help_reply,
     format_status_reply,
+    format_unknown_command_reply,
 )
 
 log = structlog.get_logger(__name__)
@@ -186,15 +187,7 @@ class TelegramDispatcher:
         log.warning("crusaderbot_telegram_dispatch_unknown_command", command=ctx.command, chat_id=ctx.chat_id)
         return DispatchResult(
             outcome="unknown_command",
-            reply_text=(
-                "⚠️ I do not recognize that command.\n\n"
-                "Try one of these:\n"
-                "• /start\n"
-                "• /help\n"
-                "• /status\n"
-                "• /mode /autotrade /positions /pnl /risk /markets /market360 /social /kill\n\n"
-                "CrusaderBot is currently public paper beta only (no manual trade-entry, no live trading)."
-            ),
+            reply_text=format_unknown_command_reply(),
         )
 
     async def _dispatch_start(self, ctx: TelegramCommandContext) -> DispatchResult:

--- a/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+++ b/projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
@@ -12,7 +12,9 @@ from projects.polymarket.polyquantbot.client.telegram.backend_client import (
     CrusaderBackendClient,
 )
 from projects.polymarket.polyquantbot.client.telegram.presentation import (
+    format_start_rejected_reply,
     format_start_session_ready_reply,
+    format_start_temp_backend_error_reply,
 )
 
 log = structlog.get_logger(__name__)
@@ -97,11 +99,7 @@ async def handle_start(
         )
         return HandleStartResult(
             outcome="rejected",
-            reply_text=(
-                "⚠️ Session could not be opened right now.\n"
-                f"Reason: {result.detail or 'not available'}\n"
-                "Please try /start again shortly."
-            ),
+            reply_text=format_start_rejected_reply(result.detail),
         )
 
     log.error(
@@ -111,8 +109,5 @@ async def handle_start(
     )
     return HandleStartResult(
         outcome="error",
-        reply_text=(
-            "⚠️ Temporary backend issue while starting your session. "
-            "Please try again shortly."
-        ),
+        reply_text=format_start_temp_backend_error_reply(),
     )

--- a/projects/polymarket/polyquantbot/client/telegram/presentation.py
+++ b/projects/polymarket/polyquantbot/client/telegram/presentation.py
@@ -23,6 +23,128 @@ def format_start_session_ready_reply() -> str:
     )
 
 
+def format_start_first_required_reply() -> str:
+    return (
+        "⚠️ Onboarding required before this command\n"
+        f"{SEP}\n"
+        "Use /start first to begin onboarding.\n"
+        "After onboarding is ready, retry your command.\n\n"
+        "Boundary:\n"
+        "• Public-ready paper beta\n"
+        "• Paper-only execution\n"
+        "• Not live-trading ready\n"
+        "• Not production-capital ready"
+    )
+
+
+def format_onboarding_started_reply() -> str:
+    return (
+        "✅ Onboarding started\n"
+        f"{SEP}\n"
+        "We created your onboarding path.\n"
+        "Send /start again to continue into session activation.\n\n"
+        "Boundary: paper-only public beta."
+    )
+
+
+def format_already_linked_reply() -> str:
+    return (
+        "ℹ️ Account already linked\n"
+        f"{SEP}\n"
+        "Your Telegram account is already linked.\n"
+        "Send /start to continue into session activation."
+    )
+
+
+def format_activation_ready_reply() -> str:
+    return (
+        "✅ Account activated\n"
+        f"{SEP}\n"
+        "Activation is complete.\n"
+        "Send /start again to open your session."
+    )
+
+
+def format_already_active_session_reply() -> str:
+    return (
+        "✅ Session already active\n"
+        f"{SEP}\n"
+        "Welcome back — your paper-beta session is ready.\n"
+        "Use /help or /status for next actions."
+    )
+
+
+def format_temporary_identity_error_reply() -> str:
+    return (
+        "⚠️ Temporary identity check issue\n"
+        f"{SEP}\n"
+        "We couldn't verify your identity right now.\n"
+        "Please try again shortly."
+    )
+
+
+def format_onboarding_rejected_reply() -> str:
+    return (
+        "⚠️ Onboarding unavailable right now\n"
+        f"{SEP}\n"
+        "We couldn't start onboarding at the moment.\n"
+        "Please try again later or contact support."
+    )
+
+
+def format_activation_rejected_reply() -> str:
+    return (
+        "⚠️ Activation unavailable for this account\n"
+        f"{SEP}\n"
+        "Activation is not available right now.\n"
+        "Please contact support if this seems unexpected."
+    )
+
+
+def format_runtime_temporary_error_reply() -> str:
+    return (
+        "⚠️ Temporary runtime issue\n"
+        f"{SEP}\n"
+        "Please retry your command in a moment."
+    )
+
+
+def format_start_rejected_reply(detail: str) -> str:
+    reason = detail or "not available"
+    return (
+        "⚠️ Session could not be opened right now\n"
+        f"{SEP}\n"
+        f"Reason: {reason}\n"
+        "Please send /start again shortly."
+    )
+
+
+def format_start_temp_backend_error_reply() -> str:
+    return (
+        "⚠️ Temporary backend issue\n"
+        f"{SEP}\n"
+        "We hit a backend issue while opening your session.\n"
+        "Please send /start again shortly."
+    )
+
+
+def format_unknown_command_reply() -> str:
+    return (
+        "⚠️ Command not recognized\n"
+        f"{SEP}\n"
+        "Try one of these:\n"
+        "• /start\n"
+        "• /help\n"
+        "• /status\n"
+        "• /mode /autotrade /positions /pnl /risk /markets /market360 /social /kill\n\n"
+        "Boundary:\n"
+        "• Public-ready paper beta\n"
+        "• Paper-only execution\n"
+        "• Not live-trading ready\n"
+        "• Not production-capital ready"
+    )
+
+
 def format_help_reply() -> str:
     lines = [
         "📘 CrusaderBot Help — Public Paper Beta",
@@ -86,4 +208,3 @@ def format_status_reply(
             "Boundary: paper-only execution. Not live-trading ready. Not production-capital ready.",
         ]
     )
-

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -36,7 +36,16 @@ from projects.polymarket.polyquantbot.client.telegram.dispatcher import (
     TelegramDispatcher,
 )
 from projects.polymarket.polyquantbot.client.telegram.presentation import (
+    format_activation_ready_reply,
+    format_activation_rejected_reply,
+    format_already_active_session_reply,
+    format_already_linked_reply,
+    format_onboarding_rejected_reply,
+    format_onboarding_started_reply,
+    format_runtime_temporary_error_reply,
+    format_start_first_required_reply,
     format_start_session_ready_reply,
+    format_temporary_identity_error_reply,
 )
 
 log = structlog.get_logger(__name__)
@@ -45,38 +54,29 @@ _STAGING_TENANT_ID = "staging"
 _STAGING_USER_ID = "staging"
 
 _REPLY_NOT_REGISTERED = (
-    "Welcome - your account is not onboarded yet.\n\n"
-    "CrusaderBot is currently public paper beta (paper-only).\n"
-    "We'll start your onboarding first; then send /start again."
+    format_start_first_required_reply()
 )
 _REPLY_ONBOARDED = (
-    "✅ Onboarding started successfully.\n"
-    "Send /start again to continue into the paper-beta control surface."
+    format_onboarding_started_reply()
 )
 _REPLY_ALREADY_LINKED = (
-    "ℹ️ Your account is already linked.\n"
-    "Send /start to continue."
+    format_already_linked_reply()
 )
 _REPLY_ACTIVATED = (
-    "✅ Your account is activated.\n"
-    "Send /start again to open your session."
+    format_activation_ready_reply()
 )
 _REPLY_SESSION_ISSUED = format_start_session_ready_reply()
 _REPLY_ALREADY_ACTIVE_SESSION_ISSUED = (
-    "✅ Welcome back. Your session is ready.\n"
-    "Boundary: paper-only execution."
+    format_already_active_session_reply()
 )
 _REPLY_ACTIVATION_REJECTED = (
-    "⚠️ Activation is not available for this account yet.\n"
-    "Please contact support if this seems unexpected."
+    format_activation_rejected_reply()
 )
 _REPLY_ONBOARDING_REJECTED = (
-    "⚠️ Onboarding could not be started right now.\n"
-    "Please try again later or contact support."
+    format_onboarding_rejected_reply()
 )
 _REPLY_IDENTITY_ERROR = (
-    "⚠️ We couldn't verify your identity right now.\n"
-    "Please try again shortly."
+    format_temporary_identity_error_reply()
 )
 
 
@@ -366,10 +366,7 @@ class TelegramPollingLoop:
                 if not requires_start_lifecycle:
                     await self._safe_send_reply(
                         update.chat_id,
-                        (
-                            "⚠️ Your account is not onboarded yet.\n"
-                            "Use /start first to begin onboarding, then retry this command."
-                        ),
+                        format_start_first_required_reply(),
                     )
                     return
                 if self._onboarding_initiator is None:
@@ -496,7 +493,7 @@ class TelegramPollingLoop:
             )
             await self._safe_send_reply(
                 update.chat_id,
-                "⚠️ Temporary runtime error. Please try your command again.",
+                format_runtime_temporary_error_reply(),
             )
             return
 

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md
@@ -1,0 +1,54 @@
+# Telegram UX 03 — Presentation Consolidation Across Remaining Public Reply Surfaces
+
+Date: 2026-04-21 19:32 (Asia/Jakarta)
+Branch: feature/extend-telegram-presentation-layer-and-sync-checklist
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Extended `client/telegram/presentation.py` with additional pure-formatting helpers for remaining public reply surfaces not yet using the structured presentation style.
+- Migrated unknown-command fallback in `TelegramDispatcher` to the shared presentation helper so it aligns with `/start`, `/help`, `/status` tone, structure, and paper-only boundary wording.
+- Migrated onboarding-required, onboarding-started, already-linked, activated, already-active-session, temporary identity error, activation rejection, and temporary runtime error replies in `TelegramPollingLoop` to shared presentation helpers.
+- Migrated `/start` handoff rejected/error replies in `client/telegram/handlers/auth.py` to shared presentation helpers for consistent temporary-failure readability.
+- Synced `projects/polymarket/polyquantbot/work_checklist.md` to mark this presentation-consolidation lane as landed in repo code truth.
+
+## 2. Current system architecture (relevant slice)
+
+1. `client/telegram/presentation.py` is the single formatting surface for public-safe Telegram reply text; helpers remain pure formatting with no runtime side effects.
+2. `client/telegram/runtime.py` remains responsible for identity resolution and lifecycle gating, but now delegates public-facing onboarding/fallback/error string construction to presentation helpers.
+3. `client/telegram/dispatcher.py` remains authoritative for command semantics and routing; unknown-command surface now delegates to presentation helper.
+4. `client/telegram/handlers/auth.py` remains responsible for `/start` handoff orchestration while sharing common presenter text for rejected/error outcomes.
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/presentation.py
+- projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/client/telegram/handlers/auth.py
+- projects/polymarket/polyquantbot/work_checklist.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- `/start`, `/help`, `/status` routing semantics remain unchanged while additional public reply surfaces now share a consistent presentation format.
+- Public onboarding-required and lifecycle variants (`already linked`, `activated`, `session already active`) now use calm, structured, action-oriented messaging.
+- Public temporary failure replies (identity/runtime/backend) now use consistent structured format with clear retry guidance.
+- Unknown-command fallback now uses shared style and keeps explicit paper-only/public-safe boundary wording.
+
+## 5. Known issues
+
+- Live Telegram render proof in deployed environment is still pending; this task validates code-level presentation consolidation only.
+- Deploy-capable verification (`fly deploy` + live chat capture) remains a next-step gate before claiming deployed rendering quality.
+
+## 6. What is next
+
+- Redeploy command-routing + presentation-consolidation branch in a deploy-capable environment.
+- Capture live `/start`, `/help`, `/status`, onboarding-required, and unknown-command Telegram outputs for render validation evidence.
+- Run COMMANDER review for STANDARD lane closure.
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : Telegram public-safe presentation consolidation for unknown-command, onboarding/lifecycle variants, and temporary error replies without command-semantics regression.
+Not in Scope      : runtime activation redesign, webhook/polling redesign, deploy/debug runtime work, live-trading enablement, production-capital readiness.
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
@@ -192,7 +192,7 @@ def test_polling_loop_run_once_dispatch_exception_sends_error_reply() -> None:
     loop = TelegramPollingLoop(adapter=adapter, dispatcher=dispatcher)
     asyncio.run(loop.run_once())
     assert len(adapter.replies) == 1
-    assert "error" in adapter.replies[0][1].lower()
+    assert "temporary runtime issue" in adapter.replies[0][1].lower()
 
 
 def test_polling_loop_run_once_advances_offset() -> None:

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -37,6 +37,8 @@ ACTIVE (Current lane)
 
 [x] Integrate Telegram design/presentation layer into live `/start`, `/help`, `/status` reply builders (repo code truth)
 
+[x] Consolidate remaining public-safe replies (onboarding required, already-linked/activated/session-ready variants, unknown command, temporary identity/runtime/backend errors) to shared presentation helpers
+
 
 NEXT (immediately after code fix + UX integration)
 


### PR DESCRIPTION
### Motivation
- Reduce mixed plain/basic fallback strings by extending the existing Telegram presentation layer so all public-safe reply surfaces share a consistent, mobile-friendly, paper-only tone and structure. 
- Preserve existing command semantics and paper-only safety boundaries while improving onboarding/fallback/error readability.

### Description
- Added shared pure-formatting helpers in `projects/polymarket/polyquantbot/client/telegram/presentation.py` for onboarding-required, onboarding-started, already-linked/activated/session-ready, temporary identity/runtime/backend errors, and unknown-command fallback. 
- Updated `projects/polymarket/polyquantbot/client/telegram/runtime.py` to delegate onboarding/fallback/error reply text to the new presentation helpers while keeping identity/lifecycle gating and dispatch responsibilities unchanged. 
- Updated `projects/polymarket/polyquantbot/client/telegram/dispatcher.py` unknown-command path to use the shared presenter output. 
- Updated `/start` handoff failure/error reply paths in `projects/polymarket/polyquantbot/client/telegram/handlers/auth.py` to use presentation helpers. 
- Adjusted one runtime test assertion to match the consolidated temporary-runtime wording and synced `projects/polymarket/polyquantbot/work_checklist.md` and a forge report `projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`; `PROJECT_STATE.md` was updated to reflect the lane. 

### Testing
- Ran `python3 -m py_compile` on the touched Telegram modules and compilation succeeded. 
- Ran focused runtime tests: `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` and the suite passed (19 passed). 
- Ran a small focused check for `/help`/unknown-command assertions which passed (selection passed; one test skipped due to environment gating). 
- Attempted a broader focused pytest including `test_phase8_13_telegram_session_issuance_20260419.py` but test collection failed in this runner due to a missing external dependency (`pydantic`); this is an environment limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76dd6bd1c8325bdf48fb44023402f)