### PR TITLE
sentinel-timeout-resilience: add stream timeout + split write rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1083,6 +1083,15 @@ If any fails: do not validate, return to WARP•FORGE.
 
 Anti-loop: max 2 WARP•SENTINEL runs per task. Run 3+ requires explicit Mr. Walker approval. WARP•FORGE should fix all findings in one pass before rerun.
 
+### Stream timeout recovery
+If a previous WARP•SENTINEL session ended with API stream timeout:
+- Do NOT re-run validation from scratch
+- Check what report sections were already written to disk
+- Resume from last confirmed written section
+- If nothing written: re-run Phase 0 checks only, then continue
+- Never re-read source files already in session context
+- Recovery counts as run 1 toward the 2-run anti-loop limit
+
 ### Report rules
 
 Path:
@@ -1575,6 +1584,10 @@ Never create a PR mid-task.
 - Do not chain more than 3 read operations without an intermediate output step.
 - If a single file requires heavy rewriting (full replacement), treat that file as its own chunk.
 - Prefer **targeted edits** (str_replace / patch) over full file rewrites whenever possible.
+- WARP•SENTINEL report: max 150 lines per write call.
+  Split into 2 calls (sections 1–5, then 6–end).
+  Signal CHUNK [N] COMPLETE between calls. Never write full
+  report in one tool call.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,19 @@ Bash rules:
 - Always set `ANTHROPIC_TIMEOUT=300000` before running long tasks
 - If stream idle timeout occurs: break task into smaller atomic units
 - Max file context per session: 5 files or ~2000 lines total
+- WARP•SENTINEL report write > 150 lines → split into 2 write calls:
+  Call A: sections 1–5 (Environment through Score Breakdown)
+  Call B: sections 6–end (Critical Issues through Deferred Backlog)
+  Signal between calls before proceeding.
+- After every 2 sequential read operations, produce intermediate
+  output before next read or write.
+
+### On Stream Timeout Recovery (SENTINEL)
+- Do NOT re-run validation from scratch
+- Check what sections were already written to disk
+- Resume from last confirmed written section
+- If nothing written: re-run from Phase 0 only
+- Never re-read all source files again if already in session context
 
 ### Task Chunking Rules
 - Large refactor → per-file basis, one file per prompt
@@ -753,6 +766,10 @@ Never create a PR mid-task.
 - Do not chain more than 3 read operations without an intermediate output step.
 - If a single file requires heavy rewriting (full replacement), treat that file as its own chunk.
 - Prefer **targeted edits** (str_replace / patch) over full file rewrites whenever possible.
+- WARP•SENTINEL report: max 150 lines per write call.
+  Split into 2 calls (sections 1–5, then 6–end).
+  Signal CHUNK [N] COMPLETE between calls. Never write full
+  report in one tool call.
 
 ---
 ## PR Size & Pagination Protocol

