### PR TITLE
Phase10.9 security baseline hardening: redact secret-like errors and tighten operator-only beta route tests

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-23 18:47
+Last Updated : 2026-04-23 18:55
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and Phase 10.9 Priority 2 security baseline hardening is implemented on the source lane pending SENTINEL gate under paper-only boundary posture.
 
 [COMPLETED]
@@ -49,7 +49,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #733 is merged on main as post-merge checklist/state continuity sync for the completed Phase 10.7 lane.
 
 [IN PROGRESS]
-- Phase 10.9 Priority 2 security baseline hardening is implemented on source lane `feature/security-phase10-9-baseline-hardening-20260423` with secret redaction hardening (including Telegram backend helper exception/response sanitization) + explicit operator-key route protection for `/beta/admin`, `/beta/mode`, `/beta/autotrade`, `/beta/kill`, and `/beta/risk`; SENTINEL validation is required before merge decision.
+- Phase 10.9 Priority 2 security baseline hardening is implemented on source lane `feature/harden-security-baseline-for-phase-10.9` with secret redaction hardening (including Telegram backend helper exception/response sanitization) + explicit operator-key route protection for `/beta/admin`, `/beta/mode`, `/beta/autotrade`, `/beta/kill`, and `/beta/risk`; SENTINEL validation is required before merge decision.
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
 [NOT STARTED]
@@ -58,7 +58,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - Automation, retry, and batching for settlement and wallet operations.
 
 [NEXT PRIORITY]
-- SENTINEL MAJOR validation gate for Phase 10.9 Priority 2 security baseline hardening on source lane `feature/security-phase10-9-baseline-hardening-20260423` before merge decision.
+- SENTINEL MAJOR validation gate for Phase 10.9 Priority 2 security baseline hardening on source lane `feature/harden-security-baseline-for-phase-10.9` before merge decision.
 - After SENTINEL gate closure, advance to Priority 2 Deployment Hardening lane continuity (paper-only boundary preserved).
 
 [KNOWN ISSUES]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-04-23 17:57
+Last Updated : 2026-04-23 18:47
 Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and Phase 10.9 Priority 2 security baseline hardening is implemented on the source lane pending SENTINEL gate under paper-only boundary posture.
 
 [COMPLETED]
@@ -49,7 +49,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - PR #733 is merged on main as post-merge checklist/state continuity sync for the completed Phase 10.7 lane.
 
 [IN PROGRESS]
-- Phase 10.9 Priority 2 security baseline hardening is implemented on source lane `feature/security-phase10-9-baseline-hardening-20260423` with secret redaction hardening + explicit operator-key route protection for `/beta/admin`, `/beta/mode`, `/beta/autotrade`, `/beta/kill`, and `/beta/risk`; SENTINEL validation is required before merge decision.
+- Phase 10.9 Priority 2 security baseline hardening is implemented on source lane `feature/security-phase10-9-baseline-hardening-20260423` with secret redaction hardening (including Telegram backend helper exception/response sanitization) + explicit operator-key route protection for `/beta/admin`, `/beta/mode`, `/beta/autotrade`, `/beta/kill`, and `/beta/risk`; SENTINEL validation is required before merge decision.
 - Python Sentry runtime integration lane validated by SENTINEL on PR #700 is currently BLOCKED pending deploy-environment evidence: Fly `SENTRY_DSN` secret presence proof, reachable `/health` + `/ready`, and at least one confirmed Sentry event receipt (`projects/polymarket/polyquantbot/reports/sentinel/sentry_01_python-runtime-validation-pr700.md`).
 
 [NOT STARTED]

--- a/projects/polymarket/polyquantbot/client/telegram/backend_client.py
+++ b/projects/polymarket/polyquantbot/client/telegram/backend_client.py
@@ -11,6 +11,16 @@ import structlog
 log = structlog.get_logger(__name__)
 
 SUPPORTED_CLIENT_TYPES: frozenset[str] = frozenset({"telegram", "web"})
