### PR TITLE
Deployment hardening: align Dockerfile & fly.toml, update operator docs and state

### DIFF
--- a/projects/polymarket/polyquantbot/Dockerfile
+++ b/projects/polymarket/polyquantbot/Dockerfile
@@ -15,16 +15,20 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
+
 COPY --from=builder /install /usr/local
 COPY . /app
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
-ENV PORT=8080
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+# Authoritative container aliveness contract.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
   CMD python -c "import os, sys, urllib.request
 url = 'http://127.0.0.1:' + os.environ.get('PORT', '8080') + '/health'
 status = 1

--- a/projects/polymarket/polyquantbot/docs/fly_runtime_troubleshooting.md
+++ b/projects/polymarket/polyquantbot/docs/fly_runtime_troubleshooting.md
@@ -1,58 +1,70 @@
 # Fly Runtime Troubleshooting (Operator Quick Guide)
 
-## A) Machine restart loops
+## A) Startup contract quick-check
+
+Expected deployment contract:
+- entrypoint = `python -m projects.polymarket.polyquantbot.scripts.run_api`
+- startup/alive check = `GET /health`
+- readiness check = `GET /ready`
+- single polling machine (`min_machines_running=1`, `max_machines_running=1`)
+
+If observed behavior differs, treat as deployment contract drift.
+
+## B) Machine restart loops
 
 Symptoms:
 - App repeatedly starts/stops.
 - Health checks flap or fail.
 
 Checks:
-1. `fly status` for machine lifecycle churn.
-2. `fly logs` for startup exceptions and crash loops.
-3. Confirm required env is present before repeated restarts.
+1. `fly status -a crusaderbot` for machine churn.
+2. `fly logs -a crusaderbot` for startup exceptions/crash loops.
+3. Confirm required env exists before repeated restarts.
 
 Actions:
 - Use **restart** for transient runtime hangs.
-- Use **redeploy** when config/image/code drift is suspected.
+- Use **rollback** if issue began after a known bad release.
+- Use **redeploy** when code/config/image drift is suspected.
 
-## B) Wrong startup path
+## C) Wrong startup path
 
 Symptoms:
-- Runtime starts but expected API/Telegram services never become healthy.
+- Runtime boots but API/Telegram services never become healthy.
 
 Checks:
-1. Inspect launch command/entrypoint from deploy logs.
-2. Confirm app starts intended module/process path.
-3. Validate `/health` vs `/ready` output after boot.
+1. Inspect deploy logs for launch command.
+2. Confirm runtime module path matches deployment contract.
+3. Validate `/health` and `/ready` after boot.
 
-## C) Health/ready mismatch
+## D) Health/ready mismatch
 
 Pattern:
-- `/health` returns OK but `/ready` remains degraded.
+- `/health` is OK but `/ready` is degraded.
 
 Interpretation:
-- Process is alive, but dependencies/runtime integrations are not fully ready.
+- Process is alive, but runtime dependencies are not operationally ready.
 
 First checks:
-1. Telegram polling startup logs.
+1. Telegram startup logs.
 2. Runtime env expectations (without exposing secrets).
 3. Recent deploy/restart timeline.
 
-## D) Single-machine polling requirement for Telegram
+## E) Restart vs rollback vs redeploy
 
-- Polling mode should run on a single active machine to avoid polling conflicts (e.g., duplicate consumers / 409 conflicts).
-- If scaling/restart operations accidentally create overlap, reduce to one active polling runtime and re-check logs.
+- **Restart**: same release, fast recovery attempt.
+- **Rollback**: return to last known-good release.
+- **Redeploy**: new release cycle for code/config/image updates.
 
-## E) Restart vs redeploy distinction
+Rollback commands:
+1. `fly releases -a crusaderbot`
+2. `fly releases rollback <RELEASE_ID> -a crusaderbot`
 
-- **Restart**: same build/config, quick recovery attempt.
-- **Redeploy**: new release cycle (code/config/image), use when startup path/config drift is likely.
+## F) Post-action smoke tests
 
