### PR TITLE
phase10-6: sync merged truth and harden runtime config/readiness gates

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 12:24
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725 and PR #726 are merged-main truth, and PR #727 persistence-boundary validation is now complete with SENTINEL verdict ready for COMMANDER merge decision.
+Last Updated : 2026-04-23 12:56
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, and PR #728 are merged-main truth, and Phase 10.6 runtime config/readiness hardening is now the active Priority 2 lane.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -40,6 +40,8 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #721 Phase 10 post-launch public-surface cleanup lane is merged on main as closed historical truth from exact head branch `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`: README/public wording and Telegram first-run onboarding guidance are aligned, `/risk_info` remains public informational, and `/risk` remains runtime/operator-only.
 - PR #725 Priority 2 DB readiness/startup blocker-closure lane is merged on main as closed truth, with canonical validation record preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-5_01_pr725-db-readiness-startup-validation.md`.
 - PR #726 is merged on main as post-merge closure sync for PR #725 gate completion; stale pre-merge decision wording for PR #725 is retired from active state/roadmap lanes.
+- PR #727 Phase 10.5 post-merge persistence stabilization lane is merged on main as closed truth from exact head branch `feature/sync-repo-truth-and-stabilize-persistence`; SENTINEL approval record is preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-5_02_pr727-persistence-boundary-validation.md`.
+- PR #728 is merged on main as SENTINEL sync closure for PR #727 and stale pre-merge gate wording for PR #727 is retired from active state/roadmap lanes.
 
 [IN PROGRESS]
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
@@ -50,7 +52,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER final gate on PR #727: review SENTINEL persistence-boundary verdict and decide merge/hold for `feature/sync-repo-truth-and-stabilize-persistence` into `main`.
+- Phase 10.6 Priority 2 lane: harden boot-time runtime config validation and enforce truthful /health + /ready dependency readiness posture in control-plane runtime (paper-only boundary preserved).
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725 DB readiness/startup hardening and PR #726 post-merge truth-sync are merged-main truth, and Phase 10.5 persistence stabilization baseline is the active Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
-**Last Updated:** 2026-04-23 11:52
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725 DB readiness/startup hardening, PR #726 post-merge truth-sync, PR #727 persistence boundary hardening, and PR #728 SENTINEL sync closure are merged-main truth, and Phase 10.6 runtime config/readiness hardening is the active Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-23 12:56
 
 # Board Overview
 
@@ -54,7 +54,7 @@
 - Phase 10.3 monitor integration hardening + observability baseline is merged on main via PR #719 (admin/internal path guarding, startup/command/reply logging baseline, missing-env/disabled-mode visibility logging, and monitor/admin visibility closure).
 - Phase 10 post-launch cleanup + public-surface wording alignment is merged on main via PR #721, with exact historical head branch traceability `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`.
 - Priority 2 DB readiness/startup hardening lane is merged on main via PR #725, and PR #726 post-merge repo-truth sync is also merged on main.
-- Active lane is Phase 10.5 post-merge sync and persistence stabilization baseline focused on restart-sensitive runtime state boundaries from `projects/polymarket/polyquantbot/work_checklist.md`.
+- Active lane is Phase 10.6 post-merge runtime config/readiness truth hardening focused on explicit boot-time env validation and truthful /health + /ready dependency gates from `projects/polymarket/polyquantbot/work_checklist.md`.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/work_checklist.md](projects/polymarket/polyquantbot/work_checklist.md).

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
@@ -1,7 +1,7 @@
 # FORGE-X Report — phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening
 
-- Timestamp: 2026-04-23 12:56 (Asia/Jakarta)
-- Branch: feature/runtime-config-and-readiness-hardening
+- Timestamp: 2026-04-23 13:07 (Asia/Jakarta)
+- Branch: feature/sync-post-merge-repo-truth-and-harden-runtime-config
 - Scope lane: post-merge repo-truth sync + Priority 2 runtime config/readiness hardening
 
 ## 1) What was built
