### PR TITLE
FORGE-X: phase10-8 post-merge sync & logging/monitoring hardening

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-23 14:54
+Last Updated : 2026-04-23 15:17
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 are merged-main truth, and Phase 10.8 logging/monitoring hardening is the active Priority 2 lane under paper-only boundary posture.
 
 [COMPLETED]
@@ -58,7 +58,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [NEXT PRIORITY]
 - Phase 10.8 Priority 2 lane: harden structured logging consistency, startup/shutdown trace readability, and minimum viable monitoring outputs in control-plane runtime (paper-only boundary preserved).
-- COMMANDER review gate for PR lane `feature/postmerge-sync-and-logging-monitoring-hardening` before SENTINEL validation handoff.
+- COMMANDER review gate for PR lane `feature/update-repository-state-and-logging-monitoring` before SENTINEL validation handoff.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 14:15
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, and PR #730 are merged-main truth, Phase 10.7 shutdown/restart/dependency resilience hardening remains the active Priority 2 lane, and PR #731 SENTINEL rerun is APPROVED pending COMMANDER merge decision.
+Last Updated : 2026-04-23 14:54
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 are merged-main truth, and Phase 10.8 logging/monitoring hardening is the active Priority 2 lane under paper-only boundary posture.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -44,9 +44,11 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #728 is merged on main as SENTINEL sync closure for PR #727 and stale pre-merge gate wording for PR #727 is retired from active state/roadmap lanes.
 - PR #729 Phase 10.6 runtime config/readiness hardening lane is merged on main as closed truth from exact head branch `feature/sync-post-merge-repo-truth-and-harden-runtime-config`; SENTINEL approval record is preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-6_01_pr729-runtime-config-and-readiness-validation.md`.
 - PR #730 is merged on main as SENTINEL sync closure for PR #729 and stale pre-merge gate wording for PR #729 is retired from active state/roadmap lanes.
+- PR #731 Phase 10.7 resilience hardening lane is merged on main as closed truth from exact head branch `feature/sync-post-merge-repo-truth-and-harden-resilience`; SENTINEL approval record is preserved in `projects/polymarket/polyquantbot/reports/sentinel/phase10-7_01_pr731-runtime-resilience-validation.md`.
+- PR #732 is merged on main as SENTINEL sync closure for PR #731 and stale pre-merge decision wording for PR #731 is retired from active state/roadmap lanes.
+- PR #733 is merged on main as post-merge checklist/state continuity sync for the completed Phase 10.7 lane.
 
 [IN PROGRESS]
-- PR #731 SENTINEL rerun gate is APPROVED for declared MAJOR narrow-resilience scope; awaiting COMMANDER merge decision on source branch `feature/sync-post-merge-repo-truth-and-harden-resilience`.
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
 [NOT STARTED]
@@ -55,8 +57,8 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- COMMANDER decision gate for PR #731 after SENTINEL APPROVED rerun on `feature/sync-post-merge-repo-truth-and-harden-resilience`.
-- Phase 10.7 Priority 2 lane: harden graceful shutdown, restart safety, bounded dependency retry/failure handling, and explicit operator-readable resilience posture in control-plane runtime (paper-only boundary preserved).
+- Phase 10.8 Priority 2 lane: harden structured logging consistency, startup/shutdown trace readability, and minimum viable monitoring outputs in control-plane runtime (paper-only boundary preserved).
+- COMMANDER review gate for PR lane `feature/postmerge-sync-and-logging-monitoring-hardening` before SENTINEL validation handoff.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725 DB readiness/startup hardening, PR #726 post-merge truth-sync, PR #727 persistence boundary hardening, PR #728 SENTINEL sync closure, PR #729 runtime config/readiness hardening, and PR #730 SENTINEL sync closure are merged-main truth, and Phase 10.7 shutdown/restart/dependency resilience hardening is the active Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
-**Last Updated:** 2026-04-23 13:55
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 are merged-main truth, and Phase 10.8 logging/monitoring hardening is the active Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-23 14:54
 
 # Board Overview
 
@@ -55,7 +55,9 @@
 - Phase 10 post-launch cleanup + public-surface wording alignment is merged on main via PR #721, with exact historical head branch traceability `feature/align-readme-and-refine-telegram-onboarding-2026-04-22`.
 - Priority 2 DB readiness/startup hardening lane is merged on main via PR #725, and PR #726 post-merge repo-truth sync is also merged on main.
 - Phase 10.6 post-merge runtime config/readiness truth hardening is merged on main via PR #729 and PR #730 sync closure as historical truth.