-## F) What to read first in Fly logs
+Run after restart, rollback, or redeploy:
+1. `curl -fsS https://crusaderbot.fly.dev/health`
+2. `curl -fsS https://crusaderbot.fly.dev/ready`
+3. `fly logs -a crusaderbot | grep -E "crusaderbot_telegram_runtime_started|crusaderbot_runtime_transition"`
+4. Verify Telegram `/start`, `/help`, `/status` responses.
 
-Prioritize, in order:
-1. Process boot line (entrypoint/module confirmation).
-2. Runtime init lines (API startup, monitor/runtime guards).
-3. Telegram polling/session lines.
-4. Exception traces around startup window.
-5. Readiness-related warnings/errors.
+Only declare recovery complete when all four checks pass.

--- a/projects/polymarket/polyquantbot/docs/operator_runbook.md
+++ b/projects/polymarket/polyquantbot/docs/operator_runbook.md
@@ -5,85 +5,64 @@
 - Public-ready **paper beta** posture is active.
 - Runtime is paper-only; no live-trading claims are allowed.
 - Fly runtime deploys a **single API machine** with embedded Telegram polling startup in the same process lifecycle.
-- Sentry integration is landed in code; first-event proof can still require runtime verification.
+- Deployment contract is defined by `projects/polymarket/polyquantbot/Dockerfile` + `projects/polymarket/polyquantbot/fly.toml`.
 - Product is **not** live-trading ready and **not** production-capital ready.
 
-## 2) Restart policy truth (Fly deployment contract)
+## 2) Authoritative deployment/startup contract
 
-- Fly machine count is pinned to one (`min_machines_running=1`, `max_machines_running=1`).
-- `auto_stop_machines="off"` keeps the machine resident instead of scale-to-zero shutdown.
-- Fly health check gates process health on `GET /health`; readiness visibility is provided by `GET /ready`.
-- Expected operator posture: if `/health` fails or startup crashes, Fly restarts the machine; operator still validates readiness and Telegram startup logs after restart.
+- Container entrypoint: `python -m projects.polymarket.polyquantbot.scripts.run_api`.
+- Container aliveness contract: Docker `HEALTHCHECK` calls `GET /health` on `127.0.0.1:$PORT`.
+- Fly machine contract:
+  - single machine pinned (`min_machines_running=1`, `max_machines_running=1`),
+  - no scale-to-zero (`auto_stop_machines="off"`),
+  - startup health gate on `GET /health`,
+  - operational readiness gate on `GET /ready`,
+  - deployment strategy `immediate` to avoid overlapping Telegram pollers.
 
-## 3) First checks after any restart/redeploy
+## 3) Restart policy truth (operator-facing)
 
-1. Root endpoint (`/`) for service reachability.
-2. `/health` for process-level health.
-3. `/ready` for dependency/runtime readiness (including Telegram runtime truth).
-4. Telegram baseline commands: `/start`, `/help`, `/status`.
-5. Fly logs for startup, polling, and error signals.
+- Restart expectation: Fly restarts the machine when process/aliveness checks fail.
+- Operator expectation after any restart:
+  1. Re-check `/health`.
+  2. Re-check `/ready`.
+  3. Verify Telegram runtime startup logs.
+  4. Verify Telegram baseline commands still respond.
 
-## 4) Interpreting `/health`
-
-- Use `/health` as a **process/aliveness** signal.
-- Expected operator interpretation:
-  - `200 OK` means app process is up and responding.
-  - Non-200/timeouts mean runtime incident; check Fly machine state + logs immediately.
-- Do not treat `/health` alone as full runtime readiness.
-
-## 5) Interpreting `/ready`
-
-- Use `/ready` as **operational readiness** signal.
-- Expected operator interpretation:
-  - `ready=true` (or equivalent all-green state) means runtime dependencies are currently in expected state.
-  - Degraded/not-ready means runtime may answer HTTP but is not operationally ready.
-- `/ready` should be checked together with logs and Telegram command behavior.
-
-## 6) Rollback procedure truth (bounded)
+## 4) Rollback procedure truth (bounded)
 
 Use rollback when a new deploy regresses `/health`, `/ready`, or Telegram startup visibility.
 
-1. Identify last known good release:
+1. Identify the last known-good release:
    - `fly releases -a crusaderbot`
 2. Roll back to that release:
    - `fly releases rollback <RELEASE_ID> -a crusaderbot`
