### PR TITLE
Consolidate Telegram public UI/UX presentation layer

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-22 02:31
+Last Updated : 2026-04-22 02:58
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; live Telegram baseline command proof is now recorded for /start, /help, /status, and unknown fallback with paper-only boundary preserved.
 
 [COMPLETED]
@@ -37,7 +37,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 [IN PROGRESS]
 - Work checklist monitor integration hardening lane is in progress on `feature/integrate-work-checklist-into-project-monitor`: malformed `projects/polymarket/polyquantbot/work_checklist.md` structure was repaired and `docs/project_monitor.html` now includes conservative fallback parsing so major checklist sections remain visible under partial markdown-format damage, pending COMMANDER review.
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram onboarding + /start /help /status public UX copy refinement is implemented on `feature/refine-telegram-onboarding-and-public-ux-copy` with cleaner onboarding/fallback messaging and explicit paper-only safety wording pending COMMANDER review.
+- Telegram UI/UX consolidation lane is implemented on `feature/consolidate-telegram-ui-ux-layer`: shared presentation helpers now align `/start` lifecycle variants, `/help`, `/status`, and unknown-command fallback under one public paper-beta structure with explicit paper-only/no-live-trading/no-production-capital boundary wording, pending COMMANDER review.
 - Telegram presentation consolidation + public command-set hygiene lane is implemented on `feature/public-command-set-hygiene-and-help-alignment`: `/help` now advertises only trusted public-safe commands (`/start`, `/help`, `/status`), unknown-command guidance no longer over-advertises operator-managed surfaces, and paper-only/public-safe boundary wording remains explicit; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md`).
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 

--- a/projects/polymarket/polyquantbot/client/telegram/presentation.py
+++ b/projects/polymarket/polyquantbot/client/telegram/presentation.py
@@ -7,142 +7,151 @@ from __future__ import annotations
 from projects.polymarket.polyquantbot.telegram.ui.components import SEP, render_kv_line
 
 
+_PUBLIC_BOUNDARY_LINES = (
+    "• Public-ready paper beta",
+    "• Paper-only execution",
+    "• Not live-trading ready",
+    "• Not production-capital ready",
+)
+
+
+def _format_public_screen(title: str, body_lines: list[str], *, next_steps: list[str] | None = None) -> str:
+    lines: list[str] = [title, SEP] + body_lines
+    if next_steps:
+        lines.extend(["", "Next steps:"] + [f"• {step}" for step in next_steps])
+    lines.extend(["", "Boundary:"] + list(_PUBLIC_BOUNDARY_LINES))
+    return "\n".join(lines)
+
+
 def format_start_session_ready_reply() -> str:
-    return (
-        "🚀 CrusaderBot — Session Ready\n"
-        f"{SEP}\n"
-        "Your paper-beta session is active.\n\n"
-        "Next steps:\n"
-        "• /help — command guide\n"
-        "• /status — runtime and guard snapshot\n\n"
-        "Boundary:\n"
-        "• Public-ready paper beta\n"
-        "• Paper-only execution\n"
-        "• Not live-trading ready\n"
-        "• Not production-capital ready"
+    return _format_public_screen(
+        "🚀 CrusaderBot — Session Ready",
+        ["Your paper-beta session is active and safe to explore."],
+        next_steps=[
+            "/help — open the public command guide",
+            "/status — check runtime and guard state",
+        ],
     )
 
 
 def format_start_first_required_reply() -> str:
-    return (
-        "⚠️ Onboarding required before this command\n"
-        f"{SEP}\n"
-        "Use /start first to begin onboarding.\n"
-        "After onboarding is ready, retry your command.\n\n"
-        "Boundary:\n"
-        "• Public-ready paper beta\n"
-        "• Paper-only execution\n"
-        "• Not live-trading ready\n"
-        "• Not production-capital ready"
+    return _format_public_screen(
+        "⚠️ Onboarding required",
+        [
+            "This command is available after onboarding starts.",
+            "Use /start to open onboarding, then retry your command.",
+        ],
     )
 
 
 def format_onboarding_started_reply() -> str:
-    return (
-        "✅ Onboarding started\n"
-        f"{SEP}\n"
-        "We created your onboarding path.\n"
-        "Send /start again to continue into session activation.\n\n"
-        "Boundary: paper-only public beta."
+    return _format_public_screen(
+        "✅ Onboarding started",
+        [
+            "Your onboarding path is now created.",
+            "Send /start again to continue into session activation.",
+        ],
     )
 
 
 def format_already_linked_reply() -> str:
-    return (
-        "ℹ️ Account already linked\n"
-        f"{SEP}\n"
-        "Your Telegram account is already linked.\n"
-        "Send /start to continue into session activation."
+    return _format_public_screen(
+        "ℹ️ Account already linked",
+        [
+            "This Telegram account is already linked.",
+            "Send /start to continue into session activation.",
+        ],
     )
 
 
 def format_activation_ready_reply() -> str:
-    return (
-        "✅ Account activated\n"
-        f"{SEP}\n"
-        "Activation is complete.\n"
-        "Send /start again to open your session."
+    return _format_public_screen(
+        "✅ Account activated",
+        [
+            "Activation is complete.",
+            "Send /start again to open your session.",
+        ],
     )
 
 
 def format_already_active_session_reply() -> str:
-    return (
-        "✅ Session already active\n"
-        f"{SEP}\n"
-        "Welcome back — your paper-beta session is ready.\n"
-        "Use /help or /status for next actions."
+    return _format_public_screen(
+        "✅ Session already active",
+        ["Welcome back — your paper-beta session is ready."],
+        next_steps=["/help", "/status"],
     )
 
 
 def format_temporary_identity_error_reply() -> str:
-    return (
-        "⚠️ Temporary identity check issue\n"
-        f"{SEP}\n"
-        "We couldn't verify your identity right now.\n"
-        "Please try again shortly."
+    return _format_public_screen(
+        "⚠️ Temporary identity check issue",
+        [
+            "We couldn't verify your identity right now.",
+            "Please try /start again shortly.",
+        ],
     )
 
 
 def format_onboarding_rejected_reply() -> str:
-    return (
-        "⚠️ Onboarding unavailable right now\n"
-        f"{SEP}\n"
-        "We couldn't start onboarding at the moment.\n"
-        "Please try again later or contact support."
+    return _format_public_screen(
+        "⚠️ Onboarding unavailable",
+        [
+            "We couldn't start onboarding right now.",
+            "Please try again later or contact support.",
+        ],
     )
 
 
 def format_activation_rejected_reply() -> str:
-    return (
-        "⚠️ Activation unavailable for this account\n"
-        f"{SEP}\n"
-        "Activation is not available right now.\n"
-        "Please contact support if this seems unexpected."
+    return _format_public_screen(
+        "⚠️ Activation unavailable",
+        [
+            "Activation is not available for this account right now.",
+            "Please contact support if this seems unexpected.",
+        ],
     )
 
 
 def format_runtime_temporary_error_reply() -> str:
-    return (
-        "⚠️ Temporary runtime issue\n"
-        f"{SEP}\n"
-        "Please retry your command in a moment."
+    return _format_public_screen(
+        "⚠️ Temporary runtime issue",
+        [
+            "The bot runtime is temporarily unavailable.",
+            "Please retry your command in a moment.",
+        ],
     )
 
 
 def format_start_rejected_reply(detail: str) -> str:
     reason = detail or "not available"
-    return (
-        "⚠️ Session could not be opened right now\n"
-        f"{SEP}\n"
-        f"Reason: {reason}\n"
-        "Please send /start again shortly."
+    return _format_public_screen(
+        "⚠️ Session could not be opened",
+        [f"Reason: {reason}", "Please send /start again shortly."],
     )
 
 
 def format_start_temp_backend_error_reply() -> str:
-    return (
-        "⚠️ Temporary backend issue\n"
-        f"{SEP}\n"
-        "We hit a backend issue while opening your session.\n"
-        "Please send /start again shortly."
+    return _format_public_screen(
+        "⚠️ Temporary backend issue",
+        [
+            "We hit a backend issue while opening your session.",
+            "Please send /start again shortly.",
+        ],
     )
 
 
 def format_unknown_command_reply() -> str:
-    return (
-        "⚠️ Command not recognized\n"
-        f"{SEP}\n"
-        "Try one of these public commands:\n"
-        "• /start\n"
-        "• /help\n"
-        "• /status\n\n"
-        "Some advanced controls are operator-managed during paper beta\n"
-        "and intentionally not shown in the public command guide.\n\n"
-        "Boundary:\n"
-        "• Public-ready paper beta\n"
-        "• Paper-only execution\n"
-        "• Not live-trading ready\n"
-        "• Not production-capital ready"
+    return _format_public_screen(
+        "⚠️ Command not recognized",
+        [
+            "Try one of these public commands:",
+            "• /start",
+            "• /help",
+            "• /status",
+            "",
+            "Advanced controls are operator-managed during paper beta",
+            "and intentionally hidden from the public command guide.",
+        ],
     )
 
 
@@ -180,10 +189,9 @@ def format_status_reply(
     autotrade: bool,
     position_count: int,
 ) -> str:
-    return "\n".join(
+    return _format_public_screen(
+        "🧭 CrusaderBot Status — Public Paper Beta",
         [
-            "🧭 CrusaderBot Status — Public Paper Beta",
-            SEP,
             "Runtime",
             render_kv_line("Mode", mode),
             render_kv_line("State", managed_state),
@@ -198,7 +206,5 @@ def format_status_reply(
             "Paper metrics",
             render_kv_line("Autotrade", str(autotrade)),
             render_kv_line("Positions", str(position_count)),
-            SEP,
-            "Boundary: paper-only execution. Not live-trading ready. Not production-capital ready.",
-        ]
+        ],
     )

--- a/projects/polymarket/polyquantbot/reports/forge/telegram_uiux_01_consolidation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/telegram_uiux_01_consolidation.md
@@ -1,0 +1,52 @@
+# Telegram UI/UX Consolidation 01 — Public Presentation Alignment
+
+Date: 2026-04-22 02:58 (Asia/Jakarta)
+Branch: feature/consolidate-telegram-ui-ux-layer
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Consolidated public Telegram copy rendering into a single shared structure in `client/telegram/presentation.py` using `_format_public_screen(...)` and one canonical boundary block.
+- Aligned `/start` lifecycle-related replies (onboarding required, onboarding started, already linked, activation ready, session active, temporary identity/backend/runtime errors) to the same visual hierarchy and tone.
+- Kept `/help`, `/status`, and unknown-command fallback consistent with explicit paper-beta posture and public-safe boundaries.
+- Added focused dispatch tests to lock help/fallback hygiene and prevent future overexposure of hidden operator-managed commands.
+- Synced `projects/polymarket/polyquantbot/work_checklist.md` to reflect this UI/UX consolidation progress while preserving open `/start` progression refinement debt.
+
+## 2. Current system architecture (relevant slice)
+
+1. `projects/polymarket/polyquantbot/client/telegram/presentation.py` is the public Telegram formatting truth for `/start` lifecycle, `/help`, `/status`, and unknown-command fallback text.
+2. `projects/polymarket/polyquantbot/client/telegram/dispatcher.py` remains the command dispatch boundary; this lane changed presentation only, not command semantics.
+3. `projects/polymarket/polyquantbot/client/telegram/runtime.py` lifecycle routing still enforces onboarding/session gating, now with more coherent reply text from shared presentation helpers.
+4. `projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py` guards help/fallback wording posture so public command hygiene remains stable.
+
+## 3. Files created / modified (full repo-root paths)
+
+- projects/polymarket/polyquantbot/client/telegram/presentation.py
+- projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+- projects/polymarket/polyquantbot/work_checklist.md
+- projects/polymarket/polyquantbot/reports/forge/telegram_uiux_01_consolidation.md
+- PROJECT_STATE.md
+
+## 4. What is working
+
+- Public-facing replies now use consistent hierarchy (`title -> separator -> body -> boundary`) and consistent paper-beta safety messaging.
+- `/help` continues exposing only public-safe commands (`/start`, `/help`, `/status`) with explicit operator-managed command posture.
+- `/status` now includes the same boundary block style as other public replies, reducing presentation split.
+- Unknown-command fallback remains safe and no longer feels disconnected from `/help` and `/start` response design.
+- Existing dispatch semantics remain intact; this lane is copy/presentation consolidation only.
+
+## 5. Known issues
+
+- Repeated multi-step `/start` lifecycle progression still feels somewhat stepwise; this remains tracked refinement debt.
+- No new live deploy proof was generated in this lane; existing baseline command proof remains the latest runtime evidence.
+
+## 6. What is next
+
+- Run one additional focused onboarding/session UX refinement pass on repeated `/start` progression (wording + flow cues only, no activation-runtime redesign).
+- Continue COMMANDER review for this STANDARD lane.
+
+Validation Tier   : STANDARD
+Claim Level       : TELEGRAM UI / UX CONSOLIDATION
+Validation Target : Public Telegram presentation layer for `/start`, `/help`, `/status`, and unknown-command fallback with explicit paper-only boundary truth.
+Not in Scope      : Runtime activation redesign, deploy rewiring, Sentry verification, wallet/portfolio expansion, live-trading enablement, production-capital readiness.
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
@@ -138,6 +138,8 @@ def test_dispatch_help_command() -> None:
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/help")))
     assert result.outcome == "ok"
     assert "CrusaderBot Help" in result.reply_text
+    assert "Boundary" in result.reply_text
+    assert "Paper-only execution" in result.reply_text
     assert "/MODE" not in result.reply_text
     assert "/KILL" not in result.reply_text
     backend.request_handoff.assert_not_awaited()
@@ -149,6 +151,7 @@ def test_dispatch_unknown_command_empty_string() -> None:
     result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("")))
     assert result.outcome == "unknown_command"
     assert "/mode" not in result.reply_text.lower()
+    assert "operator-managed" in result.reply_text.lower()
     backend.request_handoff.assert_not_awaited()
 
 

--- a/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py
@@ -303,4 +303,4 @@ def test_polling_loop_non_start_not_found_requires_start_first() -> None:
     asyncio.run(loop.run_once())
     dispatcher.dispatch.assert_not_called()
     onboarding_initiator.start_telegram_onboarding.assert_not_awaited()
-    assert "Use /start first" in adapter.replies[0][1]
+    assert "Use /start to open onboarding" in adapter.replies[0][1]

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -64,7 +64,11 @@ Telegram UX Refinement Follow-up Lane
 
 [x] Save fresh deploy evidence (live command replies and baseline runtime proof captured)
 
-### Latest attempt (2026-04-22 02:31 Asia/Jakarta)
+### Latest attempt (2026-04-22 02:58 Asia/Jakarta)
+
+- Public Telegram copy layer is now consolidated through shared presentation helpers in `client/telegram/presentation.py` so `/start`, onboarding-required, onboarding-started, linked/active-session variants, temporary backend/runtime issues, and unknown-command fallback share one structure.
+- `/help` and `/status` now keep a consistent boundary block with the same public paper-beta posture and no live-trading/production-capital readiness overclaim.
+- Remaining debt is unchanged: repeated `/start` progression flow still feels stepwise and should be refined further without expanding runtime activation scope.
 
 - Live Telegram baseline evidence is now available and recorded in `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_05_priority1-live-proof.md` with supporting log in `projects/polymarket/polyquantbot/reports/forge/telegram_runtime_05_priority1-live-proof.log`.
 - Verified from live runtime evidence: `/start`, `/help`, `/status`, and unknown command fallback all returned non-empty/non-dummy responses.
@@ -85,17 +89,17 @@ Telegram UX Refinement Follow-up Lane
 
 [x] Refine the existing Telegram command UX
 
-[ ] Refine the current welcome intro for new users
+[x] Refine the current welcome intro for new users
 
 [x] Refine the current help and status copy
 
 [x] Refine paper-only messaging across the existing Telegram flow
 
-[ ] Refine the next-step guidance for new users
+[x] Refine the next-step guidance for new users
 
-[ ] Refine the unlinked-user flow using the current foundation
+[x] Refine the unlinked-user flow using the current foundation
 
-[ ] Refine the linked-user flow using the current foundation
+[x] Refine the linked-user flow using the current foundation
 
 [x] Refine fallback and error messaging
 


### PR DESCRIPTION
### Motivation
- Reduce split-brain between legacy markdown screens and the richer component-based presentation so public Telegram flows read as one coherent product.
- Make `/start` lifecycle, `/help`, `/status`, and unknown-command fallback share a single presentation path with an explicit public paper-beta boundary and non-overclaiming copy.
- Keep behavior/routing unchanged while syncing repo truth (`work_checklist.md`, `PROJECT_STATE.md`) to reflect UI/UX consolidation progress.

### Description
- Introduced a shared formatter and canonical boundary block: `_format_public_screen(...)` and `_PUBLIC_BOUNDARY_LINES` in `projects/polymarket/polyquantbot/client/telegram/presentation.py` and migrated `/start` lifecycle variants, unknown-command, error, and `/status` replies to use it.
- Reworked `format_status_reply` and multiple `format_*` helpers to use the new shared structure so title → separator → body → boundary becomes the consistent hierarchy.
- Tightened public-help/fallback expectations by updating tests in `projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py` and `projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py` to assert the new boundary wording and onboarding phrasing.
- Synced task artifacts: updated `projects/polymarket/polyquantbot/work_checklist.md`, bumped `Last Updated` and added lane entry in `PROJECT_STATE.md`, and added the forge report `projects/polymarket/polyquantbot/reports/forge/telegram_uiux_01_consolidation.md` to record the change.
- No command routing or runtime activation logic was changed; this is presentation-only and preserves the paper-only/public-safe boundary.

### Testing
- Ran `python3 -m py_compile` on the touched modules (`client/telegram/presentation.py`, `client/telegram/dispatcher.py`, `client/telegram/runtime.py`, and the modified tests`) and compilation succeeded.
- Ran focused pytest: `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py projects/polymarket/polyquantbot/tests/test_phase8_9_telegram_runtime_20260419.py`; an initial assertion mismatch was fixed by aligning the test to the new phrasing and final test run completed with `34 passed`.
- Performed a mojibake/encoding scan on the changed files (no matches found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d669e1d88325a2c59718ea84b0cd)