-- Active lane is Phase 10.7 resilience hardening focused on graceful shutdown truth, restart-safe runtime transitions, and bounded non-fatal dependency failure handling from `projects/polymarket/polyquantbot/work_checklist.md`.
+- Phase 10.7 resilience hardening is merged on main via PR #731 and PR #732 sync closure as historical truth.
+- PR #733 is merged on main as post-merge work-checklist continuity sync for completed Phase 10.7 truth.
+- Active lane is Phase 10.8 logging/monitoring hardening focused on structured log consistency, startup/shutdown trace readability, dependency-failure trace clarity, and minimum operator-visible monitoring outputs from `projects/polymarket/polyquantbot/work_checklist.md`.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/work_checklist.md](projects/polymarket/polyquantbot/work_checklist.md).

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
@@ -1,15 +1,15 @@
 # FORGE-X Report — phase10-8_01_postmerge-sync-and-logging-monitoring-hardening
 
-- Timestamp: 2026-04-23 14:54 (Asia/Jakarta)
-- Branch: feature/postmerge-sync-and-logging-monitoring-hardening
+- Timestamp: 2026-04-23 15:17 (Asia/Jakarta)
+- Branch: feature/update-repository-state-and-logging-monitoring
 - Scope lane: post-merge repo-truth sync for PR #731 / PR #732 / PR #733 + Priority 2 logging/monitoring hardening
 
 ## 1) What was built
 - Synced repo-truth artifacts after merged PR #731, PR #732, and PR #733 so PROJECT_STATE.md and ROADMAP.md now treat Phase 10.7 as merged-main history and no longer as pending COMMANDER merge decision.
 - Promoted Phase 10.8 logging/monitoring hardening as the active Priority 2 lane.
 - Added structured runtime transition logs across startup/shutdown/dependency boundaries with consistent event naming (`crusaderbot_runtime_transition`) and monitoring snapshots.
-- Added explicit dependency-failure trace recording in runtime state (`dependency_failures_total`, last surface/error) for operator-readable debugging without secret leakage.
-- Added minimum viable monitoring outputs to `/ready` payload under `readiness.monitoring_outputs` for lifecycle/dependency trace continuity.
+- Added explicit dependency-failure trace recording in runtime state (`dependency_failures_total`, last surface/error) for operator-readable debugging.
+- Added minimum viable monitoring outputs to `/ready` payload under `readiness.monitoring_outputs` for lifecycle/dependency trace continuity while removing raw dependency error text from public payloads.
 
 ## 2) Current system architecture (relevant slice)
 - Runtime lifecycle now emits deterministic transition markers with monitoring snapshots across:
@@ -27,7 +27,8 @@
 - Dependency failure traces are stateful and operator-visible through `/ready` monitoring outputs:
   - failure count
   - last failure surface
-  - last failure error text
+  - failure_present boolean
+  - sanitized failure category
 - Paper-only boundary remains unchanged and no wallet lifecycle / execution engine expansion was introduced.
 
 ## 3) Files created / modified (full repo-root paths)
@@ -44,7 +45,7 @@
 - PROJECT_STATE.md and ROADMAP.md now record merged-main truth for PR #731 / PR #732 / PR #733 and align on Phase 10.8 as the active lane.
 - Startup/shutdown/dependency lifecycle transitions emit consistent structured logs with aligned transition keys and runtime monitoring snapshots.
 - Dependency startup/shutdown failures now record traceable surface + error metadata in runtime state for easier follow-through.
-- `/ready` now includes minimum viable monitoring outputs for operator-visible lifecycle and dependency-failure truth.
+- `/ready` now includes minimum viable monitoring outputs for operator-visible lifecycle and dependency-failure truth without exposing raw dependency exception strings.
 - Scoped tests for structured logging, shutdown trace continuity, dependency-failure readability, and monitoring-output visibility pass.
 
 ## 5) Known issues
@@ -57,4 +58,4 @@ Validation Tier   : MAJOR
 Claim Level       : NARROW INTEGRATION
 Validation Target : post-merge repo-truth sync plus Priority 2 logging and monitoring hardening in control-plane runtime
 Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
