### PR TITLE
Gate 1b: FastAPI settlement operator routes (§47)

### DIFF
--- a/projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md
+++ b/projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md
@@ -1,0 +1,134 @@
+# settlement-operator-routes — Priority 7 Forge Report
+
+## Validation Metadata
+
+- Branch: WARP/settlement-operator-routes
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `server/services/settlement_operator_service.py`, `server/api/settlement_operator_routes.py` — HTTP operator console exposure for settlement status, retry status, failed batches, and admin intervention (§47 Gate 1b)
+- Not in Scope: Live DB integration test against real PostgreSQL, Telegram wiring (Gate 1c), batch result persistence (batch persistence lane deferred)
+- Suggested Next Step: WARP🔹CMD review before merge; Gate 1c Telegram wiring after this is merged
+
+---
+
+## 1. What Was Built
+
+Gate 1b exposes the `OperatorConsole` (built in PR #777) via HTTP. The `OperatorConsole` is data-injected — it needs data loaded from `SettlementPersistence` before its methods can be called. The service layer bridges these two components.
+
+**`SettlementOperatorService`** (`server/services/settlement_operator_service.py`):
+- Constructor: takes `persistence: SettlementPersistence` + `console: OperatorConsole`
+- `get_settlement_status(workflow_id)` → loads events via `persistence.load_events_for_workflow()`, loads retry history via `persistence.load_retry_history()`, reconstructs `SettlementWorkflowResult` from events via `_build_result_from_events()`, calls `console.get_settlement_status()` → `SettlementStatusView`
+- `get_retry_status(workflow_id)` → loads retry history, calls `console.get_retry_status()` with default `RetryPolicy()` → `RetryStatusView`
+- `get_failed_batches()` → calls `console.get_failed_batches([])` (batch results not persisted in current persistence layer; returns empty list)
+- `apply_admin_intervention(intervention)` → loads events, reconstructs result, calls `console.apply_admin_intervention()`; returns `None` when workflow has no events (404 at route layer)
+- `_build_result_from_events()`: maps latest event type to workflow status string; infers `success`, `completed_at`, `blocked_reason` from event payload
+- All methods log structured events via `structlog`; exceptions propagate (no silent swallow)
+
+**`build_settlement_operator_router()`** (`server/api/settlement_operator_routes.py`):
+- 4 routes under `/admin/settlement/` — mirrors `build_orchestration_router()` pattern exactly
+- Auth: `SETTLEMENT_ADMIN_TOKEN` env var via `X-Settlement-Admin-Token` header; `_check_admin()` raises 403 on missing/wrong token
+- Service access: `getattr(request.app.state, "settlement_operator_service", None)` → 503 when not wired
+- `AdminInterventionBody` Pydantic model for POST body (maps to frozen `AdminInterventionRequest` dataclass)
+- `_serializable()` helper: converts frozen dataclasses + datetime fields to JSON-safe dicts recursively
+- Mutation route (`POST /intervene`): returns 404 when service returns `None` (workflow not found); exceptions → 500
+
+**`server/main.py` wiring** (lifespan, after P6C orchestration block):
+- `SettlementPersistence(db=state.db_client)` instantiated
+- `SettlementAlertPolicy()` + `OperatorConsole(alert_policy=...)` instantiated
+- `SettlementOperatorService(persistence=..., console=...)` → `app.state.settlement_operator_service`
+- `build_settlement_operator_router()` registered via `app.include_router()`
+
+---
+
+## 2. Current System Architecture
+
+```
+[Telegram] (Gate 1c — not yet built)
+        │
+        ▼
+[FastAPI] /admin/settlement/*  — settlement_operator_routes.py
+        │  auth: SETTLEMENT_ADMIN_TOKEN / X-Settlement-Admin-Token
+        │  503 when not wired; 403 on auth fail; 404 workflow not found; 500 on exception
+        ▼
+SettlementOperatorService
+        │
+        ├── SettlementPersistence.load_events_for_workflow()
+        │       → list[SettlementEvent]  (from settlement_events table)
+        │
+        ├── SettlementPersistence.load_retry_history()
+        │       → list[RetryAttemptRecord]  (from settlement_retry_history table)
+        │
+        ├── _build_result_from_events()
+        │       → SettlementWorkflowResult | None
+        │
+        └── OperatorConsole
+                ├── get_settlement_status()  → SettlementStatusView
+                ├── get_retry_status()       → RetryStatusView
+                ├── get_failed_batches()     → Sequence[FailedBatchView]  (always [] — batch persistence deferred)
+                └── apply_admin_intervention() → AdminInterventionResult
+
+[PostgreSQL]
+  settlement_events              — event log (DDL: migration 001, database.py)
+  settlement_retry_history       — retry attempts (DDL: migration 001, database.py)
+  settlement_reconciliation_results — recon state (DDL: migration 001, database.py)
+```
+
+---
+
+## 3. Files Created / Modified (full repo-root paths)
+
+**Created:**
+```
+projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
+projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
+projects/polymarket/polyquantbot/tests/test_settlement_p7_operator_routes.py
+projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md
+```
+
+**Modified:**
+```
+projects/polymarket/polyquantbot/server/main.py
+projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+projects/polymarket/polyquantbot/state/WORKTODO.md
+projects/polymarket/polyquantbot/state/CHANGELOG.md
+```
+
+---
+
+## 4. What Is Working
+
+- All 9 Gate 1b tests pass: ST-39..ST-47 (9/9)
+- `GET /admin/settlement/status/{workflow_id}` → 403 (no/wrong token), 503 (not wired), 200 + SettlementStatusView JSON shape
+- `GET /admin/settlement/retry/{workflow_id}` → 403 (no/wrong token), 503 (not wired), 200 + RetryStatusView JSON shape
+- `GET /admin/settlement/failed-batches` → 200 + list (empty until batch persistence built)
+- `POST /admin/settlement/intervene` → 200 + AdminInterventionResult; 404 when workflow not found; 403 on bad token; 503 not wired
+- `_serializable()` correctly converts frozen dataclasses and `datetime` fields to JSON-safe output
+- `SettlementOperatorService` correctly propagates exceptions (no silent failures)
+- `_build_result_from_events()`: returns `None` for empty event list (triggers NOT_FOUND console path); maps all 7 event types to status strings
+- `server/main.py`: settlement operator service wired in lifespan with correct dependency order (after DB connects); router registered
+
+---
+
+## 5. Known Issues
+
+- `get_failed_batches()` always returns `[]` — batch results (`SettlementBatchResult`) are not persisted in the current persistence layer; a dedicated batch persistence lane would be required to populate this endpoint
+- `apply_admin_intervention()` does not persist the intervention record — per the existing `OperatorConsole` known issue (documented in PROJECT_STATE.md): service layer callers must handle persistence explicitly; intervention effect is in-memory/logging only
+- `SettlementOperatorService` uses `SettlementPersistence.load_events_for_workflow()` which returns `[]` on DB error (fail-safe read), meaning a DB failure silently appears as workflow NOT_FOUND rather than a 500; this is the existing persistence contract and is acceptable for operator console reads
+
+---
+
+## 6. What Is Next
+
+- Gate 1c: Telegram wiring for settlement status commands (`/settlement_status`, `/retry_status`, `/failed_batches`) on branch `WARP/settlement-telegram-wiring` — depends on this PR being merged
+- After Gate 1c merged: all three P7 deferred items (§47, §48, settlement DDL) will be complete
+- Priority 8: Production-capital readiness gating (requires full SENTINEL MAJOR sweep after P8 lanes built)
+
+---
+
+## Metadata
+
+- **Validation Tier:** STANDARD
+- **Claim Level:** NARROW INTEGRATION (service + routes over existing persistence/console; no new infra)
+- **Validation Target:** §47 HTTP operator route exposure — SettlementOperatorService + 4 FastAPI routes + server/main.py wiring (ST-39..ST-47)
+- **Not in Scope:** Live DB, batch persistence, Telegram wiring, full SENTINEL pre-public sweep
+- **Suggested Next Step:** WARP🔹CMD review; Gate 1c after merge

--- a/projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md
+++ b/projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md
@@ -29,7 +29,7 @@ Gate 1b exposes the `OperatorConsole` (built in PR #777) via HTTP. The `Operator
 - Auth: `SETTLEMENT_ADMIN_TOKEN` env var via `X-Settlement-Admin-Token` header; `_check_admin()` raises 403 on missing/wrong token
 - Service access: `getattr(request.app.state, "settlement_operator_service", None)` → 503 when not wired
 - `AdminInterventionBody` Pydantic model for POST body (maps to frozen `AdminInterventionRequest` dataclass)
-- `_serializable()` helper: converts frozen dataclasses + datetime fields to JSON-safe dicts recursively
+- JSON serialization uses FastAPI `jsonable_encoder(...)` for dataclasses and datetime fields
 - Mutation route (`POST /intervene`): returns 404 when service returns `None` (workflow not found); exceptions → 500
 
 **`server/main.py` wiring** (lifespan, after P6C orchestration block):
@@ -102,7 +102,7 @@ projects/polymarket/polyquantbot/state/CHANGELOG.md
 - `GET /admin/settlement/retry/{workflow_id}` → 403 (no/wrong token), 503 (not wired), 200 + RetryStatusView JSON shape
 - `GET /admin/settlement/failed-batches` → 200 + list (empty until batch persistence built)
 - `POST /admin/settlement/intervene` → 200 + AdminInterventionResult; 404 when workflow not found; 403 on bad token; 503 not wired
-- `_serializable()` correctly converts frozen dataclasses and `datetime` fields to JSON-safe output
+- `jsonable_encoder(...)` correctly converts dataclasses and `datetime` fields to JSON-safe output
 - `SettlementOperatorService` correctly propagates exceptions (no silent failures)
 - `_build_result_from_events()`: returns `None` for empty event list (triggers NOT_FOUND console path); maps all 7 event types to status strings
 - `server/main.py`: settlement operator service wired in lifespan with correct dependency order (after DB connects); router registered

--- a/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
-from server.settlement.schemas import AdminInterventionRequest
+from projects.polymarket.polyquantbot.server.settlement.schemas import AdminInterventionRequest
 
 log = structlog.get_logger(__name__)
 

--- a/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import os
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from server.settlement.schemas import AdminInterventionRequest
+
+log = structlog.get_logger(__name__)
+
+
+class AdminInterventionBody(BaseModel):
+    workflow_id: str
+    action: str
+    admin_user_id: str
+    reason: str
+
+
+def _serializable(obj: Any) -> Any:
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return _serializable(dataclasses.asdict(obj))
+    if isinstance(obj, dict):
+        return {k: _serializable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_serializable(v) for v in obj]
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    return obj
+
+
+def build_settlement_operator_router() -> APIRouter:
+    router = APIRouter(prefix="/admin/settlement", tags=["settlement-admin"])
+
+    def _check_admin(request: Request) -> None:
+        token = request.headers.get("X-Settlement-Admin-Token", "")
+        expected = os.environ.get("SETTLEMENT_ADMIN_TOKEN", "")
+        if not expected or token != expected:
+            raise HTTPException(status_code=403, detail="forbidden")
+
+    @router.get("/status/{workflow_id}")
+    async def get_settlement_status(
+        workflow_id: str,
+        request: Request,
+        _: None = Depends(_check_admin),
+    ) -> dict:
+        svc = getattr(request.app.state, "settlement_operator_service", None)
+        if svc is None:
+            raise HTTPException(
+                status_code=503, detail="settlement_operator_service_not_ready"
+            )
+        try:
+            result = await svc.get_settlement_status(workflow_id)
+            return {"ok": True, "data": _serializable(result)}
+        except Exception as exc:
+            log.exception("settlement_status_route_error", workflow_id=workflow_id)
+            raise HTTPException(status_code=500, detail="settlement_status_error") from exc
+
+    @router.get("/retry/{workflow_id}")
+    async def get_retry_status(
+        workflow_id: str,
+        request: Request,
+        _: None = Depends(_check_admin),
+    ) -> dict:
+        svc = getattr(request.app.state, "settlement_operator_service", None)
+        if svc is None:
+            raise HTTPException(
+                status_code=503, detail="settlement_operator_service_not_ready"
+            )
+        try:
+            result = await svc.get_retry_status(workflow_id)
+            return {"ok": True, "data": _serializable(result)}
+        except Exception as exc:
+            log.exception("settlement_retry_route_error", workflow_id=workflow_id)
+            raise HTTPException(status_code=500, detail="settlement_retry_error") from exc
+
+    @router.get("/failed-batches")
+    async def get_failed_batches(
+        request: Request,
+        _: None = Depends(_check_admin),
+    ) -> dict:
+        svc = getattr(request.app.state, "settlement_operator_service", None)
+        if svc is None:
+            raise HTTPException(
+                status_code=503, detail="settlement_operator_service_not_ready"
+            )
+        try:
+            result = await svc.get_failed_batches()
+            return {"ok": True, "data": _serializable(list(result))}
+        except Exception as exc:
+            log.exception("settlement_failed_batches_route_error")
+            raise HTTPException(status_code=500, detail="settlement_failed_batches_error") from exc
+
+    @router.post("/intervene")
+    async def apply_admin_intervention(
+        body: AdminInterventionBody,
+        request: Request,
+        _: None = Depends(_check_admin),
+    ) -> dict:
+        svc = getattr(request.app.state, "settlement_operator_service", None)
+        if svc is None:
+            raise HTTPException(
+                status_code=503, detail="settlement_operator_service_not_ready"
+            )
+        try:
+            intervention = AdminInterventionRequest(
+                workflow_id=body.workflow_id,
+                action=body.action,
+                admin_user_id=body.admin_user_id,
+                reason=body.reason,
+            )
+            result = await svc.apply_admin_intervention(intervention)
+            if result is None:
+                raise HTTPException(
+                    status_code=404, detail="workflow_not_found"
+                )
+            return {"ok": True, "data": _serializable(result)}
+        except HTTPException:
+            raise
+        except Exception as exc:
+            log.exception(
+                "settlement_intervene_route_error",
+                workflow_id=body.workflow_id,
+                action=body.action,
+            )
+            raise HTTPException(status_code=500, detail="settlement_intervene_error") from exc
+
+    return router

--- a/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/settlement_operator_routes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import dataclasses
-import datetime
 import os
+import secrets
 from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
 from server.settlement.schemas import AdminInterventionRequest
@@ -21,25 +21,13 @@ class AdminInterventionBody(BaseModel):
     reason: str
 
 
-def _serializable(obj: Any) -> Any:
-    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        return _serializable(dataclasses.asdict(obj))
-    if isinstance(obj, dict):
-        return {k: _serializable(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_serializable(v) for v in obj]
-    if isinstance(obj, datetime.datetime):
-        return obj.isoformat()
-    return obj
-
-
 def build_settlement_operator_router() -> APIRouter:
     router = APIRouter(prefix="/admin/settlement", tags=["settlement-admin"])
 
     def _check_admin(request: Request) -> None:
         token = request.headers.get("X-Settlement-Admin-Token", "")
         expected = os.environ.get("SETTLEMENT_ADMIN_TOKEN", "")
-        if not expected or token != expected:
+        if not expected or not secrets.compare_digest(token, expected):
             raise HTTPException(status_code=403, detail="forbidden")
 
     @router.get("/status/{workflow_id}")
@@ -55,7 +43,7 @@ def build_settlement_operator_router() -> APIRouter:
             )
         try:
             result = await svc.get_settlement_status(workflow_id)
-            return {"ok": True, "data": _serializable(result)}
+            return {"ok": True, "data": jsonable_encoder(result)}
         except Exception as exc:
             log.exception("settlement_status_route_error", workflow_id=workflow_id)
             raise HTTPException(status_code=500, detail="settlement_status_error") from exc
@@ -73,7 +61,7 @@ def build_settlement_operator_router() -> APIRouter:
             )
         try:
             result = await svc.get_retry_status(workflow_id)
-            return {"ok": True, "data": _serializable(result)}
+            return {"ok": True, "data": jsonable_encoder(result)}
         except Exception as exc:
             log.exception("settlement_retry_route_error", workflow_id=workflow_id)
             raise HTTPException(status_code=500, detail="settlement_retry_error") from exc
@@ -90,7 +78,7 @@ def build_settlement_operator_router() -> APIRouter:
             )
         try:
             result = await svc.get_failed_batches()
