### PR TITLE
Consolidate active Telegram public UX (/start, /help, /status) into telegram package

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-22 05:38
+Last Updated : 2026-04-22 06:03
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; live Telegram baseline command proof is now recorded for /start, /help, /status, and unknown fallback with paper-only boundary preserved.
 
 [COMPLETED]
@@ -38,7 +38,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 [IN PROGRESS]
 - Work checklist monitor integration hardening lane is in progress on `feature/integrate-work-checklist-into-project-monitor`: malformed `projects/polymarket/polyquantbot/work_checklist.md` structure was repaired and `docs/project_monitor.html` now includes conservative fallback parsing so major checklist sections remain visible under partial markdown-format damage, pending COMMANDER review.
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram UX consolidation lane is implemented on `feature/ux-telegram-public-ready-20260422`: active `/start`, `/help`, `/status`, unknown-command, and home/system empty-state messaging now render through the consolidated active Telegram presentation path with explicit paper-only/public-safe boundary wording; pending COMMANDER review with evidence in `projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md`.
+- Telegram UX consolidation lane is implemented on `feature/consolidate-telegram-ux-and-clean-legacy-files-2026-04-21`: delivered scope is limited to active Telegram `/start`, `/help`, `/status`, unknown-command, and home/system empty-state wording/render alignment; no legacy archive/tree cleanup was delivered in this diff; pending COMMANDER review with evidence in `projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md`.
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
 [NOT STARTED]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-22 04:33
+Last Updated : 2026-04-22 05:38
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; live Telegram baseline command proof is now recorded for /start, /help, /status, and unknown fallback with paper-only boundary preserved.
 
 [COMPLETED]
@@ -38,7 +38,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 [IN PROGRESS]
 - Work checklist monitor integration hardening lane is in progress on `feature/integrate-work-checklist-into-project-monitor`: malformed `projects/polymarket/polyquantbot/work_checklist.md` structure was repaired and `docs/project_monitor.html` now includes conservative fallback parsing so major checklist sections remain visible under partial markdown-format damage, pending COMMANDER review.
 - Post-launch cleanup + README alignment + announcement polish lane is in progress for paper-beta public-facing clarity (paper-only/no-live-trading boundary preserved).
