### PR TITLE
warp-forge: GATE post-merge sync safety rules (COMMANDER.md)

### DIFF
--- a/COMMANDER.md
+++ b/COMMANDER.md
@@ -1038,6 +1038,62 @@ After a merge/close/hold decision, the action executes immediately in the same t
 
 ---
 
+## GATE POST-MERGE SYNC SAFETY
+
+GATE post-merge sync operations commit state file updates directly to GitHub via the API.
+Shell pipelines can swallow subprocess errors silently and commit empty or near-empty content,
+causing silent data destruction.
+
+### Pre-commit content guard (MANDATORY)
+
+Before any GitHub PUT that updates a state or report file:
+
+1. Verify non-empty: `len(new_content) > 0` — abort if empty
+2. Verify minimum size: new content must be at least 100 bytes for any state file
+3. Verify size ratio: `len(new_content) >= original_content_size * 0.5`
+   — content shrinking more than 50% in one commit = abort
+4. If any guard fails: abort the PUT, post PR comment with error, escalate to WARP🔹CMD — never commit
+
+### Safe write pattern for GATE sync scripts
+
+Use Python file I/O — not inline heredoc piping:
+
+```python
+with open('/tmp/state_update.md', 'w', encoding='utf-8') as f:
+    f.write(content)
+
+with open('/tmp/state_update.md', 'r', encoding='utf-8') as f:
+    verified = f.read()
+
+assert len(verified) > 100, "Content guard failed — abort PUT"
+encoded = base64.b64encode(verified.encode('utf-8')).decode('ascii')
+assert len(encoded) > 0, "Encoded guard failed — abort PUT"
+```
+
+Never chain Python output through bash heredoc pipelines (`python3 << ... <<< "$VAR"`).
+These pipelines swallow subprocess errors silently and can produce 0-byte output.
+
+### Unicode in Python f-strings with emoji
+
+Use escape form `\U000XXXXX` (8 hex digits), never `\u{XXXXX}` (brace form):
+
+| Correct | Wrong |
+|---|---|
+| `\U0001F4CB` | `\u{1F4CB}` |
+| `\U00002705` | `\u{2705}` |
+
+The `\u{...}` form is not valid Python syntax. A SyntaxError in an f-string used
+inside a bash heredoc pipeline silently produces 0-byte output — committing a blank file.
+
+### Incident reference
+
+Commit `4eda17c5e7fa` — 2026-05-05T01:13:23Z
+Impact: `projects/polymarket/crusaderbot/state/PROJECT_STATE.md` overwritten with 1 blank line (1927 bytes erased).
+Root cause: Python f-string SyntaxError in bash heredoc pipeline produced 0-byte output, committed as blank.
+Recovery: `c1bf7cf7d1a5`.
+
+---
+
 ## NO MANUAL FIX RULE (ABSOLUTE)
 
 Mr. Walker never fixes anything manually.

--- a/COMMANDER.md
+++ b/COMMANDER.md
@@ -1065,9 +1065,11 @@ with open('/tmp/state_update.md', 'w', encoding='utf-8') as f:
 with open('/tmp/state_update.md', 'r', encoding='utf-8') as f:
     verified = f.read()
 
-assert len(verified) > 100, "Content guard failed — abort PUT"
+if len(verified) <= 100:
+    raise ValueError("Content guard failed — abort PUT")
 encoded = base64.b64encode(verified.encode('utf-8')).decode('ascii')