-            return {"ok": True, "data": _serializable(list(result))}
+            return {"ok": True, "data": jsonable_encoder(list(result))}
         except Exception as exc:
             log.exception("settlement_failed_batches_route_error")
             raise HTTPException(status_code=500, detail="settlement_failed_batches_error") from exc
@@ -118,7 +106,7 @@ def build_settlement_operator_router() -> APIRouter:
                 raise HTTPException(
                     status_code=404, detail="workflow_not_found"
                 )
-            return {"ok": True, "data": _serializable(result)}
+            return {"ok": True, "data": jsonable_encoder(result)}
         except HTTPException:
             raise
         except Exception as exc:

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -57,6 +57,11 @@ from projects.polymarket.polyquantbot.server.orchestration.decision_store import
 from projects.polymarket.polyquantbot.server.orchestration.wallet_controls import WalletControlsStore
 from projects.polymarket.polyquantbot.server.orchestration.wallet_orchestrator import WalletOrchestrator
 from projects.polymarket.polyquantbot.server.services.orchestration_service import OrchestratorService
+from projects.polymarket.polyquantbot.server.settlement.settlement_persistence import SettlementPersistence
+from projects.polymarket.polyquantbot.server.settlement.settlement_alert_policy import SettlementAlertPolicy
+from projects.polymarket.polyquantbot.server.settlement.operator_console import OperatorConsole
+from projects.polymarket.polyquantbot.server.services.settlement_operator_service import SettlementOperatorService
+from projects.polymarket.polyquantbot.server.api.settlement_operator_routes import build_settlement_operator_router
 from projects.polymarket.polyquantbot.infra.db import DatabaseClient
 
 log = structlog.get_logger(__name__)