--- a/projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md
+++ b/projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md
@@ -1,0 +1,43 @@
+# WARP•FORGE Report: sentinel-timeout-resilience
+
+Branch: WARP/sentinel-timeout-resilience
+Date: 2026-04-29 07:24
+
+---
+
+## 1. What was changed
+
+Four surgical rule additions across CLAUDE.md and AGENTS.md to address
+WARP•SENTINEL stream idle timeout failure pattern.
+
+- CLAUDE.md — Timeout Handling section: added SENTINEL report split rule
+  (2 write calls: sections 1-5, then 6-end) and a new
+  "On Stream Timeout Recovery (SENTINEL)" block covering resume behavior.
+- CLAUDE.md — Task Chunking / Timeout Prevention Rules: added SENTINEL
+  report 150-line-per-call limit bullet.
+- AGENTS.md — Task Chunking / Timeout Prevention Rules: mirrored the same
+  150-line-per-call bullet.
+- AGENTS.md — ROLE: WARP•SENTINEL / after Anti-loop rule: added new
+  "Stream timeout recovery" section with 6 recovery rules including
+  anti-loop count behavior.
+
+No files created. No surrounding content rewritten. str_replace only.
+Version numbers in both files left unchanged.
+
+---
+
+## 2. Files modified
+
+- CLAUDE.md (repo root)
+- AGENTS.md (repo root)
+
+---
+
+## 3. Validation
+
+Validation Tier  : MINOR
+Claim Level      : FOUNDATION
+Validation Target: Rule text added correctly to 4 sections across 2 files
+Not in Scope     : Runtime behavior, actual sentinel execution, report format,
+                   COMMANDER.md, templates
+Suggested Next   : WARP🔹CMD review only (Tier = MINOR)

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-28 21:00
-Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (config-driven limits, 5-gate LIVE guard) + WalletFinancialProvider wiring + OrchestratorService enrichment hook; 12/12 tests (CR-13..CR-22), 35/35 total (P8-A+B); WARP•SENTINEL MAJOR validation required before merge.
+Last Updated : 2026-04-29 07:24
+Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (config-driven limits, 5-gate LIVE guard) + WalletFinancialProvider wiring + OrchestratorService enrichment hook; 12/12 tests (CR-13..CR-22), 35/35 total (P8-A+B); WARP•SENTINEL MAJOR validation required before merge. sentinel-timeout-resilience rule patch built, WARP🔹CMD review pending.
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
@@ -23,6 +23,7 @@ Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (co
 - Legacy string cleanup (WARP/cleanup-legacy-refs) -- WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
 - Agent env file registration (WARP/register-agent-env-files) -- CURSOR.md and ONA.md registered in AGENTS.md and CLAUDE.md; WARP🔹CMD review pending. Report: projects/polymarket/polyquantbot/reports/forge/register-agent-env-files.md.
+- sentinel-timeout-resilience rule patch (WARP/sentinel-timeout-resilience) -- 4 surgical edits to CLAUDE.md and AGENTS.md; WARP🔹CMD review pending. Report: projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md.
 
 [NOT STARTED]
 - P8-C live execution readiness audit (§52) -- validate live CLOB path, replace price_updater stub, wire allow_real_settlement; clears EXECUTION_PATH_VALIDATED gate.
@@ -34,6 +35,7 @@ Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (co
 - WARP•SENTINEL MAJOR validation required for P8-B. Source: projects/polymarket/polyquantbot/reports/forge/capital-readiness-p8b.md. Tier: MAJOR. Branch: WARP/capital-readiness-p8b.
 - WARP•SENTINEL MAJOR validation required for P8-A. Source: projects/polymarket/polyquantbot/reports/forge/capital-readiness-p8a.md. Tier: MAJOR. Branch: WARP/capital-readiness-p8a.
 - WARP🔹CMD review required for register-agent-env-files. Source: projects/polymarket/polyquantbot/reports/forge/register-agent-env-files.md. Tier: MINOR.
+- WARP🔹CMD review required for sentinel-timeout-resilience. Source: projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md. Tier: MINOR.
 
 [KNOWN ISSUES]
 - PaperBetaWorker.price_updater() is a no-op stub -- unrealized PnL updates require real market price polling (deferred to post-Priority-3 market data integration lane).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four surgical rule additions across `CLAUDE.md` and `AGENTS.md` to address WARP•SENTINEL stream idle timeout failure pattern. No full-file rewrites — `str_replace` only. Version numbers unchanged.

## Changes

**Edit 1 — CLAUDE.md / Timeout Handling**
- Added SENTINEL report split rule: reports > 150 lines → 2 write calls (sections 1–5, then 6–end)
- Added new `### On Stream Timeout Recovery (SENTINEL)` block: resume from last confirmed written section, do not re-run from scratch, Phase 0 only if nothing written

**Edit 2 — CLAUDE.md / Task Chunking → Timeout Prevention Rules**
- Added: WARP•SENTINEL report max 150 lines per write call bullet

**Edit 3 — AGENTS.md / Task Chunking → Timeout Prevention Rules**
- Mirrored Edit 2 bullet

**Edit 4 — AGENTS.md / ROLE: WARP•SENTINEL / after Anti-loop rule**
- Added `### Stream timeout recovery` block with 6 rules including recovery count toward anti-loop limit

## Files

- `CLAUDE.md` — 2 sections updated
- `AGENTS.md` — 2 sections updated
- `projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md` — forge report (MINOR, 3 sections)
- `projects/polymarket/polyquantbot/state/PROJECT_STATE.md` — updated

## Validation

```
Validation Tier  : MINOR
Claim Level      : FOUNDATION
Validation Target: Rule text added correctly to 4 sections across 2 files
Not in Scope     : Runtime behavior, actual sentinel execution, report format
Suggested Next   : WARP🔹CMD review only
```

## Done Criteria

- [x] All 4 edits applied surgically — no surrounding content touched
- [x] No full-file rewrites — str_replace only
- [x] CLAUDE.md and AGENTS.md version numbers NOT changed
- [x] Forge report exists at correct path (3 sections — MINOR tier)
- [x] PROJECT_STATE.md updated with full Asia/Jakarta timestamp (2026-04-29 07:24)
- [x] PR opened from WARP/sentinel-timeout-resilience
- [x] Final output includes Report: / State: / Validation Tier: / Claim Level:
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2027c7-73b6-4efb-bcf6-aa8707d65723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2027c7-73b6-4efb-bcf6-aa8707d65723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