@@ -15,6 +15,10 @@
   - `/health` now reports `degraded` with `503` when process readiness is false.
   - `/ready` now treats DB/Telegram dependencies as readiness-relevant when either required **or** enabled (removes false-green posture).
   - `/ready` now includes explicit `dependency_gates` and dependency `relevant` flags for Telegram/DB, and includes Falcon config gate in top-level readiness decision.
+- PR #729 traceability/validation closure updates:
+  - corrected forge report branch traceability to exact PR #729 head branch;
+  - re-ran `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` in dependency-complete environment where FastAPI executes (no skip);
+  - aligned one stale test expectation with already-landed readiness semantics (`db_runtime_enabled=true` + DB unavailable now returns `503 not_ready`).
 
 ## 2) Current system architecture (relevant slice)
 - Boot sequence remains: runtime settings parse -> startup validation -> DB runtime bootstrap -> Telegram runtime bootstrap.
@@ -40,9 +44,11 @@
 - Startup runtime summary remains minimal and safe (presence/state only, no secret value disclosure).
 - `/health` truthfully reflects process readiness state.
 - `/ready` truthfully degrades when DB runtime is enabled but unavailable, and reports dependency gates explicitly.
+- Dependency-complete runtime surface validation now executes in this runner with real result: `19 passed in 2.40s` for `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` (no import skip).
 
 ## 5) Known issues
 - None introduced in this scoped lane.
+- Validation rerun required dependency installation in runner (`fastapi`, `starlette`, `uvicorn`, `pytest-asyncio`) to move from import-skip to real execution.
 
 ## 6) What is next
 - Required next gate: SENTINEL MAJOR validation for post-merge repo-truth sync + runtime config/readiness hardening before merge decision.
@@ -51,4 +57,4 @@ Validation Tier   : MAJOR
 Claim Level       : NARROW INTEGRATION
 Validation Target : post-merge repo-truth sync plus Priority 2 runtime config and health/readiness truth hardening in control-plane runtime
 Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
-Suggested Next    : SENTINEL validation on branch `feature/runtime-config-and-readiness-hardening`
+Suggested Next    : SENTINEL validation on branch `feature/sync-post-merge-repo-truth-and-harden-runtime-config`

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
@@ -1,6 +1,6 @@
 # FORGE-X Report — phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening
 
-- Timestamp: 2026-04-23 13:07 (Asia/Jakarta)
+- Timestamp: 2026-04-23 13:31 (Asia/Jakarta)
 - Branch: feature/sync-post-merge-repo-truth-and-harden-runtime-config
 - Scope lane: post-merge repo-truth sync + Priority 2 runtime config/readiness hardening
 
@@ -18,7 +18,8 @@
 - PR #729 traceability/validation closure updates:
   - corrected forge report branch traceability to exact PR #729 head branch;
   - re-ran `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` in dependency-complete environment where FastAPI executes (no skip);
-  - aligned one stale test expectation with already-landed readiness semantics (`db_runtime_enabled=true` + DB unavailable now returns `503 not_ready`).
+  - aligned one stale test expectation with already-landed readiness semantics (`db_runtime_enabled=true` + DB unavailable now returns `503 not_ready`);
+  - added explicit `DB_DSN` setup in DB-enabled runtime-surface tests that are intended to validate post-startup DB behavior instead of startup-validation failure.
 
 ## 2) Current system architecture (relevant slice)
 - Boot sequence remains: runtime settings parse -> startup validation -> DB runtime bootstrap -> Telegram runtime bootstrap.
@@ -44,7 +45,9 @@
 - Startup runtime summary remains minimal and safe (presence/state only, no secret value disclosure).
 - `/health` truthfully reflects process readiness state.
 - `/ready` truthfully degrades when DB runtime is enabled but unavailable, and reports dependency gates explicitly.