@@ -421,6 +426,16 @@ def create_app() -> FastAPI:
                 _app.state.orchestration_service = _orchestration_svc
                 await _orchestration_svc.load_controls_from_db("system", "paper_user")
                 log.info("orchestration_service_wired")
+            # P7: wire settlement operator service after DB is connected
+            if state.db_client is not None:
+                _settlement_persistence = SettlementPersistence(db=state.db_client)
+                _settlement_alert_policy = SettlementAlertPolicy()
+                _operator_console = OperatorConsole(alert_policy=_settlement_alert_policy)
+                _app.state.settlement_operator_service = SettlementOperatorService(
+                    persistence=_settlement_persistence,
+                    console=_operator_console,
+                )
+                log.info("settlement_operator_service_wired")
             try:
                 await _start_telegram_runtime(state=state)
             except Exception as exc:
@@ -521,6 +536,7 @@ def create_app() -> FastAPI:
     app.include_router(build_public_beta_router(falcon=falcon_gateway))
     app.include_router(build_portfolio_router())
     app.include_router(build_orchestration_router())
+    app.include_router(build_settlement_operator_router())
 
     @app.get("/")
     async def root() -> JSONResponse:

--- a/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
+++ b/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
@@ -4,7 +4,7 @@ import asyncio
 import structlog
 from typing import Any, Sequence
 
