### PR TITLE
WARP•FORGE: capital-mode-confirm chunk 1 — DB layer for confirmation receipts

### DIFF
--- a/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
+++ b/projects/polymarket/polyquantbot/client/telegram/dispatcher.py
@@ -65,6 +65,9 @@ class TelegramDispatcher:
         "/settlement_intervene",
         # P8-D capital mode operator commands
         "/capital_status",
+        # P8-E capital mode confirmation flow
+        "/capital_mode_confirm",
+        "/capital_mode_revoke",
     }
 
     def __init__(self, backend: CrusaderBackendClient, operator_chat_id: str = "") -> None:
@@ -401,6 +404,98 @@ class TelegramDispatcher:
                     f"• Open positions: {d.get('open_positions', 0)}\n"
                     "Gate booleans:\n"
                     f"{gate_lines}"
+                ),
+            )
+
+        # ── P8-E capital mode confirmation flow ──────────────────────────────
+        if command == "/capital_mode_confirm":
+            payload: dict[str, object] = {
+                "operator_id": ctx.user_id,
+                "acknowledgment_token": arg,
+            }
+            data = await self._backend.beta_post(
+                "/beta/capital_mode_confirm", payload
+            )
+            if not data.get("ok"):
+                detail = data.get("detail")
+                if isinstance(detail, dict):
+                    reason = detail.get("reason", "unknown")
+                    missing = detail.get("missing")
+                    extra = f"\n• Missing: {', '.join(missing)}" if missing else ""
+                    return DispatchResult(
+                        outcome="ok",
+                        reply_text=(
+                            "❌ Capital mode confirm rejected\n"
+                            f"• Reason: {reason}{extra}"
+                        ),
+                    )
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text=(
+                        "❌ Capital mode confirm rejected\n"
+                        f"• Detail: {detail or 'unknown_error'}"
+                    ),
+                )
+            stage = data.get("stage", "")
+            if stage == "token_issued":
+                token = data.get("acknowledgment_token", "")
+                ttl = data.get("ttl_seconds", 0)
+                snapshot = data.get("snapshot", {}) or {}
+                gate_lines = "\n".join(
+                    f"  • {k}: {'✅' if v else '❌'}"
+                    for k, v in snapshot.items()
+                    if isinstance(v, bool)
+                )
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text=(
+                        "🟡 Capital mode confirm — step 1/2\n"
+                        f"• Token: `{token}`\n"
+                        f"• Reply within {ttl}s with: /capital_mode_confirm {token}\n"
+                        "• Gate snapshot:\n"
+                        f"{gate_lines or '  (no gate data)'}"
+                    ),
+                )
+            if stage == "committed":
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text=(
+                        "✅ Capital mode confirmed — receipt persisted\n"
+                        f"• confirmation_id: {data.get('confirmation_id', 'n/a')}\n"
+                        f"• operator_id: {data.get('operator_id', 'n/a')}\n"
+                        f"• mode: {data.get('mode', 'n/a')}\n"
+                        f"• confirmed_at: {data.get('confirmed_at', 'n/a')}"
+                    ),
+                )
+            return DispatchResult(
+                outcome="ok",
+                reply_text=f"Capital mode confirm: unexpected stage={stage!r}",
+            )
+
+        if command == "/capital_mode_revoke":
+            data = await self._backend.beta_post(
+                "/beta/capital_mode_revoke",
+                {
+                    "revoked_by": ctx.user_id,
+                    "reason": arg or "operator_revoke_no_reason",
+                },
+            )
+            if data.get("ok"):
+                return DispatchResult(
+                    outcome="ok",
+                    reply_text=(
+                        "🛑 Capital mode confirmation revoked\n"
+                        f"• confirmation_id: {data.get('confirmation_id', 'n/a')}\n"
+                        f"• revoked_by: {data.get('revoked_by', 'n/a')}\n"
+                        f"• revoked_at: {data.get('revoked_at', 'n/a')}\n"
+                        f"• reason: {data.get('reason', 'n/a')}"
+                    ),
+                )
+            return DispatchResult(
+                outcome="ok",
+                reply_text=(
+                    "⚠️ Capital mode revoke — no active confirmation\n"
+                    f"• Detail: {data.get('detail', 'unknown')}"
                 ),
             )
 

