### PR TITLE
WARP•FORGE: public-ready launch pack

### DIFF
--- a/projects/polymarket/polyquantbot/docs/public_ready_launch_pack.md
+++ b/projects/polymarket/polyquantbot/docs/public_ready_launch_pack.md
@@ -1,0 +1,82 @@
+# CrusaderBot Public Ready Launch Pack
+
+Last Updated: 2026-05-01 09:20 Asia/Jakarta
+
+## Launch posture
+
+CrusaderBot is public-ready as a paper-beta product.
+
+This pack is for public paper-beta launch coordination only. It does not authorize live trading, production capital, capital-mode activation, or execution-path activation.
+
+## Approved public claim
+
+CrusaderBot is a non-custodial Polymarket paper-beta trading system with public-facing paper-mode documentation, operator runbooks, admin visibility docs, and runtime smoke evidence recorded.
+
+Final WARP🔹CMD decision: ACCEPTED as public paper-beta on 2026-05-01.
+
+## Evidence basis
+
+- Priority 9 is COMPLETE.
+- Runtime smoke evidence PR #840 merged.
+- Smoke matrix result: 6/8 PASS.
+- Telegram surfaces were BLOCKED by environment constraint, not code defect.
+- Final acceptance decision is recorded in projects/polymarket/polyquantbot/docs/final_acceptance_gate.md.
+- Repo truth is synchronized across PROJECT_STATE.md, ROADMAP.md, WORKTODO.md, and CHANGELOG.md.
+
+## Public-safe launch surfaces
+
+Use these docs as the public paper-beta launch source set:
+
+- projects/polymarket/polyquantbot/README.md
+- projects/polymarket/polyquantbot/docs/launch_summary.md
+- projects/polymarket/polyquantbot/docs/onboarding.md
+- projects/polymarket/polyquantbot/docs/support.md
+- projects/polymarket/polyquantbot/docs/paper_only_boundary_statement.md
+- projects/polymarket/polyquantbot/docs/release_dashboard.md
+- projects/polymarket/polyquantbot/docs/final_acceptance_gate.md
+
+## Operator launch checks
+
+Before posting public links, confirm:
+
+- README public wording says paper-beta only.
+- Support and onboarding docs are reachable.
+- Release dashboard reflects public paper-beta accepted posture.
+- Runtime smoke report remains linked from final acceptance gate.
+- No secrets, private URLs, chat IDs, credentials, or tokens are exposed.
+- No live/capital readiness claim appears in public-facing copy.
+
+## Guard truth
+
+These guards remain NOT SET:
+
+- EXECUTION_PATH_VALIDATED
+- CAPITAL_MODE_CONFIRMED
+- ENABLE_LIVE_TRADING
+
+The following are not approved by this launch pack:
+
+- live trading
+- production capital
+- real order placement
+- capital-mode confirmation
+- execution-path validation
+- user deposit custody
+- financial advice claims
+- profit or performance claims
+
+## Suggested public announcement copy
+
+CrusaderBot is now public paper-beta ready.
+
+It is a non-custodial Polymarket paper-mode trading system built around transparent risk boundaries, operator visibility, and documented guardrails. Current public readiness is paper-beta only: live trading and production-capital activation remain disabled and require a separate explicit approval gate.
+
+## Suggested short version
+
+CrusaderBot public paper-beta is ready. Paper-only. Non-custodial. Live/capital activation remains gated and disabled.
+
+## Immediate next gate
+
+Public announcement / distribution may proceed for paper-beta only.
+
+Any live/capital activation must be handled as a separate owner-gated activation review.

--- a/projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
+++ b/projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
@@ -16,14 +16,12 @@ The launch pack consolidates public-safe claim wording, evidence basis, operator
 - projects/polymarket/polyquantbot/docs/public_ready_launch_pack.md
 - projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
 - projects/polymarket/polyquantbot/state/PROJECT_STATE.md
-- projects/polymarket/polyquantbot/state/WORKTODO.md
-- projects/polymarket/polyquantbot/state/CHANGELOG.md
 
 ## 3. Validation Tier / Claim Level / Target / Not in Scope
 
 Validation Tier: MINOR
 Claim Level: FOUNDATION
-Validation Target: public paper-beta launch documentation and state tracking only
+Validation Target: public paper-beta launch documentation and PROJECT_STATE.md tracking only
 Not in Scope: runtime behavior, API behavior, Telegram behavior, deployment, live trading, production capital, activation env vars, strategy logic, risk logic
 
 ## Guard boundary