-from server.settlement.schemas import (
+from projects.polymarket.polyquantbot.server.settlement.schemas import (
     SETTLEMENT_EVENT_CANCELLED,
     SETTLEMENT_EVENT_COMPLETED,
     SETTLEMENT_EVENT_CREATED,
@@ -21,8 +21,8 @@ from server.settlement.schemas import (
     SettlementStatusView,
     SettlementWorkflowResult,
 )
-from server.settlement.operator_console import OperatorConsole
-from server.settlement.settlement_persistence import SettlementPersistence
+from projects.polymarket.polyquantbot.server.settlement.operator_console import OperatorConsole
+from projects.polymarket.polyquantbot.server.settlement.settlement_persistence import SettlementPersistence
 
 log = structlog.get_logger(__name__)
 

--- a/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
+++ b/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import structlog
+from typing import Any, Sequence
+
+from server.settlement.schemas import (
+    SETTLEMENT_EVENT_CANCELLED,
+    SETTLEMENT_EVENT_COMPLETED,
+    SETTLEMENT_EVENT_CREATED,
+    SETTLEMENT_EVENT_FAILED,
+    SETTLEMENT_EVENT_PROCESSING,
+    SETTLEMENT_EVENT_RETRY_ATTEMPT,
+    SETTLEMENT_EVENT_RETRY_QUEUED,
+    AdminInterventionRequest,
+    AdminInterventionResult,
+    FailedBatchView,
+    RetryPolicy,
+    RetryStatusView,
+    SettlementEvent,
+    SettlementStatusView,
+    SettlementWorkflowResult,
+)
+from server.settlement.operator_console import OperatorConsole
+from server.settlement.settlement_persistence import SettlementPersistence
+
+log = structlog.get_logger(__name__)
+
+_EVENT_TYPE_TO_STATUS: dict[str, str] = {
+    SETTLEMENT_EVENT_COMPLETED:    "COMPLETED",
+    SETTLEMENT_EVENT_FAILED:       "FAILED",
+    SETTLEMENT_EVENT_CANCELLED:    "CANCELLED",
+    SETTLEMENT_EVENT_PROCESSING:   "PROCESSING",
+    SETTLEMENT_EVENT_RETRY_QUEUED: "RETRY_QUEUED",
+    SETTLEMENT_EVENT_RETRY_ATTEMPT: "RETRYING",
+    SETTLEMENT_EVENT_CREATED:      "PENDING",
+}
+
+_TERMINAL_STATUSES = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
+
+
+def _build_result_from_events(
+    workflow_id: str,
+    events: list[SettlementEvent],
+) -> SettlementWorkflowResult | None:
+    if not events:
+        return None
+    latest = max(events, key=lambda e: e.occurred_at)
+    status = _EVENT_TYPE_TO_STATUS.get(latest.event_type, "UNKNOWN")
+    success = status == "COMPLETED"
+    completed_at = latest.occurred_at if status in _TERMINAL_STATUSES else None
+    return SettlementWorkflowResult(
+        workflow_id=workflow_id,
+        status=status,
+        success=success,
+        settlement_id=latest.settlement_id,
+        blocked_reason=latest.payload.get("blocked_reason"),
+        completed_at=completed_at,
+    )
+
+
+class SettlementOperatorService:
+    """Service layer: loads from SettlementPersistence, delegates to OperatorConsole."""
+
+    def __init__(
+        self,
+        *,
+        persistence: SettlementPersistence,
+        console: OperatorConsole,
+    ) -> None:
+        self._persistence = persistence
+        self._console = console
+        self._default_retry_policy = RetryPolicy()
+
+    async def get_settlement_status(self, workflow_id: str) -> SettlementStatusView:
+        bound = log.bind(workflow_id=workflow_id)
+        bound.info("settlement_operator_service_status_request")
+        try:
+            events = await self._persistence.load_events_for_workflow(workflow_id)
+            retry_history = await self._persistence.load_retry_history(workflow_id)
+            workflow_result = _build_result_from_events(workflow_id, events)
+            request_created_at = min((e.occurred_at for e in events), default=None)
+            return await self._console.get_settlement_status(
+                workflow_id, workflow_result, retry_history, request_created_at
+            )
+        except Exception:
+            bound.exception("settlement_operator_service_status_error")
+            raise
+
+    async def get_retry_status(self, workflow_id: str) -> RetryStatusView:
+        bound = log.bind(workflow_id=workflow_id)
+        bound.info("settlement_operator_service_retry_request")
+        try:
+            retry_history = await self._persistence.load_retry_history(workflow_id)
+            return await self._console.get_retry_status(
+                workflow_id, retry_history, self._default_retry_policy
+            )
+        except Exception:
+            bound.exception("settlement_operator_service_retry_error")
+            raise
+
+    async def get_failed_batches(self) -> Sequence[FailedBatchView]:
+        # Batch results are not persisted in the current persistence layer;
+        # returns empty until a batch persistence lane is added.
+        log.info("settlement_operator_service_failed_batches_request")
+        return await self._console.get_failed_batches([])
+
+    async def apply_admin_intervention(
+        self,
+        intervention: AdminInterventionRequest,
+    ) -> AdminInterventionResult | None:
+        bound = log.bind(
+            workflow_id=intervention.workflow_id,
+            action=intervention.action,
+        )
+        bound.info("settlement_operator_service_intervention_request")
+        try:
+            events = await self._persistence.load_events_for_workflow(
+                intervention.workflow_id
+            )
+            workflow_result = _build_result_from_events(intervention.workflow_id, events)
+            if workflow_result is None:
+                bound.warning("settlement_operator_service_intervention_not_found")
+                return None
+            return await self._console.apply_admin_intervention(
+                intervention, workflow_result
+            )
+        except Exception:
+            bound.exception("settlement_operator_service_intervention_error")
+            raise

--- a/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
+++ b/projects/polymarket/polyquantbot/server/services/settlement_operator_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import structlog
 from typing import Any, Sequence
 
@@ -75,8 +76,10 @@ class SettlementOperatorService:
         bound = log.bind(workflow_id=workflow_id)
         bound.info("settlement_operator_service_status_request")
         try:
-            events = await self._persistence.load_events_for_workflow(workflow_id)
-            retry_history = await self._persistence.load_retry_history(workflow_id)
+            events, retry_history = await asyncio.gather(
+                self._persistence.load_events_for_workflow(workflow_id),
+                self._persistence.load_retry_history(workflow_id),
+            )
             workflow_result = _build_result_from_events(workflow_id, events)
             request_created_at = min((e.occurred_at for e in events), default=None)
             return await self._console.get_settlement_status(

--- a/projects/polymarket/polyquantbot/state/CHANGELOG.md
+++ b/projects/polymarket/polyquantbot/state/CHANGELOG.md
@@ -37,3 +37,5 @@
 2026-04-27 07:15 | NWAP/p6-phb-post-merge-sync | Priority 6 Phase B merge closure: PR #779 confirmed merged to main on 2026-04-26 21:15 UTC; PROJECT_STATE.md updated -- Phase B moved to COMPLETED, IN PROGRESS updated to SENTINEL gate, NEXT PRIORITY updated to Phase C gate; state drift corrected.
 
 2026-04-27 21:54 | NWAP/rebranding-identity-fix | WalkerMind OS identity rebranding (safe rename only): platform name + agent role labels updated across AGENTS.md, COMMANDER.md, CLAUDE.md, docs/workflow_and_execution_model.md; NWAP/ branch prefix and N.W.A.P protocol name kept unchanged; supersedes PR #782 (held for drift).
+
+2026-04-28 12:00 | WARP/settlement-operator-routes | Gate 1b: SettlementOperatorService + 4 FastAPI routes under /admin/settlement/ (status, retry, failed-batches, intervene); server/main.py wiring (SettlementPersistence + OperatorConsole + SettlementOperatorService); 9/9 tests passing (ST-39..ST-47); Validation Tier: STANDARD.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -17,7 +17,7 @@ Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlemen
 
 [IN PROGRESS]
 - COMMANDER review for PR #781 (Priority 6 Phase C) pending merge decision.
-- Gate 1a DDL migration (WARP/settlement-ddl-migration) — PR #786 open, WARP🔹CMD review pending. Codex P1 timestamp format fix required.
+- Gate 1a DDL migration (WARP/settlement-ddl-migration) — PR #786 open, WARP🔹CMD review pending.
 - Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) — PR open, WARP🔹CMD review pending (STANDARD tier).
 - WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) — WARP🔹CMD review pending. PR #782 held due to drift; replaced by this fix PR.
 - Legacy string cleanup (WARP/cleanup-legacy-refs) — WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP🔹CMD review pending.
@@ -45,6 +45,7 @@ Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlemen
 - Portfolio routes hardcode tenant_id=system and user_id=paper_user -- per-user route binding deferred to full multi-user rollout.
 - Portfolio unrealized PnL relies on current_price in paper_positions -- live mark-to-market deferred to market data integration lane.
 - WalletCandidate financial fields (balance_usd, exposure_pct, drawdown_pct) default to 0.0 -- risk gate thresholds will not trigger in orchestration routing until market data integration is complete.
-- settlement_events, settlement_retry_history, settlement_reconciliation_results auto-create DDL exists in infra/db/database.py but formal migration files not yet created -- required before production-capital gate.
-- OperatorConsole is data-injection ready but not HTTP/Telegram exposed -- Gate 1b and 1c in next phase plan.
+- No migration runner configured -- 001_settlement_tables.sql must be applied manually or via operator tooling; auto-create in _apply_schema() remains the runtime path.
+- OperatorConsole is HTTP-exposed (Gate 1b) but not Telegram-exposed -- Gate 1c in next phase plan.
 - OperatorConsole.apply_admin_intervention() does not persist intervention record -- service layer callers must handle explicitly.
+- get_failed_batches() always returns [] -- batch results not persisted in current settlement persistence layer.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,41 +1,34 @@
-Last Updated : 2026-04-28 13:00
-Status       : Gate 1a DDL migration merged to main (PR #786). Gate 1b FastAPI settlement operator routes built on WARP/settlement-operator-routes — SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP🔹CMD review pending. Gate 1c Telegram wiring not yet started.
+Last Updated : 2026-04-28 15:05
+Status       : Gate 1a DDL migration is merged to main via PR #786. Gate 1b FastAPI settlement operator routes are built on WARP/settlement-operator-routes -- SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP CMD review pending for PR #787. Gate 1c Telegram wiring not yet started.
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
 - Ops handoff pack lane is completed with operator runbook, Fly runtime troubleshooting, Telegram runtime troubleshooting, Sentry quick-check, and reusable runtime evidence checklist under projects/polymarket/polyquantbot/docs/.
 - Phase 10.8 logging/monitoring hardening is closed as merged-main truth via PR #734, PR #736, and PR #737.
 - Phase 10.9 security baseline hardening is closed with final SENTINEL APPROVED gate for PR #742 at projects/polymarket/polyquantbot/reports/sentinel/phase10-9_01_pr742-security-baseline-hardening-validation.md.
-- Deployment Hardening Priority 2 lane is closed via PR #759 with SENTINEL APPROVED 98/100 and zero critical issues.
-- Priority 3 paper trading product completion is merged to main via PR #770 from NWAP/paper-product-core; compact SENTINEL gate record APPROVED 95/100 with zero critical issues.
-- Priority 4 wallet lifecycle foundation is merged to main via PR #772 from NWAP/wallet-lifecycle-foundation; COMMANDER degen structure review accepted and full SENTINEL is deferred to pre-public sweep.
-- Priority 5 portfolio management logic is merged to main via PR #774 from NWAP/portfolio-management-logic; schemas, store, service, 6 routes, and 29/29 tests passing (PM-01..PM-28 + PM-13b); COMMANDER degen structure review accepted and full SENTINEL is deferred to pre-public sweep.
-- Priority 6 multi-wallet orchestration Phase A is merged to main via PR #776 from NWAP/multi-wallet-orchestration; 12/12 tests passing (WO-01..WO-12); risk gate is hard and failover relaxes strategy only.
-- Priority 7 settlement-retry-reconciliation is merged to main via PR #777 from NWAP/settlement-retry-reconciliation; 9 production modules and 66/66 tests passing (ST-01..ST-38c); owner/COMMANDER forge-merge accepted and full SENTINEL/check-all is deferred until all phases/structure are done.
-- Priority 6 Phase B multi-wallet orchestration is merged to main via PR #779 from NWAP/multi-wallet-orchestration; CrossWalletStateAggregator (sections 39), WalletControlsStore + PortfolioControlOverlay + WalletOrchestrator Phase B extension (section 40); 15/15 tests passing (WO-13..WO-27); COMMANDER forge-merge accepted and full SENTINEL is required before Phase C begins.
-- Priority 6 Phase C multi-wallet orchestration built on NWAP/multi-wallet-orchestration-phase-c (sections 41-42); OrchestratorService, OrchestrationDecisionStore, DB-backed WalletControlsStore (atomic persist via asyncpg transaction), 7 FastAPI admin routes (all mutation endpoints surface 500 on persist failure), 5 Telegram admin commands, degraded-mode outcome, wallet_controls + orchestration_decisions DDL, full orchestration package import-path normalization; 24/24 tests passing (WO-28..WO-51); Phase A+B regression 27/27 still passing; COMMANDER review pending for PR #781.
-- Priority 7 Gate 1a DDL migration merged to main via PR #786 from WARP/settlement-ddl-migration; infra/db/migrations/001_settlement_tables.sql documents settlement_events, settlement_retry_history, settlement_reconciliation_results for production deployment auditing.
+- Priority 3 paper trading product completion is merged to main via PR #770; compact SENTINEL gate record APPROVED 95/100 with zero critical issues.
+- Priority 4 wallet lifecycle foundation is merged to main via PR #772; COMMANDER degen structure review accepted and full SENTINEL is deferred to pre-public sweep.
+- Priority 5 portfolio management logic is merged to main via PR #774; 29/29 tests passing (PM-01..PM-28 + PM-13b).
+- Priority 6 Phase A and Phase B multi-wallet orchestration are merged to main via PR #776 and PR #779.
+- Priority 7 settlement-retry-reconciliation is merged to main via PR #777; 66/66 tests passing (ST-01..ST-38c).
+- Gate 1a DDL migration file for settlement tables is merged to main via PR #786 from WARP/settlement-ddl-migration.
 
 [IN PROGRESS]
 - COMMANDER review for PR #781 (Priority 6 Phase C) pending merge decision.
-- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) — PR #787 open, WARP🔹CMD review pending (STANDARD tier).
-- WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) — WARP🔹CMD review pending. PR #782 held due to drift; replaced by this fix PR.
-- Legacy string cleanup (WARP/cleanup-legacy-refs) — WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP🔹CMD review pending.
+- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) -- PR #787 open, WARP CMD review pending (STANDARD tier).
+- WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) -- WARP CMD review pending. PR #782 held due to drift; replaced by this fix PR.
+- Legacy string cleanup (WARP/cleanup-legacy-refs) -- WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
 
 [NOT STARTED]
