### PR TITLE
phase10-5: post-merge truth sync and strategy persistence boundary baseline

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 12:16
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 and PR #726 are merged-main truth, and Phase 10.5 post-merge persistence baseline is now the active Priority 2 lane.
+Last Updated : 2026-04-23 12:24
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 and PR #726 are merged-main truth, and PR #727 persistence-boundary validation is now complete with SENTINEL verdict ready for COMMANDER merge decision.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -50,7 +50,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- Execute Priority 2 persistence stabilization baseline: audit restart-sensitive runtime state and enforce one authoritative persistence boundary per scoped category while preserving paper-only posture.
+- COMMANDER final gate on PR #727: review SENTINEL persistence-boundary verdict and decide merge/hold for `feature/sync-repo-truth-and-stabilize-persistence` into `main`.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-23 11:52
+Last Updated : 2026-04-23 12:16
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 and PR #726 are merged-main truth, and Phase 10.5 post-merge persistence baseline is now the active Priority 2 lane.
 
 [COMPLETED]
@@ -39,7 +39,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #719 Phase 10.3 monitor integration + observability hardening lane is merged on main as closed truth: admin/internal path guarding, startup/command/reply logging baseline, missing-env/disabled-mode logging, and monitor/admin visibility wiring are landed while paper-only and public-safe command boundaries remain explicit.
 - PR #721 Phase 10 post-launch public-surface cleanup lane is merged on main as closed historical truth from exact head branch `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`: README/public wording and Telegram first-run onboarding guidance are aligned, `/risk_info` remains public informational, and `/risk` remains runtime/operator-only.
 - PR #725 Priority 2 DB readiness/startup blocker-closure lane is merged on main as closed truth, with canonical validation record preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-5_01_pr725-db-readiness-startup-validation.md`.
-- PR #726 post-merge repo-truth sync lane is merged on main as closed truth; stale pre-merge decision wording for PR #725 is retired from active state/roadmap lanes.
+- PR #726 is merged on main as post-merge closure sync for PR #725 gate completion; stale pre-merge decision wording for PR #725 is retired from active state/roadmap lanes.
 
 [IN PROGRESS]
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 06:54
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 source branch `feature/close-pr-#724-blockers-for-db-readiness` DB readiness/startup blocker-closure lane is SENTINEL APPROVED and returned to COMMANDER for final merge decision.
+Last Updated : 2026-04-23 11:52
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 and PR #726 are merged-main truth, and Phase 10.5 post-merge persistence baseline is now the active Priority 2 lane.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -38,7 +38,8 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #713 Phase 10.2 onboarding/public command-surface refinement lane is merged on main as closed truth: active Telegram public-safe command baseline is `/start`, `/help`, `/status`, `/paper`, `/about`, `/risk_info`, `/account`, and `/link`, while runtime/operator `/risk` remains a separate non-public informational control path with no live-trading claim.
 - PR #719 Phase 10.3 monitor integration + observability hardening lane is merged on main as closed truth: admin/internal path guarding, startup/command/reply logging baseline, missing-env/disabled-mode logging, and monitor/admin visibility wiring are landed while paper-only and public-safe command boundaries remain explicit.
 - PR #721 Phase 10 post-launch public-surface cleanup lane is merged on main as closed historical truth from exact head branch `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`: README/public wording and Telegram first-run onboarding guidance are aligned, `/risk_info` remains public informational, and `/risk` remains runtime/operator-only.