-assert len(encoded) > 0, "Encoded guard failed — abort PUT"
+if len(encoded) == 0:
+    raise ValueError("Encoded guard failed — abort PUT")
 ```
 
 Never chain Python output through bash heredoc pipelines (`python3 << ... <<< "$VAR"`).

--- a/reports/forge/gate-sync-safety.md
+++ b/reports/forge/gate-sync-safety.md
@@ -24,8 +24,8 @@ The section documents three rules to prevent silent data-destruction commits in 
 
 2. **Safe write pattern** — Python file I/O via `/tmp/` file instead of bash heredoc pipelines.
    Bash heredoc chained to Python (`python3 << ... <<< "$VAR"`) swallows subprocess errors silently
-   and can produce 0-byte output. The safe pattern reads back the written file and asserts non-empty
-   before encoding and committing.
+   and can produce 0-byte output. The safe pattern reads back the written file and raises ValueError
+   on empty or too-small content before encoding and committing.
 
 3. **Unicode escape rule** — `\U000XXXXX` (8 hex digits) not `\u{XXXXX}` (brace form).
    The brace form is not valid Python syntax; a SyntaxError in an f-string inside a heredoc pipeline

--- a/reports/forge/gate-sync-safety.md
+++ b/reports/forge/gate-sync-safety.md
@@ -1,0 +1,55 @@
+# WARP•FORGE Report — GATE Post-Merge Sync Safety
+
+Branch: `WARP/GATE-SYNC-SAFETY`
+Issue: #864
+Validation Tier: **MINOR**
+Claim Level: **FOUNDATION**
+Validation Target: COMMANDER.md documentation — GATE post-merge sync safety rules
+Not in Scope: runtime code, CI workflows, trading logic, AGENTS.md
+Suggested Next Step: WARP🔹CMD review — MINOR tier, auto-merge on clean
+
+---
+
+## 1. What was changed
+
+Added `## GATE POST-MERGE SYNC SAFETY` section to `COMMANDER.md` (repo root).
+
+The section documents three rules to prevent silent data-destruction commits in GATE post-merge sync operations:
+
+1. **Pre-commit content guard** — mandatory size checks before any GitHub PUT on state files:
+   - `len(new_content) > 0`
+   - minimum 100 bytes for any state file
+   - `len(new_content) >= original_content_size * 0.5` (no more than 50% shrink)
+   - guard failure = abort PUT + post PR comment + escalate to WARP🔹CMD
+
+2. **Safe write pattern** — Python file I/O via `/tmp/` file instead of bash heredoc pipelines.
+   Bash heredoc chained to Python (`python3 << ... <<< "$VAR"`) swallows subprocess errors silently
+   and can produce 0-byte output. The safe pattern reads back the written file and asserts non-empty
+   before encoding and committing.
+
+3. **Unicode escape rule** — `\U000XXXXX` (8 hex digits) not `\u{XXXXX}` (brace form).
+   The brace form is not valid Python syntax; a SyntaxError in an f-string inside a heredoc pipeline
+   produces 0-byte output silently.
+
+Incident reference recorded: commit `4eda17c5e7fa`, recovery `c1bf7cf7d1a5`.
+
+---
+
+## 2. Files modified
+
+```
+COMMANDER.md                            <- new section added after ## AUTO PR ACTION RULE
+reports/forge/gate-sync-safety.md       <- this report (repo root level)
+```
+
+---
+
+## 3. Validation declaration
+
+```
+Validation Tier   : MINOR
+Claim Level       : FOUNDATION
+Validation Target : COMMANDER.md documentation only — no runtime or CI files touched
+Not in Scope      : runtime code, trading logic, GitHub Actions workflows, AGENTS.md
+Suggested Next    : WARP🔹CMD review — MINOR tier
+```


### PR DESCRIPTION
## WARP•FORGE — GATE Post-Merge Sync Safety

**Branch:** `WARP/GATE-SYNC-SAFETY`
**Issue:** Closes #864
**Validation Tier:** MINOR
**Claim Level:** FOUNDATION
**Validation Target:** COMMANDER.md documentation only — no runtime files touched
**Not in Scope:** runtime code, CI workflows, trading logic, AGENTS.md

---

## What was built

Added `## GATE POST-MERGE SYNC SAFETY` section to `COMMANDER.md` documenting three rules to prevent silent data-destruction commits in GATE post-merge sync operations:

1. **Pre-commit content guard** — mandatory size checks before any GitHub PUT:
   - `len(new_content) > 0`
   - minimum 100 bytes for state files
   - `len(new_content) >= original_content_size * 0.5`
   - guard failure = abort PUT, post PR comment, escalate to WARP🔹CMD

2. **Safe write pattern** — Python file I/O via `/tmp/` file, not bash heredoc pipelines. Heredoc pipelines swallow subprocess errors silently.

3. **Unicode escape rule** — `\U000XXXXX` (8 hex digits), never `\u{XXXXX}` (brace form — not valid Python syntax, silently produces 0-byte output in heredoc pipeline).

Incident reference: commit `4eda17c5e7fa`, recovery `c1bf7cf7d1a5`.

---

## Files changed

- `COMMANDER.md` — new section added after `## AUTO PR ACTION RULE`
- `reports/forge/gate-sync-safety.md` — forge report

---

## Forge report

`reports/forge/gate-sync-safety.md`

---

## Done output

```
Done -- gate-sync-safety complete.
PR: WARP/GATE-SYNC-SAFETY
Report: reports/forge/gate-sync-safety.md
State: PROJECT_STATE.md not applicable (GATE infra task — no project PROJECT_ROOT)
Validation Tier: MINOR
Claim Level: FOUNDATION
```

**Next gate:** WARP🔹CMD review — MINOR tier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSqtrVxhSkBvLboAQ67LN3)_