### PR TITLE
Telegram: operator-chat guard for internal commands and observability hardening (Phase 10.3)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-22 11:00
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #713 Phase 10.2 onboarding/public command-surface refinement is merged truth, and current execution focus is monitor integration + observability hardening under the paper-only boundary.
+Last Updated : 2026-04-22 22:16
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #713 Phase 10.2 onboarding/public command-surface refinement is merged truth, and Phase 10.3 monitor integration + observability hardening is completed on PR #718 and pending COMMANDER review / merge under the paper-only boundary.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -38,7 +38,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #713 Phase 10.2 onboarding/public command-surface refinement lane is merged on main as closed truth: active Telegram public-safe command baseline is `/start`, `/help`, `/status`, `/paper`, `/about`, `/risk_info`, `/account`, and `/link`, while runtime/operator `/risk` remains a separate non-public informational control path with no live-trading claim.
 
 [IN PROGRESS]
-- Monitor integration hardening + observability baseline lane remains in progress: admin/internal path guarding, startup/command/reply logging baseline, and monitor/admin visibility completion are still open on the paper-only runtime surface.
+- Monitor integration hardening + observability baseline lane is completed on PR #718 and pending COMMANDER review / merge: admin/internal path guarding, startup/command/reply logging baseline, missing-env/disabled-mode logging, and monitor/admin visibility wiring are delivered on the paper-only runtime surface.
 - Post-launch cleanup + README/public-surface wording alignment lane remains in progress for paper-beta clarity (`/risk_info` public-safe informational command vs runtime/operator `/risk` distinction preserved).
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
@@ -48,7 +48,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Execute monitor integration hardening / observability hardening follow-up lane and close admin/internal path guarding plus monitor/admin visibility gaps in `projects/polymarket/polyquantbot/work_checklist.md`.
+- Merge PR #718, then run post-merge sync so Phase 10.3 moves from pending-review truth to merged-main truth before advancing to post-launch cleanup.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; Phase 10.2 onboarding/public command-surface lane is merged, and current execution lane is Phase 10.3 monitor integration plus observability hardening (paper-only boundary preserved, no live-trading or production-capital claim)
-**Last Updated:** 2026-04-22 11:00
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; Phase 10.2 onboarding/public command-surface lane is merged, and Phase 10.3 monitor integration plus observability hardening is completed on PR #718 and pending COMMANDER review / merge (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-22 22:16
 
 # Board Overview
 