-- PR #725 Priority 2 DB readiness/startup blocker-closure lane on exact source branch `feature/close-pr-#724-blockers-for-db-readiness` is SENTINEL APPROVED for declared NARROW INTEGRATION scope; canonical validation report: `projects/polymarket/polyquantbot/reports/sentinel/phase10-5_01_pr725-db-readiness-startup-validation.md`.
+- PR #725 Priority 2 DB readiness/startup blocker-closure lane is merged on main as closed truth, with canonical validation record preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-5_01_pr725-db-readiness-startup-validation.md`.
+- PR #726 post-merge repo-truth sync lane is merged on main as closed truth; stale pre-merge decision wording for PR #725 is retired from active state/roadmap lanes.
 
 [IN PROGRESS]
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
@@ -49,7 +50,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER merge decision for PR #725 (`feature/close-pr-#724-blockers-for-db-readiness`) after SENTINEL APPROVED gate closure on Priority 2 DB readiness/startup handling path.
+- Execute Priority 2 persistence stabilization baseline: audit restart-sensitive runtime state and enforce one authoritative persistence boundary per scoped category while preserving paper-only posture.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; Phase 10.2 onboarding/public command-surface lane is merged, and Phase 10.3 monitor integration plus observability hardening is merged on main via PR #719 (paper-only boundary preserved, no live-trading or production-capital claim).
-**Last Updated:** 2026-04-23 04:22
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725 DB readiness/startup hardening and PR #726 post-merge truth-sync are merged-main truth, and Phase 10.5 persistence stabilization baseline is the active Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-23 11:52
 
 # Board Overview
 
@@ -52,7 +52,9 @@
 - Phase 10.2 post-merge sync and public command-surface refinement is merged on main (PR #713) with paper-only/non-custodial posture preserved.
 - Active Telegram public-safe command baseline is `/start`, `/help`, `/status`, `/paper`, `/about`, `/risk_info`, `/account`, and `/link`; runtime/operator `/risk` remains separate and is not part of the public-safe informational set.
 - Phase 10.3 monitor integration hardening + observability baseline is merged on main via PR #719 (admin/internal path guarding, startup/command/reply logging baseline, missing-env/disabled-mode visibility logging, and monitor/admin visibility closure).
-- Phase 10 post-launch cleanup + public-surface wording alignment is merged on main via PR #721, with exact historical head branch traceability `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`; next combined lane is Priority 2 DB, persistence, and runtime hardening baseline from `projects/polymarket/polyquantbot/work_checklist.md`.
+- Phase 10 post-launch cleanup + public-surface wording alignment is merged on main via PR #721, with exact historical head branch traceability `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`.
+- Priority 2 DB readiness/startup hardening lane is merged on main via PR #725, and PR #726 post-merge repo-truth sync is also merged on main.
+- Active lane is Phase 10.5 post-merge sync and persistence stabilization baseline focused on restart-sensitive runtime state boundaries from `projects/polymarket/polyquantbot/work_checklist.md`.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/work_checklist.md](projects/polymarket/polyquantbot/work_checklist.md).

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md
@@ -1,0 +1,47 @@
+# FORGE-X Report — phase10-5_03_postmerge-sync-and-persistence-baseline
+
+- Timestamp: 2026-04-23 11:52 (Asia/Jakarta)
+- Branch: feature/phase10-postmerge-sync-and-persistence-baseline
+- Scope lane: post-merge repo-truth sync + Priority 2 persistence stabilization baseline
+
+## 1) What was built
+- Synced repo-truth artifacts after merged PR #725 / PR #726 so PROJECT_STATE.md and ROADMAP.md no longer treat PR #725 as pending COMMANDER merge decision.
+- Recorded merged-main truth for PR #725 and PR #726 and moved the active NEXT PRIORITY lane to Phase 10.5 persistence stabilization baseline.
+- Audited restart-sensitive runtime persistence path in active runtime scope and scoped the critical category to strategy toggle state.
+- Removed split-brain persistence behavior for strategy toggle state by enforcing one authoritative boundary:
+  - when DB client is present, load/save use DB only;
+  - Redis is now fallback-only when DB is absent.
+- Added split-brain prevention regression coverage proving Redis is not read/written when DB is authoritative.
+
+## 2) Current system architecture (relevant slice)
+- Scoped restart-sensitive category: strategy toggle state (`ev_momentum`, `mean_reversion`, `liquidity_edge`).
+- Authoritative persistence boundary:
+  1. DB-connected runtime path -> `StrategyStateManager.load(db=...)` and `save(db=...)` only.
+  2. DB-absent runtime path -> Redis fallback path.
+  3. If selected backend has no state, manager keeps in-memory safe defaults.
+- Result: one authoritative source per runtime path, removing dual-write/dual-read divergence for the same logical state.
+
+## 3) Files created / modified (full repo-root paths)
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+- `projects/polymarket/polyquantbot/strategy/strategy_manager.py`
+- `projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md`
+
+## 4) What is working
+- PROJECT_STATE / ROADMAP merged-truth wording now reflects PR #725 + PR #726 as merged-main truth and aligned active next lane.
+- StrategyStateManager now enforces DB-authoritative load/save behavior and prevents Redis fallback/read/write when DB is provided.
+- Regression tests for split-brain prevention and restart continuity path are passing in the touched strategy state suite.
+
+## 5) Known issues
+- None introduced in this scoped lane.
+- Environment required installation of `pytest-asyncio` to execute async tests in this runner; test suite now passes in the current environment.
+
+## 6) What is next
+- Required next gate: SENTINEL MAJOR validation for post-merge repo-truth sync + persistence stabilization baseline before merge decision.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : post-merge repo-truth sync plus Priority 2 persistence stabilization for restart-safe runtime state
+Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX/doc cleanup
+Suggested Next    : SENTINEL validation on branch `feature/phase10-postmerge-sync-and-persistence-baseline`

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md
@@ -1,7 +1,7 @@
 # FORGE-X Report — phase10-5_03_postmerge-sync-and-persistence-baseline
 