-3. Re-run post-deploy smoke checks (Section 7) before declaring restored service.
-4. Record rollback reason and failing signal (`/health`, `/ready`, or Telegram startup evidence) in task/report continuity.
+3. Run post-deploy smoke tests (Section 5).
+4. Record rollback cause and failed signals (`/health`, `/ready`, startup logs, command behavior).
 
-## 7) Post-deploy smoke test (public-safe baseline)
+## 5) Post-deploy smoke test contract
 
-Run immediately after deploy or rollback:
+Run immediately after deploy/restart/rollback:
 
 1. `curl -fsS https://crusaderbot.fly.dev/health`
 2. `curl -fsS https://crusaderbot.fly.dev/ready`
 3. `fly logs -a crusaderbot | grep -E "crusaderbot_telegram_runtime_started|crusaderbot_runtime_transition"`
-4. Baseline command sanity in Telegram chat: `/start`, `/help`, `/status`
+4. Telegram command checks: `/start`, `/help`, `/status`
 
 Pass condition (bounded scope):
-- `/health` returns success.
-- `/ready` returns operational readiness payload.
-- Logs show runtime startup transition and Telegram runtime startup visibility.
-- Telegram baseline commands return non-empty public-safe responses.
+- `/health` returns success,
+- `/ready` returns ready payload,
+- startup/transition logs are present,
+- baseline Telegram commands return non-empty public-safe replies.
 
-## 8) Paper-only boundary (operational meaning)
+## 6) Readiness interpretation rules
 
-Paper-only means:
+- `/health` confirms process aliveness only.
+- `/ready` confirms runtime/dependency readiness.
+- Do not declare recovery complete from `/health` alone.
 
-- No real-money order execution.
-- No production-capital exposure claims.
-- Public messaging must keep paper-beta limitations explicit.
-- Any capital/live-trading wording escalation requires a separate validated lane.
+## 7) Paper-only boundary (operational meaning)
 
-## 9) Public-safe claim boundaries
-
-Safe to claim publicly now:
-
-- Public-ready paper beta posture.
-- Runtime endpoints and Telegram baseline command availability (when currently verified).
-- Paper-only boundary and non-production readiness posture.
-
-Not safe to claim publicly:
-
-- Live-trading readiness.
-- Production-capital readiness.
-- Guaranteed uptime/performance beyond verified evidence window.
+- No real-money order execution claims.
+- No production-capital readiness claims.
+- Public messaging remains paper-only.
+- Any capital/live-trading claim escalation requires a separate validated lane.

--- a/projects/polymarket/polyquantbot/fly.toml
+++ b/projects/polymarket/polyquantbot/fly.toml
@@ -6,6 +6,10 @@ primary_region = "iad"
 
 [build]
 
+[deploy]
+  # Single-machine polling contract: avoid overlapping Telegram pollers.
+  strategy = "immediate"
+
 [env]
   CRUSADER_TELEGRAM_RUNTIME_REQUIRED = "true"
 
@@ -19,7 +23,7 @@ primary_region = "iad"
   processes = ["app"]
 
   [[http_service.checks]]
-    grace_period = "30s"
+    grace_period = "45s"
     interval = "30s"
     method = "GET"
     timeout = "5s"

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-10_02_deployment-hardening-contract-closure.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-10_02_deployment-hardening-contract-closure.md
@@ -1,8 +1,8 @@
 # FORGE REPORT — Phase 10.10 Deployment Hardening Contract Closure
 
 ## Metadata
-- Timestamp (Asia/Jakarta): 2026-04-24 08:25
-- Branch: unverified
+- Timestamp (Asia/Jakarta): 2026-04-24 09:12
+- Branch: NWAP/deployment-hardening-traceability-repair
 - Validation Tier: MAJOR
 - Claim Level: NARROW INTEGRATION
 - Validation target: deployment/startup/health/readiness/restart/rollback/smoke-test contract only
@@ -24,7 +24,7 @@
 3. Operator docs synchronized:
    - Restart policy truth, rollback command path, and post-deploy smoke-test contract now explicit and bounded.
 4. State truth synchronized:
-   - Closed all open Deployment Hardening checklist items and Priority 2 done condition in `WORKTODO.md`.
+   - Closed Deployment Hardening implementation checklist items in `WORKTODO.md` while keeping Priority 2 done-condition gate pending MAJOR validation.
    - Updated `PROJECT_STATE.md` active-lane wording to closure-ready state pending MAJOR validation path.
    - Added change trail entry in `CHANGELOG.md`.
 

--- a/projects/polymarket/polyquantbot/reports/forge/phase10-10_02_deployment-hardening-contract-closure.md
+++ b/projects/polymarket/polyquantbot/reports/forge/phase10-10_02_deployment-hardening-contract-closure.md
@@ -1,0 +1,37 @@
+# FORGE REPORT — Phase 10.10 Deployment Hardening Contract Closure
+
+## Metadata
+- Timestamp (Asia/Jakarta): 2026-04-24 08:25
+- Branch: unverified
+- Validation Tier: MAJOR
+- Claim Level: NARROW INTEGRATION
+- Validation target: deployment/startup/health/readiness/restart/rollback/smoke-test contract only
+
+## Scope
+- `projects/polymarket/polyquantbot/Dockerfile`
+- `projects/polymarket/polyquantbot/fly.toml`
+- `projects/polymarket/polyquantbot/docs/operator_runbook.md`
+- `projects/polymarket/polyquantbot/docs/fly_runtime_troubleshooting.md`
+- State/report sync files under `projects/polymarket/polyquantbot/state/` and `projects/polymarket/polyquantbot/reports/forge/`
+
+## Exact changes
+1. Dockerfile hardened as authoritative runtime contract:
+   - Explicit runtime env defaults (`PYTHONDONTWRITEBYTECODE`, `PYTHONUNBUFFERED`, `PORT`).
+   - Healthcheck start period aligned to deploy readiness window and bound to `/health` aliveness contract.
+2. `fly.toml` synchronized with deployment contract:
+   - Added `[deploy] strategy = "immediate"` to avoid overlapping Telegram pollers in single-machine mode.
+   - Kept pinned single-machine runtime and `/health` + `/ready` check split.
+3. Operator docs synchronized:
+   - Restart policy truth, rollback command path, and post-deploy smoke-test contract now explicit and bounded.
+4. State truth synchronized:
+   - Closed all open Deployment Hardening checklist items and Priority 2 done condition in `WORKTODO.md`.
+   - Updated `PROJECT_STATE.md` active-lane wording to closure-ready state pending MAJOR validation path.
+   - Added change trail entry in `CHANGELOG.md`.
+
+## Validation run (FORGE-X local)
+- `python3 -m py_compile projects/polymarket/polyquantbot/scripts/run_api.py`
+- `python3 -m py_compile projects/polymarket/polyquantbot/server/main.py`
+
+## Outcome
+- Deployment Hardening contract closure is complete at repo-truth level for the scoped deploy/startup/health/readiness/restart/rollback/smoke-test boundary.
+- SENTINEL MAJOR validation remains required before merge decision.

--- a/projects/polymarket/polyquantbot/state/CHANGELOG.md
+++ b/projects/polymarket/polyquantbot/state/CHANGELOG.md
@@ -6,4 +6,4 @@
 
 2026-04-24 07:00 | NWAP/repo-structure-state-migration | State files migrated from repo root and work_checklist.md to projects/polymarket/polyquantbot/state/ (PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, CHANGELOG.md); HTML files and docs updated to new paths.
 
-2026-04-24 08:25 | unverified | Deployment Hardening lane truth-sync: aligned Dockerfile + fly.toml deploy contract, updated operator restart/rollback/smoke-test documentation, and closed Priority 2 Deployment Hardening checklist items in WORKTODO/PROJECT_STATE.
+2026-04-24 09:12 | NWAP/deployment-hardening-traceability-repair | Deployment Hardening traceability+closure-wording repair: replaced unverified branch markers, kept implementation-sync complete wording, and reopened Priority 2 done-condition gate pending SENTINEL MAJOR validation.

--- a/projects/polymarket/polyquantbot/state/CHANGELOG.md
+++ b/projects/polymarket/polyquantbot/state/CHANGELOG.md
@@ -5,3 +5,5 @@
 ---
 
 2026-04-24 07:00 | NWAP/repo-structure-state-migration | State files migrated from repo root and work_checklist.md to projects/polymarket/polyquantbot/state/ (PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, CHANGELOG.md); HTML files and docs updated to new paths.
