### PR TITLE
Update PROJECT_STATE and add SENTINEL validation report for Phase 10.8 (PR #734)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 14:54
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 are merged-main truth, and Phase 10.8 logging/monitoring hardening is the active Priority 2 lane under paper-only boundary posture.
+Last Updated : 2026-04-23 15:26
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 remain merged-main truth, and PR #734 SENTINEL rerun remains BLOCKED on Phase 10.8 due to public /ready raw dependency/runtime error exposure.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -58,7 +58,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [NEXT PRIORITY]
 - Phase 10.8 Priority 2 lane: harden structured logging consistency, startup/shutdown trace readability, and minimum viable monitoring outputs in control-plane runtime (paper-only boundary preserved).
-- COMMANDER review gate for PR lane `feature/postmerge-sync-and-logging-monitoring-hardening` before SENTINEL validation handoff.
+- FORGE-X blocker closure for PR #734: sanitize public `/ready` telegram/db raw error fields while preserving operator-usable failure categories/surfaces, then rerun SENTINEL.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-23 15:26
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 remain merged-main truth, and PR #734 SENTINEL rerun remains BLOCKED on Phase 10.8 due to public /ready raw dependency/runtime error exposure.
+Last Updated : 2026-04-23 15:47
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, and PR #733 remain merged-main truth, and PR #734 SENTINEL final rerun is APPROVED for Phase 10.8 logging/monitoring hardening.
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on `feature/consolidate-telegram-ui-ux-layer`: active Telegram source of truth remains `projects/polymarket/polyquantbot/telegram`, deprecated `interface/telegram/__init__.py` legacy marker is archived under `projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/`, and only thin compatibility shims remain under `projects/polymarket/polyquantbot/interface/telegram/view_handler.py` + `projects/polymarket/polyquantbot/interface/ui_formatter.py` + `projects/polymarket/polyquantbot/interface/telegram/__init__.py`.
@@ -58,7 +58,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [NEXT PRIORITY]
 - Phase 10.8 Priority 2 lane: harden structured logging consistency, startup/shutdown trace readability, and minimum viable monitoring outputs in control-plane runtime (paper-only boundary preserved).
-- FORGE-X blocker closure for PR #734: sanitize public `/ready` telegram/db raw error fields while preserving operator-usable failure categories/surfaces, then rerun SENTINEL.
+- COMMANDER final decision gate for PR #734 (`feature/update-repository-state-and-logging-monitoring`) with SENTINEL APPROVED verdict recorded.
 
 [KNOWN ISSUES]
 - Phase 5.2 only supports single-order transport and intentionally excludes retry, batching, and async workers.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase10-8_01_pr734-logging-monitoring-hardening-validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase10-8_01_pr734-logging-monitoring-hardening-validation.md
@@ -1,0 +1,91 @@
+# SENTINEL Report — phase10-8_01_pr734-logging-monitoring-hardening-validation
+
+## Environment
+- Timestamp: 2026-04-23 15:26 (Asia/Jakarta)
+- Repository: `bayuewalker/walker-ai-team`
+- PR: #734 (`https://github.com/bayuewalker/walker-ai-team/pull/734`)
+- PR head branch (verified): `feature/update-repository-state-and-logging-monitoring`
+- PR base branch: `main`
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation target: post-merge repo-truth sync plus Priority 2 logging and monitoring hardening in control-plane runtime
+- Not in scope: wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
+
+## Validation Context
+Validation rerun executed against PR #734 source truth (GitHub PR/contents API + scoped local test execution) for:
+- exact branch traceability across PR head, FORGE report, PROJECT_STATE.md, and ROADMAP.md;
+- merged-main continuity for PR #731 / #732 / #733;
+- structured logging transition consistency and startup/shutdown trace continuity;
+- dependency-failure monitoring usefulness without public raw-error leakage;
+- `/ready` operator-safety;
+- claimed tests for declared narrow control-plane claim.
+
+## Phase 0 Checks
+- FORGE report exists with required MAJOR sections at `projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md`.
+- PR metadata reverified via GitHub API (`head=feature/update-repository-state-and-logging-monitoring`, `base=main`, `state=open`).
+- `python3 -m py_compile` on scoped runtime/test files passed.
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` passed (`25 passed`).
+
+## Findings
+1) **PASS — exact branch traceability is clean on PR #734 source artifacts**
+- PR #734 head branch is `feature/update-repository-state-and-logging-monitoring`.
+- FORGE report branch and Suggested Next reference the same exact string.
+- PROJECT_STATE.md NEXT PRIORITY references the same branch string.
+- ROADMAP.md has no conflicting branch reference for this lane.
+
+2) **PASS — PR #731 / #732 / #733 merged-main truth remains correctly synced**
+- PROJECT_STATE.md and ROADMAP.md consistently retain merged-main history for PR #731/#732/#733 while keeping Phase 10.8 as active lane.
+
+3) **PASS — structured lifecycle transition logging and continuity improved**
+- Runtime transition markers are consistently emitted for startup/reset/validation/dependency startup/runtime ready and shutdown flow.
+- Transition snapshots keep operator-readable lifecycle/dependency counters and surfaces.
+
+4) **BLOCKER — `/ready` still exposes raw dependency/runtime error text on public readiness surface**
+- `readiness.telegram_runtime.last_error` and `readiness.db_runtime.last_error` return raw stored error strings.
+- While `monitoring_outputs` now uses failure presence/category instead of raw `last_dependency_failure_error`, public readiness payload still leaks raw dependency/runtime exception text through telegram/db sections.
+- This fails the requirement: dependency-failure monitoring must be useful without exposing sensitive raw error text publicly.
+
+5) **PASS — claimed tests support declared narrow integration claim**
+- Scoped runtime resilience and runtime-surface tests execute and pass (25/25), directly covering the claimed control-plane startup/shutdown/readiness behavior slice.
+
+## Score Breakdown
+- Branch traceability: 30/30
+- Repo-truth sync continuity: 20/20
+- Structured logging + lifecycle continuity: 20/20
+- `/ready` operator-safe exposure control: 0/20
+- Executed evidence quality: 10/10
+
+**Total: 80/100**
+
+## Critical Issues
+- Public `/ready` payload still exposes raw dependency/runtime error text in telegram/db sections.
+
+## Status
+**BLOCKED**
+
+## PR Gate Result
+- Merge gate result for SENTINEL scope: **BLOCKED**.
+- Return to FORGE-X for `/ready` error-surface sanitization and focused rerun evidence.
+
+## Broader Audit Finding
+- Observability hardening is materially improved (traceability, transitions, and monitoring category surface), but public readiness confidentiality posture is still incomplete due raw telegram/db error string exposure.
+
+## Reasoning
+Branch traceability and merged-main sync checks pass on PR #734 source truth, and scoped test evidence is now complete. However, MAJOR gate remains blocked because publicly exposed `/ready` data still contains raw dependency/runtime error text in active readiness sections.
+
+## Fix Recommendations
+1. Replace public `telegram_runtime.last_error` and `db_runtime.last_error` with bounded public-safe fields (e.g., `error_present`, `error_category`, `error_reference`) while keeping detailed raw text internal logs only.
+2. Add route-level tests asserting `/ready` does not return raw exception text tokens for dependency/runtime failures.
+3. Re-run the same two scoped pytest suites and include pass evidence in rerun notes.
+
+## Out-of-scope Advisory
+- This validation does not assert wallet lifecycle completion, execution engine expansion, portfolio logic, or broad DB architecture rewrite.
+
+## Deferred Minor Backlog
+- [DEFERRED] Non-runtime `pytest.ini` warning cleanup (`asyncio_mode`) remains backlog-only and is not part of this blocker.
+
+## Telegram Visual Preview
+- Verdict: BLOCKED
+- Score: 80/100
+- Critical: 1
+- Gate: sanitize public `/ready` telegram/db error fields, then rerun SENTINEL.

--- a/projects/polymarket/polyquantbot/reports/sentinel/phase10-8_01_pr734-logging-monitoring-hardening-validation.md
+++ b/projects/polymarket/polyquantbot/reports/sentinel/phase10-8_01_pr734-logging-monitoring-hardening-validation.md
@@ -1,10 +1,11 @@
 # SENTINEL Report — phase10-8_01_pr734-logging-monitoring-hardening-validation
 
 ## Environment
-- Timestamp: 2026-04-23 15:26 (Asia/Jakarta)
+- Timestamp: 2026-04-23 15:47 (Asia/Jakarta)
 - Repository: `bayuewalker/walker-ai-team`
 - PR: #734 (`https://github.com/bayuewalker/walker-ai-team/pull/734`)
 - PR head branch (verified): `feature/update-repository-state-and-logging-monitoring`
+- PR head SHA (verified): `088c5d7eeaf920c51d6b69567fa01ababe99d4a9`
 - PR base branch: `main`
 - Validation Tier: MAJOR
 - Claim Level: NARROW INTEGRATION
@@ -12,80 +13,82 @@
 - Not in scope: wallet lifecycle expansion, portfolio logic, execution engine changes, broad DB architecture rewrite, unrelated UX cleanup
 
 ## Validation Context
-Validation rerun executed against PR #734 source truth (GitHub PR/contents API + scoped local test execution) for:
+Final rerun executed after `/ready` public error-surface sanitization on PR #734 source truth (PR API + source-file API + reproducible scoped pytest run on PR head snapshot).
+Validation scope remained strictly on declared narrow control-plane claim:
 - exact branch traceability across PR head, FORGE report, PROJECT_STATE.md, and ROADMAP.md;
 - merged-main continuity for PR #731 / #732 / #733;
-- structured logging transition consistency and startup/shutdown trace continuity;
-- dependency-failure monitoring usefulness without public raw-error leakage;
-- `/ready` operator-safety;
-- claimed tests for declared narrow control-plane claim.
+- structured lifecycle transition logging consistency;
+- public readiness exposure safety for dependency/runtime failures;
+- operator usefulness of monitoring outputs;
+- reproducibility of scoped tests supporting the narrow claim.
 
 ## Phase 0 Checks
 - FORGE report exists with required MAJOR sections at `projects/polymarket/polyquantbot/reports/forge/phase10-8_01_postmerge-sync-and-logging-monitoring-hardening.md`.
-- PR metadata reverified via GitHub API (`head=feature/update-repository-state-and-logging-monitoring`, `base=main`, `state=open`).
-- `python3 -m py_compile` on scoped runtime/test files passed.
-- `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` passed (`25 passed`).
+- PR metadata reverified via GitHub API (`head=feature/update-repository-state-and-logging-monitoring`, `base=main`, `state=open`, `sha=088c5d7eeaf920c51d6b69567fa01ababe99d4a9`).
+- `python3 -m py_compile` on scoped runtime/test files passed on PR #734 head snapshot.
+- `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` passed on PR #734 head snapshot (`31 passed`).
 
 ## Findings
-1) **PASS — exact branch traceability is clean on PR #734 source artifacts**
-- PR #734 head branch is `feature/update-repository-state-and-logging-monitoring`.
-- FORGE report branch and Suggested Next reference the same exact string.
-- PROJECT_STATE.md NEXT PRIORITY references the same branch string.
-- ROADMAP.md has no conflicting branch reference for this lane.
+1) **PASS — exact branch traceability remains clean**
+- PR #734 head is exactly `feature/update-repository-state-and-logging-monitoring`.
+- FORGE report branch and Suggested Next branch exactly match PR head.
+- PROJECT_STATE.md PR-lane reference also matches the exact PR head branch string.
 