-- Timestamp: 2026-04-23 11:52 (Asia/Jakarta)
-- Branch: feature/phase10-postmerge-sync-and-persistence-baseline
+- Timestamp: 2026-04-23 12:16 (Asia/Jakarta)
+- Branch: feature/sync-repo-truth-and-stabilize-persistence
 - Scope lane: post-merge repo-truth sync + Priority 2 persistence stabilization baseline
 
 ## 1) What was built
@@ -44,4 +44,4 @@ Validation Tier   : MAJOR
 Claim Level       : NARROW INTEGRATION
 Validation Target : post-merge repo-truth sync plus Priority 2 persistence stabilization for restart-safe runtime state
 Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX/doc cleanup
-Suggested Next    : SENTINEL validation on branch `feature/phase10-postmerge-sync-and-persistence-baseline`
+Suggested Next    : SENTINEL validation on branch `feature/sync-repo-truth-and-stabilize-persistence`

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase10-5_02_pr727-persistence-boundary-validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase10-5_02_pr727-persistence-boundary-validation.md
@@ -1,0 +1,108 @@
+# SENTINEL Report — phase10-5_02_pr727-persistence-boundary-validation
+
+- Timestamp: 2026-04-23 12:25 (Asia/Jakarta)
+- PR: #727
+- Source forge report: `projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md`
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: post-merge repo-truth sync plus Priority 2 persistence stabilization for strategy toggle state persistence boundary
+- Not in Scope: wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite
+
+## Environment
+- Repo: `bayuewalker/walker-ai-team`
+- Runtime: dev
+- Local checkout branch label: `work` (Codex worktree normalized)
+- Verified PR #727 head branch (GitHub API): `feature/sync-repo-truth-and-stabilize-persistence`
+- Verified PR #727 base branch (GitHub API): `main`
+- Locale: `LANG=C.UTF-8`, `LC_ALL=C.UTF-8`
+
+## Validation Context
+This validation audits PR #727 against the declared narrow persistence claim. Scope is strictly limited to (a) repo-truth post-merge sync integrity and (b) strategy toggle persistence boundary behavior in `StrategyStateManager`.
+
+## Phase 0 Checks
+- Forge report exists at the declared path and includes required MAJOR sections.
+- Branch traceability anchor verified from GitHub PR head branch.
+- PROJECT_STATE.md and ROADMAP.md are present and parseable as active repo-truth surfaces.
+- Mojibake scan on active truth/report files passed (no `â€`, `â†`, `ðŸ`, `\udc`, `�` patterns found).
+- Runtime evidence commands executed for scoped behavior (`py_compile` and targeted `pytest` subset).
+
+## Findings
+1) **Exact branch traceability across PR head/forge/state/roadmap: PASS**
+- PR #727 head branch from GitHub API is `feature/sync-repo-truth-and-stabilize-persistence`.
+- Forge report branch line matches exactly.
+- PROJECT_STATE.md references this exact branch in NEXT PRIORITY merge gate text.
+- ROADMAP.md contains no conflicting branch reference for this lane (no mismatch introduced).
+
+2) **Stale PR #725 merge-decision wording retired from active repo-truth surfaces: PASS**
+- PROJECT_STATE.md treats PR #725 and PR #726 as merged-main truth and explicitly says stale PR #725 pre-merge wording is retired.
+- ROADMAP.md also treats PR #725 and PR #726 as merged-main truth.
+- No active `pending COMMANDER merge decision` wording remains for PR #725 in PROJECT_STATE.md or ROADMAP.md.
+
+3) **One authoritative persistence backend per runtime path: PASS**
+- `StrategyStateManager.load(...)`: DB path returns before any Redis path evaluation when `db` is provided.
+- `StrategyStateManager.save(...)`: DB path returns before Redis path when `db` is provided.
+- This enforces a single backend authority per runtime path and removes split-brain dual backend usage for strategy toggle state.
+
+4) **DB-present path does not read Redis: PASS**
+- Code path: `load(...)` short-circuits on DB branch.
+- Test evidence: `test_st11_load_db_authoritative_does_not_read_redis_when_db_empty` asserts `redis._get_json.assert_not_called()` and passes.
+
+5) **DB-present path does not write Redis: PASS**
+- Code path: `save(...)` returns result from DB branch and never reaches Redis write branch.
+- Test evidence: `test_st17_save_db_authoritative_skips_redis_when_db_present` asserts `redis._set_json.assert_not_called()` and passes.
+
+6) **DB-absent path preserves Redis fallback: PASS**
+- `load(...)` enters Redis read path only when `db is None`.
+- `save(...)` enters Redis write path only when `db is None` and `redis` is provided.
+- Test evidence: `test_st15_save_writes_to_redis` passes.
+
+7) **In-memory defaults remain safe with no persisted state: PASS**
+- DB-authoritative empty state path logs memory default and preserves safe all-enabled defaults.
+- Redis-missing/no-backend path falls through to memory defaults.
+- Test evidence: `test_st11_load_db_authoritative_does_not_read_redis_when_db_empty`, `test_st12_load_uses_defaults_when_no_backend`, and `test_st13_load_falls_back_on_db_error` all pass.
+
+8) **Test evidence supports declared narrow persistence claim: PASS**
+- Executed targeted persistence-boundary suite (`ST-10` through `ST-17`) with 8/8 pass.
+- Tests directly validate load/save backend authority and split-brain prevention on strategy toggle state only.
+
+9) **No broader persistence/product claims implied beyond scoped strategy toggle state: PASS**
+- Forge report and code/test changes stay scoped to strategy toggle state manager boundary.
+- No claims found for broader wallet lifecycle, portfolio persistence, or execution-engine persistence overhaul.
+
+## Score Breakdown
+- Branch/repo-truth traceability integrity: 20/20
+- Persistence boundary correctness (DB vs Redis authority): 25/25
+- Safe default and fallback behavior: 20/20
+- Test evidence sufficiency for narrow claim: 20/20
+- Scope discipline (no broader implied claims): 15/15
+
+**Total: 100/100**
+
+## Critical Issues
+- None.
+
+## Status
+- **APPROVED** for declared MAJOR / NARROW INTEGRATION target scope.
+
+## PR Gate Result
+- PR #727 is validated for COMMANDER merge/hold decision on the declared narrow persistence boundary scope.
+- No SENTINEL blocker remains in scoped checks.
+
+## Broader Audit Finding
+- This approval does not claim full-system persistence architecture correctness.
+- Broader persistence categories remain out of scope and require separate scoped lanes if promoted.
+
+## Reasoning
+Code truth, state/roadmap truth, and test evidence align with the narrow claim: one authoritative backend per runtime path for strategy toggle persistence, with explicit DB authority and Redis fallback only when DB is absent.
+
+## Fix Recommendations
+- None required for this scoped gate.
+
+## Out-of-scope Advisory
+- Consider adding one integration-level test against a real DB + Redis runtime harness to preserve this backend-authority contract across future refactors.
+
+## Deferred Minor Backlog
+- None introduced by this validation pass.
+
+## Telegram Visual Preview
+- N/A (no BRIEFER artifact requested for this SENTINEL gate).