-- Gate 1c Priority 7 Telegram wiring for settlement/retry/reconciliation commands — WARP/settlement-telegram-wiring. Depends on Gate 1b merge.
-- Priority 8 capital readiness and live trading gating — requires separate SENTINEL MAJOR sweep after P8 lanes are built.
+- Gate 1c Priority 7 Telegram wiring for settlement/retry/reconciliation commands -- WARP/settlement-telegram-wiring. Depends on Gate 1b merge.
+- Priority 8 capital readiness and live trading gating -- requires separate SENTINEL MAJOR sweep after P8 lanes are built.
 - Final public product completion, launch assets, and handoff.
 
 [NEXT PRIORITY]
-- WARP🔹CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. PR #787.
+- WARP CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. Branch: WARP/settlement-operator-routes. PR #787.
 - COMMANDER review and merge decision for PR #781 (Priority 6 Phase C). Source: projects/polymarket/polyquantbot/reports/forge/multi-wallet-orchestration-phase-c.md.
-- WARP🔹CMD review for WalkerMind OS identity rebranding. Source: projects/polymarket/polyquantbot/reports/forge/rebranding-identity-fix.md. Tier: STANDARD. PR #782 superseded.
-- WARP🔹CMD review for legacy string cleanup. Source: projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md. Tier: MINOR. Branch: WARP/cleanup-legacy-refs.
 - After Gate 1b merged: Gate 1c Telegram wiring (WARP/settlement-telegram-wiring).
