### PR TITLE
Gate 1c: Settlement Telegram wiring — /settlement_status /retry_status /failed_batches /settlement_intervene

### DIFF
--- a/projects/polymarket/polyquantbot/client/telegram/backend_client.py
+++ b/projects/polymarket/polyquantbot/client/telegram/backend_client.py
@@ -505,3 +505,33 @@ class CrusaderBackendClient:
             return {"ok": False, "detail": f"http_{resp.status_code}"}
         except Exception as exc:
             return {"ok": False, "detail": self._sanitize_error_detail(str(exc))}
+
+    # ── Settlement admin helpers (Gate 1c) ────────────────────────────────────
+
+    def _settlement_headers(self) -> dict[str, str]:
+        token = os.getenv("SETTLEMENT_ADMIN_TOKEN", "").strip()
+        return {"X-Settlement-Admin-Token": token} if token else {}
+
+    async def settlement_get(self, path: str) -> dict[str, object]:
+        """Read helper for settlement admin endpoints."""
+        try:
+            async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as http_client:
+                resp = await http_client.get(path, headers=self._settlement_headers())
+            if resp.status_code == 200:
+                body = resp.json()
+                return body if isinstance(body, dict) else {"ok": False, "detail": "invalid_payload"}
+            return {"ok": False, "detail": f"http_{resp.status_code}"}
+        except Exception as exc:
+            return {"ok": False, "detail": self._sanitize_error_detail(str(exc))}
+
+    async def settlement_post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
+        """Write helper for settlement admin endpoints."""
+        try:
+            async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as http_client:
+                resp = await http_client.post(path, json=payload, headers=self._settlement_headers())
+            if resp.status_code == 200:
+                body = resp.json()
+                return body if isinstance(body, dict) else {"ok": False, "detail": "invalid_payload"}
+            return {"ok": False, "detail": f"http_{resp.status_code}"}
+        except Exception as exc:
+            return {"ok": False, "detail": self._sanitize_error_detail(str(exc))}

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -58,6 +58,11 @@ class TelegramDispatcher:
         "/wallet_disable",
         "/halt",
         "/resume",
+        # Gate 1c settlement operator commands
+        "/settlement_status",
+        "/retry_status",
+        "/failed_batches",
+        "/settlement_intervene",
     }
 
     def __init__(self, backend: CrusaderBackendClient, operator_chat_id: str = "") -> None:
@@ -274,6 +279,95 @@ class TelegramDispatcher:
             if data.get("status") == "ok":
                 return DispatchResult(outcome="ok", reply_text="Global halt cleared. Routing resumed.")
             return DispatchResult(outcome="ok", reply_text=f"Resume failed: {data.get('detail', data.get('reason', 'error'))}")
