### PR TITLE
Public command-set hygiene and /help alignment for Telegram paper beta

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-21 19:32
+Last Updated : 2026-04-21 19:51
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; Telegram command-routing semantics plus expanded public-reply presentation consolidation are implemented at code level, with deploy-capable Fly + live Telegram verification still pending.
 
 [COMPLETED]
@@ -36,7 +36,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
 - Telegram command-routing semantics fix lane is in progress on `feature/fix-telegram-command-routing-and-sync-work-checklist`: polling-loop start lifecycle is now gated to `/start` only so `/help` and `/status` no longer collapse into `/start` at code level; deploy-capable rerun is still required for live Fly + Telegram proof (`projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-fix.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_03_command-routing-semantics-evidence.log`).
 - Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
-- Telegram presentation consolidation lane is implemented on `feature/extend-telegram-presentation-layer-and-sync-checklist`: `/start` `/help` `/status` plus remaining public onboarding/fallback/error surfaces now use shared structured presentation helpers with preserved paper-only/public-safe boundaries; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`).
+- Telegram presentation consolidation + public command-set hygiene lane is implemented on `feature/public-command-set-hygiene-and-help-alignment`: `/help` now advertises only trusted public-safe commands (`/start`, `/help`, `/status`), unknown-command guidance no longer over-advertises operator-managed surfaces, and paper-only/public-safe boundary wording remains explicit; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md`).
 
 
 [NOT STARTED]

--- a/projects/polymarket/polyquantbot/client/telegram/bot.py
+++ b/projects/polymarket/polyquantbot/client/telegram/bot.py
@@ -94,7 +94,7 @@ async def run_bot() -> None:
         dispatcher="client.telegram.dispatcher.TelegramDispatcher",
         adapter="client.telegram.runtime.HttpTelegramAdapter",
         identity_resolution="backend",
-        registered_commands=["/start", "/mode", "/autotrade", "/positions", "/pnl", "/risk", "/status", "/markets", "/market360", "/social", "/kill"],
+        registered_commands=["/start", "/help", "/status"],
         phase="8.6-public-paper-beta-confidence-pass",
         staging_tenant_id=settings.staging_tenant_id,
         staging_user_id=settings.staging_user_id,