@@ -51,8 +51,8 @@
 ### Current Focus Summary (paper-only boundary preserved)
 - Phase 10.2 post-merge sync and public command-surface refinement is merged on main (PR #713) with paper-only/non-custodial posture preserved.
 - Active Telegram public-safe command baseline is `/start`, `/help`, `/status`, `/paper`, `/about`, `/risk_info`, `/account`, and `/link`; runtime/operator `/risk` remains separate and is not part of the public-safe informational set.
-- Next execution lane is monitor integration hardening + observability baseline completion (admin/internal path guarding, startup/command/reply logging baseline, and monitor/admin visibility closure).
-- Persistence/readiness hardening continuity remains aligned with `projects/polymarket/polyquantbot/work_checklist.md`.
+- Phase 10.3 monitor integration hardening + observability baseline is completed on PR #718 and pending COMMANDER review / merge (admin/internal path guarding, startup/command/reply logging baseline, and monitor/admin visibility closure).
+- Next execution lane remains PR #718 merge + post-merge sync; post-launch cleanup starts only after merge truth is confirmed.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/work_checklist.md](projects/polymarket/polyquantbot/work_checklist.md).

--- a/projects/polymarket/polyquantbot/client/telegram/bot.py
+++ b/projects/polymarket/polyquantbot/client/telegram/bot.py
@@ -82,7 +82,16 @@ async def run_bot() -> None:
         base_url=settings.backend_base_url,
         identity_tenant_id=settings.staging_tenant_id,
     )
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(
+        backend=backend,
+        operator_chat_id=settings.telegram_chat_id,
+    )
+    if not settings.telegram_chat_id:
+        log.warning(
+            "crusaderbot_telegram_operator_chat_guard_disabled",
+            reason="missing_TELEGRAM_CHAT_ID",
+            internal_command_surface="blocked_for_public_runtime",
+        )
     adapter = HttpTelegramAdapter(token=settings.telegram_token)
 
     log.info(

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -42,12 +42,42 @@ class DispatchResult:
 
 
 class TelegramDispatcher:
-    def __init__(self, backend: CrusaderBackendClient) -> None:
+    _INTERNAL_COMMANDS = {
+        "/mode",
+        "/autotrade",
+        "/positions",
+        "/pnl",
+        "/risk",
+        "/markets",
+        "/market360",
+        "/social",
+        "/kill",
+    }
+
+    def __init__(self, backend: CrusaderBackendClient, operator_chat_id: str = "") -> None:
         self._backend = backend
+        self._operator_chat_id = operator_chat_id.strip()
+        self._internal_commands_enabled = bool(self._operator_chat_id)
+        if not self._internal_commands_enabled:
+            log.info(
+                "crusaderbot_telegram_internal_commands_disabled",
+                reason="missing_operator_chat_id",
+            )
 
     async def dispatch(self, ctx: TelegramCommandContext) -> DispatchResult:
         command = ctx.command.strip().lower()
         arg = ctx.argument.strip()
+        if command in self._INTERNAL_COMMANDS and not self._is_internal_command_allowed(ctx):
+            log.warning(
+                "crusaderbot_telegram_internal_command_guarded",
+                command=command,
+                chat_id=ctx.chat_id,
+                guard_mode=("chat_id_match" if self._internal_commands_enabled else "disabled"),
+            )
+            return DispatchResult(
+                outcome="unknown_command",
+                reply_text=format_unknown_command_reply(),
+            )
         if command == "/start":
             return await self._dispatch_start(ctx)
         if command == "/help":
@@ -200,3 +230,8 @@ class TelegramDispatcher:
         )
         result: HandleStartResult = await handle_start(context=handoff_ctx, backend=self._backend)
         return DispatchResult(outcome=result.outcome, reply_text=result.reply_text, session_id=result.session_id)
+
+    def _is_internal_command_allowed(self, ctx: TelegramCommandContext) -> bool:
+        if not self._internal_commands_enabled:
+            return False
+        return ctx.chat_id == self._operator_chat_id

--- a/projects/polymarket/polyquantbot/client/telegram/runtime.py
+++ b/projects/polymarket/polyquantbot/client/telegram/runtime.py
@@ -341,6 +341,14 @@ class TelegramPollingLoop:
             )
             return
 
+        log.info(
+            "crusaderbot_telegram_command_received",
+            update_id=update.update_id,
+            chat_id=update.chat_id,
+            from_user_id=update.from_user_id,
+            command=ctx.command,
+        )
+
         requires_start_lifecycle = ctx.command == "/start"
 
         if self._identity_resolver is not None:
@@ -523,11 +531,25 @@ class TelegramPollingLoop:
             )
             return
 
+        log.info(
+            "crusaderbot_telegram_command_handled",
+            update_id=update.update_id,
+            chat_id=update.chat_id,
+            command=ctx.command,
+            outcome=result.outcome,
+            has_reply_text=bool(result.reply_text.strip()),
+        )
+
         await self._safe_send_reply(update.chat_id, result.reply_text)
 
     async def _safe_send_reply(self, chat_id: str, text: str) -> None:
         try:
             await self._adapter.send_reply(chat_id, text)
