### PR TITLE
FORGE-X: blueprint repo-truth sync after manual replace

### DIFF
--- a/projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md
@@ -2,7 +2,7 @@
 
 - Performed blueprint artifact source-lock verification between `docs/crusader_blueprint_v2.html` and `docs/blueprint/crusaderbot_final_decisions.md` after the manual replace event.
 - Verified section-level parity by checking all `##` blueprint sections from the source-lock markdown are represented in the HTML navigation/anchor surface (21/21 section anchors resolved; 0 missing).
-- Verified exact active branch string with `git rev-parse --abbrev-ref HEAD` and locked traceability to `feature/core-blueprint-sync-manual-replace-2026-04-22` for this FORGE report context.
+- Verified exact active branch string with `git rev-parse --abbrev-ref HEAD` and locked traceability to `feature/sync-blueprint-and-repo-truth-after-manual-replace-2026-04-22` for this FORGE report context.
 - Reviewed repo-truth state scope and determined `PROJECT_STATE.md` branch traceability did not contain stale branch references for this task scope; no state-line edits were required.
 - Confirmed `ROADMAP.md` requires **no change** because this task is artifact/state consistency only with no milestone/phase sequencing impact.
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md
@@ -1,0 +1,19 @@
+## 1. What was changed
+
+- Performed blueprint artifact source-lock verification between `docs/crusader_blueprint_v2.html` and `docs/blueprint/crusaderbot_final_decisions.md` after the manual replace event.
+- Verified section-level parity by checking all `##` blueprint sections from the source-lock markdown are represented in the HTML navigation/anchor surface (21/21 section anchors resolved; 0 missing).
+- Verified exact active branch string with `git rev-parse --abbrev-ref HEAD` and locked traceability to `feature/core-blueprint-sync-manual-replace-2026-04-22` for this FORGE report context.
+- Reviewed repo-truth state scope and determined `PROJECT_STATE.md` branch traceability did not contain stale branch references for this task scope; no state-line edits were required.
+- Confirmed `ROADMAP.md` requires **no change** because this task is artifact/state consistency only with no milestone/phase sequencing impact.
+
+## 2. Files modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md`
+
+## 3. Validation Tier / Claim Level / Validation Target / Not in Scope / Suggested Next
+
+Validation Tier   : MINOR  
+Claim Level       : FOUNDATION  
+Validation Target : Blueprint artifact + repo-truth sync only (`docs/crusader_blueprint_v2.html` source-lock check against `docs/blueprint/crusaderbot_final_decisions.md`, plus branch traceability confirmation for this report context).  
+Not in Scope      : Runtime code, risk/execution logic, structural refactor, roadmap milestone changes, and any runtime behavior modification.  
+Suggested Next    : COMMANDER review.


### PR DESCRIPTION
### Motivation
- Ensure repo-truth continuity after a manual replacement of `docs/crusader_blueprint_v2.html` by verifying the HTML artifact matches the source-lock `docs/blueprint/crusaderbot_final_decisions.md` and that branch traceability is accurate.

### Description
- Added a MINOR FORGE continuity report at `projects/polymarket/polyquantbot/reports/forge/phase10-2_03_blueprint-sync-after-manual-replace.md` that records the blueprint artifact parity check and locks report traceability to `feature/sync-blueprint-and-repo-truth-after-manual-replace-2026-04-22`, with no edits required to `PROJECT_STATE.md` or `ROADMAP.md`.

### Testing
- Verified environment locale, confirmed active branch string, ran a Python section-anchor parity check (21/21 anchors resolved), and performed UTF-8/BOM and mojibake scans on the touched files, with all automated checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c5a017b083259247e4e7d153edaf)