+
+        # ── Gate 1c settlement operator commands ──────────────────────────────
+        if command == "/settlement_status":
+            workflow_id = arg
+            if not workflow_id:
+                return DispatchResult(outcome="ok", reply_text="Usage: /settlement_status <workflow_id>")
+            data = await self._backend.settlement_get(f"/admin/settlement/status/{workflow_id}")
+            if not data.get("ok"):
+                return DispatchResult(outcome="ok", reply_text=f"Settlement status: unavailable — {data.get('detail', 'error')}")
+            d = data.get("data", {})
+            return DispatchResult(
+                outcome="ok",
+                reply_text=(
+                    f"Settlement status: {workflow_id}\n"
+                    f"• Status: {d.get('status', 'unknown')}\n"
+                    f"• Retry attempts: {d.get('retry_attempt_count', 0)}\n"
+                    f"• Amount: {d.get('amount', 0.0)} {d.get('currency', '')}\n"
+                    f"• Mode: {d.get('mode', 'unknown')}\n"
+                    f"• Blocked reason: {d.get('blocked_reason') or 'none'}\n"
+                    f"• Wallet: {d.get('wallet_id') or 'n/a'}"
+                ),
+            )
+
+        if command == "/retry_status":
+            workflow_id = arg
+            if not workflow_id:
+                return DispatchResult(outcome="ok", reply_text="Usage: /retry_status <workflow_id>")
+            data = await self._backend.settlement_get(f"/admin/settlement/retry/{workflow_id}")
+            if not data.get("ok"):
+                return DispatchResult(outcome="ok", reply_text=f"Retry status: unavailable — {data.get('detail', 'error')}")
+            d = data.get("data", {})
+            return DispatchResult(
+                outcome="ok",
+                reply_text=(
+                    f"Retry status: {workflow_id}\n"
+                    f"• Total attempts: {d.get('total_attempts', 0)}\n"
+                    f"• Exhausted: {d.get('exhausted', False)}\n"
+                    f"• Last error: {d.get('last_error') or 'none'}\n"
+                    f"• Next retry at: {d.get('next_retry_at') or 'n/a'}"
+                ),
+            )
+
+        if command == "/failed_batches":
+            data = await self._backend.settlement_get("/admin/settlement/failed-batches")
+            if not data.get("ok"):
+                return DispatchResult(outcome="ok", reply_text=f"Failed batches: unavailable — {data.get('detail', 'error')}")
+            batches = data.get("data", [])
+            if not batches:
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text="Failed batches: none\n• Note: batch result persistence is not yet active; this list will always be empty until that lane is built.",
+                )
+            lines = [f"Failed batches ({len(batches)})"]
+            for b in batches:
+                lines.append(f"  • {b.get('batch_id', 'unknown')} | {b.get('error', 'no detail')}")
+            return DispatchResult(outcome="ok", reply_text="\n".join(lines))
+
+        if command == "/settlement_intervene":
+            parts = arg.split(" ", 2)
+            if len(parts) < 2:
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text="Usage: /settlement_intervene <workflow_id> <action> [reason]",
+                )
+            workflow_id, action = parts[0], parts[1]
+            reason = parts[2] if len(parts) > 2 else "operator intervention via Telegram"
+            payload: dict[str, object] = {
+                "workflow_id": workflow_id,
+                "action": action,
+                "admin_user_id": ctx.from_user_id,
+                "reason": reason,
+            }
+            data = await self._backend.settlement_post("/admin/settlement/intervene", payload)
+            if not data.get("ok"):
+                detail = data.get("detail", "error")
+                if "http_404" in str(detail):
+                    return DispatchResult(outcome="ok", reply_text=f"Intervention: workflow {workflow_id} not found.")
+                return DispatchResult(outcome="ok", reply_text=f"Intervention failed: {detail}")
+            d = data.get("data", {})
+            return DispatchResult(
+                outcome="ok",
+                reply_text=(
+                    f"Intervention applied: {workflow_id}\n"
+                    f"• Action: {action}\n"
+                    f"• Applied: {d.get('applied', False)}\n"
+                    f"• Resulting status: {d.get('resulting_status', 'unknown')}\n"
+                    f"• Note: intervention record is not persisted in current layer."
+                ),
+            )
 
         log.warning("crusaderbot_telegram_dispatch_unknown_command", command=ctx.command, chat_id=ctx.chat_id)
         return DispatchResult(

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -337,7 +337,7 @@ class TelegramDispatcher:
             return DispatchResult(outcome="ok", reply_text="\n".join(lines))
 
         if command == "/settlement_intervene":
-            parts = arg.split(" ", 2)
+            parts = arg.split(None, 2)
             if len(parts) < 2:
                 return DispatchResult(
                     outcome="ok",

--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -297,7 +297,7 @@ class TelegramDispatcher:
                     f"• Retry attempts: {d.get('retry_attempt_count', 0)}\n"
                     f"• Amount: {d.get('amount', 0.0)} {d.get('currency', '')}\n"
                     f"• Mode: {d.get('mode', 'unknown')}\n"
-                    f"• Blocked reason: {d.get('blocked_reason') or 'none'}\n"
+                    f"• Blocked reason: {d.get('last_blocked_reason') or 'none'}\n"
                     f"• Wallet: {d.get('wallet_id') or 'n/a'}"
                 ),
             )
@@ -314,9 +314,9 @@ class TelegramDispatcher:
                 outcome="ok",
                 reply_text=(
                     f"Retry status: {workflow_id}\n"
-                    f"• Total attempts: {d.get('total_attempts', 0)}\n"
-                    f"• Exhausted: {d.get('exhausted', False)}\n"
-                    f"• Last error: {d.get('last_error') or 'none'}\n"
+                    f"• Total attempts: {d.get('current_attempt', 0)}\n"
+                    f"• Exhausted: {d.get('is_exhausted', False)}\n"
+                    f"• Last error: {d.get('last_outcome') or 'none'}\n"
                     f"• Next retry at: {d.get('next_retry_at') or 'n/a'}"
                 ),
             )