-- After all Gate 1 lanes merged: Priority 8 capital readiness (chunked per §49-54, each SENTINEL MAJOR).
-- Maintain no public-ready, live-trading-ready, or production-capital-ready claim until Priority 8 SENTINEL MAJOR sweep complete.
 
 [KNOWN ISSUES]
 - PaperBetaWorker.price_updater() is a no-op stub -- unrealized PnL updates require real market price polling (deferred to post-Priority-3 market data integration lane).

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-28 12:00
-Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlement operator routes built on WARP/settlement-operator-routes — SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP🔹CMD review pending. Gate 1c Telegram wiring not yet started.
+Last Updated : 2026-04-28 13:00
+Status       : Gate 1a DDL migration merged to main (PR #786). Gate 1b FastAPI settlement operator routes built on WARP/settlement-operator-routes — SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP🔹CMD review pending. Gate 1c Telegram wiring not yet started.
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
@@ -14,11 +14,11 @@ Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlemen
 - Priority 7 settlement-retry-reconciliation is merged to main via PR #777 from NWAP/settlement-retry-reconciliation; 9 production modules and 66/66 tests passing (ST-01..ST-38c); owner/COMMANDER forge-merge accepted and full SENTINEL/check-all is deferred until all phases/structure are done.
 - Priority 6 Phase B multi-wallet orchestration is merged to main via PR #779 from NWAP/multi-wallet-orchestration; CrossWalletStateAggregator (sections 39), WalletControlsStore + PortfolioControlOverlay + WalletOrchestrator Phase B extension (section 40); 15/15 tests passing (WO-13..WO-27); COMMANDER forge-merge accepted and full SENTINEL is required before Phase C begins.
 - Priority 6 Phase C multi-wallet orchestration built on NWAP/multi-wallet-orchestration-phase-c (sections 41-42); OrchestratorService, OrchestrationDecisionStore, DB-backed WalletControlsStore (atomic persist via asyncpg transaction), 7 FastAPI admin routes (all mutation endpoints surface 500 on persist failure), 5 Telegram admin commands, degraded-mode outcome, wallet_controls + orchestration_decisions DDL, full orchestration package import-path normalization; 24/24 tests passing (WO-28..WO-51); Phase A+B regression 27/27 still passing; COMMANDER review pending for PR #781.
+- Priority 7 Gate 1a DDL migration merged to main via PR #786 from WARP/settlement-ddl-migration; infra/db/migrations/001_settlement_tables.sql documents settlement_events, settlement_retry_history, settlement_reconciliation_results for production deployment auditing.
 
 [IN PROGRESS]
 - COMMANDER review for PR #781 (Priority 6 Phase C) pending merge decision.
-- Gate 1a DDL migration (WARP/settlement-ddl-migration) — PR #786 open, WARP🔹CMD review pending.
-- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) — PR open, WARP🔹CMD review pending (STANDARD tier).
+- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) — PR #787 open, WARP🔹CMD review pending (STANDARD tier).
 - WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) — WARP🔹CMD review pending. PR #782 held due to drift; replaced by this fix PR.
 - Legacy string cleanup (WARP/cleanup-legacy-refs) — WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP🔹CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
@@ -29,8 +29,7 @@ Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlemen
 - Final public product completion, launch assets, and handoff.
 
 [NEXT PRIORITY]
-- WARP🔹CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. Branch: WARP/settlement-operator-routes.
-- WARP🔹CMD review for Gate 1a DDL migration (fix Codex P1 timestamp before merge). Branch: WARP/settlement-ddl-migration. PR #786.
+- WARP🔹CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. PR #787.
 - COMMANDER review and merge decision for PR #781 (Priority 6 Phase C). Source: projects/polymarket/polyquantbot/reports/forge/multi-wallet-orchestration-phase-c.md.
 - WARP🔹CMD review for WalkerMind OS identity rebranding. Source: projects/polymarket/polyquantbot/reports/forge/rebranding-identity-fix.md. Tier: STANDARD. PR #782 superseded.
 - WARP🔹CMD review for legacy string cleanup. Source: projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md. Tier: MINOR. Branch: WARP/cleanup-legacy-refs.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-28 07:02
-Status       : SENTINEL full sweep P4+P5+P6+P7 APPROVED 89/100 on WARP/sentinel-full-sweep — zero critical issues; 171/171 tests pass. Structure-build validation gate closed. COMMANDER review pending for PR #781 (P6 Phase C) before main-branch merge. Gate 1 work (P7 operator routes, Telegram wiring, DDL migration files) not yet started.
+Last Updated : 2026-04-28 12:00
+Status       : Gate 1a DDL migration closed (PR #786). Gate 1b FastAPI settlement operator routes built on WARP/settlement-operator-routes — SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP🔹CMD review pending. Gate 1c Telegram wiring not yet started.
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
@@ -17,24 +17,25 @@ Status       : SENTINEL full sweep P4+P5+P6+P7 APPROVED 89/100 on WARP/sentinel-
 
 [IN PROGRESS]
 - COMMANDER review for PR #781 (Priority 6 Phase C) pending merge decision.
+- Gate 1a DDL migration (WARP/settlement-ddl-migration) — PR #786 open, WARP🔹CMD review pending. Codex P1 timestamp format fix required.
+- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) — PR open, WARP🔹CMD review pending (STANDARD tier).
 - WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) — WARP🔹CMD review pending. PR #782 held due to drift; replaced by this fix PR.
 - Legacy string cleanup (WARP/cleanup-legacy-refs) — WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP🔹CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
 
 [NOT STARTED]
