### PR TITLE
docs: add sentinel timeout recovery rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1083,6 +1083,15 @@ If any fails: do not validate, return to WARP•FORGE.
 
 Anti-loop: max 2 WARP•SENTINEL runs per task. Run 3+ requires explicit Mr. Walker approval. WARP•FORGE should fix all findings in one pass before rerun.
 
+### Stream timeout recovery
+If a previous WARP•SENTINEL session ended with API stream timeout:
+- Do NOT re-run validation from scratch
+- Check what report sections were already written to disk
+- Resume from last confirmed written section
+- If nothing written: re-run Phase 0 checks only, then continue
+- Never re-read source files already in session context
+- Recovery counts as run 1 toward the 2-run anti-loop limit
+
 ### Report rules
 
 Path:
@@ -1575,6 +1584,10 @@ Never create a PR mid-task.
 - Do not chain more than 3 read operations without an intermediate output step.
 - If a single file requires heavy rewriting (full replacement), treat that file as its own chunk.
 - Prefer **targeted edits** (str_replace / patch) over full file rewrites whenever possible.
+- WARP•SENTINEL report: max 150 lines per write call.
+  Split into 2 calls (sections 1–5, then 6–end).
+  Signal CHUNK [N] COMPLETE between calls. Never write full
+  report in one tool call.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,9 +214,22 @@ Bash rules:
 - Never run pip list or env dumps unless debugging a specific error
 
 ### Timeout Handling
-- Always set `ANTHROPIC_TIMEOUT=300000` before running long tasks
+- Always set ANTHROPIC_TIMEOUT=300000 before running long tasks
 - If stream idle timeout occurs: break task into smaller atomic units
 - Max file context per session: 5 files or ~2000 lines total
+- WARP•SENTINEL report write > 150 lines → split into 2 write calls:
+  Call A: sections 1–5 (Environment through Score Breakdown)
+  Call B: sections 6–end (Critical Issues through Deferred Backlog)
+  Signal between calls before proceeding.
+- After every 2 sequential read operations, produce intermediate
+  output before next read or write.
+
+### On Stream Timeout Recovery (SENTINEL)
+- Do NOT re-run validation from scratch
+- Check what sections were already written to disk
+- Resume from last confirmed written section
+- If nothing written: re-run from Phase 0 only
+- Never re-read all source files again if already in session context
 
 ### Task Chunking Rules
 - Large refactor → per-file basis, one file per prompt
@@ -753,6 +766,10 @@ Never create a PR mid-task.
 - Do not chain more than 3 read operations without an intermediate output step.
 - If a single file requires heavy rewriting (full replacement), treat that file as its own chunk.
 - Prefer **targeted edits** (str_replace / patch) over full file rewrites whenever possible.
+- WARP•SENTINEL report: max 150 lines per write call.
+  Split into 2 calls (sections 1–5, then 6–end).
+  Signal CHUNK [N] COMPLETE between calls. Never write full
+  report in one tool call.
 
 ---
 ## PR Size & Pagination Protocol

--- a/projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md
+++ b/projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md
@@ -1,0 +1,34 @@
+# sentinel-timeout-resilience
+
+Branch: WARP/sentinel-timeout-resilience
+Date: 2026-04-29 07:24 Asia/Jakarta
+
+---
+
+## 1. What was changed
+
+Added the requested WARP•SENTINEL stream-timeout resilience rules as surgical text updates only.
+
+- `CLAUDE.md` Timeout Handling now includes split-write guidance for WARP•SENTINEL reports, an intermediate-output rule after every 2 reads, and a dedicated stream-timeout recovery subsection.
+- `CLAUDE.md` Task Chunking Protocol now limits WARP•SENTINEL report writes to 150 lines per call with a required two-call split and `CHUNK [N] COMPLETE` signal.
+- `AGENTS.md` Task Chunking Protocol now mirrors the same WARP•SENTINEL report write limit and split-call rule.
+- `AGENTS.md` ROLE: WARP•SENTINEL — VALIDATE now includes a stream-timeout recovery block directly after the anti-loop rule.
+
+---
+
+## 2. Files modified
+
+- CLAUDE.md
+- AGENTS.md
+- projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md
+- projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+
+---
+
+## 3. Validation metadata
+
+Validation Tier   : MINOR
+Claim Level       : FOUNDATION
+Validation Target : Rule text added correctly to the 4 requested sections across CLAUDE.md and AGENTS.md
+Not in Scope      : COMMANDER.md, report templates, sentinel report structure, runtime behavior, actual sentinel execution, any file outside the scoped docs plus required forge report and PROJECT_STATE.md update
+Suggested Next    : WARP🔹CMD review

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-04-28 21:00
-Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (config-driven limits, 5-gate LIVE guard) + WalletFinancialProvider wiring + OrchestratorService enrichment hook; 12/12 tests (CR-13..CR-22), 35/35 total (P8-A+B); WARP•SENTINEL MAJOR validation required before merge.
+Last Updated : 2026-04-29 07:24
+Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (config-driven limits, 5-gate LIVE guard) + WalletFinancialProvider wiring + OrchestratorService enrichment hook; 12/12 tests (CR-13..CR-22), 35/35 total (P8-A+B); WARP•SENTINEL MAJOR validation required before merge. MINOR rules lane WARP/sentinel-timeout-resilience updates timeout recovery guidance in AGENTS.md and CLAUDE.md for WARP•SENTINEL stream idle timeout resilience.
 
 [COMPLETED]
 - Priority 1 Telegram live baseline truth-sync lane is closed with recorded live command evidence under projects/polymarket/polyquantbot/reports/forge/.