+            log.info(
+                "crusaderbot_telegram_reply_send_succeeded",
+                chat_id=chat_id,
+                reply_length=len(text),
+            )
             if self._observer is not None:
                 self._observer.on_reply_sent()
         except Exception as exc:

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-3_01_monitor-integration-observability-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-3_01_monitor-integration-observability-hardening.md
@@ -1,0 +1,48 @@
+## 1. What was built
+
+- Added explicit guardrails for runtime-internal monitor/admin command routes in `TelegramDispatcher` so public-safe chats cannot execute internal `/mode`, `/autotrade`, `/positions`, `/pnl`, `/risk`, `/markets`, `/market360`, `/social`, or `/kill` surfaces unless they match configured operator chat identity.
+- Wired operator chat guard configuration from runtime bootstraps (`server/main.py` and `client/telegram/bot.py`) and added missing-env visibility logs when `TELEGRAM_CHAT_ID` is absent.
+- Hardened Telegram runtime observability baseline in `client/telegram/runtime.py` with lifecycle logs for command received, command handled, and reply send success/failure.
+- Preserved public-safe command truth (`/start`, `/help`, `/status`) and paper-only execution boundary by routing blocked internal command attempts to the same public-safe unknown-command response surface.
+
+## 2. Current system architecture (relevant slice)
+
+- Telegram inbound updates enter through `client/telegram/runtime.py` and are normalized into `TelegramCommandContext`.
+- `TelegramPollingLoop` now emits command lifecycle observability events (`command_received` -> `command_handled` -> `reply_send_succeeded`/error) around dispatcher execution.
+- `TelegramDispatcher` now enforces internal command access boundaries before any backend beta route call; guarded attempts short-circuit to public-safe unknown-command output.
+- Runtime bootstrap (`server/main.py` and `client/telegram/bot.py`) injects `operator_chat_id` into dispatcher wiring; missing operator chat configuration emits explicit guard-disabled logs with blocked internal command posture.
+
+## 3. Files created / modified (full repo-root paths)
+
+- `projects/polymarket/polyquantbot/client/telegram/dispatcher.py`
+- `projects/polymarket/polyquantbot/client/telegram/runtime.py`
+- `projects/polymarket/polyquantbot/client/telegram/bot.py`
+- `projects/polymarket/polyquantbot/server/main.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase10-3_01_monitor-integration-observability-hardening.md`
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+
+## 4. What is working
+
+- Public-safe chats no longer reach restricted monitor/admin internal command routes through Telegram dispatcher.
+- Operator-authorized chat path retains internal command execution continuity where explicitly configured.
+- Startup/runtime logs now expose monitorable lifecycle checkpoints for startup config posture, inbound command handling, and outbound reply success/failure.
+- Missing-env (`TELEGRAM_CHAT_ID`) and disabled internal-command mode states are logged explicitly, preserving truthful observability.
+- Existing paper-only and public-safe command responses remain intact in tested paths.
+
+## 5. Known issues
+
+- Internal command guard currently relies on single `TELEGRAM_CHAT_ID` exact-match boundary; broader role-based operator authorization remains out of scope.
+- Sentry environment proof remains separately blocked pending deploy-side evidence (`SENTRY_DSN` + first event receipt), unchanged by this lane.
+
+## 6. What is next
+
+- Continue post-launch cleanup and README/public-surface wording alignment while keeping `/risk_info` public-safe informational command and runtime/operator `/risk` separation explicit.
+
+Validation Tier   : STANDARD
+Claim Level       : NARROW INTEGRATION
+Validation Target : live runtime monitor/admin visibility + path guarding + observability baseline only
+Not in Scope      : risk engine, execution engine, strategy logic, wallet lifecycle, portfolio logic, production-capital readiness, roadmap resequencing
+Suggested Next    : COMMANDER review

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -97,7 +97,16 @@ async def _start_telegram_runtime(state: RuntimeState) -> None:
         base_url=settings.backend_base_url,
         identity_tenant_id=settings.staging_tenant_id,
     )
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(
+        backend=backend,
+        operator_chat_id=settings.telegram_chat_id,
+    )
+    if not settings.telegram_chat_id:
+        log.warning(
+            "crusaderbot_telegram_operator_chat_guard_disabled",
+            reason="missing_TELEGRAM_CHAT_ID",
+            internal_command_surface="blocked_for_public_runtime",
+        )
     adapter = HttpTelegramAdapter(token=settings.telegram_token)
     observer = RuntimeTelegramObserver(state=state)
     state.telegram_runtime_task = asyncio.create_task(

--- a/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_3_public_paper_beta_spine_20260419.py
@@ -189,14 +189,14 @@ def test_monitoring_stages_still_run_when_entries_blocked() -> None:
 
 def test_positions_command_maps_to_positions_endpoint() -> None:
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
     asyncio.run(dispatcher.dispatch(_make_ctx("/positions")))
     assert backend.last_get_path == "/beta/positions"
 
 
 def test_pnl_and_risk_commands_map_to_dedicated_endpoints() -> None:
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
     asyncio.run(dispatcher.dispatch(_make_ctx("/pnl")))
     assert backend.last_get_path == "/beta/pnl"
     asyncio.run(dispatcher.dispatch(_make_ctx("/risk")))
@@ -212,7 +212,7 @@ def test_connect_wallet_removed_from_public_shell() -> None:
 
 def test_mode_command_reply_reports_blocked_live_mode_request() -> None:
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
     result = asyncio.run(dispatcher.dispatch(_make_ctx("/mode", "live")))
     assert "Mode change blocked" in result.reply_text
     assert "mode=live is disabled" in result.reply_text
@@ -223,7 +223,7 @@ def test_unknown_command_reply_lists_supported_commands() -> None:
     dispatcher = TelegramDispatcher(backend=backend)
     result = asyncio.run(dispatcher.dispatch(_make_ctx("/noop")))
     assert result.outcome == "unknown_command"
-    assert "/kill" in result.reply_text
+    assert "/kill" not in result.reply_text
 
 
 def test_autotrade_and_kill_interaction_forces_autotrade_off() -> None:
@@ -233,7 +233,7 @@ def test_autotrade_and_kill_interaction_forces_autotrade_off() -> None:
     STATE.kill_switch = False
 
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
     asyncio.run(dispatcher.dispatch(_make_ctx("/kill")))
 
     assert backend.last_post_path == "/beta/kill"
@@ -242,7 +242,7 @@ def test_autotrade_and_kill_interaction_forces_autotrade_off() -> None:
 
 def test_autotrade_reply_preserves_live_mode_boundary_detail() -> None:
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
     result = asyncio.run(dispatcher.dispatch(_make_ctx("/autotrade", "on")))
     assert "Autotrade" in result.reply_text
 
@@ -317,7 +317,7 @@ def test_status_command_reply_surfaces_execution_guard_and_boundary() -> None:
 
 def test_positions_pnl_risk_replies_keep_paper_beta_boundaries_visible() -> None:
     backend = FakeBackend()
-    dispatcher = TelegramDispatcher(backend=backend)
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="chat-1")
 
     positions_reply = asyncio.run(dispatcher.dispatch(_make_ctx("/positions"))).reply_text
     pnl_reply = asyncio.run(dispatcher.dispatch(_make_ctx("/pnl"))).reply_text