+
+2026-04-24 08:25 | unverified | Deployment Hardening lane truth-sync: aligned Dockerfile + fly.toml deploy contract, updated operator restart/rollback/smoke-test documentation, and closed Priority 2 Deployment Hardening checklist items in WORKTODO/PROJECT_STATE.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-24 07:00
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, PR #741, PR #742, and PR #752 are merged-main truth; state files migrated to projects/polymarket/polyquantbot/state/ and Deployment Hardening is the active next Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
+Last Updated : 2026-04-24 08:25
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, PR #741, PR #742, and PR #752 are merged-main truth; Deployment Hardening deploy contract sync (Dockerfile + fly.toml + operator docs) is now closed in repo truth and Priority 2 done condition is marked closed (paper-only boundary preserved, no live-trading or production-capital claim).
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on feature/consolidate-telegram-ui-ux-layer: active Telegram source of truth remains projects/polymarket/polyquantbot/telegram, deprecated interface/telegram/__init__.py legacy marker is archived under projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/, and only thin compatibility shims remain under projects/polymarket/polyquantbot/interface/telegram/view_handler.py + projects/polymarket/polyquantbot/interface/ui_formatter.py + projects/polymarket/polyquantbot/interface/telegram/__init__.py.
@@ -13,7 +13,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - repo-structure-state-migration lane: state files (PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, CHANGELOG.md) migrated to projects/polymarket/polyquantbot/state/; HTML files (docs/project_monitor.html, docs/crusaderbot_blueprint.html) and docs updated. Branch: NWAP/repo-structure-state-migration.
 
 [IN PROGRESS]
-- Deployment Hardening (Priority 2 lane) — active per projects/polymarket/polyquantbot/state/WORKTODO.md.
+- Deployment Hardening (Priority 2 lane) — implementation lane closed in repo truth; awaits COMMANDER review + MAJOR validation flow.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation.
@@ -22,7 +22,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 
 [NEXT PRIORITY]
 - COMMANDER review for NWAP/repo-structure-state-migration (Validation Tier: STANDARD).
-- Continue Deployment Hardening lane from projects/polymarket/polyquantbot/state/WORKTODO.md after merge.
+- Run MAJOR validation path for Deployment Hardening (deployment/startup/health/readiness/restart/rollback/smoke-test contract scope only).
 
 [KNOWN ISSUES]
 - None

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-24 08:25
-Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, PR #741, PR #742, and PR #752 are merged-main truth; Deployment Hardening deploy contract sync (Dockerfile + fly.toml + operator docs) is now closed in repo truth and Priority 2 done condition is marked closed (paper-only boundary preserved, no live-trading or production-capital claim).
+Last Updated : 2026-04-24 09:12
+Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, PR #741, PR #742, and PR #752 are merged-main truth; Deployment Hardening deploy contract sync (Dockerfile + fly.toml + operator docs) is implementation-complete in repo truth and now awaits SENTINEL MAJOR validation gate before any Priority 2 done-claim wording (paper-only boundary preserved, no live-trading or production-capital claim).
 
 [COMPLETED]
 - Telegram UI/UX consolidation archival cleanup lane is completed on feature/consolidate-telegram-ui-ux-layer: active Telegram source of truth remains projects/polymarket/polyquantbot/telegram, deprecated interface/telegram/__init__.py legacy marker is archived under projects/polymarket/polyquantbot/archive/deprecated/interface/telegram_legacy_20260421/, and only thin compatibility shims remain under projects/polymarket/polyquantbot/interface/telegram/view_handler.py + projects/polymarket/polyquantbot/interface/ui_formatter.py + projects/polymarket/polyquantbot/interface/telegram/__init__.py.
@@ -13,7 +13,7 @@ Status       : Phase 9.1 + 9.2 + 9.3 public-ready paper beta path remains comple
 - repo-structure-state-migration lane: state files (PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, CHANGELOG.md) migrated to projects/polymarket/polyquantbot/state/; HTML files (docs/project_monitor.html, docs/crusaderbot_blueprint.html) and docs updated. Branch: NWAP/repo-structure-state-migration.
 
 [IN PROGRESS]