--- a/projects/polymarket/polyquantbot/client/telegram/presentation.py
+++ b/projects/polymarket/polyquantbot/client/telegram/presentation.py
@@ -132,11 +132,12 @@ def format_unknown_command_reply() -> str:
     return (
         "⚠️ Command not recognized\n"
         f"{SEP}\n"
-        "Try one of these:\n"
+        "Try one of these public commands:\n"
         "• /start\n"
         "• /help\n"
-        "• /status\n"
-        "• /mode /autotrade /positions /pnl /risk /markets /market360 /social /kill\n\n"
+        "• /status\n\n"
+        "Some advanced controls are operator-managed during paper beta\n"
+        "and intentionally not shown in the public command guide.\n\n"
         "Boundary:\n"
         "• Public-ready paper beta\n"
         "• Paper-only execution\n"
@@ -154,16 +155,9 @@ def format_help_reply() -> str:
         render_kv_line("/HELP", "View this guide"),
         render_kv_line("/STATUS", "Runtime + guard snapshot"),
         SEP,
-        "Paper control surfaces",
-        render_kv_line("/MODE", "Set paper mode only"),
-        render_kv_line("/AUTOTRADE", "Toggle paper autotrade"),
-        render_kv_line("/POSITIONS", "Read open paper positions"),
-        render_kv_line("/PNL", "Read paper PnL"),
-        render_kv_line("/RISK", "Read risk state"),
-        render_kv_line("/MARKETS", "Query market scan"),
-        render_kv_line("/MARKET360", "View market detail"),
-        render_kv_line("/SOCIAL", "View social pulse"),
-        render_kv_line("/KILL", "Force paper kill switch"),
+        "Public posture",
+        "• Public-safe command set is intentionally small during paper beta.",
+        "• Advanced controls remain operator-managed until broader readiness proof.",
         SEP,
         "Boundary",
         "• Public-ready paper beta",

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -548,7 +548,7 @@ async def run_polling_loop(
     log.info(
         "crusaderbot_telegram_polling_started",
         phase="8.13",
-        registered_commands=["/start","/mode","/autotrade","/positions","/pnl","/risk","/status","/markets","/market360","/social","/kill"],
+        registered_commands=["/start", "/help", "/status"],
         identity_resolution="enabled" if identity_resolver is not None else "staging_fallback",
         onboarding="enabled" if onboarding_initiator is not None else "disabled",
         activation="enabled" if activation_confirmer is not None else "disabled",

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md
@@ -1,0 +1,55 @@
+# Telegram UX 04 — Public Command-Set Hygiene + Help Surface Alignment
+
+Date: 2026-04-21 19:51 (Asia/Jakarta)
+Branch: feature/public-command-set-hygiene-and-help-alignment
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Audited the currently exposed public command copy and tightened `/help` to a trusted public-safe baseline (`/start`, `/help`, `/status`) only.
+- Removed premature command advertising from shared public-facing reply surfaces so the public guide no longer over-promises control-plane/operator-managed commands.
+- Softened unknown-command guidance to direct users to the trusted public baseline and explicitly state that advanced controls are operator-managed during paper beta.
+- Synced runtime startup/polling observability metadata (`registered_commands`) to match the public command set shown in `/help`.
+- Added focused test assertions to lock help-surface hygiene (hidden commands not shown in `/help` and unknown fallback).
+- Synced `projects/polymarket/polyquantbot/work_checklist.md` with public command-set hygiene completion for the current lane.
+
+## 2. Current system architecture (relevant slice)
+
+1. `client/telegram/presentation.py` remains the single formatting authority for public Telegram copy, including `/help` and unknown-command fallback.
+2. `client/telegram/dispatcher.py` still supports the broader command router surfaces, but public guidance now intentionally exposes only trusted commands for paper-beta users.
+3. `client/telegram/bot.py` and `client/telegram/runtime.py` startup logs now report the same public baseline command set to keep presentation and runtime metadata aligned.
+4. `tests/test_phase8_8_telegram_dispatch_20260419.py` includes explicit anti-regression checks to prevent overexposed command listings from reappearing in the public help surface.
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/presentation.py
+- projects/polymarket/polyquantbot/client/telegram/bot.py
+- projects/polymarket/polyquantbot/client/telegram/runtime.py
+- projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+- projects/polymarket/polyquantbot/work_checklist.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- `/help` now presents a concise public-safe command guide aligned with current paper-beta truth boundaries.
+- Unknown-command fallback no longer advertises non-public/advanced command surfaces.
+- `/start`, `/help`, `/status` dispatch semantics are unchanged and preserved.
+- Existing command router behavior remains intact while public command copy is tightened.
+- Checklist truth now reflects that public command-set hygiene/help alignment is landed at code level.
+
+## 5. Known issues
+
+- Deploy-capable live Telegram render proof for the updated `/help` surface is still pending in this runner environment.
+- Hidden commands remain routable internally but are intentionally not advertised publicly until readiness and posture are validated for broader exposure.
+
+## 6. What is next
+
+- Run deploy-capable verification on the updated help surface and collect live Telegram `/help` render evidence.
+- Continue COMMANDER review for this STANDARD lane with paper-only/public-safe posture validation.
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : Public-facing `/help` + unknown-command copy hygiene and runtime metadata alignment for trusted paper-beta command surface.
+Not in Scope      : Runtime activation redesign, command-routing redesign, deploy/debug work, live-trading enablement, production-capital readiness.
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
@@ -138,6 +138,8 @@ def test_dispatch_help_command() -> None:
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/help")))
     assert result.outcome == "ok"
     assert "CrusaderBot Help" in result.reply_text
+    assert "/MODE" not in result.reply_text
+    assert "/KILL" not in result.reply_text
     backend.request_handoff.assert_not_awaited()
 
 
@@ -146,6 +148,7 @@ def test_dispatch_unknown_command_empty_string() -> None:
     dispatcher = TelegramDispatcher(backend=backend)
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("")))
     assert result.outcome == "unknown_command"
+    assert "/mode" not in result.reply_text.lower()
     backend.request_handoff.assert_not_awaited()
 
 

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -39,6 +39,8 @@ ACTIVE (Current lane)
 
 [x] Consolidate remaining public-safe replies (onboarding required, already-linked/activated/session-ready variants, unknown command, temporary identity/runtime/backend errors) to shared presentation helpers
 
+[x] Align `/help` to trusted public-safe command surface only (hide operator-managed or not-ready commands from public guide)
+
 
 NEXT (immediately after code fix + UX integration)
 
@@ -81,7 +83,7 @@ NEXT (immediately after code fix + UX integration)
 
 4. Public Command Set
 
-[ ] Keep the existing public command baseline clean and useful
+[x] Keep the existing public command baseline clean and useful
 
 [ ] Prepare /paper
 
@@ -91,9 +93,9 @@ NEXT (immediately after code fix + UX integration)
 
 [ ] Prepare /account or /link
 
-[ ] Separate public commands from admin/operator commands
+[x] Separate public commands from admin/operator commands
 
-[ ] Hide commands that are not ready yet
+[x] Hide commands that are not ready yet
 
 
 5. Public-Safe Boundaries


### PR DESCRIPTION
### Motivation
- Prevent the public `/help` surface from advertising operator-managed or premature commands and keep public guidance truthful to the paper-beta posture.
- Keep `/start`, `/help`, and `/status` semantics intact while reducing over-exposure of advanced control-plane surfaces.

### Description
- Tightened public help copy in `projects/polymarket/polyquantbot/client/telegram/presentation.py` so `/help` and unknown-command fallback list only the trusted public commands (`/start`, `/help`, `/status`) and explicitly note that advanced controls are operator-managed during paper beta.
- Aligned startup/polling `registered_commands` metadata to the public-facing baseline by updating `projects/polymarket/polyquantbot/client/telegram/bot.py` and `projects/polymarket/polyquantbot/client/telegram/runtime.py` to report `['/start', '/help', '/status']`.
- Added anti-regression assertions to `projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py` to ensure hidden commands do not reappear in the public help/unknown replies.
- Synced `projects/polymarket/polyquantbot/work_checklist.md` to mark public command-set hygiene as landed for the active lane.
- Added a FORGE report at `projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md` and updated `PROJECT_STATE.md` timestamp and in-scope lane wording to reflect the change.

### Testing
- Ran `python3 -m py_compile` on the touched modules and there were no syntax errors for the modified files.
- Ran `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` and received `34 passed` (all tests passed).
- Unit-level regression assertions confirm the help/unknown surfaces do not expose hidden/operator-managed commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7727ae6fc832585b2f17a3f8a5251)