-Suggested Next    : SENTINEL validation on branch `feature/postmerge-sync-and-logging-monitoring-hardening`
+Suggested Next    : SENTINEL validation on branch `feature/update-repository-state-and-logging-monitoring`

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
@@ -1,0 +1,60 @@
+# FORGE-X Report — phase10-8_01_postmerge-sync-and-logging-monitoring-hardening
+
+- Timestamp: 2026-04-23 14:54 (Asia/Jakarta)
+- Branch: feature/postmerge-sync-and-logging-monitoring-hardening
+- Scope lane: post-merge repo-truth sync for PR #731 / PR #732 / PR #733 + Priority 2 logging/monitoring hardening
+
+## 1) What was built
+- Synced repo-truth artifacts after merged PR #731, PR #732, and PR #733 so PROJECT_STATE.md and ROADMAP.md now treat Phase 10.7 as merged-main history and no longer as pending COMMANDER merge decision.
+- Promoted Phase 10.8 logging/monitoring hardening as the active Priority 2 lane.
+- Added structured runtime transition logs across startup/shutdown/dependency boundaries with consistent event naming (`crusaderbot_runtime_transition`) and monitoring snapshots.
+- Added explicit dependency-failure trace recording in runtime state (`dependency_failures_total`, last surface/error) for operator-readable debugging without secret leakage.
+- Added minimum viable monitoring outputs to `/ready` payload under `readiness.monitoring_outputs` for lifecycle/dependency trace continuity.
+
+## 2) Current system architecture (relevant slice)
+- Runtime lifecycle now emits deterministic transition markers with monitoring snapshots across:
+  1) `startup_begin`
+  2) `startup_reset`
+  3) `startup_validation`
+  4) `db_startup`
+  5) `telegram_startup`
+  6) `runtime_ready`
+  7) `shutdown_begin`
+  8) `telegram_shutdown`
+  9) `db_shutdown`
+  10) `shutdown_complete`
+  11) `stopped`
+- Dependency failure traces are stateful and operator-visible through `/ready` monitoring outputs:
+  - failure count
+  - last failure surface
+  - last failure error text
+- Paper-only boundary remains unchanged and no wallet lifecycle / execution engine expansion was introduced.
+
+## 3) Files created / modified (full repo-root paths)
+- `PROJECT_STATE.md`
+- `ROADMAP.md`
+- `projects/polymarket/polyquantbot/server/core/runtime.py`
+- `projects/polymarket/polyquantbot/server/main.py`
+- `projects/polymarket/polyquantbot/server/api/routes.py`
+- `projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py`
+- `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`
+- `projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md`
+
+## 4) What is working
+- PROJECT_STATE.md and ROADMAP.md now record merged-main truth for PR #731 / PR #732 / PR #733 and align on Phase 10.8 as the active lane.
+- Startup/shutdown/dependency lifecycle transitions emit consistent structured logs with aligned transition keys and runtime monitoring snapshots.
+- Dependency startup/shutdown failures now record traceable surface + error metadata in runtime state for easier follow-through.
+- `/ready` now includes minimum viable monitoring outputs for operator-visible lifecycle and dependency-failure truth.
+- Scoped tests for structured logging, shutdown trace continuity, dependency-failure readability, and monitoring-output visibility pass.
+
+## 5) Known issues
+- Python Sentry runtime integration lane remains externally blocked on deploy-environment proof (`SENTRY_DSN` secret presence, `/health` + `/ready` reachability, event receipt confirmation).
+
+## 6) What is next
+- Required next gate: SENTINEL MAJOR validation for post-merge repo-truth sync plus Phase 10.8 logging/monitoring hardening before merge decision.
+
+Validation Tier   : MAJOR
+Claim Level       : NARROW INTEGRATION
+Validation Target : post-merge repo-truth sync plus Priority 2 logging and monitoring hardening in control-plane runtime
+Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
+Suggested Next    : SENTINEL validation on branch `feature/postmerge-sync-and-logging-monitoring-hardening`

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md
@@ -1,6 +1,6 @@
 # FORGE-X Report — phase10-8_01_postmerge-sync-and-logging-monitoring-hardening
 
-- Timestamp: 2026-04-23 15:17 (Asia/Jakarta)
+- Timestamp: 2026-04-23 15:37 (Asia/Jakarta)
 - Branch: feature/update-repository-state-and-logging-monitoring
 - Scope lane: post-merge repo-truth sync for PR #731 / PR #732 / PR #733 + Priority 2 logging/monitoring hardening
 
@@ -10,6 +10,7 @@
 - Added structured runtime transition logs across startup/shutdown/dependency boundaries with consistent event naming (`crusaderbot_runtime_transition`) and monitoring snapshots.
 - Added explicit dependency-failure trace recording in runtime state (`dependency_failures_total`, last surface/error) for operator-readable debugging.
 - Added minimum viable monitoring outputs to `/ready` payload under `readiness.monitoring_outputs` for lifecycle/dependency trace continuity while removing raw dependency error text from public payloads.
+- Sanitized `readiness.telegram_runtime` and `readiness.db_runtime` public error surfaces by replacing `last_error` raw text with bounded public-safe fields: `error_present`, `error_category`, `error_reference`.
 
 ## 2) Current system architecture (relevant slice)
 - Runtime lifecycle now emits deterministic transition markers with monitoring snapshots across:
@@ -46,6 +47,7 @@
 - Startup/shutdown/dependency lifecycle transitions emit consistent structured logs with aligned transition keys and runtime monitoring snapshots.
 - Dependency startup/shutdown failures now record traceable surface + error metadata in runtime state for easier follow-through.
 - `/ready` now includes minimum viable monitoring outputs for operator-visible lifecycle and dependency-failure truth without exposing raw dependency exception strings.
+- `/ready` telegram/db readiness sections now expose only bounded safe error metadata and no longer expose raw exception text.
 - Scoped tests for structured logging, shutdown trace continuity, dependency-failure readability, and monitoring-output visibility pass.
 
 ## 5) Known issues
@@ -56,6 +58,6 @@
 
 Validation Tier   : MAJOR
 Claim Level       : NARROW INTEGRATION