+_SENSITIVE_ERROR_MARKERS: tuple[str, ...] = (
+    "token",
+    "secret",
+    "password",
+    "dsn",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+)
 
 HandoffOutcome = Literal["issued", "rejected", "error"]
 TelegramIdentityOutcome = Literal["resolved", "not_found", "error"]
@@ -106,6 +116,17 @@ class CrusaderBackendClient:
             else {}
         )
 
+    def _sanitize_error_detail(self, detail: str) -> str:
+        raw = (detail or "").strip()
+        if not raw:
+            return "backend_runtime_error"
+        lowered = raw.lower()
+        if any(marker in lowered for marker in _SENSITIVE_ERROR_MARKERS):
+            return "sensitive_runtime_error_redacted"
+        if len(raw) > 240:
+            return f"{raw[:240]}..."
+        return raw
+
     async def request_handoff(self, request: BackendHandoffRequest) -> BackendHandoffResult:
         """Call POST /auth/handoff and return a typed outcome.
 
@@ -143,14 +164,15 @@ class CrusaderBackendClient:
             ) as http_client:
                 resp = await http_client.post("/auth/handoff", json=payload)
         except Exception as exc:
+            safe_detail = self._sanitize_error_detail(str(exc))
             log.error(
                 "crusaderbot_backend_handoff_http_error",
                 client_type=request.client_type,
-                error=str(exc),
+                error=safe_detail,
             )
             return BackendHandoffResult(
                 outcome="error",
-                detail=f"backend call failed: {exc}",
+                detail=f"backend call failed: {safe_detail}",
             )
 
         if resp.status_code == 200:
@@ -162,7 +184,7 @@ class CrusaderBackendClient:
             log.info(
                 "crusaderbot_backend_handoff_issued",
                 client_type=request.client_type,
-                session_id=session_id,
+                session_id_present=bool(session_id),
             )
             return BackendHandoffResult(outcome="issued", session_id=session_id)
 
@@ -171,16 +193,17 @@ class CrusaderBackendClient:
             detail = resp.json().get("detail", "")
         except Exception:
             detail = resp.text or f"http {resp.status_code}"
+        safe_detail = self._sanitize_error_detail(detail)
 
         log.warning(
             "crusaderbot_backend_handoff_rejected",
             client_type=request.client_type,
             status_code=resp.status_code,
-            detail=detail,
+            detail=safe_detail,
         )
         return BackendHandoffResult(
             outcome="rejected" if resp.status_code < 500 else "error",
-            detail=detail,
+            detail=safe_detail,
         )
 
     async def resolve_telegram_identity(
@@ -204,10 +227,11 @@ class CrusaderBackendClient:
                     params={"tenant_id": self._identity_tenant_id},
                 )
         except Exception as exc:
+            safe_detail = self._sanitize_error_detail(str(exc))
             log.error(
                 "crusaderbot_backend_identity_resolve_http_error",
                 telegram_user_id=telegram_user_id,
-                error=str(exc),
+                error=safe_detail,
             )
             return TelegramIdentityResolution(outcome="error")
 
@@ -254,12 +278,13 @@ class CrusaderBackendClient:
             ) as http_client:
                 resp = await http_client.post("/auth/telegram-onboarding/start", json=payload)
         except Exception as exc:
+            safe_detail = self._sanitize_error_detail(str(exc))
             log.error(
                 "crusaderbot_backend_onboarding_http_error",
                 telegram_user_id=telegram_user_id,
-                error=str(exc),
+                error=safe_detail,
             )
-            return TelegramOnboardingResult(outcome="error", detail=str(exc))
+            return TelegramOnboardingResult(outcome="error", detail=safe_detail)
 
         if resp.status_code == 200:
             try:
@@ -279,9 +304,10 @@ class CrusaderBackendClient:
             detail = str(resp.json().get("detail", ""))
         except Exception:
             detail = resp.text or f"http {resp.status_code}"
+        safe_detail = self._sanitize_error_detail(detail)
         return TelegramOnboardingResult(
             outcome="error" if resp.status_code >= 500 else "rejected",
-            detail=detail,
+            detail=safe_detail,
         )
 
     async def confirm_telegram_activation(
@@ -306,12 +332,13 @@ class CrusaderBackendClient:
             ) as http_client:
                 resp = await http_client.post("/auth/telegram-onboarding/confirm", json=payload)
         except Exception as exc:
+            safe_detail = self._sanitize_error_detail(str(exc))
             log.error(
                 "crusaderbot_backend_activation_http_error",
                 telegram_user_id=telegram_user_id,
-                error=str(exc),
+                error=safe_detail,
             )
-            return TelegramActivationResult(outcome="error", detail=str(exc))
+            return TelegramActivationResult(outcome="error", detail=safe_detail)
 
         if resp.status_code == 200:
             try:
@@ -331,9 +358,10 @@ class CrusaderBackendClient:
             detail = str(resp.json().get("detail", ""))
         except Exception:
             detail = resp.text or f"http {resp.status_code}"
+        safe_detail = self._sanitize_error_detail(detail)
         return TelegramActivationResult(
             outcome="error" if resp.status_code >= 500 else "rejected",
-            detail=detail,
+            detail=safe_detail,
         )
 
     async def issue_telegram_session(
@@ -363,12 +391,13 @@ class CrusaderBackendClient:
                     "/auth/telegram-onboarding/session-issue", json=payload
                 )
         except Exception as exc:
+            safe_detail = self._sanitize_error_detail(str(exc))
             log.error(
                 "crusaderbot_backend_session_issuance_http_error",
                 telegram_user_id=telegram_user_id,
-                error=str(exc),
+                error=safe_detail,
             )
-            return TelegramSessionIssuanceResult(outcome="error", detail=str(exc))
+            return TelegramSessionIssuanceResult(outcome="error", detail=safe_detail)
 
         if resp.status_code == 200:
             try:
@@ -392,9 +421,10 @@ class CrusaderBackendClient:
             detail = str(resp.json().get("detail", ""))
         except Exception:
             detail = resp.text or f"http {resp.status_code}"
+        safe_detail = self._sanitize_error_detail(detail)
         return TelegramSessionIssuanceResult(
             outcome="error" if resp.status_code >= 500 else "rejected",
-            detail=detail,
+            detail=safe_detail,
         )
 
     async def beta_get(self, path: str, params: dict[str, object] | None = None) -> dict[str, object]:
@@ -411,7 +441,7 @@ class CrusaderBackendClient:
                 return payload if isinstance(payload, dict) else {"ok": False, "detail": "invalid_payload"}
             return {"ok": False, "detail": f"http_{resp.status_code}"}
         except Exception as exc:
-            return {"ok": False, "detail": str(exc)}
+            return {"ok": False, "detail": self._sanitize_error_detail(str(exc))}
 
     async def beta_post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
         """Write helper for beta control plane endpoints."""
@@ -427,4 +457,4 @@ class CrusaderBackendClient:
                 return body if isinstance(body, dict) else {"ok": False, "detail": "invalid_payload"}
             return {"ok": False, "detail": f"http_{resp.status_code}"}
         except Exception as exc:
-            return {"ok": False, "detail": str(exc)}
+            return {"ok": False, "detail": self._sanitize_error_detail(str(exc))}

--- a/projects/polymarket/polyquantbot/client/telegram/backend_client.py
+++ b/projects/polymarket/polyquantbot/client/telegram/backend_client.py
@@ -116,8 +116,13 @@ class CrusaderBackendClient:
             else {}
         )
 
-    def _sanitize_error_detail(self, detail: str) -> str:
-        raw = (detail or "").strip()
+    def _sanitize_error_detail(self, detail: object) -> str:
+        if detail is None:
+            raw = ""
+        elif isinstance(detail, str):
+            raw = detail.strip()
+        else:
+            raw = str(detail).strip()
         if not raw:
             return "backend_runtime_error"
         lowered = raw.lower()

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
@@ -1,7 +1,7 @@
 # FORGE-X Report — phase10-9_01_security-baseline-hardening
 
-- Timestamp: 2026-04-23 18:47 (Asia/Jakarta)
-- Branch: feature/security-phase10-9-baseline-hardening-20260423
+- Timestamp: 2026-04-23 18:55 (Asia/Jakarta)
+- Branch: feature/harden-security-baseline-for-phase-10.9
 - Scope lane: Priority 2 Phase 10.9 security baseline hardening over control-plane runtime surfaces
 
 ## 1) What was built
@@ -43,7 +43,10 @@
 - Unauthorized calls return deterministic 403 behavior with stable denial detail values.
 - `/ready` continues to avoid raw secret leakage while preserving bounded error categories/references.
 - Runtime error persistence/logging now redacts secret-like strings before state/log exposure.
-- Targeted security baseline tests pass for guarded-route behavior and payload boundary checks.
+- Dependency-complete evidence (executed):
+  - `python3 -m py_compile projects/polymarket/polyquantbot/client/telegram/backend_client.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` (pass)
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` → `33 passed in 3.86s`
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` → `22 passed in 0.37s`
 
 ## 5) Known issues
 - Python Sentry runtime integration lane remains externally blocked pending deploy-environment proof (`SENTRY_DSN` secret presence proof, `/health` + `/ready` reachability, event receipt confirmation).
@@ -55,4 +58,4 @@ Validation Tier   : MAJOR
 Claim Level       : NARROW INTEGRATION
 Validation Target : control-plane security baseline over active public-safe and operator-only runtime surfaces
 Not in Scope      : broad platform security certification, production-capital readiness, live-trading authority, wallet lifecycle expansion, strategy logic
-Suggested Next    : SENTINEL validation on branch `feature/security-phase10-9-baseline-hardening-20260423`
+Suggested Next    : SENTINEL validation on branch `feature/harden-security-baseline-for-phase-10.9`

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
@@ -1,6 +1,6 @@
 # FORGE-X Report — phase10-9_01_security-baseline-hardening
 
-- Timestamp: 2026-04-23 18:55 (Asia/Jakarta)
+- Timestamp: 2026-04-23 19:14 (Asia/Jakarta)
 - Branch: feature/harden-security-baseline-for-phase-10.9
 - Scope lane: Priority 2 Phase 10.9 security baseline hardening over control-plane runtime surfaces
 
@@ -11,6 +11,7 @@
 - Added operator-key header propagation for Telegram backend beta helper calls so operator-only surfaces remain reachable only under configured key.
 - Added and updated targeted tests for protected-route denial behavior and public-safe payload non-exposure boundaries.
 - Hardened Telegram backend helper error surfaces by redacting secret-like exception details before operator-facing response payloads and runtime logs.
+- Hardened sanitizer type-safety by allowing non-string backend `detail` inputs to be normalized safely before redaction checks (prevents `.strip()` AttributeError risk on rejected-response paths).
 
 ## 2) Current system architecture (relevant slice)
 - Public-safe control/read surfaces:
@@ -45,8 +46,8 @@
 - Runtime error persistence/logging now redacts secret-like strings before state/log exposure.
 - Dependency-complete evidence (executed):
   - `python3 -m py_compile projects/polymarket/polyquantbot/client/telegram/backend_client.py projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` (pass)
-  - `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` → `33 passed in 3.86s`
-  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` → `22 passed in 0.37s`
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py` → `33 passed in 3.68s`
+  - `pytest -q projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py` → `23 passed in 0.45s`
 
 ## 5) Known issues
 - Python Sentry runtime integration lane remains externally blocked pending deploy-environment proof (`SENTRY_DSN` secret presence proof, `/health` + `/ready` reachability, event receipt confirmation).

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md
@@ -1,6 +1,6 @@
 # FORGE-X Report — phase10-9_01_security-baseline-hardening
 
-- Timestamp: 2026-04-23 17:57 (Asia/Jakarta)
+- Timestamp: 2026-04-23 18:47 (Asia/Jakarta)
 - Branch: feature/security-phase10-9-baseline-hardening-20260423
 - Scope lane: Priority 2 Phase 10.9 security baseline hardening over control-plane runtime surfaces
 
@@ -10,6 +10,7 @@
 - Hardened runtime error handling by sanitizing secret-like error strings before storing/logging dependency and runtime error surfaces.
 - Added operator-key header propagation for Telegram backend beta helper calls so operator-only surfaces remain reachable only under configured key.
 - Added and updated targeted tests for protected-route denial behavior and public-safe payload non-exposure boundaries.
+- Hardened Telegram backend helper error surfaces by redacting secret-like exception details before operator-facing response payloads and runtime logs.
 
 ## 2) Current system architecture (relevant slice)
 - Public-safe control/read surfaces:
@@ -32,6 +33,7 @@
 - `projects/polymarket/polyquantbot/client/telegram/backend_client.py`
 - `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`
 - `projects/polymarket/polyquantbot/tests/test_phase8_8_public_paper_beta_exit_criteria_20260420.py`
+- `projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py`
 - `projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md`
 - `PROJECT_STATE.md`
 - `ROADMAP.md`

--- a/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
+++ b/projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py
@@ -183,6 +183,44 @@ def test_beta_sensitive_routes_reject_when_operator_key_not_configured(monkeypat
     assert admin_response.json()["detail"] == "operator_route_disabled_missing_operator_api_key"
 
 
+@pytest.mark.parametrize(
+    ("method", "route", "payload"),
+    [
+        ("get", "/beta/admin", None),
+        ("post", "/beta/mode", {"mode": "paper"}),
+        ("post", "/beta/autotrade", {"enabled": True}),
+        ("post", "/beta/kill", None),
+        ("get", "/beta/risk", None),
+    ],
+)
+def test_beta_sensitive_routes_reject_invalid_operator_key(monkeypatch, method: str, route: str, payload) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("CRUSADER_OPERATOR_API_KEY", "operator-test-key")
+    app = create_app()
+    with TestClient(app) as client:
+        if method == "post":
+            response = client.post(route, json=payload, headers={"X-Operator-Api-Key": "wrong-key"})
+        else:
+            response = client.get(route, headers={"X-Operator-Api-Key": "wrong-key"})
+    assert response.status_code == 403
+    assert response.json()["detail"] == "operator_route_forbidden_invalid_operator_api_key"
+
+
+def test_beta_status_payload_does_not_expose_operator_api_key_value(monkeypatch) -> None:
+    monkeypatch.setenv("PORT", "8080")
+    monkeypatch.setenv("TRADING_MODE", "PAPER")
+    monkeypatch.setenv("CRUSADER_OPERATOR_API_KEY", "super-secret-operator-key")
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/beta/status")
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = str(payload).lower()
+    assert "super-secret-operator-key" not in serialized
+    assert "operator_api_key" not in serialized
+
+
 def test_ready_route_reports_readiness_semantics(monkeypatch) -> None:
     monkeypatch.setenv("PORT", "8080")
     monkeypatch.setenv("TRADING_MODE", "PAPER")

--- a/projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from projects.polymarket.polyquantbot.client.telegram.backend_client import (
+    BackendHandoffRequest,
     CrusaderBackendClient,
     TelegramIdentityResolution,
 )
@@ -268,6 +269,47 @@ def test_backend_client_resolve_telegram_identity_empty_id() -> None:
     resolution = asyncio.get_event_loop().run_until_complete(run())
 
     assert resolution.outcome == "error"
+
+
+def test_backend_client_beta_get_redacts_secret_like_exception_detail() -> None:
+    client = CrusaderBackendClient(base_url="http://localhost:8080")
+
+    async def run() -> dict[str, object]:
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.get = AsyncMock(side_effect=RuntimeError("Authorization bearer secret-token-value"))
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_http
+            return await client.beta_get("/beta/admin")
+
+    payload = asyncio.get_event_loop().run_until_complete(run())
+    assert payload["ok"] is False
+    assert payload["detail"] == "sensitive_runtime_error_redacted"
+
+
+def test_backend_client_request_handoff_redacts_secret_like_exception_detail() -> None:
+    client = CrusaderBackendClient(base_url="http://localhost:8080")
+    request = BackendHandoffRequest(
+        client_type="telegram",
+        client_identity_claim="tg_12345678",
+        tenant_id="t1",
+        user_id="usr_abc",
+    )
+
+    async def run():
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(side_effect=RuntimeError("DB_DSN=postgres://user:pass@host/db"))
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_http
+            return await client.request_handoff(request)
+
+    result = asyncio.get_event_loop().run_until_complete(run())
+    assert result.outcome == "error"
+    assert "sensitive_runtime_error_redacted" in result.detail
+    assert "postgres://user:pass@host/db" not in result.detail
 
 
 # ---------------------------------------------------------------------------

--- a/projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py
+++ b/projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py
@@ -312,6 +312,33 @@ def test_backend_client_request_handoff_redacts_secret_like_exception_detail() -
     assert "postgres://user:pass@host/db" not in result.detail
 
 
+def test_backend_client_request_handoff_handles_non_string_rejected_detail() -> None:
+    client = CrusaderBackendClient(base_url="http://localhost:8080")
+    request = BackendHandoffRequest(
+        client_type="telegram",
+        client_identity_claim="tg_12345678",
+        tenant_id="t1",
+        user_id="usr_abc",
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.json.return_value = {"detail": {"error": "not_authorized", "code": 403}}
+
+    async def run():
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_http
+            return await client.request_handoff(request)
+
+    result = asyncio.get_event_loop().run_until_complete(run())
+    assert result.outcome == "rejected"
+    assert "not_authorized" in result.detail
+    assert "403" in result.detail
+
+
 # ---------------------------------------------------------------------------
 # TelegramPollingLoop with identity resolver tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Harden the Phase 10.9 control-plane security baseline to prevent secret exposure in operator-facing payloads and logs and to ensure admin/sensitive beta routes are protected by an explicit operator key. 
- Ensure deterministic denial semantics for protected routes and add tests that verify public-safe payloads do not leak operator-only secrets. 

### Description
- Added centralized secret-like sanitization in `CrusaderBackendClient` by introducing `_SENSITIVE_ERROR_MARKERS` and `_sanitize_error_detail` to redact sensitive tokens in exception messages and HTTP response details. 
- Replaced noisy session logging with a presence-only signal (`session_id_present`) and sanitized logged error details to avoid raw secret leakage in logs and operator responses. 
- Expanded runtime-surface tests by adding `test_beta_sensitive_routes_reject_invalid_operator_key` and `test_beta_status_payload_does_not_expose_operator_api_key_value` in `projects/polymarket/polyquantbot/tests/test_crusader_runtime_surface.py`. 
- Added targeted backend-client tests `test_backend_client_beta_get_redacts_secret_like_exception_detail` and `test_backend_client_request_handoff_redacts_secret_like_exception_detail` in `projects/polymarket/polyquantbot/tests/test_phase8_10_telegram_identity_20260419.py`. 
- Updated FORGE report `projects/polymarket/polyquantbot/reports/forge/phase10-9_01_security-baseline-hardening.md` and bumped `PROJECT_STATE.md` `Last Updated` timestamp and in-progress wording for the Phase 10.9 lane. 

### Testing
- `python3 -m py_compile` was run against the touched files (`projects/polymarket/polyquantbot/client/telegram/backend_client.py` and the modified tests) and passed. 
- A full `pytest -q` invocation including the updated suites failed collection due to missing environment dependency (`ModuleNotFoundError: No module named 'pydantic'`) in this runner. 
- A focused `pytest -q` selection for the added route tests was attempted but skipped in this environment due to missing FastAPI runtime deps, so the new tests could not be exercised end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea06847f2c8325b8ff2afa096025ba)