-- Priority 7 FastAPI route exposure for operator console (§47) — WARP/settlement-operator-routes.
-- Priority 7 Telegram wiring for settlement/retry/reconciliation commands — WARP/settlement-telegram-wiring.
-- Priority 7 formal DDL migration files for settlement_events, settlement_retry_history, settlement_reconciliation_results — WARP/settlement-ddl-migration. Note: auto-create DDL already exists in infra/db/database.py _apply_schema().
+- Gate 1c Priority 7 Telegram wiring for settlement/retry/reconciliation commands — WARP/settlement-telegram-wiring. Depends on Gate 1b merge.
 - Priority 8 capital readiness and live trading gating — requires separate SENTINEL MAJOR sweep after P8 lanes are built.
 - Final public product completion, launch assets, and handoff.
 
 [NEXT PRIORITY]
-- SENTINEL structure-build sweep CLOSED: APPROVED 89/100. Source: projects/polymarket/polyquantbot/reports/sentinel/full-sweep.md. Branch: WARP/sentinel-full-sweep.
-- WARP🔹CMD review for legacy string cleanup. Source: projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md. Tier: MINOR. Branch: WARP/cleanup-legacy-refs.
+- WARP🔹CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. Branch: WARP/settlement-operator-routes.
+- WARP🔹CMD review for Gate 1a DDL migration (fix Codex P1 timestamp before merge). Branch: WARP/settlement-ddl-migration. PR #786.
 - COMMANDER review and merge decision for PR #781 (Priority 6 Phase C). Source: projects/polymarket/polyquantbot/reports/forge/multi-wallet-orchestration-phase-c.md.
 - WARP🔹CMD review for WalkerMind OS identity rebranding. Source: projects/polymarket/polyquantbot/reports/forge/rebranding-identity-fix.md. Tier: STANDARD. PR #782 superseded.
-- After Phase C is merged: FORGE-X Gate 1 Priority 7 remaining (WARP/settlement-operator-routes, WARP/settlement-telegram-wiring, WARP/settlement-ddl-migration).
-- After Gate 1 complete: Priority 8 capital readiness (chunked per §49-54, each SENTINEL MAJOR).
+- WARP🔹CMD review for legacy string cleanup. Source: projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md. Tier: MINOR. Branch: WARP/cleanup-legacy-refs.
+- After Gate 1b merged: Gate 1c Telegram wiring (WARP/settlement-telegram-wiring).
+- After all Gate 1 lanes merged: Priority 8 capital readiness (chunked per §49-54, each SENTINEL MAJOR).
 - Maintain no public-ready, live-trading-ready, or production-capital-ready claim until Priority 8 SENTINEL MAJOR sweep complete.
 
 [KNOWN ISSUES]

--- a/projects/polymarket/polyquantbot/state/WORKTODO.md
+++ b/projects/polymarket/polyquantbot/state/WORKTODO.md
@@ -456,7 +456,9 @@ Build this after orchestration is ready.
 - [x] Add critical alerts
 - [x] Add drift alerts
 - [x] Validate all flows