-- Telegram presentation consolidation + public command-set hygiene lane is implemented on `feature/public-command-set-hygiene-and-help-alignment`: `/help` now advertises only trusted public-safe commands (`/start`, `/help`, `/status`), unknown-command guidance no longer over-advertises operator-managed surfaces, and paper-only/public-safe boundary wording remains explicit; deploy-capable Telegram render proof is pending (`projects/polymarket/polyquantbot/reports/forge/telegram_ux_03_presentation-consolidation.md`, `projects/polymarket/polyquantbot/reports/forge/telegram_ux_04_public-command-hygiene.md`).
+- Telegram UX consolidation lane is implemented on `feature/ux-telegram-public-ready-20260422`: active `/start`, `/help`, `/status`, unknown-command, and home/system empty-state messaging now render through the consolidated active Telegram presentation path with explicit paper-only/public-safe boundary wording; pending COMMANDER review with evidence in `projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md`.
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
 [NOT STARTED]

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md
@@ -1,0 +1,54 @@
+# Phase 10.1 Telegram UX Consolidation (Public Paper-Beta Surface)
+
+Date: 2026-04-22 05:38 (Asia/Jakarta)
+Branch: feature/ux-telegram-public-ready-20260422
+Project Root: projects/polymarket/polyquantbot/
+
+## 1. What was built
+
+- Consolidated active command UX handling so `/start` remains home-focused, `/help` renders a dedicated public guidance view, and `/status` renders a dedicated runtime/system snapshot view from the active Telegram runtime path.
+- Upgraded unknown-command fallback to route through the same active help presentation layer, keeping a single UX system for success and fallback states.
+- Refined help/guidance copy in the active formatter to keep paper-only/public-safe boundary language explicit while reducing ambiguity about supported public commands.
+- Added explicit home/system empty-state rendering guidance when telemetry is sparse (no portfolio snapshot yet), so fallback states remain clear rather than appearing broken.
+- Added command-router coverage for `/help`, `/status`, and unknown-command fallback behavior in the Telegram numeric safety regression test suite.
+
+## 2. Current system architecture (relevant slice)
+
+1. `telegram.command_handler.CommandHandler` is the authoritative runtime command dispatcher for `/start`, `/help`, `/status`, and unknown command fallback output payloads.
+2. Command payloads are rendered only through `telegram.view_handler.render_view(...)`.
+3. `telegram.view_handler` normalizes actions and delegates rendering to `telegram.ui_formatter.render_dashboard(...)`.
+4. `telegram.ui_formatter` remains the single active presentation layer for main states, section cards, empty states, and operator/fallback guidance text.
+5. Legacy `interface/telegram` remains thin compatibility-only shim territory; active UX/runtime ownership is still exclusively under `projects/polymarket/polyquantbot/telegram`.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/telegram/command_handler.py`
+- `projects/polymarket/polyquantbot/telegram/ui_formatter.py`
+- `projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md`
+- `PROJECT_STATE.md`
+
+## 4. What is working
+
+- `/start` remains home/menu oriented and now carries explicit public-safe/paper-only operator guidance text.
+- `/help` now renders a dedicated Help Center view with explicit trusted public commands (`/start`, `/help`, `/status`) instead of piggybacking on home.
+- `/status` now renders dedicated system/runtime posture view instead of aliasing directly to home.
+- Unknown commands render a structured help fallback view (not plain text only), improving user recovery UX.
+- Home/system telemetry-empty paths now return explicit empty-state guidance blocks, reducing ambiguity during sparse-runtime periods.
+- Added regression checks for `/help`, `/status`, and unknown fallback in active Telegram command routing tests.
+
+## 5. Known issues
+
+- This task intentionally keeps compatibility shims in `projects/polymarket/polyquantbot/interface/telegram/` and `projects/polymarket/polyquantbot/interface/ui_formatter.py`; full shim retirement remains out of scope until all downstream legacy imports are migrated.
+- Broader onboarding/session repetition UX debt remains tracked separately in PROJECT_STATE and was not expanded here.
+
+## 6. What is next
+
+- COMMANDER review of this STANDARD lane and merge decision.
+- If approved, optionally continue thin-shim usage audit to identify remaining callers before a dedicated archive/removal pass.
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : Active Telegram public UX/runtime surface under `projects/polymarket/polyquantbot/telegram`, including `/start`, `/help`, `/status`, unknown fallback, and empty-state rendering clarity.
+Not in Scope      : Trading/risk/execution logic, wallet lifecycle, DB hardening, live-trading claims, third runtime path, architecture rewrite.
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md
@@ -1,7 +1,7 @@
 # Phase 10.1 Telegram UX Consolidation (Public Paper-Beta Surface)
 
 Date: 2026-04-22 05:38 (Asia/Jakarta)
-Branch: feature/ux-telegram-public-ready-20260422
+Branch: feature/consolidate-telegram-ux-and-clean-legacy-files-2026-04-21
 Project Root: projects/polymarket/polyquantbot/
 
 ## 1. What was built
@@ -18,7 +18,7 @@ Project Root: projects/polymarket/polyquantbot/
 2. Command payloads are rendered only through `telegram.view_handler.render_view(...)`.
 3. `telegram.view_handler` normalizes actions and delegates rendering to `telegram.ui_formatter.render_dashboard(...)`.
 4. `telegram.ui_formatter` remains the single active presentation layer for main states, section cards, empty states, and operator/fallback guidance text.
-5. Legacy `interface/telegram` remains thin compatibility-only shim territory; active UX/runtime ownership is still exclusively under `projects/polymarket/polyquantbot/telegram`.
+5. This PR diff does not add/remove legacy archive files; it only updates active Telegram UX behavior and wording within existing runtime/test/state/report files.
 
 ## 3. Files created / modified (full repo-root paths)
 
@@ -39,13 +39,13 @@ Project Root: projects/polymarket/polyquantbot/
 
 ## 5. Known issues
 
-- This task intentionally keeps compatibility shims in `projects/polymarket/polyquantbot/interface/telegram/` and `projects/polymarket/polyquantbot/interface/ui_formatter.py`; full shim retirement remains out of scope until all downstream legacy imports are migrated.
+- No legacy/archive directory cleanup was delivered in this diff; claims are intentionally limited to Telegram UX command/view consolidation and wording alignment in touched files.
 - Broader onboarding/session repetition UX debt remains tracked separately in PROJECT_STATE and was not expanded here.
 
 ## 6. What is next
 
 - COMMANDER review of this STANDARD lane and merge decision.
-- If approved, optionally continue thin-shim usage audit to identify remaining callers before a dedicated archive/removal pass.
+- Keep follow-up work (if any) on legacy archive/tree cleanup as a separate scoped task with its own diff and evidence.
 
 Validation Tier   : STANDARD
 Claim Level       : NARROW INTEGRATION

--- a/projects/polymarket/polyquantbot/telegram/command_handler.py
+++ b/projects/polymarket/polyquantbot/telegram/command_handler.py
@@ -221,11 +221,18 @@ class CommandHandler:
         self, cmd: str, value: Optional[float | str], cid: str
     ) -> CommandResult:
         """Route command string to the corresponding handler method."""
-        if cmd in ("start", "help", "menu", "main_menu"):
+        if cmd in ("start", "menu", "main_menu"):
             payload = self._build_home_payload()
             return CommandResult(
                 success=True,
                 message=await render_view("home", payload),
+                payload=payload,
+            )
+        if cmd == "help":
+            payload = self._build_help_payload()
+            return CommandResult(
+                success=True,
+                message=await render_view("help", payload),
                 payload=payload,
             )
         if cmd == "status":
@@ -329,9 +336,8 @@ class CommandHandler:
 
         return CommandResult(
             success=True,
-            message=(
-                "Unknown command. Type /start or /help for available commands."
-            ),
+            message=await render_view("help", self._build_unknown_command_payload(cmd)),
+            payload=self._build_unknown_command_payload(cmd),
         )
 
     async def _handle_trade(self, args: Optional[float | str] = None) -> CommandResult:
@@ -562,7 +568,12 @@ class CommandHandler:
         )
 
     async def _handle_status(self) -> CommandResult:
-        return await self._handle_home()
+        payload = self._build_status_payload()
+        return CommandResult(
+            success=True,
+            message=await render_view("system", payload),
+            payload=payload,
+        )
 
     def _get_metrics_snapshot(self) -> dict:
         if self._metrics_source is None or not hasattr(self._metrics_source, "snapshot"):
@@ -592,7 +603,41 @@ class CommandHandler:
             "insight": (
                 f"Risk {risk_multiplier:.2f} • Max Pos {max_position:.2f}"
             ),
+            "operator_note": "Paper-only public beta; use /status for runtime posture.",
+            "decision": "Public-safe surface active",
         }
+
+    def _build_status_payload(self) -> dict[str, object]:
+        payload = self._build_home_payload()
+        payload.update(
+            {
+                "mode": "system",
+                "decision": "Runtime health snapshot for paper-beta monitoring",
+                "operator_note": "Paper-only boundary enforced; no live capital actions.",
+            }
+        )
+        return payload
+
+    def _build_help_payload(self) -> dict[str, object]:
+        payload = self._build_home_payload()
+        payload.update(
+            {
+                "mode": "help",
+                "decision": "Use /start, /help, and /status for the public-safe flow",
+                "operator_note": "Paper-only beta: runtime guidance only, no live trading claims.",
+            }
+        )
+        return payload
+
+    def _build_unknown_command_payload(self, cmd: str) -> dict[str, object]:
+        payload = self._build_help_payload()
+        payload.update(
+            {
+                "decision": f"Unknown command '/{cmd}'. Use the trusted public command set.",
+                "operator_note": "Supported commands: /start, /help, /status",
+            }
+        )
+        return payload
 
     async def _handle_home(self) -> CommandResult:
         payload = self._build_home_payload()

--- a/projects/polymarket/polyquantbot/telegram/ui_formatter.py
+++ b/projects/polymarket/polyquantbot/telegram/ui_formatter.py
@@ -373,17 +373,17 @@ def _primary_block(mode: str, payload: Mapping[str, Any]) -> str:
         "help": (
             "❓ Help Center",
             [
-                ("Guidance", "How to use menus and scope controls"),
-                ("Bot Info", "Runtime behavior and control surfaces"),
-                ("Style", "Concise and mobile-first"),
+                ("Public Commands", "/start · /help · /status"),
+                ("Navigation", "Home menu + section callbacks"),
+                ("Boundary", "Paper-only beta, no live-capital control"),
             ],
         ),
         "guidance": (
             "🧭 Operator Guidance",
             [
-                ("Main Menu", "Dashboard · Portfolio · Markets · Settings · Help"),
-                ("Scope Control", "Markets → All Markets / Categories / Active Scope"),
-                ("Refresh", "Use Refresh All in Dashboard or Markets"),
+                ("Start", "/start opens home overview and section menu"),
+                ("Status", "/status shows runtime posture and health summary"),
+                ("Unknown Input", "Unsupported commands route back to help safely"),
             ],
         ),
         "bot_info": (
@@ -558,6 +558,17 @@ def _render_scope_warning(payload: Mapping[str, Any]) -> str:
 
 
 def _render_empty_state(mode: str, payload: Mapping[str, Any]) -> str:
+    if mode in {"home", "system"} and _safe_float(payload.get("equity"), 0.0) <= 0 and _safe_int(payload.get("positions")) <= 0:
+        return _section(
+            "🫥 Empty State",
+            _tree_group(
+                [
+                    ("Status", "No portfolio telemetry yet"),
+                    ("Next", "Values will populate after runtime snapshots arrive"),
+                    ("Tip", "Use /status and Refresh All to fetch the latest view"),
+                ]
+            ),
+        )
     if mode == "positions" and _safe_int(payload.get("positions")) <= 0:
         return "No open positions"
     if mode == "exposure" and _safe_int(payload.get("positions")) <= 0:

--- a/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
+++ b/projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py
@@ -11,7 +11,7 @@ from projects.polymarket.polyquantbot.core import market_scope
 from projects.polymarket.polyquantbot.core.system_state import SystemStateManager
 from projects.polymarket.polyquantbot.telegram.command_handler import CommandHandler
 from projects.polymarket.polyquantbot.telegram.command_router import CommandRouter
-from projects.polymarket.polyquantbot.interface.telegram.view_handler import render_view
+from projects.polymarket.polyquantbot.telegram.view_handler import render_view
 from projects.polymarket.polyquantbot.telegram.handlers.callback_router import CallbackRouter
 from projects.polymarket.polyquantbot.telegram.ui.reply_keyboard import REPLY_MENU_MAP
 
@@ -196,6 +196,78 @@ def test_command_router_start_live_path_tolerates_na_metrics_payload() -> None:
     assert "🏠 Home Command" in result.message
     assert "CRITICAL ERROR" not in result.message
     assert "_keyboard" in result.payload
+
+
+def test_command_router_help_uses_public_command_guidance() -> None:
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    handler = CommandHandler(
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+    router = CommandRouter(handler=handler)
+
+    result = asyncio.run(
+        router.route_update(
+            {
+                "update_id": 2,
+                "message": {"text": "/help", "from": {"id": 1001}, "chat": {"id": 1001}},
+            }
+        )
+    )
+
+    assert result is not None
+    assert "❓ Help Center" in result.message
+    assert "/start · /help · /status" in result.message
+
+
+def test_command_router_status_routes_to_system_snapshot() -> None:
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    handler = CommandHandler(
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+    router = CommandRouter(handler=handler)
+
+    result = asyncio.run(
+        router.route_update(
+            {
+                "update_id": 3,
+                "message": {"text": "/status", "from": {"id": 1001}, "chat": {"id": 1001}},
+            }
+        )
+    )
+
+    assert result is not None
+    assert "🧠 System Status" in result.message
+    assert "paper-only boundary enforced" in result.message.lower()
+
+
+def test_unknown_command_returns_help_style_fallback() -> None:
+    state_manager = SystemStateManager()
+    config_manager = ConfigManager()
+    handler = CommandHandler(
+        state_manager=state_manager,
+        config_manager=config_manager,
+        mode="PAPER",
+    )
+    router = CommandRouter(handler=handler)
+
+    result = asyncio.run(
+        router.route_update(
+            {
+                "update_id": 4,
+                "message": {"text": "/unsupported", "from": {"id": 1001}, "chat": {"id": 1001}},
+            }
+        )
+    )
+
+    assert result is not None
+    assert "❓ Help Center" in result.message
+    assert "Unknown command '/unsupported'" in result.message
 
 
 def test_reply_keyboard_routes_align_with_root_menu_actions() -> None:


### PR DESCRIPTION
### Motivation
- Consolidate legacy interface view code into the active Telegram runtime so the public paper-beta UX is single-source, clearer, and preserves an explicit paper-only boundary.
- Make the public command surface unambiguous for users (`/start`, `/help`, `/status`, unknown fallback) and ensure empty / sparse telemetry states render clear guidance.

### Description
- Updated `projects/polymarket/polyquantbot/telegram/command_handler.py` to route `/help` and `/status` to dedicated payload builders and to render unknown-command fallbacks via the active help view instead of plain text.
- Refined `projects/polymarket/polyquantbot/telegram/ui_formatter.py` help/guidance content and added an explicit empty-state block for sparse home/system telemetry.
- Adjusted tests to import the active renderer (`projects.polymarket.polyquantbot.telegram.view_handler`) and added regression checks for `/help`, `/status`, and unknown-command fallback in `projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py`.
- Added the FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase10-1_01_telegram-ux-consolidation.md` and performed a scoped `PROJECT_STATE.md` truth update.

### Testing
- `python3 -m py_compile` on the modified modules (`telegram/command_handler.py`, `telegram/ui_formatter.py`, touched tests) succeeded with no syntax errors.
- Ran targeted pytest on the touched Telegram test suite: `pytest -q projects/polymarket/polyquantbot/tests/test_telegram_start_numeric_safety.py` — result: `12 passed`.
- A broader initial pytest run showed two failures caused by unrelated execution/engine dependency/network issues; those test file edits were reverted and the targeted regression suite above was re-run and passed. Validation Tier: STANDARD. Claim Level: NARROW INTEGRATION.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fb9a5aec832592aaf892a52414af)