--- a/projects/polymarket/polyquantbot/strategy/strategy_manager.py
+++ b/projects/polymarket/polyquantbot/strategy/strategy_manager.py
@@ -56,8 +56,9 @@ _DEFAULT_STATE: Dict[str, bool] = {name: True for name in KNOWN_STRATEGIES}
 class StrategyStateManager:
     """Manages per-strategy toggle state with Redis and/or DB persistence.
 
-    Persistence priority on load: DB → Redis → in-memory defaults.
-    On save, all available backends are written (DB first, then Redis).
+    Authoritative persistence boundary:
+    - When a DB client is provided, DB is the only persistence backend used.
+    - Redis is used only when DB is not provided.
 
     Thread-safety: designed for single asyncio event loop.  Protect shared
     state with an asyncio.Lock for concurrent toggle operations.
@@ -163,20 +164,20 @@ class StrategyStateManager:
         redis: Optional["RedisClient"] = None,
         db: Optional["DatabaseClient"] = None,
     ) -> None:
-        """Load strategy state, preferring DB over Redis over in-memory defaults.
+        """Load strategy state from one authoritative backend.
 
         Load order:
-          1. DB (``DatabaseClient``) — if provided and data exists.
-          2. Redis — if provided and no DB data found.
-          3. In-memory defaults — if neither backend returns data.
+          1. DB (``DatabaseClient``) — when provided.
+          2. Redis — only when DB is not provided.
+          3. In-memory defaults — if selected backend returns no data.
 
         Falls back silently to the current in-memory state on any error.
 
         Args:
-            redis: Connected RedisClient.  Used when DB is unavailable or empty.
-            db: Connected DatabaseClient.  Preferred persistence backend.
+            redis: Connected RedisClient. Used only when DB is not provided.
+            db: Connected DatabaseClient. Authoritative persistence backend.
         """