-2) **PASS — PR #731 / #732 / #733 merged-main truth remains correctly synced**
-- PROJECT_STATE.md and ROADMAP.md consistently retain merged-main history for PR #731/#732/#733 while keeping Phase 10.8 as active lane.
+2) **PASS — PR #731 / #732 / #733 merged-main truth remains synced**
+- PROJECT_STATE.md and ROADMAP.md both preserve merged-main continuity for PR #731/#732/#733 while keeping Phase 10.8 as active lane.
 
-3) **PASS — structured lifecycle transition logging and continuity improved**
-- Runtime transition markers are consistently emitted for startup/reset/validation/dependency startup/runtime ready and shutdown flow.
-- Transition snapshots keep operator-readable lifecycle/dependency counters and surfaces.
+3) **PASS — structured lifecycle logging remains consistent**
+- Runtime readiness surface still carries lifecycle phase and transition counters.
+- Monitoring outputs retain failure counters/surface/category without widening claim scope.
 
-4) **BLOCKER — `/ready` still exposes raw dependency/runtime error text on public readiness surface**
-- `readiness.telegram_runtime.last_error` and `readiness.db_runtime.last_error` return raw stored error strings.
-- While `monitoring_outputs` now uses failure presence/category instead of raw `last_dependency_failure_error`, public readiness payload still leaks raw dependency/runtime exception text through telegram/db sections.
-- This fails the requirement: dependency-failure monitoring must be useful without exposing sensitive raw error text publicly.
+4) **PASS — `/ready` no longer exposes raw telegram/db runtime error strings**
+- `readiness.telegram_runtime` and `readiness.db_runtime` now expose bounded public-safe fields (`error_present`, `error_category`, `error_reference`) via `_public_error_view`.
+- Raw `last_error` fields are no longer present in these public sections.
+- Monitoring outputs removed raw `last_dependency_failure_error` and now expose `failure_present`, `last_dependency_failure_category`, and `last_dependency_failure_surface`.
 