-- [ ] Sync docs after completion (DDL migration + HTTP route wiring deferred)
+- [x] DDL migration files created (Gate 1a — PR #786)
+- [x] HTTP route wiring complete (Gate 1b — WARP/settlement-operator-routes)
+- [ ] Telegram wiring (Gate 1c — WARP/settlement-telegram-wiring)
 
 ### Done Condition
 

--- a/projects/polymarket/polyquantbot/tests/test_settlement_p7_operator_routes.py
+++ b/projects/polymarket/polyquantbot/tests/test_settlement_p7_operator_routes.py
@@ -1,0 +1,251 @@
+"""Priority 7 — Settlement Operator Routes — Tests.
+
+Test IDs: ST-39 .. ST-47
+
+Coverage:
+  ST-39  GET /admin/settlement/status returns 403 on missing token
+  ST-40  GET /admin/settlement/retry returns 403 on wrong token
+  ST-41  GET /admin/settlement/status returns 503 when service not wired
+  ST-42  GET /admin/settlement/retry returns 503 when service not wired
+  ST-43  GET /admin/settlement/status/{id} returns SettlementStatusView shape
+  ST-44  GET /admin/settlement/retry/{id} returns RetryStatusView shape
+  ST-45  GET /admin/settlement/failed-batches returns list
+  ST-46  POST /admin/settlement/intervene returns AdminInterventionResult shape
+  ST-47  POST /admin/settlement/intervene returns 404 when workflow not found
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from projects.polymarket.polyquantbot.server.api.settlement_operator_routes import (
+    build_settlement_operator_router,
+)
+from projects.polymarket.polyquantbot.server.settlement.schemas import (
+    AdminInterventionResult,
+    FailedBatchView,
+    RetryStatusView,
+    SettlementStatusView,
+)
+
+_TOKEN = "test_settlement_token"
+_HEADERS = {"X-Settlement-Admin-Token": _TOKEN}
+
+
+def _utc() -> datetime:
+    return datetime(2026, 4, 28, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_app(svc=None) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_settlement_operator_router())
+    if svc is not None:
+        app.state.settlement_operator_service = svc
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _mock_status_view(workflow_id: str = "wf_001") -> SettlementStatusView:
+    return SettlementStatusView(
+        workflow_id=workflow_id,
+        status="NOT_FOUND",
+        amount=0.0,
+        currency="USD",
+        wallet_id="",
+        mode="paper",
+        retry_attempt_count=0,
+        created_at=_utc(),
+        updated_at=_utc(),
+    )
+
+
+def _mock_retry_view(workflow_id: str = "wf_001") -> RetryStatusView:
+    return RetryStatusView(
+        workflow_id=workflow_id,
+        current_attempt=0,
+        max_attempts=5,
+        last_outcome="none",
+        is_exhausted=False,
+        is_fatal=False,
+    )
+
+
+def _mock_intervention_result(workflow_id: str = "wf_001") -> AdminInterventionResult:
+    return AdminInterventionResult(
+        workflow_id=workflow_id,
+        action="force_cancel",
+        success=True,
+        previous_status="PROCESSING",
+        new_status="CANCELLED",
+    )
+
+
+def _make_svc(**overrides):
+    svc = MagicMock()
+    svc.get_settlement_status = AsyncMock(
+        return_value=overrides.get("status", _mock_status_view())
+    )
+    svc.get_retry_status = AsyncMock(
+        return_value=overrides.get("retry", _mock_retry_view())
+    )
+    svc.get_failed_batches = AsyncMock(
+        return_value=overrides.get("batches", [])
+    )
+    svc.apply_admin_intervention = AsyncMock(
+        return_value=overrides.get("intervention", _mock_intervention_result())
+    )
+    return svc
+
+
+# ── ST-39: 403 on missing token ───────────────────────────────────────────────
+
+def test_st_39_status_requires_token():
+    """ST-39: GET /admin/settlement/status returns 403 when token is absent."""
+    client = _make_app()
+    resp = client.get("/admin/settlement/status/wf_001")
+    assert resp.status_code == 403
+
+
+# ── ST-40: 403 on wrong token ─────────────────────────────────────────────────
+
+def test_st_40_retry_wrong_token_returns_403():
+    """ST-40: GET /admin/settlement/retry returns 403 when token is incorrect."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app()
+        resp = client.get(
+            "/admin/settlement/retry/wf_001",
+            headers={"X-Settlement-Admin-Token": "wrong_token"},
+        )
+    assert resp.status_code == 403
+
+
+# ── ST-41: 503 when service not wired (status) ────────────────────────────────
+
+def test_st_41_status_503_when_not_wired():
+    """ST-41: GET /admin/settlement/status returns 503 when service absent from app.state."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=None)
+        resp = client.get(
+            "/admin/settlement/status/wf_001",
+            headers=_HEADERS,
+        )
+    assert resp.status_code == 503
+
+
+# ── ST-42: 503 when service not wired (retry) ─────────────────────────────────
+
+def test_st_42_retry_503_when_not_wired():
+    """ST-42: GET /admin/settlement/retry returns 503 when service absent from app.state."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=None)
+        resp = client.get(
+            "/admin/settlement/retry/wf_001",
+            headers=_HEADERS,
+        )
+    assert resp.status_code == 503
+
+
+# ── ST-43: Status route returns SettlementStatusView shape ────────────────────
+
+def test_st_43_status_route_returns_view_shape():
+    """ST-43: GET /admin/settlement/status/{id} returns ok=True and view fields."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=_make_svc())
+        resp = client.get(
+            "/admin/settlement/status/wf_001",
+            headers=_HEADERS,
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["workflow_id"] == "wf_001"
+    assert data["status"] == "NOT_FOUND"
+    assert "retry_attempt_count" in data
+    assert "created_at" in data
+
+
+# ── ST-44: Retry route returns RetryStatusView shape ──────────────────────────
+
+def test_st_44_retry_route_returns_view_shape():
+    """ST-44: GET /admin/settlement/retry/{id} returns ok=True and view fields."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=_make_svc())
+        resp = client.get(
+            "/admin/settlement/retry/wf_001",
+            headers=_HEADERS,
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["workflow_id"] == "wf_001"
+    assert data["current_attempt"] == 0
+    assert data["max_attempts"] == 5
+    assert data["is_exhausted"] is False
+
+
+# ── ST-45: Failed-batches returns list ────────────────────────────────────────
+
+def test_st_45_failed_batches_returns_list():
+    """ST-45: GET /admin/settlement/failed-batches returns ok=True with list data."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=_make_svc(batches=[]))
+        resp = client.get(
+            "/admin/settlement/failed-batches",
+            headers=_HEADERS,
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert isinstance(body["data"], list)
+
+
+# ── ST-46: Intervene returns AdminInterventionResult shape ────────────────────
+
+def test_st_46_intervene_returns_result_shape():
+    """ST-46: POST /admin/settlement/intervene returns ok=True and intervention fields."""
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=_make_svc())
+        resp = client.post(
+            "/admin/settlement/intervene",
+            headers=_HEADERS,
+            json={
+                "workflow_id": "wf_001",
+                "action": "force_cancel",
+                "admin_user_id": "op_01",
+                "reason": "test intervention",
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["workflow_id"] == "wf_001"
+    assert data["action"] == "force_cancel"
+    assert data["success"] is True
+
+
+# ── ST-47: Intervene returns 404 when workflow not found ──────────────────────
+
+def test_st_47_intervene_404_when_workflow_not_found():
+    """ST-47: POST /admin/settlement/intervene returns 404 when service returns None."""
+    svc = _make_svc(intervention=None)
+    svc.apply_admin_intervention = AsyncMock(return_value=None)
+    with patch.dict("os.environ", {"SETTLEMENT_ADMIN_TOKEN": _TOKEN}):
+        client = _make_app(svc=svc)
+        resp = client.post(
+            "/admin/settlement/intervene",
+            headers=_HEADERS,
+            json={
+                "workflow_id": "wf_missing",
+                "action": "force_cancel",
+                "admin_user_id": "op_01",
+                "reason": "test",
+            },
+        )
+    assert resp.status_code == 404
+    assert "workflow_not_found" in resp.json().get("detail", "")


### PR DESCRIPTION
## Gate 1b — FastAPI Settlement Operator Routes

**Validation Tier:** STANDARD
**Claim Level:** NARROW INTEGRATION
**Branch:** `WARP/settlement-operator-routes`
**Report:** `projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md`

---

## What Was Built

Exposes the `OperatorConsole` (built in PR #777) via HTTP admin routes. The `OperatorConsole` is data-injected — this PR adds the service layer that loads from `SettlementPersistence` and delegates to console methods.

**`SettlementOperatorService`** (`server/services/settlement_operator_service.py`):
- Wraps `SettlementPersistence` + `OperatorConsole`
- `get_settlement_status(workflow_id)` — loads events + retry history, reconstructs `SettlementWorkflowResult` from event log, calls console
- `get_retry_status(workflow_id)` — loads retry history, calls console with default `RetryPolicy`
- `get_failed_batches()` — returns `[]` (batch results not persisted in current layer; known limitation)
- `apply_admin_intervention(intervention)` — loads events, reconstructs result, calls console; returns `None` if no events (404 at route)

**`build_settlement_operator_router()`** (`server/api/settlement_operator_routes.py`):
- 4 routes under `/admin/settlement/` — mirrors `build_orchestration_router()` pattern
- Auth: `SETTLEMENT_ADMIN_TOKEN` env + `X-Settlement-Admin-Token` header → 403 on fail
- 503 when service not on `app.state`; 404 when workflow not found; 500 on exception

**Routes:**
| Method | Path | Description |
|--------|------|-------------|
| GET | `/admin/settlement/status/{workflow_id}` | SettlementStatusView |
| GET | `/admin/settlement/retry/{workflow_id}` | RetryStatusView |
| GET | `/admin/settlement/failed-batches` | list[FailedBatchView] |
| POST | `/admin/settlement/intervene` | AdminInterventionResult |

**`server/main.py`:** Settlement operator service wired in lifespan (after DB connects, after P6C orchestration block); router registered.

## Tests

9/9 passing — ST-39..ST-47:
- 403 on missing token (status route)
- 403 on wrong token (retry route)
- 503 when service not wired (status + retry)
- Status route returns SettlementStatusView shape
- Retry route returns RetryStatusView shape
- Failed-batches returns list
- Intervene returns AdminInterventionResult
- Intervene returns 404 when workflow not found

## Known Limitations

- `get_failed_batches()` always returns `[]` — batch results are not persisted in the current persistence layer
- `apply_admin_intervention()` does not persist the intervention record (existing known issue; must be handled by caller)

## What Is Next

Gate 1c: Telegram wiring (`/settlement_status`, `/retry_status`, `/failed_batches`) — `WARP/settlement-telegram-wiring` — depends on this PR being merged.

https://claude.ai/code/session_01WefWx8VMKPAtoisxqkwNKz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WefWx8VMKPAtoisxqkwNKz)_