-Validation Target : post-merge repo-truth sync plus Priority 2 logging and monitoring hardening in control-plane runtime
+Validation Target : public-safe readiness exposure closure for Phase 10.8 logging/monitoring hardening
 Not in Scope      : wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
 Suggested Next    : SENTINEL validation on branch `feature/update-repository-state-and-logging-monitoring`

--- a/projects/polymarket/polyquantbot/server/api/routes.py
+++ b/projects/polymarket/polyquantbot/server/api/routes.py
@@ -9,6 +9,19 @@ from projects.polymarket.polyquantbot.server.core.public_beta_state import Publi
 from projects.polymarket.polyquantbot.server.core.runtime import ApiSettings, RuntimeState
 
 
+def _dependency_failure_category(raw_error: str) -> str:
+    if not raw_error:
+        return "none"
+    lowered = raw_error.lower()
+    if "timeout" in lowered:
+        return "timeout"
+    if "healthcheck" in lowered:
+        return "healthcheck_failed"
+    if "refused" in lowered or "unavailable" in lowered:
+        return "connection_failed"
+    return "runtime_error"
+
+
 def build_router(
     settings: ApiSettings,
     state: RuntimeState,
@@ -116,8 +129,11 @@ def build_router(
                 "lifecycle_phase": state.lifecycle_phase,
                 "lifecycle_transitions_total": state.lifecycle_transitions_total,
                 "dependency_failures_total": state.dependency_failures_total,
+                "failure_present": bool(state.last_dependency_failure_error),
+                "last_dependency_failure_category": _dependency_failure_category(
+                    state.last_dependency_failure_error
+                ),
                 "last_dependency_failure_surface": state.last_dependency_failure_surface,
-                "last_dependency_failure_error": state.last_dependency_failure_error,
                 "operator_trace_contract": "startup_shutdown_dependency_monitoring_minimum_v1",
             },
         }

--- a/projects/polymarket/polyquantbot/server/api/routes.py
+++ b/projects/polymarket/polyquantbot/server/api/routes.py
@@ -22,6 +22,15 @@ def _dependency_failure_category(raw_error: str) -> str:
     return "runtime_error"
 
 