-5) **PASS — claimed tests support declared narrow integration claim**
-- Scoped runtime resilience and runtime-surface tests execute and pass (25/25), directly covering the claimed control-plane startup/shutdown/readiness behavior slice.
+5) **PASS — monitoring output remains operator-safe and useful**
+- Public payload keeps operator-actionable shape: lifecycle state, failure count, failure category, failure surface, and deterministic operator trace contract.
+
+6) **PASS — scoped pytest evidence is reproducible and supports narrow claim**
+- Runtime resilience + runtime surface tests pass on PR head snapshot and include checks for sanitized readiness fields and absent raw error exposure.
 
 ## Score Breakdown
 - Branch traceability: 30/30
 - Repo-truth sync continuity: 20/20
 - Structured logging + lifecycle continuity: 20/20
-- `/ready` operator-safe exposure control: 0/20
+- `/ready` operator-safe exposure control: 20/20
 - Executed evidence quality: 10/10
 
-**Total: 80/100**
+**Total: 100/100**
 
 ## Critical Issues
-- Public `/ready` payload still exposes raw dependency/runtime error text in telegram/db sections.
+- None.
 
 ## Status
-**BLOCKED**
+**APPROVED**
 
 ## PR Gate Result
-- Merge gate result for SENTINEL scope: **BLOCKED**.
-- Return to FORGE-X for `/ready` error-surface sanitization and focused rerun evidence.
+- Merge gate result for SENTINEL scope: **APPROVED**.
+- COMMANDER final merge decision remains required.
 
 ## Broader Audit Finding