@@ -333,7 +333,7 @@ class TelegramDispatcher:
                 )
             lines = [f"Failed batches ({len(batches)})"]
             for b in batches:
-                lines.append(f"  • {b.get('batch_id', 'unknown')} | {b.get('error', 'no detail')}")
+                lines.append(f"  • {b.get('batch_id', 'unknown')} | {b.get('batch_status', 'unknown')}")
             return DispatchResult(outcome="ok", reply_text="\n".join(lines))
 
         if command == "/settlement_intervene":
@@ -363,8 +363,8 @@ class TelegramDispatcher:
                 reply_text=(
                     f"Intervention applied: {workflow_id}\n"
                     f"• Action: {action}\n"
-                    f"• Applied: {d.get('applied', False)}\n"
-                    f"• Resulting status: {d.get('resulting_status', 'unknown')}\n"
+                    f"• Applied: {d.get('success', False)}\n"
+                    f"• Resulting status: {d.get('new_status', 'unknown')}\n"
                     f"• Note: intervention record is not persisted in current layer."
                 ),
             )

--- a/projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md
+++ b/projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md
@@ -1,0 +1,127 @@
+# WARP•FORGE REPORT: settlement-telegram-wiring
+Branch: WARP/settlement-telegram-wiring
+Date: 2026-04-28 17:00 Asia/Jakarta
+
+---
+
+## Validation Metadata
+
+- Branch: WARP/settlement-telegram-wiring
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: `client/telegram/backend_client.py`, `client/telegram/dispatcher.py` — Telegram command wiring for 4 settlement operator commands (§48 Gate 1c)
+- Not in Scope: Live DB integration, batch result persistence, full SENTINEL pre-public sweep, live Fly.io deploy test
+- Suggested Next Step: WARP🔹CMD review before merge; Priority 8 capital readiness after Gate 1c merged
+
+---
+
+## 1. What Was Built
+
+Gate 1c wires the OperatorConsole HTTP routes (Gate 1b, PR #787) to Telegram operator commands. Operators can now manage settlement/retry/reconciliation directly from Telegram without raw HTTP calls.
+
+**`CrusaderBackendClient`** (`client/telegram/backend_client.py`) — 2 new helpers:
+- `_settlement_headers()` — reads `SETTLEMENT_ADMIN_TOKEN` env var; returns `X-Settlement-Admin-Token` header dict
+- `settlement_get(path)` — GET with settlement headers; mirrors `orchestration_get()` pattern
+- `settlement_post(path, payload)` — POST with settlement headers; mirrors `orchestration_post()` pattern
+
+**`TelegramDispatcher`** (`client/telegram/dispatcher.py`) — 4 new operator commands:
+
+| Command | Backend endpoint | Notes |
+|---|---|---|
+| `/settlement_status <workflow_id>` | GET /admin/settlement/status/{id} | Returns status, retry count, amount, mode, blocked reason, wallet |
+| `/retry_status <workflow_id>` | GET /admin/settlement/retry/{id} | Returns total attempts, exhausted flag, last error, next retry at |
+| `/failed_batches` | GET /admin/settlement/failed-batches | Acknowledges empty list + batch persistence limitation clearly |
+| `/settlement_intervene <workflow_id> <action> [reason]` | POST /admin/settlement/intervene | Applies admin intervention; surfaces 404 (workflow not found) cleanly |
+
+All 4 commands added to `_INTERNAL_COMMANDS` set — guarded by existing `_is_internal_command_allowed()` (operator chat_id match required). Non-operator chats receive `unknown_command` outcome.
+
+---
+
+## 2. Current System Architecture
+
+```
+[Telegram Operator]
+        │
+        ▼
+TelegramDispatcher.dispatch()
+  /settlement_status <wf_id>  ──→ settlement_get(/admin/settlement/status/{wf_id})
+  /retry_status <wf_id>       ──→ settlement_get(/admin/settlement/retry/{wf_id})
+  /failed_batches             ──→ settlement_get(/admin/settlement/failed-batches)
+  /settlement_intervene       ──→ settlement_post(/admin/settlement/intervene, {...})
+        │ (all guarded by operator chat_id)
+        ▼
+CrusaderBackendClient
+  settlement_get(path)   → X-Settlement-Admin-Token header → SETTLEMENT_ADMIN_TOKEN env
+  settlement_post(path)  → X-Settlement-Admin-Token header → SETTLEMENT_ADMIN_TOKEN env
+        │
+        ▼
+FastAPI /admin/settlement/* (Gate 1b — PR #787 merged)
+        │
+        ▼
+SettlementOperatorService → OperatorConsole → SettlementPersistence
+        │
+        ▼
+[PostgreSQL: settlement_events, settlement_retry_history]
+```
+
+---
+
+## 3. Files Created / Modified (full repo-root paths)
+
+**Created:**
+```
+projects/polymarket/polyquantbot/tests/test_settlement_p7_telegram_wiring.py
+projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md
+```
+
+**Modified:**
+```
+projects/polymarket/polyquantbot/client/telegram/backend_client.py
+projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+projects/polymarket/polyquantbot/state/WORKTODO.md
+projects/polymarket/polyquantbot/state/CHANGELOG.md
+```
+
+---
+
+## 4. What Is Working
+
+- All 8 Gate 1c tests pass: ST-48..ST-55 (8/8)
+- `/settlement_status <workflow_id>` — guarded, calls correct backend path, formats reply with status/retry/amount/mode/blocked_reason/wallet
+- `/retry_status <workflow_id>` — guarded, calls correct backend path, formats reply with attempts/exhausted/last_error/next_retry_at
+- `/failed_batches` — guarded, calls correct backend path, returns empty-list acknowledgement with batch persistence limitation note
+- `/settlement_intervene <workflow_id> <action> [reason]` — guarded, parses args, calls backend, formats result, surfaces 404 as clean "not found" message
+- Backend errors (any non-ok response) surfaced cleanly — no exception propagation to Telegram user
+- Missing-arg usage hints returned for commands requiring arguments
+- `SETTLEMENT_ADMIN_TOKEN` env var read by `_settlement_headers()` — same pattern as orchestration token; never hardcoded
+
+---
+
+## 5. Known Issues
+
+- `get_failed_batches()` (service layer) always returns `[]` — this is a carry-over from Gate 1b; batch result persistence is not in the current lane. The `/failed_batches` Telegram command acknowledges this limitation explicitly in its reply.
+- `apply_admin_intervention()` does not persist the intervention record — existing known issue from Gate 1b; the `/settlement_intervene` Telegram reply includes a note about this.
+- `SETTLEMENT_ADMIN_TOKEN` env var must be set in the Fly.io deployment for settlement commands to authenticate against the backend; missing token will produce 403 from the backend, which is surfaced as `http_403` in the Telegram error reply.
+
+---
+
+## 6. What Is Next
+
+- Priority 8: Production-capital readiness gating — 5 chunked FORGE tasks, each requiring SENTINEL MAJOR sweep before merge
+  - P8-A: Capability boundary review + capital-mode config model (§49-50)
+  - P8-B: Capital risk controls hardening (§51)
+  - P8-C: Live execution readiness audit (§52)
+  - P8-D: Security + observability hardening (§53)
+  - P8-E: Capital validation + claim review (§54)
+- After all P8 SENTINEL gates pass: Priority 9 final product completion, launch assets, and handoff
+
+---
+
+## Metadata
+
+- **Validation Tier:** STANDARD
+- **Claim Level:** NARROW INTEGRATION (Telegram command surface over existing Gate 1b HTTP routes; no new infra)
+- **Validation Target:** §48 Gate 1c — 4 Telegram settlement operator commands + 2 backend client helpers (ST-48..ST-55)
+- **Not in Scope:** Live DB, batch persistence, full SENTINEL pre-public sweep, Fly.io deploy test
+- **Suggested Next Step:** WARP🔹CMD review; Priority 8 after merge

--- a/projects/polymarket/polyquantbot/state/CHANGELOG.md
+++ b/projects/polymarket/polyquantbot/state/CHANGELOG.md
@@ -4,6 +4,8 @@
 # Format: YYYY-MM-DD HH:MM | branch | summary
 ---
 
+2026-04-28 17:00 | WARP/settlement-telegram-wiring | Gate 1c: 4 settlement operator Telegram commands wired (/settlement_status, /retry_status, /failed_batches, /settlement_intervene) + 2 backend client helpers (settlement_get, settlement_post). 8/8 tests passing (ST-48..ST-55). WORKTODO §48 Gate 1c ticked. Tier: STANDARD. WARP CMD review pending.
+
 2026-04-28 08:00 | WARP/settlement-ddl-migration | Gate 1a: DDL migration file created for settlement domain tables (settlement_events, settlement_retry_history, settlement_reconciliation_results) at infra/db/migrations/001_settlement_tables.sql. Tier: MINOR. WORKTODO §48 DDL item ticked.
 
 2026-04-24 07:00 | NWAP/repo-structure-state-migration | State files migrated from repo root and work_checklist.md to projects/polymarket/polyquantbot/state/ (PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, CHANGELOG.md); HTML files and docs updated to new paths.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-28 15:05
-Status       : Gate 1a DDL migration is merged to main via PR #786. Gate 1b FastAPI settlement operator routes are built on WARP/settlement-operator-routes -- SettlementOperatorService + 4 routes + 9/9 tests (ST-39..ST-47) + server/main.py wiring; WARP CMD review pending for PR #787. Gate 1c Telegram wiring not yet started.
+Last Updated : 2026-04-28 17:00
+Status       : Gate 1a DDL migration merged to main via PR #786. Gate 1b settlement operator HTTP routes merged to main via PR #787. Gate 1c Telegram wiring built on WARP/settlement-telegram-wiring -- 4 settlement operator commands + 2 backend client helpers + 8/8 tests (ST-48..ST-55); WARP CMD review pending (STANDARD tier).
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
@@ -12,24 +12,23 @@ Status       : Gate 1a DDL migration is merged to main via PR #786. Gate 1b Fast
 - Priority 6 Phase A and Phase B multi-wallet orchestration are merged to main via PR #776 and PR #779.
 - Priority 7 settlement-retry-reconciliation is merged to main via PR #777; 66/66 tests passing (ST-01..ST-38c).
 - Gate 1a DDL migration file for settlement tables is merged to main via PR #786 from WARP/settlement-ddl-migration.
+- Gate 1b FastAPI settlement operator routes merged to main via PR #787 from WARP/settlement-operator-routes; 9/9 tests (ST-39..ST-47).
 
 [IN PROGRESS]
 - COMMANDER review for PR #781 (Priority 6 Phase C) pending merge decision.
-- Gate 1b FastAPI settlement operator routes (WARP/settlement-operator-routes) -- PR #787 open, WARP CMD review pending (STANDARD tier).
+- Gate 1c Telegram settlement wiring (WARP/settlement-telegram-wiring) -- 4 commands + 8/8 tests (ST-48..ST-55); WARP CMD review pending (STANDARD tier). Report: projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md.
 - WalkerMind OS identity rebranding (NWAP/rebranding-identity-fix) -- WARP CMD review pending. PR #782 held due to drift; replaced by this fix PR.
 - Legacy string cleanup (WARP/cleanup-legacy-refs) -- WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
 
 [NOT STARTED]
-- Gate 1c Priority 7 Telegram wiring for settlement/retry/reconciliation commands -- WARP/settlement-telegram-wiring. Depends on Gate 1b merge.
-- Priority 8 capital readiness and live trading gating -- requires separate SENTINEL MAJOR sweep after P8 lanes are built.
+- Priority 8 capital readiness and live trading gating -- requires separate SENTINEL MAJOR sweep after P8 lanes are built (P8-A through P8-E, chunked).
 - Final public product completion, launch assets, and handoff.
 
 [NEXT PRIORITY]
-- WARP CMD review for Gate 1b settlement operator routes. Source: projects/polymarket/polyquantbot/reports/forge/settlement-operator-routes.md. Tier: STANDARD. Branch: WARP/settlement-operator-routes. PR #787.
+- WARP CMD review for Gate 1c settlement Telegram wiring. Source: projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md. Tier: STANDARD. Branch: WARP/settlement-telegram-wiring.
 - COMMANDER review and merge decision for PR #781 (Priority 6 Phase C). Source: projects/polymarket/polyquantbot/reports/forge/multi-wallet-orchestration-phase-c.md.
-- After Gate 1b merged: Gate 1c Telegram wiring (WARP/settlement-telegram-wiring).
-- After all Gate 1 lanes merged: Priority 8 capital readiness (chunked per §49-54, each SENTINEL MAJOR).
+- After Gate 1c merged: Priority 8 capital readiness (chunked per §49-54 as P8-A through P8-E, each SENTINEL MAJOR).
 - Maintain no public-ready, live-trading-ready, or production-capital-ready claim until Priority 8 SENTINEL MAJOR sweep complete.
 
 [KNOWN ISSUES]
@@ -40,6 +39,5 @@ Status       : Gate 1a DDL migration is merged to main via PR #786. Gate 1b Fast
 - Portfolio unrealized PnL relies on current_price in paper_positions -- live mark-to-market deferred to market data integration lane.
 - WalletCandidate financial fields (balance_usd, exposure_pct, drawdown_pct) default to 0.0 -- risk gate thresholds will not trigger in orchestration routing until market data integration is complete.
 - No migration runner configured -- 001_settlement_tables.sql must be applied manually or via operator tooling; auto-create in _apply_schema() remains the runtime path.
-- OperatorConsole is HTTP-exposed (Gate 1b) but not Telegram-exposed -- Gate 1c in next phase plan.
-- OperatorConsole.apply_admin_intervention() does not persist intervention record -- service layer callers must handle explicitly.
-- get_failed_batches() always returns [] -- batch results not persisted in current settlement persistence layer.
+- OperatorConsole.apply_admin_intervention() does not persist intervention record -- service layer callers must handle explicitly; Telegram /settlement_intervene reply surfaces this note.
+- get_failed_batches() always returns [] -- batch results not persisted in current settlement persistence layer; /failed_batches Telegram reply acknowledges this explicitly.

--- a/projects/polymarket/polyquantbot/state/WORKTODO.md
+++ b/projects/polymarket/polyquantbot/state/WORKTODO.md
@@ -458,7 +458,7 @@ Build this after orchestration is ready.
 - [x] Validate all flows
 - [x] DDL migration files created (Gate 1a — PR #786)
 - [x] HTTP route wiring complete (Gate 1b — WARP/settlement-operator-routes)
-- [ ] Telegram wiring (Gate 1c — WARP/settlement-telegram-wiring)
+- [x] Telegram wiring (Gate 1c — WARP/settlement-telegram-wiring)
 
 ### Done Condition
 

--- a/projects/polymarket/polyquantbot/tests/test_settlement_p7_telegram_wiring.py
+++ b/projects/polymarket/polyquantbot/tests/test_settlement_p7_telegram_wiring.py
@@ -1,0 +1,196 @@
+"""Priority 7 — Settlement Telegram Wiring — Tests (Gate 1c).
+
+Test IDs: ST-48 .. ST-55
+
+Coverage:
+  ST-48  /settlement_status guarded from non-operator chat
+  ST-49  /settlement_status calls correct backend endpoint and formats reply
+  ST-50  /settlement_status returns usage hint when no workflow_id given
+  ST-51  /retry_status calls correct backend endpoint and formats reply
+  ST-52  /failed_batches returns empty-list acknowledgement
+  ST-53  /settlement_intervene returns usage hint when args missing
+  ST-54  /settlement_intervene calls backend and formats result
+  ST-55  backend error is surfaced cleanly (no exception propagation)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from projects.polymarket.polyquantbot.client.telegram.dispatcher import (
+    DispatchResult,
+    TelegramCommandContext,
+    TelegramDispatcher,
+)
+
+_OPERATOR_CHAT = "op_chat_001"
+
+
+def _ctx(
+    command: str,
+    argument: str = "",
+    chat_id: str = _OPERATOR_CHAT,
+    from_user_id: str = "tg_admin",
+) -> TelegramCommandContext:
+    return TelegramCommandContext(
+        command=command,
+        from_user_id=from_user_id,
+        chat_id=chat_id,
+        tenant_id="t1",
+        user_id="u1",
+        argument=argument,
+    )
+
+
+def _dispatcher(backend: object) -> TelegramDispatcher:
+    return TelegramDispatcher(backend=backend, operator_chat_id=_OPERATOR_CHAT)  # type: ignore[arg-type]
+
+
+# ── ST-48: guard — non-operator chat blocked ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st48_settlement_status_guarded_from_public_chat() -> None:
+    backend = MagicMock()
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/settlement_status", argument="wf_001", chat_id="public_chat"))
+    assert result.outcome == "unknown_command"
+
+
+# ── ST-49: /settlement_status formats reply ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st49_settlement_status_formats_reply() -> None:
+    backend = MagicMock()
+    backend.settlement_get = AsyncMock(
+        return_value={
+            "ok": True,
+            "data": {
+                "workflow_id": "wf_001",
+                "status": "COMPLETED",
+                "retry_attempt_count": 1,
+                "amount": 50.0,
+                "currency": "USD",
+                "mode": "paper",
+                "blocked_reason": None,
+                "wallet_id": "wallet_abc",
+            },
+        }
+    )
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/settlement_status", argument="wf_001"))
+    assert result.outcome == "ok"
+    assert "wf_001" in result.reply_text
+    assert "COMPLETED" in result.reply_text
+    assert "wallet_abc" in result.reply_text
+    backend.settlement_get.assert_called_once_with("/admin/settlement/status/wf_001")
+
+
+# ── ST-50: /settlement_status usage hint ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st50_settlement_status_usage_hint() -> None:
+    backend = MagicMock()
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/settlement_status", argument=""))
+    assert result.outcome == "ok"
+    assert "Usage" in result.reply_text
+
+
+# ── ST-51: /retry_status formats reply ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st51_retry_status_formats_reply() -> None:
+    backend = MagicMock()
+    backend.settlement_get = AsyncMock(
+        return_value={
+            "ok": True,
+            "data": {
+                "workflow_id": "wf_002",
+                "total_attempts": 3,
+                "exhausted": False,
+                "last_error": "timeout",
+                "next_retry_at": "2026-04-29T00:00:00Z",
+            },
+        }
+    )
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/retry_status", argument="wf_002"))
+    assert result.outcome == "ok"
+    assert "wf_002" in result.reply_text
+    assert "3" in result.reply_text
+    assert "timeout" in result.reply_text
+    backend.settlement_get.assert_called_once_with("/admin/settlement/retry/wf_002")
+
+
+# ── ST-52: /failed_batches empty-list acknowledgement ─────────────────────
+
+@pytest.mark.asyncio
+async def test_st52_failed_batches_empty_list_acknowledged() -> None:
+    backend = MagicMock()
+    backend.settlement_get = AsyncMock(return_value={"ok": True, "data": []})
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/failed_batches"))
+    assert result.outcome == "ok"
+    assert "none" in result.reply_text.lower()
+    assert "batch result persistence" in result.reply_text
+    backend.settlement_get.assert_called_once_with("/admin/settlement/failed-batches")
+
+
+# ── ST-53: /settlement_intervene usage hint ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st53_settlement_intervene_usage_hint() -> None:
+    backend = MagicMock()
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/settlement_intervene", argument="only_one_arg"))
+    assert result.outcome == "ok"
+    assert "Usage" in result.reply_text
+
+
+# ── ST-54: /settlement_intervene calls backend and formats result ──────────
+
+@pytest.mark.asyncio
+async def test_st54_settlement_intervene_formats_result() -> None:
+    backend = MagicMock()
+    backend.settlement_post = AsyncMock(
+        return_value={
+            "ok": True,
+            "data": {
+                "workflow_id": "wf_003",
+                "action": "force_complete",
+                "applied": True,
+                "resulting_status": "COMPLETED",
+            },
+        }
+    )
+    d = _dispatcher(backend)
+    result = await d.dispatch(
+        _ctx("/settlement_intervene", argument="wf_003 force_complete operator review passed")
+    )
+    assert result.outcome == "ok"
+    assert "wf_003" in result.reply_text
+    assert "force_complete" in result.reply_text
+    assert "COMPLETED" in result.reply_text
+    backend.settlement_post.assert_called_once_with(
+        "/admin/settlement/intervene",
+        {
+            "workflow_id": "wf_003",
+            "action": "force_complete",
+            "admin_user_id": "tg_admin",
+            "reason": "operator review passed",
+        },
+    )
+
+
+# ── ST-55: backend error surfaced cleanly ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_st55_backend_error_surfaced_cleanly() -> None:
+    backend = MagicMock()
+    backend.settlement_get = AsyncMock(return_value={"ok": False, "detail": "http_503"})
+    d = _dispatcher(backend)
+    result = await d.dispatch(_ctx("/settlement_status", argument="wf_error"))
+    assert result.outcome == "ok"
+    assert "unavailable" in result.reply_text
+    assert "http_503" in result.reply_text

--- a/projects/polymarket/polyquantbot/tests/test_settlement_p7_telegram_wiring.py
+++ b/projects/polymarket/polyquantbot/tests/test_settlement_p7_telegram_wiring.py
@@ -72,7 +72,7 @@ async def test_st49_settlement_status_formats_reply() -> None:
                 "amount": 50.0,
                 "currency": "USD",
                 "mode": "paper",
-                "blocked_reason": None,
+                "last_blocked_reason": None,
                 "wallet_id": "wallet_abc",
             },
         }
@@ -107,9 +107,9 @@ async def test_st51_retry_status_formats_reply() -> None:
             "ok": True,
             "data": {
                 "workflow_id": "wf_002",
-                "total_attempts": 3,
-                "exhausted": False,
-                "last_error": "timeout",
+                "current_attempt": 3,
+                "is_exhausted": False,
+                "last_outcome": "timeout",
                 "next_retry_at": "2026-04-29T00:00:00Z",
             },
         }
@@ -159,8 +159,8 @@ async def test_st54_settlement_intervene_formats_result() -> None:
             "data": {
                 "workflow_id": "wf_003",
                 "action": "force_complete",
-                "applied": True,
-                "resulting_status": "COMPLETED",
+                "success": True,
+                "new_status": "COMPLETED",
             },
         }
     )


### PR DESCRIPTION
## Gate 1c — Settlement Telegram Wiring

**Validation Tier:** STANDARD
**Claim Level:** NARROW INTEGRATION
**Branch:** `WARP/settlement-telegram-wiring`
**Report:** `projects/polymarket/polyquantbot/reports/forge/settlement-telegram-wiring.md`
**Depends on:** PR #787 (Gate 1b) — merged ✓

---

## What Was Built

Wires the Gate 1b OperatorConsole HTTP routes to 4 Telegram operator commands, allowing settlement/retry/reconciliation management directly from Telegram.

### New: `CrusaderBackendClient` settlement helpers (`client/telegram/backend_client.py`)
- `_settlement_headers()` — reads `SETTLEMENT_ADMIN_TOKEN` env; returns `X-Settlement-Admin-Token` header
- `settlement_get(path)` — GET with settlement headers (mirrors `orchestration_get()`)
- `settlement_post(path, payload)` — POST with settlement headers (mirrors `orchestration_post()`)

### New: 4 Telegram operator commands (`client/telegram/dispatcher.py`)

| Command | Backend endpoint | Guard |
|---|---|---|
| `/settlement_status <workflow_id>` | GET /admin/settlement/status/{id} | operator chat_id |
| `/retry_status <workflow_id>` | GET /admin/settlement/retry/{id} | operator chat_id |
| `/failed_batches` | GET /admin/settlement/failed-batches | operator chat_id |
| `/settlement_intervene <workflow_id> <action> [reason]` | POST /admin/settlement/intervene | operator chat_id |

All 4 commands added to `_INTERNAL_COMMANDS` — guarded by existing `_is_internal_command_allowed()`.

## Tests

8/8 passing — ST-48..ST-55:
- ST-48: `/settlement_status` guarded from non-operator chat
- ST-49: `/settlement_status` calls correct backend path and formats reply
- ST-50: `/settlement_status` returns usage hint when no workflow_id
- ST-51: `/retry_status` calls correct backend path and formats reply
- ST-52: `/failed_batches` returns empty-list with batch persistence limitation note
- ST-53: `/settlement_intervene` returns usage hint when args missing
- ST-54: `/settlement_intervene` calls backend and formats result
- ST-55: backend error surfaced cleanly

## Known Limitations

- `get_failed_batches()` always returns `[]` — batch persistence not in current lane; `/failed_batches` reply acknowledges this explicitly
- `apply_admin_intervention()` does not persist intervention record — existing Gate 1b known issue; `/settlement_intervene` reply surfaces this note

## What Is Next

Priority 8: Production-capital readiness (P8-A through P8-E, each SENTINEL MAJOR gate)

https://claude.ai/code/session_01TugDV2F8ofrnabGoHzEDmi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TugDV2F8ofrnabGoHzEDmi)_