### PR TITLE
docs: note Phase 10.8 post-merge repo-truth drift and next lane

### DIFF
--- a/projects/polymarket/polyquantbot/reports/forge/phase10-8_03_postmerge-repo-truth-sync-note.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-8_03_postmerge-repo-truth-sync-note.md
@@ -1,0 +1,31 @@
+# FORGE-X Report — phase10-8_03_postmerge-repo-truth-sync-note
+
+## Environment
+- Timestamp: 2026-04-23 16:05 (Asia/Jakarta)
+- Repository: bayuewalker/walker-ai-team
+- Source base: main
+- Source truth: PR #734 merged on main, SENTINEL sync closure merged via PR #736 and PR #737
+- Scope: repo-truth sync note only
+
+## Context
+Post-merge check after Pr #734 + #736 + #737 confirmed that the Phase 10.8 logging/monitoring hardening lane is merged on main, but three repo-truth surfaces still show pre-merge langengue: `PROJECT_STATE.md`, `ROADMAP.md`, and `projects/polymarket/polyquantbot/work_checklist.md`.
+
+## Confirmed drift
+- `PROJECT_STATE.md` still says Phase 10.8 logging/monitoring hardening is the active Priority 2 lane
+- `PROJECT_STATE.md` still lists Phase 10.8 under [NEXT PRIORITY]
+- `ROADMAP.md` still says Phase 10.8 is  the active Priority 2 lane
+- `projects/polymarket/polyquantbot/work_checklist.md` still shows Logging and Monitoring Hardening as the active current lane
+
+## Canonical truth after merge
+- Phase 10.8 logging/monitoring hardening is closed on main
+- SENTINEL final approved validation for PR #734 is closed on main via PR #736 and PR #737
+- Next Priority 2 focus should be: Security Baseline Hardening
+- After security, the follow-on Priority 2 lane should be Deployment Hardening
+
+## Next repo-truth sync requirements
+- Update `PROJECT_STATE.md` so Phase 10.8 is recorded as merged-main truth
+- Update `ROADMAP.md` so Phase 10.8 is not longer the active lane
+- Update `work_checklist.md` so Logging/Monitoring Hardening is marked completed and Security Baseline Hardening becomes the active lane
+
+## Status
+CONDITIONAL: repo-truth PRqueue is clean, but state/roadmap/checklist sync surfaces still need one docs-only closure change.


### PR DESCRIPTION
## Summary
- add a Phase 10.8 post-merge repo-truth sync note under FORGE reports
- document the remaining state drift after merged PR #734 / #736 / #737
- record the canonical next Priority 2 lane as Security Baseline Hardening

## Scope
- docs-only note
- no runtime code changes

## Why this PR exists
The runtime lane is already merged and queue is clean, but `PROJECT_STATE.md`, `ROADMAP.md`, and `projects/polymarket/polyquantbot/work_checklist.md` still carry pre-merge Phase 10.8 wording. This PR records the drift explicitly and preserves the next-lane truth while a full multi-file docs sync is prepared.

## Follow-up required
A dedicated docs sync PR is still needed to update:
- `PROJECT_STATE.md`
- `ROADMAP.md`
- `projects/polymarket/polyquantbot/work_checklist.md`