-- Dependency-complete runtime surface validation now executes in this runner with real result: `19 passed in 2.40s` for `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` (no import skip).
+- Reproducible scoped validation now executes cleanly in this runner:
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` -> `19 passed in 2.84s`
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py` -> `4 passed in 0.08s`
 
 ## 5) Known issues
 - None introduced in this scoped lane.

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md
@@ -1,0 +1,54 @@
+# FORGE-X Report — phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening
+
+- Timestamp: 2026-04-23 12:56 (Asia/Jakarta)
+- Branch: feature/runtime-config-and-readiness-hardening
+- Scope lane: post-merge repo-truth sync + Priority 2 runtime config/readiness hardening
+
+## 1) What was built
+- Synced repo-truth artifacts after merged PR #727 and PR #728 so PROJECT_STATE.md and ROADMAP.md no longer present PR #727 as pending COMMANDER merge decision.
+- Updated active lane truth to Phase 10.6 runtime config/readiness hardening.
+- Added explicit boot-time runtime dependency validation for operator-critical env state:
+  - `DB_DSN` is now required when `CRUSADER_DB_RUNTIME_ENABLED=true`.
+  - `FALCON_API_KEY` is now required when `FALCON_ENABLED=true`.
+- Added safe startup config summary logging that exposes only boolean/config-state signals (no secret values).
+- Hardened control-plane health/readiness truth:
+  - `/health` now reports `degraded` with `503` when process readiness is false.
+  - `/ready` now treats DB/Telegram dependencies as readiness-relevant when either required **or** enabled (removes false-green posture).
+  - `/ready` now includes explicit `dependency_gates` and dependency `relevant` flags for Telegram/DB, and includes Falcon config gate in top-level readiness decision.
+
+## 2) Current system architecture (relevant slice)
+- Boot sequence remains: runtime settings parse -> startup validation -> DB runtime bootstrap -> Telegram runtime bootstrap.
+- Startup validation layer now combines API contract checks with runtime dependency env checks before process marks ready.
+- Readiness evaluation path now computes dependency relevance and gate status for:
+  1. API boot completion,
+  2. Telegram runtime,
+  3. DB runtime,
+  4. Falcon config validity.
+- Overall `/ready` status is authoritative only when all relevant gates are healthy.
+
+## 3) Files created / modified (full repo-root paths)
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+- `projects/polymarket/polyquantbot/server/core/runtime.py`
+- `projects/polymarket/polyquantbot/server/api/routes.py`
+- `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md`
+
+## 4) What is working
+- Repo-truth artifacts now record PR #727 and PR #728 as merged-main truth and align active next lane to Phase 10.6.
+- Missing required DB/Falcon config for enabled runtime surfaces now fails startup with explicit operator-readable errors.
+- Startup runtime summary remains minimal and safe (presence/state only, no secret value disclosure).
+- `/health` truthfully reflects process readiness state.
+- `/ready` truthfully degrades when DB runtime is enabled but unavailable, and reports dependency gates explicitly.
+
+## 5) Known issues
+- None introduced in this scoped lane.
+
+## 6) What is next
+- Required next gate: SENTINEL MAJOR validation for post-merge repo-truth sync + runtime config/readiness hardening before merge decision.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : post-merge repo-truth sync plus Priority 2 runtime config and health/readiness truth hardening in control-plane runtime
+Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
+Suggested Next    : SENTINEL validation on branch `feature/runtime-config-and-readiness-hardening`

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase10-6_01_pr729-runtime-config-and-readiness-validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase10-6_01_pr729-runtime-config-and-readiness-validation.md
@@ -1,0 +1,98 @@
+# SENTINEL Report — phase10-6_01_pr729-runtime-config-and-readiness-validation
+
+- Timestamp: 2026-04-23 13:39 (Asia/Jakarta)
+- PR: #729
+- Source forge report: `projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md`
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation Target: post-merge repo-truth sync plus Priority 2 runtime config and health/readiness truth hardening in control-plane runtime
+- Not in Scope: wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
+
+## Environment
+- Repo: `bayuewalker/walker-ai-team`
+- Runtime: dev
+- Local checkout branch label: `work` (Codex worktree normalized)
+- Verified PR #729 head branch (GitHub API): `feature/sync-post-merge-repo-truth-and-harden-runtime-config`
+- Verified PR #729 base branch (GitHub API): `main`
+- Validated PR head commit SHA: `c38d54ac386f03e270dcfab591d60a427f973bee`
+- Note: direct `git fetch` for remote branch remains blocked in this runner (`HTTP 403`); validation executed from PR-head source archive (exact SHA tarball) plus GitHub API/raw-source cross-check.
+- Locale: `LANG=C.UTF-8`, `LC_ALL=C.UTF-8`
+
+## Validation Context
+Final rerun after runtime-surface test alignment. Scope remains strictly on exact branch traceability, #727/#728 repo-truth sync continuity, DB/Falcon startup-guard correctness, secret-safe startup summary, and truthful `/health` + `/ready` behavior evidence for declared NARROW INTEGRATION claim.
+
+## Phase 0 Checks
+- Forge report exists and branch traceability now matches exact PR #729 head branch.
+- PROJECT_STATE.md and ROADMAP.md remain aligned on merged-main truth for PR #727 and PR #728.
+- Mojibake scan passed on scoped report/state/roadmap/source files.
+- `py_compile` passed on touched runtime/API/tests files from PR head SHA snapshot.
+- Runtime-surface and runtime-config pytest evidence re-executed against PR head SHA snapshot with dependency-complete runner.
+
+## Findings
+1) **Exact branch traceability across PR head/forge/state/roadmap: PASS**
+- PR #729 head branch is `feature/sync-post-merge-repo-truth-and-harden-runtime-config`.
+- Forge report branch and Suggested Next use this exact branch.
+- PROJECT_STATE.md and ROADMAP.md contain no conflicting PR #729 branch artifact.
+
+2) **Repo-truth sync for PR #727 / PR #728 remains truthful: PASS**
+- PROJECT_STATE.md status and completed items keep PR #727 / #728 as merged-main truth.
+- ROADMAP.md status summary also preserves merged-main truth for PR #727 / #728.
+- No stale pending-merge wording detected for this pair.
+
+3) **Boot-time env validation for DB and Falcon enabled paths: PASS**
+- Startup validation requires `DB_DSN` when `CRUSADER_DB_RUNTIME_ENABLED=true`.
+- Startup validation requires `FALCON_API_KEY` when `FALCON_ENABLED=true`.
+- `run_startup_validation()` composes runtime dependency checks with API checks and raises on invalid startup state.
+
+4) **Startup config summary remains secret-safe: PASS**
+- Startup summary surfaces only safe state/presence booleans (`*_configured`, enabled/required flags).
+- No secret value payloads are emitted through summary fields.
+
+5) **`/health` and `/ready` semantics remain truthful: PASS**
+- `/health`: returns `ok` + HTTP 200 only when process is ready, otherwise `degraded` + HTTP 503.
+- `/ready`: uses dependency relevance (`required OR enabled`) for DB/Telegram, includes explicit dependency gates, and includes Falcon config validity in overall readiness.
+- DB-enabled unavailable path remains degraded (`503 not_ready`) and does not false-green.
+
+6) **Runtime-surface pytest evidence reproducibility for narrow claim: PASS**
+- Re-executed against PR-head SHA snapshot:
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` -> `19 passed in 2.54s`
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py` -> `4 passed in 0.09s`
+- Prior stale expectation is now aligned (`test_bounded_retry_timeout_alignment_preserves_retry_path` expects `503 not_ready`).
+- DB-enabled tests now set explicit `DB_DSN` where post-startup DB behavior is under test.
+
+## Score Breakdown
+- Branch/artifact traceability integrity: 20/20
+- Repo-truth sync integrity (#727/#728): 20/20
+- Runtime dependency guard correctness (DB/Falcon): 20/20
+- Health/readiness truthfulness: 20/20
+- Reproducible evidence sufficiency for NARROW claim: 20/20
+
+**Total: 100/100**
+
+## Critical Issues
+- None.
+
+## Status
+- **APPROVED**
+
+## PR Gate Result
+- PR #729 is validated for COMMANDER merge/hold decision on declared MAJOR / NARROW INTEGRATION scope.
+
+## Broader Audit Finding
+- Approval is scoped to control-plane runtime config/readiness hardening and post-merge repo-truth sync claims only.
+- No broader wallet/portfolio/execution-engine completeness claim is implied.
+
+## Reasoning
+Branch traceability is clean, repo-truth sync remains coherent, runtime guards/health/readiness behavior are code-consistent, and updated runtime-surface test evidence is now reproducible on exact PR-head source.
+
+## Fix Recommendations
+- None required for scoped gate.
+
+## Out-of-scope Advisory
+- N/A.
+
+## Deferred Minor Backlog
+- None introduced by this validation rerun.
+
+## Telegram Visual Preview
+- N/A (no BRIEFER artifact requested for this SENTINEL gate).

--- a/projects/polymarket/polyquantbot/server/api/routes.py
+++ b/projects/polymarket/polyquantbot/server/api/routes.py
@@ -18,13 +18,14 @@ def build_router(
     router = APIRouter()
 
     @router.get("/health")
-    async def health() -> dict[str, object]:
-        return {
-            "status": "ok",
+    async def health() -> JSONResponse:
+        payload = {
+            "status": "ok" if state.ready else "degraded",
             "service": settings.app_name,
             "runtime": "server.main",
             "ready": state.ready,
         }
+        return JSONResponse(payload, status_code=200 if state.ready else 503)
 
     @router.get("/ready")
     async def ready() -> JSONResponse:
@@ -43,9 +44,13 @@ def build_router(
         telegram_runtime_ready = (
             state.telegram_runtime_startup_complete and state.telegram_runtime_active
         )
-        telegram_readiness_ok = telegram_runtime_ready if state.telegram_runtime_required else True
+        telegram_runtime_relevant = state.telegram_runtime_required or state.telegram_runtime_enabled
+        telegram_readiness_ok = telegram_runtime_ready if telegram_runtime_relevant else True
         db_runtime_ready = state.db_runtime_connected and state.db_runtime_healthcheck_ok
-        db_readiness_ok = db_runtime_ready if state.db_runtime_required else True
+        db_runtime_relevant = state.db_runtime_required or state.db_runtime_enabled
+        db_readiness_ok = db_runtime_ready if db_runtime_relevant else True
+        falcon_config_ready = (not falcon_settings.enabled) or falcon_api_key_configured
+        overall_ready = state.ready and telegram_readiness_ok and db_readiness_ok and falcon_config_ready
         ready_dimensions = {
             "scope": {
                 "contract_version": "phase8-6-public-paper-beta-confidence-pass",
@@ -64,6 +69,7 @@ def build_router(
                 "last_error": beta_state.worker_runtime.last_error,
             },
             "telegram_runtime": {
+                "relevant": telegram_runtime_relevant,
                 "required": state.telegram_runtime_required,
                 "enabled": state.telegram_runtime_enabled,
                 "startup_complete": state.telegram_runtime_startup_complete,
@@ -74,6 +80,7 @@ def build_router(
                 "last_error": state.telegram_runtime_last_error,
             },
             "db_runtime": {
+                "relevant": db_runtime_relevant,
                 "required": state.db_runtime_required,
                 "enabled": state.db_runtime_enabled,
                 "connected": state.db_runtime_connected,
@@ -88,9 +95,14 @@ def build_router(
                 "enabled": falcon_settings.enabled,
                 "api_key_configured": falcon_api_key_configured,
                 "enabled_without_api_key": falcon_settings.enabled and not falcon_api_key_configured,
-                "config_valid_for_enabled_mode": (not falcon_settings.enabled)
-                or falcon_api_key_configured,
+                "config_valid_for_enabled_mode": falcon_config_ready,
                 "candidate_source_contract": "placeholder_bounded_narrow_integration",
+            },
+            "dependency_gates": {
+                "api_boot_complete": state.ready,
+                "telegram_runtime_ready": telegram_readiness_ok,
+                "db_runtime_ready": db_readiness_ok,
+                "falcon_config_ready": falcon_config_ready,
             },
             "control_plane": {
                 "trading_mode_env": settings.trading_mode,
@@ -103,12 +115,12 @@ def build_router(
         }
         return JSONResponse(
             {
-                "status": "ready" if state.ready and telegram_readiness_ok and db_readiness_ok else "not_ready",
+                "status": "ready" if overall_ready else "not_ready",
                 "service": settings.app_name,
                 "validation_errors": state.validation_errors,
                 "readiness": ready_dimensions,
             },
-            status_code=200 if state.ready and telegram_readiness_ok and db_readiness_ok else 503,
+            status_code=200 if overall_ready else 503,
         )
 
     return router

--- a/projects/polymarket/polyquantbot/server/core/runtime.py
+++ b/projects/polymarket/polyquantbot/server/core/runtime.py
@@ -96,13 +96,67 @@ def validate_api_environment(settings: ApiSettings) -> list[str]:
     return errors
 
 
+def validate_runtime_dependencies_from_env() -> list[str]:
+    errors: list[str] = []
+    db_runtime_enabled = os.getenv("CRUSADER_DB_RUNTIME_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    falcon_enabled = os.getenv("FALCON_ENABLED", "false").strip().lower() == "true"
+
+    if db_runtime_enabled and not os.getenv("DB_DSN", "").strip():
+        errors.append(
+            "DB_DSN is required when CRUSADER_DB_RUNTIME_ENABLED=true to avoid unsafe local-default persistence targets."
+        )
+
+    if falcon_enabled and not os.getenv("FALCON_API_KEY", "").strip():
+        errors.append(
+            "FALCON_API_KEY is required when FALCON_ENABLED=true; disabled or missing-key mode is not startup-valid."
+        )
+
+    return errors
+
+
+def startup_config_summary(settings: ApiSettings) -> dict[str, object]:
+    db_runtime_enabled = os.getenv("CRUSADER_DB_RUNTIME_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    db_runtime_required = os.getenv("CRUSADER_DB_RUNTIME_REQUIRED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    telegram_runtime_required = telegram_runtime_required_from_env()
+    falcon_enabled = os.getenv("FALCON_ENABLED", "false").strip().lower() == "true"
+
+    return {
+        "startup_mode": settings.startup_mode,
+        "trading_mode": settings.trading_mode,
+        "environment": settings.environment,
+        "paper_only_boundary": settings.trading_mode == "PAPER",
+        "db_runtime_enabled": db_runtime_enabled,
+        "db_runtime_required": db_runtime_required,
+        "db_dsn_configured": bool(os.getenv("DB_DSN", "").strip()),
+        "telegram_runtime_required": telegram_runtime_required,
+        "telegram_token_configured": bool(os.getenv("TELEGRAM_BOT_TOKEN", "").strip()),
+        "falcon_enabled": falcon_enabled,
+        "falcon_api_key_configured": bool(os.getenv("FALCON_API_KEY", "").strip()),
+    }
+
+
 def telegram_runtime_required_from_env() -> bool:
     raw = os.getenv("CRUSADER_TELEGRAM_RUNTIME_REQUIRED", "false").strip().lower()
     return raw in {"1", "true", "yes", "on"}
 
 
 async def run_startup_validation(settings: ApiSettings, state: RuntimeState) -> None:
-    validation_errors = validate_api_environment(settings)
+    validation_errors = validate_api_environment(settings) + validate_runtime_dependencies_from_env()
     state.validation_errors = validation_errors
 
     if validation_errors:
@@ -115,11 +169,12 @@ async def run_startup_validation(settings: ApiSettings, state: RuntimeState) -> 
 
     await asyncio.sleep(0)
     state.mark_started()
+    summary = startup_config_summary(settings)
     log.info(
         "crusaderbot_api_ready",
         app_name=settings.app_name,
         port=settings.port,
-        trading_mode=settings.trading_mode,
+        startup_config_summary=summary,
     )
 
 

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -9,7 +9,10 @@ pytest.importorskip(
 )
 from fastapi.testclient import TestClient
 
-from projects.polymarket.polyquantbot.server.core.runtime import ApiSettings, validate_api_environment
+from projects.polymarket.polyquantbot.server.core.runtime import (
+    ApiSettings,
+    validate_api_environment,
+)
 from projects.polymarket.polyquantbot.server.main import create_app
 
 
@@ -69,6 +72,7 @@ def test_health_route_reports_crusaderbot_service(monkeypatch) -> None:
     payload = response.json()
     assert payload["service"] == "CrusaderBot"
     assert payload["runtime"] == "server.main"
+    assert payload["status"] == "ok"
 
 
 def test_ready_route_reports_ready_after_startup(monkeypatch) -> None:
@@ -98,6 +102,7 @@ def test_ready_route_reports_readiness_dimensions(monkeypatch) -> None:
     assert "db_runtime" in readiness
     assert "worker_prerequisites" in readiness
     assert "falcon_config_state" in readiness
+    assert "dependency_gates" in readiness
     assert "control_plane" in readiness
     assert readiness["control_plane"]["paper_only_execution_boundary"] is True
 
@@ -274,8 +279,10 @@ def test_ready_status_after_db_unavailable_when_not_required(monkeypatch) -> Non
     with TestClient(app) as client:
         response = client.get("/ready")
 
-    assert response.status_code == 200
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
     readiness = response.json()["readiness"]["db_runtime"]
+    assert readiness["relevant"] is True
     assert readiness["connected"] is False
     assert readiness["healthcheck_ok"] is False
     assert readiness["last_error"] != ""
@@ -298,10 +305,9 @@ def test_ready_route_falcon_enabled_without_key_is_not_valid(monkeypatch) -> Non
     monkeypatch.setenv("FALCON_ENABLED", "true")
     monkeypatch.delenv("FALCON_API_KEY", raising=False)
     app = create_app()
-    with TestClient(app) as client:
-        response = client.get("/ready")
-    readiness = response.json()["readiness"]
-    assert readiness["falcon_config_state"]["enabled"] is True
-    assert readiness["falcon_config_state"]["api_key_configured"] is False
-    assert readiness["falcon_config_state"]["enabled_without_api_key"] is True
-    assert readiness["falcon_config_state"]["config_valid_for_enabled_mode"] is False
+    with pytest.raises(
+        RuntimeError,
+        match="FALCON_API_KEY is required when FALCON_ENABLED=true",
+    ):
+        with TestClient(app):
+            pass

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -229,7 +229,8 @@ def test_bounded_retry_timeout_alignment_preserves_retry_path(monkeypatch) -> No
     with TestClient(app) as client:
         response = client.get("/ready")
 
-    assert response.status_code == 200
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
     readiness = response.json()["readiness"]["db_runtime"]
     assert _SlowFailingDBClient.seen_max_attempts == 3
     assert readiness["connect_timeout_s"] > 0.02

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -15,6 +15,8 @@ from projects.polymarket.polyquantbot.server.core.runtime import (
 )
 from projects.polymarket.polyquantbot.server.main import create_app
 
+_TEST_DB_DSN = "postgresql://test-user:test-pass@localhost:5432/test_crusader"
+
 
 @pytest.mark.parametrize(
     ("route", "required_keys"),
@@ -156,6 +158,7 @@ def test_startup_success_path_sets_db_runtime_ready(monkeypatch) -> None:
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "true")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
     monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _HealthyDBClient)
     app = create_app()
 
@@ -190,6 +193,7 @@ def test_startup_failure_before_yield_closes_db_client(monkeypatch) -> None:
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "true")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
     monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _DBClient)
     monkeypatch.setattr("projects.polymarket.polyquantbot.server.main._start_telegram_runtime", _boom)
     app = create_app()
@@ -220,6 +224,7 @@ def test_bounded_retry_timeout_alignment_preserves_retry_path(monkeypatch) -> No
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "false")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
     monkeypatch.setenv("CRUSADER_DB_CONNECT_MAX_ATTEMPTS", "3")
     monkeypatch.setenv("CRUSADER_DB_CONNECT_BASE_BACKOFF_S", "0.01")
     monkeypatch.setenv("CRUSADER_DB_CONNECT_TIMEOUT_S", "0.02")
@@ -251,6 +256,7 @@ def test_ready_status_after_db_unavailable_when_required(monkeypatch) -> None:
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "true")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
     monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _UnhealthyDBClient)
     app = create_app()
 
@@ -274,6 +280,7 @@ def test_ready_status_after_db_unavailable_when_not_required(monkeypatch) -> Non
     monkeypatch.setenv("TRADING_MODE", "PAPER")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
     monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "false")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
     monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _UnavailableDBClient)
     app = create_app()
 

--- a/projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from projects.polymarket.polyquantbot.server.core.runtime import (
+    ApiSettings,
+    RuntimeState,
+    startup_config_summary,
+    validate_runtime_dependencies_from_env,
+)
+
+
+def test_runtime_dependency_validation_requires_db_dsn_when_db_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
+    monkeypatch.delenv("DB_DSN", raising=False)
+    errors = validate_runtime_dependencies_from_env()
+    assert any("DB_DSN is required when CRUSADER_DB_RUNTIME_ENABLED=true" in error for error in errors)
+
+
+def test_runtime_dependency_validation_requires_falcon_api_key_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("FALCON_ENABLED", "true")
+    monkeypatch.delenv("FALCON_API_KEY", raising=False)
+    errors = validate_runtime_dependencies_from_env()
+    assert any("FALCON_API_KEY is required when FALCON_ENABLED=true" in error for error in errors)
+
+
+def test_startup_config_summary_redacts_secret_values(monkeypatch) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("DB_DSN", "postgresql://secret-user:secret-pass@db.example:5432/db")
+    monkeypatch.setenv("FALCON_ENABLED", "true")
+    monkeypatch.setenv("FALCON_API_KEY", "secret-key")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "secret-telegram-token")
+
+    settings = ApiSettings.from_env()
+    summary = startup_config_summary(settings)
+
+    assert summary["db_dsn_configured"] is True
+    assert summary["falcon_api_key_configured"] is True
+    assert summary["telegram_token_configured"] is True
+    assert "secret" not in str(summary)
+
+
+def test_health_payload_truth_when_runtime_not_ready() -> None:
+    state = RuntimeState()
+    assert state.ready is False


### PR DESCRIPTION
### Motivation
- Close post-merge repo-truth drift after merged PR #727 and PR #728 and advance the active Priority 2 lane to runtime config/readiness hardening. 
- Reduce unsafe defaults and make boot-time missing-config / missing-secret failures explicit and operator-readable. 
- Replace false-green `/health` and `/ready` behavior with truthful dependency-aware readiness reporting while preserving the paper-only public posture.

### Description
- Synced repo truth: updated `PROJECT_STATE.md` and `ROADMAP.md` to record PR #727 and PR #728 as merged and set the active lane to Phase 10.6. 
- Boot-time validation: added `validate_runtime_dependencies_from_env()` and `startup_config_summary()` in `projects/polymarket/polyquantbot/server/core/runtime.py` and wired dependency checks into `run_startup_validation()` so missing required envs (e.g. `DB_DSN` when `CRUSADER_DB_RUNTIME_ENABLED=true`, `FALCON_API_KEY` when `FALCON_ENABLED=true`) raise explicit startup errors. 
- Health/readiness hardening: changed `/health` to return `degraded` + HTTP `503` when process readiness is false, and rewrote `/ready` evaluation in `projects/polymarket/polyquantbot/server/api/routes.py` to: treat DB/Telegram as readiness-relevant when either required or enabled, include a `falcon_config` gate, expose `dependency_gates` and `relevant` flags, and compute an `overall_ready` result used for status and HTTP code. 
- Tests and report: updated runtime-surface expectations in `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`, added `projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py` with targeted env-validation and summary redaction checks, and added the FORGE report at `projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md`.

### Testing
- Ran `python3 -m py_compile` on touched files (`projects/polymarket/polyquantbot/server/core/runtime.py`, `projects/polymarket/polyquantbot/server/api/routes.py`, updated tests) and it passed. 
- Executed `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_6_runtime_config_validation_20260423.py` and it passed (`4 passed`). 
- Executed `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` in this runner and it was skipped due to the module-level FastAPI import gate (`1 skipped`) in the test harness; the test file was adjusted to match the new readiness semantics. 
- Mojibake/encoding checks on modified files returned clean results. 

Report: `projects/polymarket/polyquantbot/reports/forge/phase10-6_01_postmerge-sync-runtime-config-and-readiness-hardening.md`
State: `PROJECT_STATE.md` updated
Validation Tier: MAJOR
Claim Level: NARROW INTEGRATION

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b420dacc8325911674de9e2e47f3)