--- a/projects/polymarket/polyquantbot/infra/db/database.py
+++ b/projects/polymarket/polyquantbot/infra/db/database.py
@@ -330,6 +330,28 @@ CREATE TABLE IF NOT EXISTS settlement_reconciliation_results (
 """
 
 
+# ── Priority 8-E: Capital mode confirmation receipts ──────────────────────────
+
+_DDL_CAPITAL_MODE_CONFIRMATIONS = """
+CREATE TABLE IF NOT EXISTS capital_mode_confirmations (
+    confirmation_id         TEXT        PRIMARY KEY,
+    operator_id             TEXT        NOT NULL,
+    mode                    TEXT        NOT NULL,
+    acknowledgment_token    TEXT        NOT NULL,
+    upstream_gates_snapshot JSONB       NOT NULL DEFAULT '{}',
+    confirmed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at              TIMESTAMPTZ,
+    revoked_by              TEXT,
+    revoke_reason           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_capital_mode_confirmations_active
+    ON capital_mode_confirmations (mode, confirmed_at DESC)
+    WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_capital_mode_confirmations_operator
+    ON capital_mode_confirmations (operator_id, confirmed_at DESC);
+"""
+
+
 # ── DatabaseClient ─────────────────────────────────────────────────────────────
 
 
@@ -501,6 +523,8 @@ class DatabaseClient:
             await conn.execute(_DDL_SETTLEMENT_EVENTS)
             await conn.execute(_DDL_SETTLEMENT_RETRY_HISTORY)
             await conn.execute(_DDL_SETTLEMENT_RECONCILIATION_RESULTS)
+            # Priority 8-E: capital mode confirmation receipts
+            await conn.execute(_DDL_CAPITAL_MODE_CONFIRMATIONS)
         log.info("db_schema_applied")
 
     # ── Trades ────────────────────────────────────────────────────────────────

--- a/projects/polymarket/polyquantbot/infra/db/migrations/002_capital_mode_confirmations.sql
+++ b/projects/polymarket/polyquantbot/infra/db/migrations/002_capital_mode_confirmations.sql
@@ -1,0 +1,37 @@
+-- Migration 002: Capital mode confirmation receipts
+-- Priority 8-E -- Capital Mode Confirmation Flow (CAPITAL_MODE_CONFIRMED gate)
+-- Branch: WARP/capital-mode-confirm
+-- Date: 2026-04-30
+--
+-- Adds the runtime acknowledgment receipt that complements the env-var gate
+-- CAPITAL_MODE_CONFIRMED. The LiveExecutionGuard requires BOTH the env var
+-- AND an unrevoked confirmation row in this table before allowing live capital
+-- execution.  This is the second layer of the capital-mode defence-in-depth.
+--
+-- Auto-created idempotently by DatabaseClient._apply_schema() on every connect.
+-- This file exists for production deployment auditing and migration tooling
+-- that requires explicit SQL files.
+--
+-- Safe to run multiple times (CREATE TABLE IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS capital_mode_confirmations (
+    confirmation_id         TEXT        PRIMARY KEY,
+    operator_id             TEXT        NOT NULL,
+    mode                    TEXT        NOT NULL,
+    acknowledgment_token    TEXT        NOT NULL,
+    upstream_gates_snapshot JSONB       NOT NULL DEFAULT '{}',
+    confirmed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at              TIMESTAMPTZ,
+    revoked_by              TEXT,
+    revoke_reason           TEXT
+);
+
+-- Latest-unrevoked lookup: guard checks the most recent active confirmation
+-- per mode.  Partial index keeps the hot path narrow.
+CREATE INDEX IF NOT EXISTS idx_capital_mode_confirmations_active
+    ON capital_mode_confirmations (mode, confirmed_at DESC)
+    WHERE revoked_at IS NULL;
+
+-- Operator audit lookup: list every confirmation/revoke event for a given operator.
+CREATE INDEX IF NOT EXISTS idx_capital_mode_confirmations_operator
+    ON capital_mode_confirmations (operator_id, confirmed_at DESC);

--- a/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
+++ b/projects/polymarket/polyquantbot/server/api/public_beta_routes.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 import os
+import secrets
+import time
+from typing import Optional
+
 import structlog
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from starlette import status as http_status
 from pydantic import BaseModel
 
@@ -14,6 +18,24 @@ from projects.polymarket.polyquantbot.server.risk.capital_risk_gate import Capit
 
 log = structlog.get_logger(__name__)
 _OPERATOR_API_KEY_HEADER = "X-Operator-Api-Key"
+
+# ── P8-E: capital mode confirmation pending-token store ──────────────────────
+# Per-operator pending two-step tokens. Step 1 issues a token + snapshot;
+# step 2 must echo the same token within _CAPITAL_MODE_TOKEN_TTL_S seconds to
+# commit the receipt. In-process only — single-instance deployment is current
+# operating envelope. Multi-replica rollout would require Redis-backed storage.
+_CAPITAL_MODE_TOKEN_TTL_S: float = 60.0
+_PENDING_CAPITAL_CONFIRMS: dict[str, dict[str, object]] = {}
+
+
+class CapitalModeConfirmRequest(BaseModel):
+    operator_id: str
+    acknowledgment_token: str = ""
+
+
+class CapitalModeRevokeRequest(BaseModel):
+    revoked_by: str
+    reason: str = ""
 
 
 class ModeRequest(BaseModel):
@@ -310,5 +332,228 @@ def build_public_beta_router(falcon: FalconGateway) -> APIRouter:
         except Exception as exc:
             log.error("capital_status_error", error=str(exc))
             return {"ok": False, "detail": "capital_status_unavailable", "error": str(exc)}
+
+    @router.post("/capital_mode_confirm")
+    async def capital_mode_confirm(
+        body: CapitalModeConfirmRequest,
+        request: Request,
+        __: None = Depends(_require_operator_api_key),
+    ) -> dict[str, object]:
+        """Two-step capital-mode confirmation.
+
+        Step 1 (no token): pre-flight all 5 env gates, issue a 60-second
+        token plus the gate snapshot. No DB row is written.
+        Step 2 (with token): re-verify pre-flight, validate the echoed token
+        against the pending entry for the operator, insert a receipt row.
+
+        Operator-only — requires X-Operator-Api-Key header.
+        """
+        cfg = CapitalModeConfig.from_env()
+        snapshot = cfg.open_gates_report()
+        snapshot["trading_mode"] = cfg.trading_mode
+        missing = cfg._missing_gates() if cfg.trading_mode == "LIVE" else []
+
+        if cfg.trading_mode != "LIVE":
+            log.info(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="rejected_not_live",
+                trading_mode=cfg.trading_mode,
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_409_CONFLICT,
+                detail={
+                    "outcome": "rejected_not_live",
+                    "reason": "capital_mode_confirm_only_in_live_mode",
+                    "trading_mode": cfg.trading_mode,
+                },
+            )
+
+        if missing:
+            log.info(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="rejected_missing_gates",
+                missing=missing,
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_409_CONFLICT,
+                detail={
+                    "outcome": "rejected_missing_gates",
+                    "reason": "capital_mode_env_gates_missing",
+                    "missing": missing,
+                    "snapshot": snapshot,
+                },
+            )
+
+        store = getattr(request.app.state, "capital_mode_confirmation_store", None)
+        if store is None:
+            log.error(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="store_not_ready",
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="capital_mode_confirmation_store_not_ready",
+            )
+
+        now = time.monotonic()
+        # Drop expired pending entries before any work.
+        for op_id in list(_PENDING_CAPITAL_CONFIRMS):
+            if _PENDING_CAPITAL_CONFIRMS[op_id]["expires_at"] <= now:
+                _PENDING_CAPITAL_CONFIRMS.pop(op_id, None)
+
+        # ── Step 1: issue a token ────────────────────────────────────────
+        if not body.acknowledgment_token:
+            token = secrets.token_hex(8)
+            _PENDING_CAPITAL_CONFIRMS[body.operator_id] = {
+                "token": token,
+                "mode": "LIVE",
+                "snapshot": snapshot,
+                "expires_at": now + _CAPITAL_MODE_TOKEN_TTL_S,
+            }
+            log.info(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="token_issued",
+                ttl_seconds=int(_CAPITAL_MODE_TOKEN_TTL_S),
+            )
+            return {
+                "ok": True,
+                "stage": "token_issued",
+                "acknowledgment_token": token,
+                "ttl_seconds": int(_CAPITAL_MODE_TOKEN_TTL_S),
+                "snapshot": snapshot,
+                "detail": (
+                    "Reply with /capital_mode_confirm <token> within "
+                    f"{int(_CAPITAL_MODE_TOKEN_TTL_S)}s to commit."
+                ),
+            }
+
+        # ── Step 2: validate token and commit ────────────────────────────
+        pending = _PENDING_CAPITAL_CONFIRMS.get(body.operator_id)
+        if pending is None:
+            log.info(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="rejected_no_pending_token",
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_409_CONFLICT,
+                detail={
+                    "outcome": "rejected_no_pending_token",
+                    "reason": "no_pending_token_request_one_first",
+                },
+            )
+        if not secrets.compare_digest(
+            str(pending["token"]), body.acknowledgment_token
+        ):
+            log.warning(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="rejected_token_mismatch",
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_409_CONFLICT,
+                detail={
+                    "outcome": "rejected_token_mismatch",
+                    "reason": "acknowledgment_token_does_not_match_pending",
+                },
+            )
+
+        _PENDING_CAPITAL_CONFIRMS.pop(body.operator_id, None)
+
+        record = await store.insert(
+            operator_id=body.operator_id,
+            mode="LIVE",
+            acknowledgment_token=body.acknowledgment_token,
+            upstream_gates_snapshot=snapshot,
+        )
+        if record is None:
+            log.error(
+                "capital_mode_confirm_attempt",
+                operator_id=body.operator_id,
+                outcome="db_insert_failed",
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "outcome": "db_insert_failed",
+                    "reason": "capital_mode_confirm_persistence_failed",
+                },
+            )
+        log.info(
+            "capital_mode_confirm_attempt",
+            operator_id=body.operator_id,
+            outcome="committed",
+            confirmation_id=record.confirmation_id,
+            mode=record.mode,
+        )
+        return {
+            "ok": True,
+            "stage": "committed",
+            "confirmation_id": record.confirmation_id,
+            "operator_id": record.operator_id,
+            "mode": record.mode,
+            "confirmed_at": record.confirmed_at.isoformat(),
+            "snapshot": record.upstream_gates_snapshot,
+        }
+
+    @router.post("/capital_mode_revoke")
+    async def capital_mode_revoke(
+        body: CapitalModeRevokeRequest,
+        request: Request,
+        __: None = Depends(_require_operator_api_key),
+    ) -> dict[str, object]:
+        """Revoke the most-recent active capital-mode confirmation.
+
+        Single-step (no token) — revocation must be fast for incident response.
+        Operator-only — requires X-Operator-Api-Key header.
+        """
+        store = getattr(request.app.state, "capital_mode_confirmation_store", None)
+        if store is None:
+            log.error(
+                "capital_mode_revoke_attempt",
+                revoked_by=body.revoked_by,
+                outcome="store_not_ready",
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="capital_mode_confirmation_store_not_ready",
+            )
+
+        reason = body.reason.strip() or "operator_revoke_no_reason"
+        record = await store.revoke_latest(
+            mode="LIVE",
+            revoked_by=body.revoked_by,
+            reason=reason,
+        )
+        if record is None:
+            log.info(
+                "capital_mode_revoke_attempt",
+                revoked_by=body.revoked_by,
+                outcome="no_active_to_revoke",
+            )
+            return {
+                "ok": False,
+                "stage": "no_active",
+                "detail": "no active capital_mode confirmation to revoke",
+            }
+        log.warning(
+            "capital_mode_revoke_attempt",
+            revoked_by=body.revoked_by,
+            outcome="revoked",
+            confirmation_id=record.confirmation_id,
+            reason=reason,
+        )
+        return {
+            "ok": True,
+            "stage": "revoked",
+            "confirmation_id": record.confirmation_id,
+            "revoked_by": record.revoked_by,
+            "revoked_at": record.revoked_at.isoformat() if record.revoked_at else None,
+            "reason": record.revoke_reason,
+        }
 
     return router

--- a/projects/polymarket/polyquantbot/server/config/capital_mode_config.py
+++ b/projects/polymarket/polyquantbot/server/config/capital_mode_config.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import structlog
 
@@ -220,6 +221,46 @@ class CapitalModeConfig:
             "execution_path_validated": self.execution_path_validated,
             "security_hardening_validated": self.security_hardening_validated,
         }
+
+    async def is_capital_mode_fully_allowed(
+        self, store: Any
+    ) -> tuple[bool, str | None]:
+        """Two-layer capital-mode gate (env var + DB receipt).
+
+        Combines :meth:`is_capital_mode_allowed` (env-var layer) with a runtime
+        check that an unrevoked confirmation row exists for the current
+        ``trading_mode`` in :class:`CapitalModeConfirmationStore`.
+
+        ``store`` must expose ``async get_active(mode: str) -> object | None``.
+
+        Returns:
+            (True, None) when both layers pass; (False, reason) otherwise. The
+            reason is a stable machine-readable token suitable for structured
+            logging or operator alerts.
+        """
+        if not self.is_capital_mode_allowed():
+            missing = self._missing_gates()
+            reason = (
+                "capital_mode_env_gates_missing:" + ",".join(missing)
+                if missing
+                else "capital_mode_not_live"
+            )
+            return False, reason
+
+        try:
+            active = await store.get_active(self.trading_mode)
+        except Exception as exc:
+            log.error(
+                "capital_mode_confirmation_lookup_error",
+                error=str(exc),
+                trading_mode=self.trading_mode,
+            )
+            return False, "capital_mode_confirmation_lookup_error"
+
+        if active is None:
+            return False, "capital_mode_no_active_receipt"
+
+        return True, None
 
     # ── Internal helpers ──────────────────────────────────────────────────────
 

--- a/projects/polymarket/polyquantbot/server/core/live_execution_control.py
+++ b/projects/polymarket/polyquantbot/server/core/live_execution_control.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Any
 
 import structlog
 
@@ -210,6 +211,62 @@ class LiveExecutionGuard:
             kill_switch=state.kill_switch,
             trading_mode=self._config.trading_mode,
             capital_mode_allowed=self._config.is_capital_mode_allowed(),
+            wallet_id=wallet_id,
+        )
+
+    async def check_with_receipt(
+        self,
+        state: PublicBetaState,
+        store: Any,
+        provider: WalletFinancialProvider | None = None,
+        wallet_id: str = _STUB_WALLET_ID,
+    ) -> None:
+        """Run the full live-execution guard PLUS the DB-receipt check.
+
+        Equivalent to :meth:`check` (env-var layer) followed by a query against
+        :class:`CapitalModeConfirmationStore` for an unrevoked confirmation row
+        matching the current ``trading_mode``.
+
+        ``store`` must expose ``async get_active(mode: str) -> object | None``.
+
+        Live execution paths that require the full P8-E gate (env + receipt)
+        must call this method instead of :meth:`check`.
+
+        Raises:
+            LiveExecutionBlockedError: Any check fails — including the receipt
+            layer (reason ``capital_mode_no_active_receipt`` or
+            ``capital_mode_confirmation_lookup_error``).
+        """
+        # 1-5: existing synchronous guard chain — kill switch, mode, env var,
+        # config gates, financial provider zero-field check.
+        self.check(state, provider=provider, wallet_id=wallet_id)
+
+        # 6: DB-backed confirmation receipt — required even if all env vars
+        # are flipped on. This prevents an env-only misconfiguration from
+        # admitting capital execution without operator acknowledgment.
+        try:
+            active = await store.get_active(self._config.trading_mode)
+        except Exception as exc:
+            self._block(
+                "capital_mode_confirmation_lookup_error",
+                f"CapitalModeConfirmationStore lookup raised: {exc}",
+            )
+            return
+
+        if active is None:
+            self._block(
+                "capital_mode_no_active_receipt",
+                "no unrevoked capital_mode_confirmations row for "
+                f"trading_mode={self._config.trading_mode!r} — "
+                "operator must issue /capital_mode_confirm before live execution",
+            )
+
+        log.info(
+            "live_execution_guard_with_receipt_passed",
+            mode=state.mode,
+            trading_mode=self._config.trading_mode,
+            confirmation_id=getattr(active, "confirmation_id", None),
+            operator_id=getattr(active, "operator_id", None),
             wallet_id=wallet_id,
         )
 

--- a/projects/polymarket/polyquantbot/server/main.py
+++ b/projects/polymarket/polyquantbot/server/main.py
@@ -62,6 +62,9 @@ from projects.polymarket.polyquantbot.server.settlement.settlement_alert_policy 
 from projects.polymarket.polyquantbot.server.settlement.operator_console import OperatorConsole
 from projects.polymarket.polyquantbot.server.services.settlement_operator_service import SettlementOperatorService
 from projects.polymarket.polyquantbot.server.api.settlement_operator_routes import build_settlement_operator_router
+from projects.polymarket.polyquantbot.server.storage.capital_mode_confirmation_store import (
+    CapitalModeConfirmationStore,
+)
 from projects.polymarket.polyquantbot.infra.db import DatabaseClient
 
 log = structlog.get_logger(__name__)
@@ -436,6 +439,12 @@ def create_app() -> FastAPI:
                     console=_operator_console,
                 )
                 log.info("settlement_operator_service_wired")
+            # P8-E: wire capital-mode confirmation store after DB is connected
+            if state.db_client is not None:
+                _app.state.capital_mode_confirmation_store = (
+                    CapitalModeConfirmationStore(db=state.db_client)
+                )
+                log.info("capital_mode_confirmation_store_wired")
             try:
                 await _start_telegram_runtime(state=state)
             except Exception as exc:

--- a/projects/polymarket/polyquantbot/server/storage/capital_mode_confirmation_store.py
+++ b/projects/polymarket/polyquantbot/server/storage/capital_mode_confirmation_store.py
@@ -1,0 +1,226 @@
+"""Capital mode confirmation store — Priority 8-E.
+
+PostgreSQL-backed persistence for the runtime acknowledgment receipt that
+complements the CAPITAL_MODE_CONFIRMED env-var gate. The LiveExecutionGuard
+requires BOTH the env var AND an unrevoked row in `capital_mode_confirmations`
+before admitting live capital execution.
+
+Idempotent inserts (ON CONFLICT DO NOTHING on confirmation_id). Failed writes
+return False; failed reads return None / []. Callers must not assume success.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import structlog
+
+from projects.polymarket.polyquantbot.infra.db import DatabaseClient
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CapitalModeConfirmation:
+    """Immutable view of a single capital-mode confirmation row.
+
+    Attributes:
+        confirmation_id:         Server-assigned UUID hex.
+        operator_id:             Operator who issued the confirmation.
+        mode:                    "LIVE" or "PAPER".
+        acknowledgment_token:    Two-step confirmation anti-misclick token.
+        upstream_gates_snapshot: Dict of all 5 gate booleans at confirm time.
+        confirmed_at:            UTC timestamp of the confirmation.
+        revoked_at:              UTC timestamp if revoked, else None.
+        revoked_by:              Operator who revoked, else None.
+        revoke_reason:           Reason supplied at revoke, else None.
+    """
+
+    confirmation_id: str
+    operator_id: str
+    mode: str
+    acknowledgment_token: str
+    upstream_gates_snapshot: dict[str, Any]
+    confirmed_at: datetime
+    revoked_at: Optional[datetime]
+    revoked_by: Optional[str]
+    revoke_reason: Optional[str]
+
+    @property
+    def is_active(self) -> bool:
+        return self.revoked_at is None
+
+
+class CapitalModeConfirmationStore:
+    """PostgreSQL-backed store for capital_mode_confirmations rows.
+
+    Args:
+        db: DatabaseClient instance (from server runtime state).
+    """
+
+    def __init__(self, db: DatabaseClient) -> None:
+        self._db = db
+
+    # ── Writes ────────────────────────────────────────────────────────────────
+
+    async def insert(
+        self,
+        *,
+        operator_id: str,
+        mode: str,
+        acknowledgment_token: str,
+        upstream_gates_snapshot: dict[str, Any],
+    ) -> Optional[CapitalModeConfirmation]:
+        """Insert a new confirmation receipt. Returns the persisted record on success.
+
+        Returns None if the DB write fails — caller must treat as a refusal.
+        """
+        confirmation_id = uuid.uuid4().hex
+        confirmed_at = datetime.now(timezone.utc)
+        sql = """
+            INSERT INTO capital_mode_confirmations (
+                confirmation_id, operator_id, mode, acknowledgment_token,
+                upstream_gates_snapshot, confirmed_at
+            ) VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+            ON CONFLICT (confirmation_id) DO NOTHING
+        """
+        ok = await self._db._execute(
+            sql,
+            confirmation_id,
+            operator_id,
+            mode,
+            acknowledgment_token,
+            json.dumps(upstream_gates_snapshot),
+            confirmed_at,
+            op_label="capital_mode_confirm_insert",
+        )
+        if not ok:
+            log.error(
+                "capital_mode_confirm_insert_failed",
+                operator_id=operator_id,
+                mode=mode,
+            )
+            return None
+        return CapitalModeConfirmation(
+            confirmation_id=confirmation_id,
+            operator_id=operator_id,
+            mode=mode,
+            acknowledgment_token=acknowledgment_token,
+            upstream_gates_snapshot=dict(upstream_gates_snapshot),
+            confirmed_at=confirmed_at,
+            revoked_at=None,
+            revoked_by=None,
+            revoke_reason=None,
+        )
+
+    async def revoke_latest(
+        self,
+        *,
+        mode: str,
+        revoked_by: str,
+        reason: str,
+    ) -> Optional[CapitalModeConfirmation]:
+        """Revoke the newest active confirmation for the given mode.
+
+        Returns the revoked record on success, None if no active row exists or
+        the DB write fails.
+        """
+        active = await self.get_active(mode)
+        if active is None:
+            return None
+        revoked_at = datetime.now(timezone.utc)
+        sql = """
+            UPDATE capital_mode_confirmations
+               SET revoked_at = $1,
+                   revoked_by = $2,
+                   revoke_reason = $3
+             WHERE confirmation_id = $4
+               AND revoked_at IS NULL
+        """
+        ok = await self._db._execute(
+            sql,
+            revoked_at,
+            revoked_by,
+            reason,
+            active.confirmation_id,
+            op_label="capital_mode_confirm_revoke",
+        )
+        if not ok:
+            log.error(
+                "capital_mode_confirm_revoke_failed",
+                confirmation_id=active.confirmation_id,
+                revoked_by=revoked_by,
+            )
+            return None
+        return CapitalModeConfirmation(
+            confirmation_id=active.confirmation_id,
+            operator_id=active.operator_id,
+            mode=active.mode,
+            acknowledgment_token=active.acknowledgment_token,
+            upstream_gates_snapshot=active.upstream_gates_snapshot,
+            confirmed_at=active.confirmed_at,
+            revoked_at=revoked_at,
+            revoked_by=revoked_by,
+            revoke_reason=reason,
+        )
+
+    # ── Reads ─────────────────────────────────────────────────────────────────
+
+    async def get_active(self, mode: str) -> Optional[CapitalModeConfirmation]:
+        """Return the most-recent unrevoked confirmation for `mode`, or None."""
+        sql = """
+            SELECT confirmation_id, operator_id, mode, acknowledgment_token,
+                   upstream_gates_snapshot, confirmed_at,
+                   revoked_at, revoked_by, revoke_reason
+              FROM capital_mode_confirmations
+             WHERE mode = $1 AND revoked_at IS NULL
+             ORDER BY confirmed_at DESC
+             LIMIT 1
+        """
+        rows = await self._db._fetch(sql, mode, op_label="capital_mode_confirm_get_active")
+        if not rows:
+            return None
+        return _row_to_record(rows[0])
+
+    async def list_recent(self, *, limit: int = 20) -> list[CapitalModeConfirmation]:
+        """Return the most-recent confirmations (active and revoked) for audit display."""
+        sql = """
+            SELECT confirmation_id, operator_id, mode, acknowledgment_token,
+                   upstream_gates_snapshot, confirmed_at,
+                   revoked_at, revoked_by, revoke_reason
+              FROM capital_mode_confirmations
+             ORDER BY confirmed_at DESC
+             LIMIT $1
+        """
+        rows = await self._db._fetch(sql, limit, op_label="capital_mode_confirm_list_recent")
+        return [_row_to_record(row) for row in rows]
+
+
+# ── Module helpers ────────────────────────────────────────────────────────────
+
+
+def _row_to_record(row: dict[str, Any]) -> CapitalModeConfirmation:
+    snapshot_raw = row.get("upstream_gates_snapshot") or {}
+    if isinstance(snapshot_raw, str):
+        try:
+            snapshot = json.loads(snapshot_raw)
+        except json.JSONDecodeError:
+            snapshot = {}
+    elif isinstance(snapshot_raw, dict):
+        snapshot = snapshot_raw
+    else:
+        snapshot = {}
+    return CapitalModeConfirmation(
+        confirmation_id=row["confirmation_id"],
+        operator_id=row["operator_id"],
+        mode=row["mode"],
+        acknowledgment_token=row["acknowledgment_token"],
+        upstream_gates_snapshot=snapshot,
+        confirmed_at=row["confirmed_at"],
+        revoked_at=row.get("revoked_at"),
+        revoked_by=row.get("revoked_by"),
+        revoke_reason=row.get("revoke_reason"),
+    )

--- a/projects/polymarket/polyquantbot/tests/test_capital_readiness_p8e.py
+++ b/projects/polymarket/polyquantbot/tests/test_capital_readiness_p8e.py
@@ -1,0 +1,531 @@
+"""Priority 8-E — Capital Mode Confirmation Flow — Tests.
+
+Test IDs: P8E-01 .. P8E-15
+
+Coverage:
+  P8E-01  CapitalModeConfirmationStore.insert returns persisted record
+  P8E-02  store.get_active returns None when no row exists
+  P8E-03  store.get_active returns most-recent unrevoked row
+  P8E-04  store.revoke_latest revokes active row; get_active then returns None
+  P8E-05  store.revoke_latest returns None when no active row exists
+  P8E-06  CapitalModeConfig.is_capital_mode_fully_allowed: env gates missing -> (False, reason)
+  P8E-07  is_capital_mode_fully_allowed: env all set but no receipt -> (False, no_active_receipt)
+  P8E-08  is_capital_mode_fully_allowed: env all set + active receipt -> (True, None)
+  P8E-09  LiveExecutionGuard.check_with_receipt raises when receipt missing
+  P8E-10  check_with_receipt passes when env + receipt + provider all green
+  P8E-11  POST /beta/capital_mode_confirm step 1 issues token + gate snapshot
+  P8E-12  POST /beta/capital_mode_confirm rejects with 409 when env gates missing
+  P8E-13  POST /beta/capital_mode_confirm step 2 commits receipt with valid token
+  P8E-14  POST /beta/capital_mode_confirm step 2 rejects mismatched token with 409
+  P8E-15  POST /beta/capital_mode_revoke revokes active confirmation
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from projects.polymarket.polyquantbot.configs.falcon import FalconSettings
+from projects.polymarket.polyquantbot.server.api.public_beta_routes import (
+    _PENDING_CAPITAL_CONFIRMS,
+    build_public_beta_router,
+)
+from projects.polymarket.polyquantbot.server.config.capital_mode_config import (
+    CapitalModeConfig,
+)
+from projects.polymarket.polyquantbot.server.core.live_execution_control import (
+    LiveExecutionBlockedError,
+    LiveExecutionGuard,
+)
+from projects.polymarket.polyquantbot.server.core.public_beta_state import (
+    PublicBetaState,
+)
+from projects.polymarket.polyquantbot.server.integrations.falcon_gateway import FalconGateway
+from projects.polymarket.polyquantbot.server.storage.capital_mode_confirmation_store import (
+    CapitalModeConfirmation,
+    CapitalModeConfirmationStore,
+)
+
+
+# ── Shared env fixtures ───────────────────────────────────────────────────────
+
+_ALL_GATES_ON = {
+    "TRADING_MODE": "LIVE",
+    "ENABLE_LIVE_TRADING": "true",
+    "CAPITAL_MODE_CONFIRMED": "true",
+    "RISK_CONTROLS_VALIDATED": "true",
+    "EXECUTION_PATH_VALIDATED": "true",
+    "SECURITY_HARDENING_VALIDATED": "true",
+}
+
+_ALL_GATES_OFF = {
+    "TRADING_MODE": "PAPER",
+    "ENABLE_LIVE_TRADING": "false",
+    "CAPITAL_MODE_CONFIRMED": "false",
+    "RISK_CONTROLS_VALIDATED": "false",
+    "EXECUTION_PATH_VALIDATED": "false",
+    "SECURITY_HARDENING_VALIDATED": "false",
+}
+
+_OPERATOR_API_KEY = "test_operator_api_key"
+_OPERATOR_HEADERS = {"X-Operator-Api-Key": _OPERATOR_API_KEY}
+
+
+# ── In-memory stub DB matching DatabaseClient._execute/_fetch interface ──────
+
+
+class _StubDB:
+    """Test-only DB that records every call and serves rows from a fake table."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+        self.executes: list[tuple[str, tuple]] = []
+        self.fetches: list[tuple[str, tuple]] = []
+        self.fail_execute: bool = False
+        self.fail_fetch: bool = False
+
+    async def _execute(self, sql: str, *args: Any, op_label: str = "execute") -> bool:
+        self.executes.append((sql, args))
+        if self.fail_execute:
+            return False
+        sql_l = sql.strip().lower()
+        if sql_l.startswith("insert into capital_mode_confirmations"):
+            (cid, op_id, mode, token, snap_json, confirmed_at) = args
+            try:
+                snapshot = json.loads(snap_json)
+            except Exception:
+                snapshot = {}
+            self.rows.append(
+                {
+                    "confirmation_id": cid,
+                    "operator_id": op_id,
+                    "mode": mode,
+                    "acknowledgment_token": token,
+                    "upstream_gates_snapshot": snapshot,
+                    "confirmed_at": confirmed_at,
+                    "revoked_at": None,
+                    "revoked_by": None,
+                    "revoke_reason": None,
+                }
+            )
+            return True
+        if sql_l.startswith("update capital_mode_confirmations"):
+            (revoked_at, revoked_by, reason, cid) = args
+            for row in self.rows:
+                if row["confirmation_id"] == cid and row["revoked_at"] is None:
+                    row["revoked_at"] = revoked_at
+                    row["revoked_by"] = revoked_by
+                    row["revoke_reason"] = reason
+                    return True
+            return False
+        return True
+
+    async def _fetch(
+        self, sql: str, *args: Any, op_label: str = "fetch"
+    ) -> list[dict[str, Any]]:
+        self.fetches.append((sql, args))
+        if self.fail_fetch:
+            return []
+        sql_l = sql.strip().lower()
+        if "from capital_mode_confirmations" in sql_l and "limit 1" in sql_l:
+            mode = args[0]
+            active = [
+                r for r in self.rows if r["mode"] == mode and r["revoked_at"] is None
+            ]
+            active.sort(key=lambda r: r["confirmed_at"], reverse=True)
+            return [active[0]] if active else []
+        if "from capital_mode_confirmations" in sql_l:
+            limit = args[0] if args else 20
+            ordered = sorted(
+                self.rows, key=lambda r: r["confirmed_at"], reverse=True
+            )
+            return ordered[:limit]
+        return []
+
+
+def _make_record(
+    *,
+    confirmation_id: str = "cid_001",
+    operator_id: str = "op_alice",
+    mode: str = "LIVE",
+    token: str = "tok_abc",
+    revoked: bool = False,
+) -> CapitalModeConfirmation:
+    now = datetime.now(timezone.utc)
+    return CapitalModeConfirmation(
+        confirmation_id=confirmation_id,
+        operator_id=operator_id,
+        mode=mode,
+        acknowledgment_token=token,
+        upstream_gates_snapshot={"trading_mode": mode, "enable_live_trading": True},
+        confirmed_at=now,
+        revoked_at=now if revoked else None,
+        revoked_by="op_bob" if revoked else None,
+        revoke_reason="ops_drill" if revoked else None,
+    )
+
+
+def _make_falcon() -> FalconGateway:
+    settings = FalconSettings(
+        enabled=False, api_key="", base_url="http://localhost", timeout_seconds=10
+    )
+    return FalconGateway(settings)
+
+
+def _make_app(store: CapitalModeConfirmationStore | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_public_beta_router(falcon=_make_falcon()))
+    if store is not None:
+        app.state.capital_mode_confirmation_store = store
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_tokens():
+    _PENDING_CAPITAL_CONFIRMS.clear()
+    yield
+    _PENDING_CAPITAL_CONFIRMS.clear()
+
+
+# ── P8E-01 .. P8E-05: CapitalModeConfirmationStore unit tests ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_p8e_01_store_insert_returns_record() -> None:
+    """P8E-01: store.insert returns persisted CapitalModeConfirmation on success."""
+    store = CapitalModeConfirmationStore(db=_StubDB())  # type: ignore[arg-type]
+    record = await store.insert(
+        operator_id="op_alice",
+        mode="LIVE",
+        acknowledgment_token="tok_abc",
+        upstream_gates_snapshot={"enable_live_trading": True},
+    )
+    assert record is not None
+    assert record.operator_id == "op_alice"
+    assert record.mode == "LIVE"
+    assert record.acknowledgment_token == "tok_abc"
+    assert record.upstream_gates_snapshot == {"enable_live_trading": True}
+    assert record.revoked_at is None
+    assert record.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_p8e_02_store_get_active_returns_none_when_empty() -> None:
+    """P8E-02: store.get_active returns None when no row exists."""
+    store = CapitalModeConfirmationStore(db=_StubDB())  # type: ignore[arg-type]
+    assert await store.get_active("LIVE") is None
+
+
+@pytest.mark.asyncio
+async def test_p8e_03_store_get_active_returns_latest_unrevoked() -> None:
+    """P8E-03: store.get_active returns most-recent unrevoked row for the mode."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    first = await store.insert(
+        operator_id="op_alice",
+        mode="LIVE",
+        acknowledgment_token="t1",
+        upstream_gates_snapshot={},
+    )
+    assert first is not None
+    # Force a later confirmed_at on the second row.
+    await asyncio.sleep(0.01)
+    second = await store.insert(
+        operator_id="op_bob",
+        mode="LIVE",
+        acknowledgment_token="t2",
+        upstream_gates_snapshot={},
+    )
+    assert second is not None
+    active = await store.get_active("LIVE")
+    assert active is not None
+    assert active.confirmation_id == second.confirmation_id
+
+
+@pytest.mark.asyncio
+async def test_p8e_04_store_revoke_latest_clears_active() -> None:
+    """P8E-04: store.revoke_latest revokes the active row; get_active then returns None."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    inserted = await store.insert(
+        operator_id="op_alice",
+        mode="LIVE",
+        acknowledgment_token="t1",
+        upstream_gates_snapshot={},
+    )
+    assert inserted is not None
+    revoked = await store.revoke_latest(
+        mode="LIVE", revoked_by="op_bob", reason="ops_drill"
+    )
+    assert revoked is not None
+    assert revoked.confirmation_id == inserted.confirmation_id
+    assert revoked.revoked_by == "op_bob"
+    assert revoked.revoke_reason == "ops_drill"
+    assert await store.get_active("LIVE") is None
+
+
+@pytest.mark.asyncio
+async def test_p8e_05_store_revoke_latest_returns_none_when_no_active() -> None:
+    """P8E-05: store.revoke_latest returns None when no active row exists."""
+    store = CapitalModeConfirmationStore(db=_StubDB())  # type: ignore[arg-type]
+    revoked = await store.revoke_latest(
+        mode="LIVE", revoked_by="op_alice", reason="nothing_to_revoke"
+    )
+    assert revoked is None
+
+
+# ── P8E-06 .. P8E-08: CapitalModeConfig.is_capital_mode_fully_allowed ─────────
+
+
+@pytest.mark.asyncio
+async def test_p8e_06_fully_allowed_blocked_when_env_gates_missing() -> None:
+    """P8E-06: env gates not all set -> (False, missing-gates reason)."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    with patch.dict(os.environ, _ALL_GATES_OFF, clear=False):
+        cfg = CapitalModeConfig.from_env()
+    ok, reason = await cfg.is_capital_mode_fully_allowed(store)
+    assert ok is False
+    assert reason is not None
+    assert "capital_mode" in reason
+
+
+@pytest.mark.asyncio
+async def test_p8e_07_fully_allowed_blocked_without_receipt() -> None:
+    """P8E-07: env all set but no DB row -> (False, capital_mode_no_active_receipt)."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        cfg = CapitalModeConfig.from_env()
+    ok, reason = await cfg.is_capital_mode_fully_allowed(store)
+    assert ok is False
+    assert reason == "capital_mode_no_active_receipt"
+
+
+@pytest.mark.asyncio
+async def test_p8e_08_fully_allowed_passes_with_env_and_receipt() -> None:
+    """P8E-08: env all set + active receipt -> (True, None)."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    await store.insert(
+        operator_id="op_alice",
+        mode="LIVE",
+        acknowledgment_token="tok_x",
+        upstream_gates_snapshot={"enable_live_trading": True},
+    )
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        cfg = CapitalModeConfig.from_env()
+    ok, reason = await cfg.is_capital_mode_fully_allowed(store)
+    assert ok is True
+    assert reason is None
+
+
+# ── P8E-09 .. P8E-10: LiveExecutionGuard.check_with_receipt ───────────────────
+
+
+class _StubProvider:
+    """WalletFinancialProvider stub returning non-zero financial fields."""
+
+    def get_balance_usd(self, wallet_id: str) -> float:
+        return 5_000.0
+
+    def get_exposure_pct(self, wallet_id: str) -> float:
+        return 0.05
+
+    def get_drawdown_pct(self, wallet_id: str) -> float:
+        return 0.01
+
+
+@pytest.mark.asyncio
+async def test_p8e_09_check_with_receipt_blocks_when_no_receipt() -> None:
+    """P8E-09: check_with_receipt raises capital_mode_no_active_receipt when env passes but DB empty."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        cfg = CapitalModeConfig.from_env()
+    guard = LiveExecutionGuard(config=cfg)
+    state = PublicBetaState()
+    state.mode = "live"
+    state.kill_switch = False
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        with pytest.raises(LiveExecutionBlockedError) as exc_info:
+            await guard.check_with_receipt(
+                state, store=store, provider=_StubProvider()
+            )
+    assert exc_info.value.reason == "capital_mode_no_active_receipt"
+
+
+@pytest.mark.asyncio
+async def test_p8e_10_check_with_receipt_passes_with_full_chain() -> None:
+    """P8E-10: env + receipt + non-zero provider -> guard passes without raising."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    await store.insert(
+        operator_id="op_alice",
+        mode="LIVE",
+        acknowledgment_token="tok_x",
+        upstream_gates_snapshot={"enable_live_trading": True},
+    )
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        cfg = CapitalModeConfig.from_env()
+    guard = LiveExecutionGuard(config=cfg)
+    state = PublicBetaState()
+    state.mode = "live"
+    state.kill_switch = False
+    with patch.dict(os.environ, _ALL_GATES_ON, clear=False):
+        await guard.check_with_receipt(
+            state, store=store, provider=_StubProvider()
+        )
+
+
+# ── P8E-11 .. P8E-15: Backend route tests ────────────────────────────────────
+
+
+def test_p8e_11_confirm_step1_issues_token_and_snapshot() -> None:
+    """P8E-11: POST /beta/capital_mode_confirm step 1 (no token) returns token + snapshot."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    env = {**_ALL_GATES_ON, "CRUSADER_OPERATOR_API_KEY": _OPERATOR_API_KEY}
+    with patch.dict(os.environ, env, clear=False):
+        client = _make_app(store=store)
+        resp = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice"},
+            headers=_OPERATOR_HEADERS,
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["stage"] == "token_issued"
+    assert isinstance(body["acknowledgment_token"], str)
+    assert len(body["acknowledgment_token"]) >= 16
+    assert body["snapshot"]["enable_live_trading"] is True
+    # No DB row yet — only step 2 commits.
+    assert db.rows == []
+
+
+def test_p8e_12_confirm_rejects_with_409_when_env_gates_missing() -> None:
+    """P8E-12: POST returns 409 with missing-gates list when env not all set."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    # All gates off except TRADING_MODE=LIVE → missing-gates reason should fire.
+    env = {
+        **_ALL_GATES_OFF,
+        "TRADING_MODE": "LIVE",
+        "CRUSADER_OPERATOR_API_KEY": _OPERATOR_API_KEY,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        client = _make_app(store=store)
+        resp = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice"},
+            headers=_OPERATOR_HEADERS,
+        )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["outcome"] == "rejected_missing_gates"
+    assert "ENABLE_LIVE_TRADING" in detail["missing"]
+    assert "CAPITAL_MODE_CONFIRMED" in detail["missing"]
+
+
+def test_p8e_13_confirm_step2_commits_receipt() -> None:
+    """P8E-13: POST step 2 (with valid token) inserts receipt + returns committed stage."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    env = {**_ALL_GATES_ON, "CRUSADER_OPERATOR_API_KEY": _OPERATOR_API_KEY}
+    with patch.dict(os.environ, env, clear=False):
+        client = _make_app(store=store)
+        # Step 1
+        first = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice"},
+            headers=_OPERATOR_HEADERS,
+        )
+        token = first.json()["acknowledgment_token"]
+        # Step 2
+        resp = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice", "acknowledgment_token": token},
+            headers=_OPERATOR_HEADERS,
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["stage"] == "committed"
+    assert body["mode"] == "LIVE"
+    assert body["operator_id"] == "op_alice"
+    # DB row inserted; pending entry cleared.
+    assert len(db.rows) == 1
+    assert db.rows[0]["operator_id"] == "op_alice"
+    assert "op_alice" not in _PENDING_CAPITAL_CONFIRMS
+
+
+def test_p8e_14_confirm_step2_rejects_token_mismatch() -> None:
+    """P8E-14: POST step 2 with wrong token returns 409 rejected_token_mismatch."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    env = {**_ALL_GATES_ON, "CRUSADER_OPERATOR_API_KEY": _OPERATOR_API_KEY}
+    with patch.dict(os.environ, env, clear=False):
+        client = _make_app(store=store)
+        # Step 1 to seed pending entry
+        first = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice"},
+            headers=_OPERATOR_HEADERS,
+        )
+        assert first.status_code == 200
+        # Step 2 with bogus token
+        resp = client.post(
+            "/beta/capital_mode_confirm",
+            json={
+                "operator_id": "op_alice",
+                "acknowledgment_token": "deadbeefdeadbeef",
+            },
+            headers=_OPERATOR_HEADERS,
+        )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["outcome"] == "rejected_token_mismatch"
+    assert db.rows == []  # nothing committed
+
+
+def test_p8e_15_revoke_clears_active_confirmation() -> None:
+    """P8E-15: POST /beta/capital_mode_revoke marks the active row revoked."""
+    db = _StubDB()
+    store = CapitalModeConfirmationStore(db=db)  # type: ignore[arg-type]
+    env = {**_ALL_GATES_ON, "CRUSADER_OPERATOR_API_KEY": _OPERATOR_API_KEY}
+    with patch.dict(os.environ, env, clear=False):
+        client = _make_app(store=store)
+        # Confirm first (steps 1+2).
+        first = client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice"},
+            headers=_OPERATOR_HEADERS,
+        )
+        token = first.json()["acknowledgment_token"]
+        client.post(
+            "/beta/capital_mode_confirm",
+            json={"operator_id": "op_alice", "acknowledgment_token": token},
+            headers=_OPERATOR_HEADERS,
+        )
+        # Revoke
+        resp = client.post(
+            "/beta/capital_mode_revoke",
+            json={"revoked_by": "op_bob", "reason": "ops_drill"},
+            headers=_OPERATOR_HEADERS,
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["stage"] == "revoked"
+    assert body["revoked_by"] == "op_bob"
+    assert body["reason"] == "ops_drill"
+    # Underlying row is now revoked → next get_active returns None.
+    assert db.rows[0]["revoked_by"] == "op_bob"
+    assert db.rows[0]["revoked_at"] is not None


### PR DESCRIPTION
Adds capital_mode_confirmations table (Priority 8-E) — the runtime acknowledgment
receipt that complements the CAPITAL_MODE_CONFIRMED env-var gate. Two-layer
defence: env var + unrevoked DB row both required before LiveExecutionGuard
admits live capital execution.

- infra/db/migrations/002_capital_mode_confirmations.sql (new): standalone DDL
  with active-lookup partial index + operator audit index.
- infra/db/database.py: _DDL_CAPITAL_MODE_CONFIRMATIONS constant + idempotent
  _apply_schema execution.

Branch: WARP/capital-mode-confirm
Validation Tier: MAJOR
Claim Level: NARROW INTEGRATION
Chunk: 1/5 — guard wiring + endpoint + Telegram + tests + docs follow.