-        # ── Try DB first ──────────────────────────────────────────────────────
+        # ── DB authoritative path ─────────────────────────────────────────────
         if db is not None:
             try:
                 db_state = await asyncio.wait_for(
@@ -186,7 +187,7 @@ class StrategyStateManager:
                 log.warning(
                     "strategy_state_load_db_error",
                     error=str(exc),
-                    fallback="redis_or_memory",
+                    fallback="memory_default",
                 )
                 db_state = {}
 
@@ -210,7 +211,15 @@ class StrategyStateManager:
                 )
                 return
 
-        # ── Fall back to Redis ────────────────────────────────────────────────
+            log.info(
+                "strategy_state_loaded",
+                source="memory_default",
+                reason="db_authoritative_no_persisted_state",
+                state=self.get_state(),
+            )
+            return
+
+        # ── Redis fallback path (only when DB is absent) ─────────────────────
         if redis is not None:
             try:
                 data: Optional[Any] = await asyncio.wait_for(
@@ -256,17 +265,17 @@ class StrategyStateManager:
         redis: Optional["RedisClient"] = None,
         db: Optional["DatabaseClient"] = None,
     ) -> bool:
-        """Persist current strategy state to DB and/or Redis.
+        """Persist current strategy state to one authoritative backend.
 
-        Both backends are attempted when provided.  Returns True only if at
-        least one backend successfully persists the state.
+        If DB is provided, Redis is intentionally not written to prevent
+        split-brain state across persistence backends.
 
         Args:
-            redis: Connected RedisClient.
-            db: Connected DatabaseClient.
+            redis: Connected RedisClient. Used only when DB is not provided.
+            db: Connected DatabaseClient. Authoritative persistence backend.
 
         Returns:
-            True if at least one write succeeded, False if all failed.
+            True if the selected backend write succeeded, False otherwise.
         """
         if redis is None and db is None:
             log.warning(
@@ -275,10 +284,9 @@ class StrategyStateManager:
             )
             return False
 
-        any_ok = False
         current_state = self.get_state()
 
-        # ── DB ────────────────────────────────────────────────────────────────
+        # ── DB authoritative path ─────────────────────────────────────────────
         if db is not None:
             try:
                 ok: bool = await asyncio.wait_for(
@@ -288,9 +296,12 @@ class StrategyStateManager:
                 log.warning("strategy_state_save_db_error", error=str(exc))
                 ok = False
             if ok:
-                any_ok = True
+                log.info("strategy_state_saved", backend="db", state=current_state)
+            else:
+                log.warning("strategy_state_save_failed", backend="db", state=current_state)
+            return ok
 
-        # ── Redis ─────────────────────────────────────────────────────────────
+        # ── Redis fallback path (only when DB is absent) ─────────────────────
         if redis is not None:
             try:
                 redis_ok: bool = await asyncio.wait_for(
@@ -300,11 +311,9 @@ class StrategyStateManager:
                 log.warning("strategy_state_save_redis_error", error=str(exc))
                 redis_ok = False
             if redis_ok:
-                any_ok = True
+                log.info("strategy_state_saved", backend="redis", state=current_state)
+            else:
+                log.warning("strategy_state_save_failed", backend="redis", state=current_state)
+            return redis_ok
 
-        if any_ok:
-            log.info("strategy_state_saved", state=current_state)
-        else:
-            log.warning("strategy_state_save_failed", state=current_state)
-        return any_ok
-
+        return False

--- a/projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py
+++ b/projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py
@@ -13,13 +13,13 @@ Validates the strategy toggle system end-to-end:
   ST-08  is_active() returns False for unknown strategy
   ST-09  Disabling last strategy auto-enables all (failsafe)
   ST-10  load() uses DB data when db provided and non-empty
-  ST-11  load() falls back to Redis when DB returns empty
+  ST-11  load() does not fall back to Redis when DB is authoritative and empty
   ST-12  load() uses in-memory defaults when neither backend provides data
   ST-13  load() falls back to defaults when DB raises error
   ST-14  save() writes to DB when db provided
   ST-15  save() writes to Redis when redis provided
   ST-16  save() returns False when neither backend provided
-  ST-17  save() returns True if at least one backend succeeds
+  ST-17  save() uses DB-only write path when DB is provided
 
   ── DatabaseClient strategy_state methods ──
   ST-18  load_strategy_state() returns empty dict when no rows
@@ -142,6 +142,7 @@ class TestSTManagerCore:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.asyncio
 class TestSTManagerPersistence:
     """Persistence load/save tests using async mocks."""
 
@@ -159,8 +160,8 @@ class TestSTManagerPersistence:
         assert mgr.is_active("mean_reversion") is True
         db.load_strategy_state.assert_called_once()
 
-    async def test_st11_load_falls_back_to_redis_when_db_empty(self) -> None:
-        """ST-11: load() uses Redis when DB returns empty dict."""
+    async def test_st11_load_db_authoritative_does_not_read_redis_when_db_empty(self) -> None:
+        """ST-11: DB-authoritative load() keeps defaults and skips Redis on empty DB state."""
         mgr = _make_manager()
         db = MagicMock()
         db.load_strategy_state = AsyncMock(return_value={})
@@ -172,8 +173,8 @@ class TestSTManagerPersistence:
 
         await mgr.load(redis=redis, db=db)
 
-        assert mgr.is_active("ev_momentum") is False
-        redis._get_json.assert_called_once()
+        assert all(mgr.is_active(s) for s in KNOWN_STRATEGIES)
+        redis._get_json.assert_not_called()
 
     async def test_st12_load_uses_defaults_when_no_backend(self) -> None:
         """ST-12: load() keeps in-memory defaults when neither backend is provided."""
@@ -219,17 +220,19 @@ class TestSTManagerPersistence:
         result = await mgr.save()
         assert result is False
 
-    async def test_st17_save_returns_true_if_at_least_one_succeeds(self) -> None:
-        """ST-17: save() returns True if DB fails but Redis succeeds."""
+    async def test_st17_save_db_authoritative_skips_redis_when_db_present(self) -> None:
+        """ST-17: save() writes only to DB when DB is provided (split-brain prevention)."""
         mgr = _make_manager()
         db = MagicMock()
-        db.save_strategy_state = AsyncMock(return_value=False)
+        db.save_strategy_state = AsyncMock(return_value=True)
         redis = MagicMock()
         redis._set_json = AsyncMock(return_value=True)
 
         result = await mgr.save(redis=redis, db=db)
 
         assert result is True
+        db.save_strategy_state.assert_called_once_with(mgr.get_state())
+        redis._set_json.assert_not_called()
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -237,6 +240,7 @@ class TestSTManagerPersistence:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.asyncio
 class TestDBClientStrategyState:
     """DatabaseClient.load_strategy_state / save_strategy_state behaviour."""
 
@@ -266,6 +270,7 @@ class TestDBClientStrategyState:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.asyncio
 class TestSignalEngineStrategyGuard:
     """generate_signals() respects the active strategy guard."""
 


### PR DESCRIPTION
### Motivation
- Close repo-truth drift after merged PR #725 / PR #726 and move the active Phase 10 Priority 2 lane to a post-merge persistence stabilization baseline. 
- Remove split-brain persistence for restart-sensitive runtime state so the same logical state cannot diverge across DB and file/Redis boundaries. 

### Description
- Synced repo truth: updated `PROJECT_STATE.md` and `ROADMAP.md` to record PR #725 and PR #726 as merged-main truth and set Phase 10.5 persistence stabilization as the active NEXT PRIORITY lane. 
- Enforced one authoritative persistence boundary for strategy toggle state in `StrategyStateManager`: when a DB client is provided, load/save use DB only; Redis is fallback-only when DB is absent. 
- Added/adjusted tests in `projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py` to validate DB-authoritative load/save semantics and to prevent DB+Redis split-brain behavior. 
- Added FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase10-5_03_postmerge-sync-and-persistence-baseline.md` documenting scope, changes, and next gate (SENTINEL required). 

### Testing
- `python3 -m py_compile projects/polymarket/polyquantbot/strategy/strategy_manager.py projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py` — passed. 
- `pytest -q projects/polymarket/polyquantbot/tests/test_strategy_toggle_system.py` — executed with `pytest-asyncio` support in the runner; result: `22 passed`.
- No failing automated tests in the touched suite; environment required the `pytest-asyncio` plugin to run async tests (installed in the test runner during validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a4e095b88325aef6e7775558efb1)