--- a/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_8_telegram_dispatch_20260419.py
@@ -155,6 +155,25 @@ def test_dispatch_unknown_command_empty_string() -> None:
     backend.request_handoff.assert_not_awaited()
 
 
+def test_internal_command_guarded_when_operator_chat_not_configured() -> None:
+    backend = _make_mock_backend(outcome="issued")
+    backend.beta_post = AsyncMock(return_value={"ok": True, "mode": "paper"})
+    dispatcher = TelegramDispatcher(backend=backend)
+    result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/mode", chat_id="public-chat")))
+    assert result.outcome == "unknown_command"
+    backend.beta_post.assert_not_awaited()
+
+
+def test_internal_command_allowed_for_configured_operator_chat() -> None:
+    backend = _make_mock_backend(outcome="issued")
+    backend.beta_post = AsyncMock(return_value={"ok": True, "mode": "paper", "detail": "ok"})
+    dispatcher = TelegramDispatcher(backend=backend, operator_chat_id="operator-chat")
+    result: DispatchResult = asyncio.run(dispatcher.dispatch(_make_ctx("/mode", chat_id="operator-chat")))
+    assert result.outcome == "ok"
+    assert "Mode updated" in result.reply_text
+    backend.beta_post.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Reply text contract — all outcomes must return non-empty reply_text
 # ---------------------------------------------------------------------------