-- Deployment Hardening (Priority 2 lane) — implementation lane closed in repo truth; awaits COMMANDER review + MAJOR validation flow.
+- Deployment Hardening (Priority 2 lane) — implementation sync complete on branch NWAP/deployment-hardening-traceability-repair; awaiting SENTINEL MAJOR validation gate.
 
 [NOT STARTED]
 - Full wallet lifecycle implementation.

--- a/projects/polymarket/polyquantbot/state/ROADMAP.md
+++ b/projects/polymarket/polyquantbot/state/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and PR #742 Phase 10.9 Priority 2 security baseline hardening now has final SENTINEL APPROVED gate; Deployment Hardening is the active next Priority 2 lane (paper-only boundary preserved, no live-trading or production-capital claim).
-**Last Updated:** 2026-04-24 03:48
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and PR #742 Phase 10.9 Priority 2 security baseline hardening now has final SENTINEL APPROVED gate; Deployment Hardening implementation sync is closed in repo truth and now awaits MAJOR validation gate (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-24 08:25
 
 # Board Overview
 
@@ -59,7 +59,7 @@
 - PR #733 is merged on main as post-merge work-checklist continuity sync for completed Phase 10.7 truth.
 - Phase 10.8 logging/monitoring hardening is closed as merged-main truth (PR #734 / #736 / #737).
 - Phase 10.9 security baseline hardening is closed with final SENTINEL APPROVED gate for PR #742 (59-pass targeted rerun evidence and exact branch-truth sync recorded in `projects/polymarket/polyquantbot/reports/sentinel/phase10-9_01_pr742-security-baseline-hardening-validation.md`).
-- Deployment Hardening is now the active Priority 2 lane per `projects/polymarket/polyquantbot/state/WORKTODO.md`.
+- Deployment Hardening implementation sync is complete in repo truth; MAJOR validation gate remains required before merge decision.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/state/WORKTODO.md](projects/polymarket/polyquantbot/state/WORKTODO.md).

--- a/projects/polymarket/polyquantbot/state/ROADMAP.md
+++ b/projects/polymarket/polyquantbot/state/ROADMAP.md
@@ -23,8 +23,8 @@
 
 **Description:** Non-custodial Polymarket trading platform — multi-user, closed beta first.  
 **Tech Stack:** Python · FastAPI · PostgreSQL · Redis · Polymarket CLOB API · WebSocket · Polygon · Telegram Bot · Fly.io  
-**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and PR #742 Phase 10.9 Priority 2 security baseline hardening now has final SENTINEL APPROVED gate; Deployment Hardening implementation sync is closed in repo truth and now awaits MAJOR validation gate (paper-only boundary preserved, no live-trading or production-capital claim).
-**Last Updated:** 2026-04-24 08:25
+**Status:** Public-ready paper beta path (Phase 9.1/9.2/9.3) is complete on main; PR #725, PR #726, PR #727, PR #728, PR #729, PR #730, PR #731, PR #732, PR #733, PR #734, PR #736, PR #737, and PR #741 are merged-main truth, and PR #742 Phase 10.9 Priority 2 security baseline hardening now has final SENTINEL APPROVED gate; Deployment Hardening implementation sync on `NWAP/deployment-hardening-traceability-repair` is complete in repo truth and now awaits SENTINEL MAJOR validation gate (paper-only boundary preserved, no live-trading or production-capital claim).
+**Last Updated:** 2026-04-24 09:12
 
 # Board Overview
 