+def _public_error_view(raw_error: str, reference: str) -> dict[str, str | bool]:
+    category = _dependency_failure_category(raw_error)
+    return {
+        "error_present": bool(raw_error),
+        "error_category": category,
+        "error_reference": reference if raw_error else "",
+    }
+
+
 def build_router(
     settings: ApiSettings,
     state: RuntimeState,
@@ -90,7 +99,10 @@ def build_router(
                 "shutdown_complete": state.telegram_runtime_shutdown_complete,
                 "iterations_total": state.telegram_runtime_iterations_total,
                 "last_iteration_visible": state.telegram_runtime_iterations_total > 0,
-                "last_error": state.telegram_runtime_last_error,
+                **_public_error_view(
+                    raw_error=state.telegram_runtime_last_error,
+                    reference="telegram_runtime",
+                ),
             },
             "db_runtime": {
                 "relevant": db_runtime_relevant,
@@ -101,7 +113,10 @@ def build_router(
                 "connect_max_attempts": state.db_connect_max_attempts,
                 "connect_base_backoff_s": state.db_connect_base_backoff_s,
                 "connect_timeout_s": state.db_connect_timeout_s,
-                "last_error": state.db_runtime_last_error,
+                **_public_error_view(
+                    raw_error=state.db_runtime_last_error,
+                    reference="db_runtime",
+                ),
             },
             "worker_prerequisites": worker_prerequisites,
             "falcon_config_state": {

--- a/projects/polymarket/polyquantbot/server/api/routes.py
+++ b/projects/polymarket/polyquantbot/server/api/routes.py
@@ -112,6 +112,14 @@ def build_router(
                 "live_mode_execution_allowed": False,
                 "paper_only_execution_boundary": True,
             },
+            "monitoring_outputs": {
+                "lifecycle_phase": state.lifecycle_phase,
+                "lifecycle_transitions_total": state.lifecycle_transitions_total,
+                "dependency_failures_total": state.dependency_failures_total,
+                "last_dependency_failure_surface": state.last_dependency_failure_surface,
+                "last_dependency_failure_error": state.last_dependency_failure_error,
+                "operator_trace_contract": "startup_shutdown_dependency_monitoring_minimum_v1",
+            },
         }
         return JSONResponse(
             {

--- a/projects/polymarket/polyquantbot/server/core/runtime.py
+++ b/projects/polymarket/polyquantbot/server/core/runtime.py
@@ -77,6 +77,11 @@ class RuntimeState:
     db_connect_base_backoff_s: float = 0.0
     db_connect_timeout_s: float = 0.0
     db_client: object | None = None
+    lifecycle_phase: str = "created"
+    lifecycle_transitions_total: int = 0
+    dependency_failures_total: int = 0
+    last_dependency_failure_surface: str = ""
+    last_dependency_failure_error: str = ""
 
     def mark_started(self) -> None:
         self.started_at = datetime.now(timezone.utc)

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -51,6 +51,40 @@ from projects.polymarket.polyquantbot.infra.db import DatabaseClient
 log = structlog.get_logger(__name__)
 
 
+def _runtime_monitoring_snapshot(state: RuntimeState) -> dict[str, object]:
+    return {
+        "lifecycle_phase": state.lifecycle_phase,
+        "lifecycle_transitions_total": state.lifecycle_transitions_total,
+        "dependency_failures_total": state.dependency_failures_total,
+        "last_dependency_failure_surface": state.last_dependency_failure_surface,
+        "telegram_runtime": {
+            "required": state.telegram_runtime_required,
+            "enabled": state.telegram_runtime_enabled,
+            "active": state.telegram_runtime_active,
+            "shutdown_complete": state.telegram_runtime_shutdown_complete,
+            "last_error_present": bool(state.telegram_runtime_last_error),
+        },
+        "db_runtime": {
+            "required": state.db_runtime_required,
+            "enabled": state.db_runtime_enabled,
+            "connected": state.db_runtime_connected,
+            "healthcheck_ok": state.db_runtime_healthcheck_ok,
+            "last_error_present": bool(state.db_runtime_last_error),
+        },
+    }
+
+
+def _transition_runtime_phase(state: RuntimeState, phase: str) -> None:
+    state.lifecycle_phase = phase
+    state.lifecycle_transitions_total += 1
+
+
+def _record_dependency_failure(state: RuntimeState, surface: str, error: str) -> None:
+    state.dependency_failures_total += 1
+    state.last_dependency_failure_surface = surface
+    state.last_dependency_failure_error = error
+
+
 class RuntimeTelegramObserver:
     def __init__(self, state: RuntimeState) -> None:
         self._state = state
@@ -79,6 +113,7 @@ class RuntimeTelegramObserver:
 
 
 def _reset_runtime_state_for_startup(state: RuntimeState) -> None:
+    _transition_runtime_phase(state=state, phase="startup_reset")
     state.validation_errors = []
     state.telegram_runtime_startup_complete = False
     state.telegram_runtime_active = False
@@ -89,19 +124,30 @@ def _reset_runtime_state_for_startup(state: RuntimeState) -> None:
     state.db_runtime_healthcheck_ok = False
     state.db_runtime_last_error = ""
     state.db_client = None
+    state.last_dependency_failure_surface = ""
+    state.last_dependency_failure_error = ""
+    log.info("crusaderbot_runtime_transition", transition="startup_reset", monitoring=_runtime_monitoring_snapshot(state))
 
 
 async def _start_telegram_runtime(state: RuntimeState) -> None:
+    _transition_runtime_phase(state=state, phase="telegram_startup")
+    log.info("crusaderbot_runtime_transition", transition="telegram_startup", monitoring=_runtime_monitoring_snapshot(state))
     settings = TelegramBotSettings.from_env()
     validation_errors = validate_bot_environment(settings)
     state.telegram_runtime_required = telegram_runtime_required_from_env()
     state.telegram_runtime_enabled = not validation_errors
     if validation_errors:
         state.telegram_runtime_last_error = "; ".join(validation_errors)
+        _record_dependency_failure(
+            state=state,
+            surface="telegram_runtime_startup",
+            error=state.telegram_runtime_last_error,
+        )
         log.error(
             "crusaderbot_telegram_runtime_disabled",
             required=state.telegram_runtime_required,
             errors=validation_errors,
+            failure_surface="telegram_runtime_startup",
         )
         if state.telegram_runtime_required:
             raise RuntimeError(state.telegram_runtime_last_error)
@@ -145,6 +191,8 @@ async def _start_telegram_runtime(state: RuntimeState) -> None:
 
 
 async def _shutdown_telegram_runtime(state: RuntimeState, timeout_s: float = 5.0) -> None:
+    _transition_runtime_phase(state=state, phase="telegram_shutdown")
+    log.info("crusaderbot_runtime_transition", transition="telegram_shutdown", monitoring=_runtime_monitoring_snapshot(state))
     task = state.telegram_runtime_task
     if task is None:
         state.telegram_runtime_active = False
@@ -158,9 +206,11 @@ async def _shutdown_telegram_runtime(state: RuntimeState, timeout_s: float = 5.0
         pass
     except asyncio.TimeoutError:
         state.telegram_runtime_last_error = "telegram_shutdown_timeout"
+        _record_dependency_failure(state=state, surface="telegram_runtime_shutdown", error=state.telegram_runtime_last_error)
         log.error("crusaderbot_telegram_runtime_shutdown_timeout", timeout_s=timeout_s)
     except Exception as exc:  # noqa: BLE001
         state.telegram_runtime_last_error = str(exc)
+        _record_dependency_failure(state=state, surface="telegram_runtime_shutdown", error=state.telegram_runtime_last_error)
         log.error("crusaderbot_telegram_runtime_shutdown_error", error=state.telegram_runtime_last_error)
     finally:
         state.telegram_runtime_task = None
@@ -188,6 +238,8 @@ def _db_retry_budget_s(max_attempts: int, base_backoff_s: float, per_attempt_tim
 
 
 async def _start_database_runtime(state: RuntimeState) -> None:
+    _transition_runtime_phase(state=state, phase="db_startup")
+    log.info("crusaderbot_runtime_transition", transition="db_startup", monitoring=_runtime_monitoring_snapshot(state))
     state.db_runtime_required = _db_runtime_required_from_env()
     state.db_runtime_enabled = _db_runtime_enabled_from_env()
     state.db_runtime_last_error = ""
@@ -229,6 +281,11 @@ async def _start_database_runtime(state: RuntimeState) -> None:
         log.info("crusaderbot_db_runtime_ready")
     except Exception as exc:
         state.db_runtime_last_error = str(exc)
+        _record_dependency_failure(
+            state=state,
+            surface="db_runtime_startup",
+            error=state.db_runtime_last_error,
+        )
         state.db_runtime_connected = False
         state.db_runtime_healthcheck_ok = False
         if state.db_client is not None:
@@ -238,12 +295,15 @@ async def _start_database_runtime(state: RuntimeState) -> None:
             "crusaderbot_db_runtime_startup_failed",
             required=state.db_runtime_required,
             error=state.db_runtime_last_error,
+            failure_surface="db_runtime_startup",
         )
         if state.db_runtime_required:
             raise
 
 
 async def _stop_database_runtime(state: RuntimeState) -> None:
+    _transition_runtime_phase(state=state, phase="db_shutdown")
+    log.info("crusaderbot_runtime_transition", transition="db_shutdown", monitoring=_runtime_monitoring_snapshot(state))
     if state.db_client is None:
         return
     close_attempts = 2
@@ -256,6 +316,11 @@ async def _stop_database_runtime(state: RuntimeState) -> None:
             return
         except Exception as exc:  # noqa: BLE001
             state.db_runtime_last_error = f"db_close_attempt_{attempt}_failed: {exc}"
+            _record_dependency_failure(
+                state=state,
+                surface="db_runtime_shutdown",
+                error=state.db_runtime_last_error,
+            )
             log.warning(
                 "crusaderbot_db_runtime_shutdown_retry",
                 attempt=attempt,
@@ -270,8 +335,12 @@ async def _stop_database_runtime(state: RuntimeState) -> None:
 
 
 async def _shutdown_runtime_components(state: RuntimeState) -> None:
+    _transition_runtime_phase(state=state, phase="shutdown_begin")
+    log.info("crusaderbot_runtime_transition", transition="shutdown_begin", monitoring=_runtime_monitoring_snapshot(state))
     await _shutdown_telegram_runtime(state=state)
     await _stop_database_runtime(state=state)
+    _transition_runtime_phase(state=state, phase="shutdown_complete")
+    log.info("crusaderbot_runtime_transition", transition="shutdown_complete", monitoring=_runtime_monitoring_snapshot(state))
 
 
 def create_app() -> FastAPI:
@@ -283,7 +352,15 @@ def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         try:
+            _transition_runtime_phase(state=state, phase="startup_begin")
+            log.info("crusaderbot_runtime_transition", transition="startup_begin", monitoring=_runtime_monitoring_snapshot(state))
             _reset_runtime_state_for_startup(state)
+            _transition_runtime_phase(state=state, phase="startup_validation")
+            log.info(
+                "crusaderbot_runtime_transition",
+                transition="startup_validation",
+                monitoring=_runtime_monitoring_snapshot(state),
+            )
             await run_startup_validation(settings=settings, state=state)
             await _start_database_runtime(state=state)
             try:
@@ -291,10 +368,14 @@ def create_app() -> FastAPI:
             except Exception as exc:
                 capture_runtime_exception(exc, surface="telegram_runtime_startup")
                 raise
+            _transition_runtime_phase(state=state, phase="runtime_ready")
+            log.info("crusaderbot_runtime_transition", transition="runtime_ready", monitoring=_runtime_monitoring_snapshot(state))
             yield
         finally:
             await _shutdown_runtime_components(state=state)
             await run_shutdown(state=state)
+            _transition_runtime_phase(state=state, phase="stopped")
+            log.info("crusaderbot_runtime_transition", transition="stopped", monitoring=_runtime_monitoring_snapshot(state))
 
     app = FastAPI(
         title=settings.app_name,

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -13,6 +13,7 @@ from projects.polymarket.polyquantbot.server.core.runtime import (
     ApiSettings,
     validate_api_environment,
 )
+from projects.polymarket.polyquantbot.server.api.routes import _dependency_failure_category
 from projects.polymarket.polyquantbot.server.main import create_app
 
 _TEST_DB_DSN = "postgresql://test-user:test-pass@localhost:5432/test_crusader"
@@ -111,6 +112,29 @@ def test_ready_route_reports_readiness_dimensions(monkeypatch) -> None:
     assert readiness["monitoring_outputs"]["operator_trace_contract"] == (
         "startup_shutdown_dependency_monitoring_minimum_v1"
     )
+    assert isinstance(readiness["monitoring_outputs"]["failure_present"], bool)
+    assert readiness["monitoring_outputs"]["last_dependency_failure_category"] in {
+        "none",
+        "runtime_error",
+        "timeout",
+        "healthcheck_failed",
+        "connection_failed",
+    }
+    assert "last_dependency_failure_error" not in readiness["monitoring_outputs"]
+
+
+@pytest.mark.parametrize(
+    ("raw_error", "expected"),
+    [
+        ("", "none"),
+        ("telegram_shutdown_timeout", "timeout"),
+        ("Database healthcheck failed after startup connect path.", "healthcheck_failed"),
+        ("db_connect_refused", "connection_failed"),
+        ("unexpected_runtime_boom", "runtime_error"),
+    ],
+)
+def test_dependency_failure_category_is_sanitized(raw_error: str, expected: str) -> None:
+    assert _dependency_failure_category(raw_error) == expected
 
 
 def test_beta_admin_route_exists_and_preserves_paper_boundary(monkeypatch) -> None:

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -121,6 +121,14 @@ def test_ready_route_reports_readiness_dimensions(monkeypatch) -> None:
         "connection_failed",
     }
     assert "last_dependency_failure_error" not in readiness["monitoring_outputs"]
+    assert "last_error" not in readiness["telegram_runtime"]
+    assert "last_error" not in readiness["db_runtime"]
+    assert "error_present" in readiness["telegram_runtime"]
+    assert "error_category" in readiness["telegram_runtime"]
+    assert "error_reference" in readiness["telegram_runtime"]
+    assert "error_present" in readiness["db_runtime"]
+    assert "error_category" in readiness["db_runtime"]
+    assert "error_reference" in readiness["db_runtime"]
 
 
 @pytest.mark.parametrize(
@@ -323,7 +331,45 @@ def test_ready_status_after_db_unavailable_when_not_required(monkeypatch) -> Non
     assert readiness["relevant"] is True
     assert readiness["connected"] is False
     assert readiness["healthcheck_ok"] is False
-    assert readiness["last_error"] != ""
+    assert readiness["error_present"] is True
+    assert readiness["error_category"] == "connection_failed"
+    assert readiness["error_reference"] == "db_runtime"
+    assert "last_error" not in readiness
+
+
+def test_ready_payload_sanitizes_telegram_and_db_error_surfaces(monkeypatch) -> None:
+    class _UnavailableDBClient:
+        async def connect_with_retry(self, max_attempts: int = 4, base_backoff_s: float = 1.0) -> None:
+            raise RuntimeError("db_unavailable")
+
+        async def healthcheck(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
+    monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "false")
+    monkeypatch.setenv("DB_DSN", _TEST_DB_DSN)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _UnavailableDBClient)
+    app = create_app()
+
+    with TestClient(app) as client:
+        payload = client.get("/ready").json()
+
+    telegram_runtime = payload["readiness"]["telegram_runtime"]
+    db_runtime = payload["readiness"]["db_runtime"]
+    assert telegram_runtime["error_present"] is True
+    assert telegram_runtime["error_category"] == "runtime_error"
+    assert telegram_runtime["error_reference"] == "telegram_runtime"
+    assert "last_error" not in telegram_runtime
+    assert db_runtime["error_present"] is True
+    assert db_runtime["error_category"] == "connection_failed"
+    assert db_runtime["error_reference"] == "db_runtime"
+    assert "last_error" not in db_runtime
 
 
 def test_ready_route_not_ready_when_telegram_required_without_token(monkeypatch) -> None:

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -106,7 +106,11 @@ def test_ready_route_reports_readiness_dimensions(monkeypatch) -> None:
     assert "falcon_config_state" in readiness
     assert "dependency_gates" in readiness
     assert "control_plane" in readiness
+    assert "monitoring_outputs" in readiness
     assert readiness["control_plane"]["paper_only_execution_boundary"] is True
+    assert readiness["monitoring_outputs"]["operator_trace_contract"] == (
+        "startup_shutdown_dependency_monitoring_minimum_v1"
+    )
 
 
 def test_beta_admin_route_exists_and_preserves_paper_boundary(monkeypatch) -> None:

--- a/projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py
@@ -6,6 +6,7 @@ import pytest
 
 from projects.polymarket.polyquantbot.server.core.runtime import RuntimeState
 from projects.polymarket.polyquantbot.server.main import (
+    _start_database_runtime,
     _reset_runtime_state_for_startup,
     _shutdown_runtime_components,
     _shutdown_telegram_runtime,
@@ -88,3 +89,79 @@ def test_reset_runtime_state_for_startup_clears_stale_failure_posture() -> None:
     assert state.db_runtime_healthcheck_ok is False
     assert state.db_runtime_last_error == ""
     assert state.db_client is None
+
+
+def test_reset_runtime_state_emits_structured_startup_transition_log(monkeypatch) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **kwargs: object) -> None:
+        captured.append((event, kwargs))
+
+    monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.log.info", _capture)
+    state = RuntimeState()
+
+    _reset_runtime_state_for_startup(state)
+
+    assert captured
+    event, payload = captured[-1]
+    assert event == "crusaderbot_runtime_transition"
+    assert payload["transition"] == "startup_reset"
+    assert "monitoring" in payload
+
+
+@pytest.mark.asyncio
+async def test_shutdown_runtime_components_emits_structured_shutdown_transition_logs(monkeypatch) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **kwargs: object) -> None:
+        captured.append((event, kwargs))
+
+    monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.log.info", _capture)
+    state = RuntimeState()
+    state.telegram_runtime_task = asyncio.create_task(asyncio.sleep(1))
+
+    await _shutdown_runtime_components(state=state)
+
+    transitions = [payload["transition"] for event, payload in captured if event == "crusaderbot_runtime_transition"]
+    assert "shutdown_begin" in transitions
+    assert "telegram_shutdown" in transitions
+    assert "db_shutdown" in transitions
+    assert "shutdown_complete" in transitions
+
+
+@pytest.mark.asyncio
+async def test_db_dependency_failure_trace_is_structured_and_readable(monkeypatch) -> None:
+    class _FailingDBClient:
+        async def connect_with_retry(self, max_attempts: int = 4, base_backoff_s: float = 1.0) -> None:
+            raise RuntimeError("db_connect_refused")
+
+        async def healthcheck(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            return None
+
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **kwargs: object) -> None:
+        captured.append((event, kwargs))
+
+    monkeypatch.setenv("CRUSADER_DB_RUNTIME_ENABLED", "true")
+    monkeypatch.setenv("CRUSADER_DB_RUNTIME_REQUIRED", "false")
+    monkeypatch.setenv("DB_DSN", "postgresql://runtime:runtime@localhost:5432/runtime")
+    monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.DatabaseClient", _FailingDBClient)
+    monkeypatch.setattr("projects.polymarket.polyquantbot.server.main.log.error", _capture)
+    state = RuntimeState()
+
+    await _start_database_runtime(state=state)
+
+    assert state.dependency_failures_total == 1
+    assert state.last_dependency_failure_surface == "db_runtime_startup"
+    assert state.last_dependency_failure_error == "db_connect_refused"
+    failure_logs = [
+        payload
+        for event, payload in captured
+        if event == "crusaderbot_db_runtime_startup_failed"
+    ]
+    assert failure_logs
+    assert failure_logs[-1]["failure_surface"] == "db_runtime_startup"


### PR DESCRIPTION
### Motivation
- Close post-merge repo-truth drift after PR #731 / PR #732 / PR #733 and advance the next Priority 2 lane for logging and monitoring hardening. 
- Improve operator-visible runtime traceability for startup/shutdown and dependency failures without expanding into wallet/execution logic. 
- Normalize structured logging and provide a minimum viable monitoring surface so readiness endpoints and operators can follow lifecycle transitions and dependency failures. 

### Description
- Updated repo-truth: `PROJECT_STATE.md` and `ROADMAP.md` were synced to record PR #731 / PR #732 / PR #733 as merged-main and to promote Phase 10.8 logging/monitoring hardening as the active Priority 2 lane. 
- Runtime state and monitoring: added lifecycle fields to `RuntimeState` (`lifecycle_phase`, `lifecycle_transitions_total`, `dependency_failures_total`, `last_dependency_failure_surface`, `last_dependency_failure_error`) in `projects/polymarket/polyquantbot/server/core/runtime.py`. 
- Structured logging and phase transitions: added `_runtime_monitoring_snapshot`, `_transition_runtime_phase`, and `_record_dependency_failure` helpers and emitted `crusaderbot_runtime_transition` structured events across startup, validation, db/telegram startup/shutdown, and stop phases in `projects/polymarket/polyquantbot/server/main.py`. 
- Monitoring outputs: exposed minimum viable monitoring outputs under `readiness.monitoring_outputs` in `projects/polymarket/polyquantbot/server/api/routes.py` with an `operator_trace_contract` marker. 
- Tests and report: added/updated tests for structured startup/shutdown transition logs, dependency-failure trace readability, and monitoring output visibility in `projects/polymarket/polyquantbot/tests/`; added FORGE report `projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md`. 

### Testing
- Ran static/compile checks using `python3 -m py_compile` on touched files and they passed. 
- Executed unit tests with `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` and all tests passed (`25 passed`). 
- Verified merged-main truth for PR #731 / PR #732 / PR #733 via GitHub pull metadata (`merged_at` present for each PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cf427394832590cf412b9dfc4e55)