--- a/projects/polymarket/polyquantbot/work_checklist.md
+++ b/projects/polymarket/polyquantbot/work_checklist.md
@@ -59,19 +59,19 @@ Monitor Integration + Observability Hardening Lane
 
 #### RIGHT NOW (post-merge sync lane)
 
-[ ] Guard admin/internal paths properly
+[x] Guard admin/internal paths properly
 
-[ ] Add bot startup logs
+[x] Add bot startup logs
 
-[ ] Add command received logs
+[x] Add command received logs
 
-[ ] Add command handled logs
+[x] Add command handled logs
 
-[ ] Add reply success/failure logs
+[x] Add reply success/failure logs
 
-[ ] Add missing env / disabled mode logs
+[x] Add missing env / disabled mode logs
 
-[ ] Complete monitor/admin visibility wiring for checklist/state parity
+[x] Complete monitor/admin visibility wiring for checklist/state parity
 
 
 #### NEXT (immediately after code fix + UX integration)
@@ -151,20 +151,20 @@ Monitor Integration + Observability Hardening Lane
 
 [x] Keep the paper-only boundary visible everywhere
 
-[ ] Guard admin/internal paths properly
+[x] Guard admin/internal paths properly
 
 
 ### 6. Observability Baseline
 
-[ ] Add bot startup logs
+[x] Add bot startup logs
 
-[ ] Add command received logs
+[x] Add command received logs
 
-[ ] Add command handled logs
+[x] Add command handled logs
 
-[ ] Add reply success/failure logs
+[x] Add reply success/failure logs
 
-[ ] Add missing env / disabled mode logs
+[x] Add missing env / disabled mode logs
 
 [x] Add Sentry Python runtime initialization + exception capture guardrails (env-only `SENTRY_DSN`, FastAPI + Telegram/runtime exception surfaces)
 


### PR DESCRIPTION
### Motivation
- Prevent public chats from invoking internal/monitoring/admin Telegram commands and close the monitor-integration/observability hardening lane. 
- Improve runtime observability with lifecycle logs for command receipt, handling, and reply delivery to aid monitor/admin visibility and troubleshooting. 

### Description
- Added operator chat wiring into bootstraps by passing `operator_chat_id` from `client/telegram/bot.py` and `server/main.py` into `TelegramDispatcher`. 
- Implemented an internal command allowlist and guard in `TelegramDispatcher` that short-circuits restricted commands (`/mode`, `/autotrade`, `/positions`, `/pnl`, `/risk`, `/markets`, `/market360`, `/social`, `/kill`) unless the incoming chat matches the configured operator chat. 
- Emitted explicit missing-env / disabled-mode visibility logs when `TELEGRAM_CHAT_ID` is not configured and logged internal-command guard events for blocked attempts. 
- Hardened runtime observability in `client/telegram/runtime.py` with `command_received`, `command_handled`, and `reply_send_succeeded`/error logs and added reply-send success logging in `_safe_send_reply`. 
- Updated and added unit tests to cover operator-guard semantics and adjusted expectations for help/unknown-command replies in `projects/polymarket/polyquantbot/tests/*`. 
- Updated operational docs and meta-files: `projects/polymarket/polyquantbot/reports/forge/phase10-3_01_monitor-integration-observability-hardening.md`, `PROJECT_STATE.md`, `ROADMAP.md`, and `projects/polymarket/polyquantbot/work_checklist.md` to reflect lane completion and next steps. 

### Testing
- Updated and added unit tests under `projects/polymarket/polyquantbot/tests/`, including guard checks in `test_phase8_8_telegram_dispatch_20260419.py` and adjusted expectations in `test_phase8_3_public_paper_beta_spine_20260419.py`. 
- Ran the test suite with `pytest` and all modified/added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d2c021508325bfe158568e11993e)