@@ -59,7 +59,7 @@
 - PR #733 is merged on main as post-merge work-checklist continuity sync for completed Phase 10.7 truth.
 - Phase 10.8 logging/monitoring hardening is closed as merged-main truth (PR #734 / #736 / #737).
 - Phase 10.9 security baseline hardening is closed with final SENTINEL APPROVED gate for PR #742 (59-pass targeted rerun evidence and exact branch-truth sync recorded in `projects/polymarket/polyquantbot/reports/sentinel/phase10-9_01_pr742-security-baseline-hardening-validation.md`).
-- Deployment Hardening implementation sync is complete in repo truth; MAJOR validation gate remains required before merge decision.
+- Deployment Hardening implementation sync is complete on `NWAP/deployment-hardening-traceability-repair`; SENTINEL MAJOR validation gate remains required before merge decision.
 
 ### Execution Tracking Source
 - Detailed checklist, priority ordering, and right-now operational tasks live at: [projects/polymarket/polyquantbot/state/WORKTODO.md](projects/polymarket/polyquantbot/state/WORKTODO.md).

--- a/projects/polymarket/polyquantbot/state/WORKTODO.md
+++ b/projects/polymarket/polyquantbot/state/WORKTODO.md
@@ -99,7 +99,7 @@ Current truth (2026-04-22 02:31 Asia/Jakarta): live baseline command proof now e
 
 Finish this after the public bot baseline works.
 
-### Status Snapshot (2026-04-24 03:48 Asia/Jakarta)
+### Status Snapshot (2026-04-24 08:25 Asia/Jakarta)
 
 #### MERGED ON MAIN
 
@@ -120,15 +120,15 @@ Finish this after the public bot baseline works.
 
 Deployment Hardening lane
 
-- [ ] Clean up the Dockerfile
-- [ ] Keep `fly.toml` in sync
-- [ ] Define restart policy clearly
-- [ ] Define rollback strategy clearly
-- [ ] Define post-deploy smoke tests clearly
+- [x] Clean up the Dockerfile
+- [x] Keep `fly.toml` in sync
+- [x] Define restart policy clearly
+- [x] Define rollback strategy clearly
+- [x] Define post-deploy smoke tests clearly
 
 #### NEXT
 
-- [ ] Close Priority 2 done condition after deployment lane is merged
+- [x] Close Priority 2 done condition after deployment lane is merged
 
 ### 9. Supabase / Postgres Integration Hardening
 
@@ -184,15 +184,15 @@ Deployment Hardening lane
 
 ### 16. Deployment Hardening
 
-- [ ] Clean up the Dockerfile
-- [ ] Keep `fly.toml` in sync
-- [ ] Define restart policy clearly
-- [ ] Define rollback strategy clearly
-- [ ] Define post-deploy smoke tests clearly
+- [x] Clean up the Dockerfile
+- [x] Keep `fly.toml` in sync
+- [x] Define restart policy clearly
+- [x] Define rollback strategy clearly
+- [x] Define post-deploy smoke tests clearly
 
 ### Done Condition
 
-- [ ] The bot is not just running, but stable and persistent
+- [x] The bot is not just running, but stable and persistent
 
 ---
 

--- a/projects/polymarket/polyquantbot/state/WORKTODO.md
+++ b/projects/polymarket/polyquantbot/state/WORKTODO.md
@@ -99,7 +99,7 @@ Current truth (2026-04-22 02:31 Asia/Jakarta): live baseline command proof now e
 
 Finish this after the public bot baseline works.
 
-### Status Snapshot (2026-04-24 08:25 Asia/Jakarta)
+### Status Snapshot (2026-04-24 09:12 Asia/Jakarta)
 
 #### MERGED ON MAIN
 
@@ -128,7 +128,7 @@ Deployment Hardening lane
 
 #### NEXT
 
-- [x] Close Priority 2 done condition after deployment lane is merged
+- [ ] Close Priority 2 done condition after Deployment Hardening passes SENTINEL MAJOR validation
 
 ### 9. Supabase / Postgres Integration Hardening
 
@@ -192,7 +192,7 @@ Deployment Hardening lane
 
 ### Done Condition
 
-- [x] The bot is not just running, but stable and persistent
+- [ ] The bot is not just running, but stable and persistent
 
 ---
 


### PR DESCRIPTION
### Superseded
This PR is superseded by PR #759.

### Why this PR was closed
- The original head branch `nwap/close-deployment-hardening-items` could not satisfy authoritative `NWAP/...` branch-format requirements cleanly while preserving exact repo-truth traceability.
- Remaining blockers (Dockerfile `HEALTHCHECK` syntax risk and stale Fly rollback guidance) were repaired on the authoritative replacement branch `NWAP/deployment-hardening-traceability-repair`.
- PR #759 is now the sole intended merge candidate for the Deployment Hardening lane and the only PR that should proceed to SENTINEL MAJOR validation.

### Replacement PR
- #759 — Deployment hardening total fix: authoritative branch, safe Dockerfile, Fly rollback docs