### PR TITLE
docs: fix agent file inconsistencies and bump versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 
 Owner: Bayue Walker
 Repo: https://github.com/bayuewalker/walkermind-os
-Version: 2.4
-Last Updated: 2026-04-28 20:46 Asia/Jakarta
+Version: 2.5
+Last Updated: 2026-04-29 13:44 Asia/Jakarta
 Authority: This file is the single source of truth for all team rules,
            workflow, and operational boundaries. All other files are
            supporting documents. When conflict exists, AGENTS.md wins.
@@ -493,6 +493,11 @@ On every new session, WARP🔹CMD must read in this order before any action:
 4. `{PROJECT_ROOT}/state/ROADMAP.md`
 5. `{PROJECT_ROOT}/state/WORKTODO.md`
 6. `{PROJECT_ROOT}/state/CHANGELOG.md`
+
+Agent environments: also read the relevant agent file before any action:
+- Ona Agent → `ONA.md`
+- Cursor Agent → `CURSOR.md`
+- Claude Code → `CLAUDE.md`
 
 After reading all six, WARP🔹CMD has full context:
 - Active project and current status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 
 Owner: Bayue Walker
 Repo: https://github.com/bayuewalker/walkermind-os
-Version: 2.3
-Last Updated: 2026-04-28 20:46 Asia/Jakarta
+Version: 2.4
+Last Updated: 2026-04-29 13:44 Asia/Jakarta
 
 ---
 

--- a/COMMANDER.md
+++ b/COMMANDER.md
@@ -5,8 +5,8 @@ For all system rules (tiers, claims, branch format, report/state/roadmap rules, 
 
 Rule priority: `AGENTS.md` > `PROJECT_REGISTRY.md` > `{PROJECT_ROOT}/state/PROJECT_STATE.md` > `{PROJECT_ROOT}/state/ROADMAP.md` > latest relevant forge report > this file.
 
-Version: 2.3
-Last Updated: 2026-04-29 08:07 Asia/Jakarta
+Version: 2.4
+Last Updated: 2026-04-29 13:44 Asia/Jakarta
 
 ---
 
@@ -479,7 +479,7 @@ Velocity check before any block / task / escalation:
 
 ### Blueprint guidance
 - Shortcut/mode outputs must stay aligned with `AGENTS.md` priority and must never override repo truth gates.
-- Use `docs/blueprint/crusaderbot_final_decisions.md` as the authoritative CrusaderBot final-decisions reference for shortcut guidance.
+- Use `docs/blueprint/crusaderbot.md` as the authoritative CrusaderBot architecture and final-decisions reference for shortcut guidance.
 - Use `docs/crusader_blueprint_v2.html` if present in repo as supplemental architecture-intent context only; it never overrides AGENTS/project/code truth.
 
 ### Interpretation rule for shortcut-only prompts
@@ -611,7 +611,7 @@ PROJECT_REGISTRY.md             <- project list and active status (repo root)
 docs/COMMANDER.md               <- this file
 docs/CLAUDE.md                  <- Claude Code agent rules
 docs/KNOWLEDGE_BASE.md          <- architecture, infra, API, conventions
-docs/blueprint/crusaderbot_final_decisions.md
+docs/blueprint/crusaderbot.md
 
 docs/templates/PROJECT_STATE_TEMPLATE.md
 docs/templates/ROADMAP_TEMPLATE.md

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -5,8 +5,8 @@
 
 Owner: Bayue Walker
 Repo: https://github.com/bayuewalker/walkermind-os
-Version: 1.1
-Last Updated: 2026-04-28 21:45 Asia/Jakarta
+Version: 1.2
+Last Updated: 2026-04-29 13:44 Asia/Jakarta
 
 ---
 
@@ -215,6 +215,7 @@ AGENTS.md                                    <- master rules (repo root)
 PROJECT_REGISTRY.md                          <- project list and active status (repo root)
 CURSOR.md                                    <- this file (repo root)
 CLAUDE.md                                    <- Claude Code agent rules (repo root)
+ONA.md                                       <- Ona Agent rules (repo root)
 docs/KNOWLEDGE_BASE.md
 docs/blueprint/crusaderbot.md
 docs/templates/TPL_INTERACTIVE_REPORT.html

--- a/ONA.md
+++ b/ONA.md
@@ -5,8 +5,8 @@
 
 Owner: Bayue Walker
 Repo: https://github.com/bayuewalker/walkermind-os
-Version: 1.1
-Last Updated: 2026-04-28 21:45 Asia/Jakarta
+Version: 1.2
+Last Updated: 2026-04-29 13:44 Asia/Jakarta
 
 ---
 


### PR DESCRIPTION
## What

Targeted fixes for cross-file inconsistencies and gaps across the five core agent instruction files. No structural changes — only the specific issues identified in the spec.

## Changes

**AGENTS.md** (v2.4 → v2.5)
- Add agent-environment reading note to `SESSION RESUME RULE`: Ona Agent → `ONA.md`, Cursor Agent → `CURSOR.md`, Claude Code → `CLAUDE.md`

**COMMANDER.md** (v2.3 → v2.4)
- Replace broken reference `docs/blueprint/crusaderbot_final_decisions.md` → `docs/blueprint/crusaderbot.md` (2 occurrences: Blueprint guidance section + key files list)

**CURSOR.md** (v1.1 → v1.2)
- Add `ONA.md` to KEY FILE LOCATIONS (was missing, present in ONA.md and CLAUDE.md already)

**ONA.md** (v1.1 → v1.2), **CLAUDE.md** (v2.3 → v2.4)
- Version and timestamp bump only — no content changes

## Validation Tier

MINOR — documentation files only, no runtime code changes.