### PR TITLE
devcontainer: fix port mappings and add missing requirements install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,18 +10,22 @@
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker": {}
 	},
-	"forwardPorts": [8080, 5173, 3000, 5432, 6379],
+	"forwardPorts": [8080, 3000, 5000, 8787, 5432, 6379],
 	"portsAttributes": {
 		"8080": {
 			"label": "PolyQuantBot API",
 			"onAutoForward": "notify"
 		},
-		"5173": {
-			"label": "Frontend Dev Server",
+		"3000": {
+			"label": "PolyQuantBot Frontend",
 			"onAutoForward": "notify"
 		},
-		"3000": {
-			"label": "WalkerDevOps App",
+		"5000": {
+			"label": "WalkerDevOps Frontend",
+			"onAutoForward": "notify"
+		},
+		"8787": {
+			"label": "WalkerDevOps API",
 			"onAutoForward": "notify"
 		},
 		"5432": {

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -5,6 +5,7 @@ tasks:
     command: |
       pip install --upgrade pip
       pip install -r requirements.txt
+      pip install -r projects/polymarket/requirements.txt
       pip install -r projects/polymarket/polyquantbot/requirements.txt
     triggeredBy:
       - postDevcontainerStart


### PR DESCRIPTION
## What

Corrects port configuration and dependency install coverage in the devcontainer setup.

## Changes

**`.devcontainer/devcontainer.json`**
- Remove port `5173` — not used by any project
- Add port `5000` — WalkerDevOps Frontend (Vite, confirmed in `frontend/vite.config.ts`)
- Add port `8787` — WalkerDevOps API (Express, confirmed in `server/index.ts`)
- Correct port `3000` label from `WalkerDevOps App` → `PolyQuantBot Frontend` (matches `projects/polymarket/polyquantbot/frontend/vite.config.ts`)

**`.ona/automations.yaml`**
- Add `pip install -r projects/polymarket/requirements.txt` to `install-python-deps` task — this file was present but not installed on `postDevcontainerStart`

## Validation Tier

MINOR — devcontainer config and automation task only, no runtime code changes.