-- Observability hardening is materially improved (traceability, transitions, and monitoring category surface), but public readiness confidentiality posture is still incomplete due raw telegram/db error string exposure.
+- Phase 10.8 narrow integration claim is now evidence-backed with clean traceability and public-safe readiness diagnostics.
 
 ## Reasoning
-Branch traceability and merged-main sync checks pass on PR #734 source truth, and scoped test evidence is now complete. However, MAJOR gate remains blocked because publicly exposed `/ready` data still contains raw dependency/runtime error text in active readiness sections.
+The previous blocker (public raw error exposure on `/ready`) is closed in PR #734 head by replacing raw error strings with bounded category/reference signals while preserving operator utility. Traceability and merged-main sync remain clean, and scoped test evidence is reproducible.
 
 ## Fix Recommendations
-1. Replace public `telegram_runtime.last_error` and `db_runtime.last_error` with bounded public-safe fields (e.g., `error_present`, `error_category`, `error_reference`) while keeping detailed raw text internal logs only.
-2. Add route-level tests asserting `/ready` does not return raw exception text tokens for dependency/runtime failures.
-3. Re-run the same two scoped pytest suites and include pass evidence in rerun notes.
+1. Preserve `_public_error_view`/category exposure contract for future readiness changes.
+2. Keep route-level assertions that guard against reintroducing raw error strings on public `/ready`.
 
 ## Out-of-scope Advisory
 - This validation does not assert wallet lifecycle completion, execution engine expansion, portfolio logic, or broad DB architecture rewrite.
 
 ## Deferred Minor Backlog
-- [DEFERRED] Non-runtime `pytest.ini` warning cleanup (`asyncio_mode`) remains backlog-only and is not part of this blocker.
+- [DEFERRED] Non-runtime `pytest.ini` warning cleanup (`asyncio_mode`) remains backlog-only.
 
 ## Telegram Visual Preview
-- Verdict: BLOCKED
-- Score: 80/100
-- Critical: 1
-- Gate: sanitize public `/ready` telegram/db error fields, then rerun SENTINEL.
+- Verdict: APPROVED
+- Score: 100/100
+- Critical: 0
+- Gate: SENTINEL MAJOR validation satisfied for declared scope.


### PR DESCRIPTION
### Motivation
- Bring repository state documentation into sync with the PR head and record the current FORGE/SENTINEL validation status for the Phase 10.8 logging/monitoring hardening lane. 
- Capture the validation findings and blocker details about public `/ready` error exposure to drive the next remediation steps.

### Description
- Updated `PROJECT_STATE.md` timestamp and NEXT PRIORITY entry to reference the FORGE-X blocker closure objective for PR #734 and to reflect the blocked `/ready` sanitization requirement. 
- Added a new SENTINEL report file `projects/polymarket/polyquantbot/reports/sentinel/phase10-8_01_pr734-logging-monitoring-hardening-validation.md` that documents environment, validation context, findings, score, and recommended fixes. 
- The report explicitly documents a blocking issue where public `/ready` still exposes raw `telegram_runtime.last_error` and `db_runtime.last_error` strings and recommends sanitizing public readiness fields.

### Testing
- Ran bytecode check with `python3 -m py_compile` on scoped runtime/test files which passed. 
- Executed the scoped pytest suites with `pytest -q projects/polymarket/polyquantbot/tests/test_phase10_7_runtime_resilience_20260423.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` resulting in `25 passed`.
- The SENTINEL validation concluded as **BLOCKED** due to the `/ready` public exposure issue despite passing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d5655a70832586fe7bfa34affdca)