--- a/projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
+++ b/projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
@@ -1,0 +1,37 @@
+# WARP•FORGE Report: public-ready-launch-pack
+
+Timestamp: 2026-05-01 09:20 Asia/Jakarta
+Branch: WARP/public-ready-launch-pack
+Tier: MINOR
+Claim Level: FOUNDATION
+
+## 1. What was changed
+
+Added a public paper-beta launch pack for CrusaderBot after Priority 9 completion and final public paper-beta acceptance.
+
+The launch pack consolidates public-safe claim wording, evidence basis, operator launch checks, and explicit live/capital guard boundaries.
+
+## 2. Files modified
+
+- projects/polymarket/polyquantbot/docs/public_ready_launch_pack.md
+- projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
+- projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+- projects/polymarket/polyquantbot/state/WORKTODO.md
+- projects/polymarket/polyquantbot/state/CHANGELOG.md
+
+## 3. Validation Tier / Claim Level / Target / Not in Scope
+
+Validation Tier: MINOR
+Claim Level: FOUNDATION
+Validation Target: public paper-beta launch documentation and state tracking only
+Not in Scope: runtime behavior, API behavior, Telegram behavior, deployment, live trading, production capital, activation env vars, strategy logic, risk logic
+
+## Guard boundary
+
+No activation guard is changed.
+
+- EXECUTION_PATH_VALIDATED: NOT SET
+- CAPITAL_MODE_CONFIRMED: NOT SET
+- ENABLE_LIVE_TRADING: NOT SET
+
+No live-trading readiness or production-capital readiness is claimed.

--- a/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/polyquantbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-01 08:39 Asia/Jakarta
-Status       : Priority 9 COMPLETE. P9 Lane 5 ACCEPTED as public paper-beta (2026-05-01 06:37 WIB). Runtime smoke evidence: 6/8 PASS, Telegram BLOCKED (env, not code defect). All activation guards NOT SET. Live/capital activation remains blocked pending separate owner decision.
+Last Updated : 2026-05-01 09:20 Asia/Jakarta
+Status       : Priority 9 COMPLETE. P9 Lane 5 ACCEPTED as public paper-beta (2026-05-01 06:37 WIB). Public-ready launch pack prepared on WARP/public-ready-launch-pack. Runtime smoke evidence: 6/8 PASS, Telegram BLOCKED (env, not code defect). All activation guards NOT SET. Live/capital activation remains blocked pending separate owner decision.
 
 [COMPLETED]
 - Priorities 1-7 completed.
@@ -13,11 +13,12 @@ Status       : Priority 9 COMPLETE. P9 Lane 5 ACCEPTED as public paper-beta (202
 - Priority 9 COMPLETE. Smoke evidence PR #840 merged (SHA 91929fa34534). WARP🔹CMD decision: ACCEPTED as public paper-beta. Date: 2026-05-01.
 - Priority 9 smoke evidence captured via PR #840 (WARP/p9-runtime-smoke-evidence). WARP🔹CMD decision: ACCEPTED as public paper-beta. SHA 91929fa34534.
 - Priority 9 Lane 5 ACCEPTED: smoke evidence merged via PR #840 SHA 91929fa34534. WARP🔹CMD final decision recorded in docs/final_acceptance_gate.md. Priority 9 COMPLETE.
+- Public-ready launch pack prepared on WARP/public-ready-launch-pack: docs/public_ready_launch_pack.md added with public paper-beta claim, launch checklist, and guard boundary. No runtime/env/capital changes.
 
 [IN PROGRESS]
 - None.
 
 [BLOCKED / GATED]
-- Capital/live activation (ENABLE_LIVE_TRADING, CAPITAL_MODE_CONFIRMED, EXECUTION_PATH_VALIDATED) — NOT SET. Requires separate explicit Mr. Walker + WARP🔹CMD decision.
+- Capital/live activation (ENABLE_LIVE_TRADING, CAPITAL_MODE_CONFIRMED, EXECUTION_PATH_VALIDATED) -- NOT SET. Requires separate explicit Mr. Walker + WARP🔹CMD decision.
 [NEXT PRIORITY]
-- No active priority. P9 complete. Awaiting Mr. Walker decision on next priority or live/capital activation.
+- No active priority. P9 complete. Public paper-beta launch pack prepared. Awaiting Mr. Walker decision on public distribution or separate live/capital activation review.


### PR DESCRIPTION
## Summary
- Adds public paper-beta launch pack for CrusaderBot.
- Records public-ready launch pack in PROJECT_STATE.md.
- Adds WARP•FORGE report.

## Scope
- Docs/state only.
- No runtime behavior change.
- No env var change.
- No live/capital activation.

## Validation
- Validation Tier: MINOR
- Claim Level: FOUNDATION
- Target: public paper-beta launch documentation + PROJECT_STATE.md tracking only
- Not in scope: runtime, API, Telegram behavior, deployment, live trading, production capital, activation env vars, strategy/risk logic

## Guard boundary
- EXECUTION_PATH_VALIDATED: NOT SET
- CAPITAL_MODE_CONFIRMED: NOT SET
- ENABLE_LIVE_TRADING: NOT SET

Report: projects/polymarket/polyquantbot/reports/forge/public-ready-launch-pack.md
State: PROJECT_STATE.md updated
Validation Tier: MINOR
Claim Level: FOUNDATION