@@ -23,6 +23,7 @@ Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (co
 - Legacy string cleanup (WARP/cleanup-legacy-refs) -- WARP/cleanup-legacy-refs branch opened, forge report at projects/polymarket/polyquantbot/reports/forge/cleanup-legacy-refs.md; WARP CMD review pending.
 - Structure build continues under forge-merge mode; do not claim public-ready, live-trading-ready, or production-capital-ready until Priority 8 SENTINEL MAJOR sweep is complete.
 - Agent env file registration (WARP/register-agent-env-files) -- CURSOR.md and ONA.md registered in AGENTS.md and CLAUDE.md; WARP🔹CMD review pending. Report: projects/polymarket/polyquantbot/reports/forge/register-agent-env-files.md.
+- Sentinel timeout resilience (WARP/sentinel-timeout-resilience) -- timeout handling and chunking recovery rules updated in AGENTS.md and CLAUDE.md; WARP🔹CMD review pending. Report: projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md.
 
 [NOT STARTED]
 - P8-C live execution readiness audit (§52) -- validate live CLOB path, replace price_updater stub, wire allow_real_settlement; clears EXECUTION_PATH_VALIDATED gate.
@@ -34,6 +35,7 @@ Status       : P8-B capital risk controls hardening built -- CapitalRiskGate (co
 - WARP•SENTINEL MAJOR validation required for P8-B. Source: projects/polymarket/polyquantbot/reports/forge/capital-readiness-p8b.md. Tier: MAJOR. Branch: WARP/capital-readiness-p8b.
 - WARP•SENTINEL MAJOR validation required for P8-A. Source: projects/polymarket/polyquantbot/reports/forge/capital-readiness-p8a.md. Tier: MAJOR. Branch: WARP/capital-readiness-p8a.
 - WARP🔹CMD review required for register-agent-env-files. Source: projects/polymarket/polyquantbot/reports/forge/register-agent-env-files.md. Tier: MINOR.
+- WARP🔹CMD review required for sentinel-timeout-resilience. Source: projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md. Tier: MINOR.
 
 [KNOWN ISSUES]
 - PaperBetaWorker.price_updater() is a no-op stub -- unrealized PnL updates require real market price polling (deferred to post-Priority-3 market data integration lane).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the requested WARP•SENTINEL timeout-handling and recovery rules to `CLAUDE.md`
- mirror the WARP•SENTINEL report write-limit rule in `AGENTS.md` and add the new stream-timeout recovery block under the validation role
- add the required MINOR forge report and update `PROJECT_STATE.md` for WARP🔹CMD review

## Testing
- `git diff --check -- CLAUDE.md AGENTS.md projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md projects/polymarket/polyquantbot/state/PROJECT_STATE.md`
- verified inserted rule text with focused `rg` checks for the four requested sections
- verified `Version:` lines in `CLAUDE.md` and `AGENTS.md` remained unchanged

## Report
- `projects/polymarket/polyquantbot/reports/forge/sentinel-timeout-resilience.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0de5a155-6dcd-4213-8164-63c793175a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0de5a155-6dcd-4213-8164-63c793175a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

