### PR TITLE
feat(crusaderbot): R12f operator dashboard + kill switch + job monitor

### DIFF
--- a/projects/polymarket/crusaderbot/bot/dispatcher.py
+++ b/projects/polymarket/crusaderbot/bot/dispatcher.py
@@ -44,6 +44,11 @@ def register(app: Application) -> None:
     app.add_handler(CommandHandler("emergency", emergency.emergency_root))
     app.add_handler(CommandHandler("admin", admin.admin_root))
     app.add_handler(CommandHandler("allowlist", admin.allowlist_command))
+    # R12f operator dashboard / ops plane.
+    app.add_handler(CommandHandler("ops_dashboard", admin.ops_dashboard_command))
+    app.add_handler(CommandHandler("killswitch", admin.killswitch_command))
+    app.add_handler(CommandHandler("jobs", admin.jobs_command))
+    app.add_handler(CommandHandler("auditlog", admin.auditlog_command))
 
     # Callback queries
     app.add_handler(CallbackQueryHandler(wallet.wallet_callback, pattern=r"^wallet:"))
@@ -66,6 +71,8 @@ def register(app: Application) -> None:
     app.add_handler(CallbackQueryHandler(emergency.emergency_callback,
                                          pattern=r"^emergency:"))
     app.add_handler(CallbackQueryHandler(admin.admin_callback,  pattern=r"^admin:"))
+    app.add_handler(CallbackQueryHandler(admin.ops_dashboard_callback,
+                                         pattern=r"^ops:"))
 
     # Free text — must be last
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, _text_router))

--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -2,25 +2,57 @@
 from __future__ import annotations
 
 import logging
+import os
+import socket
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterable
 
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
-from ... import audit
+from ... import audit, notifications
 from ...config import get_settings
 from ...database import get_pool, is_kill_switch_active, set_kill_switch
+from ...domain.ops import job_tracker
+from ...domain.ops import kill_switch as ops_kill_switch
 from ...users import force_set_tier, get_user_by_username
 from ..keyboards import admin_menu
+from ..keyboards.admin import ops_dashboard_keyboard
 from ..tier import Tier
 
 logger = logging.getLogger(__name__)
+
+# Process boot timestamp — used by the dashboard uptime line. Captured at
+# import time so it survives module reloads in long-running deployments
+# (Fly.io deploys produce a fresh process anyway, so this is also the
+# correct "this machine" timestamp).
+_BOOT_MONOTONIC = time.monotonic()
 
 
 def _is_operator(update: Update) -> bool:
     if update.effective_user is None:
         return False
     return update.effective_user.id == get_settings().OPERATOR_CHAT_ID
+
+
+# --------------------------------------------------------------------------
+# Operator-only gate.
+#
+# The gate intentionally fails SILENT for non-operators on the new R12f
+# commands — replying "Unauthorized" leaks the existence of a privileged
+# command surface. The legacy ``admin_root`` / ``allowlist_command``
+# replies "⛔ Operator only." for back-compat with their existing UX.
+# --------------------------------------------------------------------------
+
+async def _reject_silently(update: Update) -> None:
+    """No-op reply for non-operators on R12f commands."""
+    if update.callback_query is not None:
+        try:
+            await update.callback_query.answer()
+        except Exception:  # noqa: BLE001 — answer is best-effort
+            pass
 
 
 async def admin_root(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -128,8 +160,447 @@ async def allowlist_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> N
     )
     # Route through notifications.send so the call inherits R12's
     # tenacity retry+backoff and consistent ERROR-on-final-failure logging.
-    from ... import notifications
     await notifications.send(
         user["telegram_user_id"],
         f"🎉 You've been promoted to Tier {tier}. New features unlocked!",
+    )
+
+
+# ==========================================================================
+# R12f — Operator dashboard, kill switch, jobs, audit log
+# ==========================================================================
+
+
+def _format_uptime(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h {minutes}m"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _format_duration_ms(start: datetime | None, end: datetime | None) -> str:
+    if start is None or end is None:
+        return "—"
+    delta = (end - start).total_seconds()
+    if delta < 1:
+        return f"{int(delta * 1000)}ms"
+    if delta < 60:
+        return f"{delta:.1f}s"
+    return f"{delta / 60:.1f}m"
+
+
+def _truncate(value: str | None, limit: int) -> str:
+    if not value:
+        return ""
+    return value if len(value) <= limit else value[: max(0, limit - 1)] + "…"
+
+
+async def _collect_dashboard_snapshot() -> dict[str, Any]:
+    """Pull every datum the operator dashboard needs.
+
+    Each fetch is wrapped so a single broken dependency degrades that
+    field to ``None`` rather than crashing the whole snapshot — the
+    operator must still get *something* even when the DB is sick.
+    """
+    snapshot: dict[str, Any] = {
+        "uptime_seconds": time.monotonic() - _BOOT_MONOTONIC,
+        "hostname": os.environ.get("FLY_MACHINE_ID")
+        or os.environ.get("FLY_ALLOC_ID")
+        or socket.gethostname(),
+        "db_ok": False,
+        "active_users": None,
+        "open_positions": None,
+        "total_usdc": None,
+        "auto_trade_users": None,
+        "kill_switch_active": False,
+        "lock_mode": False,
+        "recent_jobs": [],
+        "errors": [],
+    }
+    try:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            snapshot["db_ok"] = await conn.fetchval("SELECT 1") == 1
+            snapshot["active_users"] = int(await conn.fetchval(
+                "SELECT COUNT(*) FROM users WHERE access_tier >= 2"
+            ) or 0)
+            snapshot["open_positions"] = int(await conn.fetchval(
+                "SELECT COUNT(*) FROM positions WHERE status = 'open'"
+            ) or 0)
+            snapshot["total_usdc"] = float(await conn.fetchval(
+                "SELECT COALESCE(SUM(balance_usdc), 0) FROM wallets"
+            ) or 0)
+            snapshot["auto_trade_users"] = int(await conn.fetchval(
+                "SELECT COUNT(*) FROM users "
+                "WHERE auto_trade_on = TRUE AND paused = FALSE"
+            ) or 0)
+            snapshot["kill_switch_active"] = await ops_kill_switch.is_active(conn)
+            snapshot["lock_mode"] = await ops_kill_switch.get_lock_mode(conn)
+    except Exception as exc:  # noqa: BLE001 — degrade-not-crash
+        logger.error("ops_dashboard snapshot DB read failed: %s", exc)
+        snapshot["errors"].append(f"db: {exc}")
+
+    try:
+        snapshot["recent_jobs"] = await job_tracker.fetch_recent(limit=3)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("ops_dashboard recent jobs read failed: %s", exc)
+        snapshot["errors"].append(f"jobs: {exc}")
+
+    return snapshot
+
+
+def _render_dashboard(snapshot: dict[str, Any]) -> str:
+    kill_state = "🔴 ACTIVE" if snapshot["kill_switch_active"] else "🟢 inactive"
+    lock = " (LOCK)" if snapshot.get("lock_mode") else ""
+    db = "✅" if snapshot["db_ok"] else "❌"
+
+    def _val(key: str, fmt=str, default: str = "N/A") -> str:
+        v = snapshot.get(key)
+        if v is None:
+            return default
+        try:
+            return fmt(v)
+        except Exception:
+            return default
+
+    lines = [
+        "*⚙️ Operator Dashboard*",
+        "",
+        f"Uptime: {_format_uptime(snapshot['uptime_seconds'])}",
+        f"Host:   `{snapshot['hostname']}`",
+        f"DB:     {db}",
+        "",
+        f"Active users (Tier 2+): {_val('active_users')}",
+        f"Open positions:         {_val('open_positions')}",
+        f"Total USDC in pool:     "
+        f"{_val('total_usdc', lambda v: f'${v:,.2f}')}",
+        f"Auto-trade users:       {_val('auto_trade_users')}",
+        "",
+        f"Kill switch: {kill_state}{lock}",
+    ]
+
+    jobs = snapshot.get("recent_jobs") or []
+    if jobs:
+        lines.append("")
+        lines.append("*Recent jobs (last 3):*")
+        for j in jobs:
+            status = "✅" if j["status"] == "success" else "❌"
+            duration = _format_duration_ms(j.get("started_at"),
+                                           j.get("finished_at"))
+            lines.append(
+                f"  {status} `{j['job_name']}` · {duration}"
+            )
+    else:
+        lines.append("")
+        lines.append("_No recent job runs recorded._")
+
+    if snapshot.get("errors"):
+        lines.append("")
+        lines.append(
+            "_Some fields unavailable: "
+            + "; ".join(snapshot["errors"][:3]) + "_"
+        )
+    return "\n".join(lines)
+
+
+async def ops_dashboard_command(update: Update,
+                                ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """``/ops_dashboard`` — operator-only system snapshot."""
+    if not _is_operator(update) or update.message is None:
+        await _reject_silently(update)
+        return
+    snapshot = await _collect_dashboard_snapshot()
+    await update.message.reply_text(
+        _render_dashboard(snapshot),
+        parse_mode=ParseMode.MARKDOWN,
+        reply_markup=ops_dashboard_keyboard(snapshot["kill_switch_active"]),
+    )
+
+
+async def ops_dashboard_callback(update: Update,
+                                 ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the ``ops:`` callback prefix (refresh + quick actions)."""
+    q = update.callback_query
+    if q is None:
+        return
+    if not _is_operator(update):
+        await _reject_silently(update)
+        return
+    await q.answer()
+    data = q.data or ""
+    sub = data.split(":", 2)[1] if ":" in data else ""
+
+    if sub == "refresh":
+        snapshot = await _collect_dashboard_snapshot()
+        try:
+            await q.edit_message_text(
+                _render_dashboard(snapshot),
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=ops_dashboard_keyboard(snapshot["kill_switch_active"]),
+            )
+        except Exception:  # noqa: BLE001 — same-content edits raise
+            pass
+        return
+
+    if sub in ("pause", "resume", "lock"):
+        await _apply_killswitch_action(
+            sub,
+            actor_id=update.effective_user.id if update.effective_user else None,
+            reply=q.message.reply_text if q.message else None,
+            broadcast_via_ctx=ctx,
+        )
+        return
+
+
+# --------------------------------------------------------------------------
+# /killswitch
+# --------------------------------------------------------------------------
+
+_KS_USAGE = (
+    "Usage: `/killswitch <pause|resume|lock>`\n"
+    "  pause  — block all new trades (cached 30s before risk gate sees it)\n"
+    "  resume — re-open trade flow (clears lock mode)\n"
+    "  lock   — pause + force every user's auto_trade_on=false"
+)
+
+
+async def _broadcast_pause(ctx: ContextTypes.DEFAULT_TYPE | None,
+                           message: str) -> int:
+    """Notify every active auto-trade user that the operator paused trading.
+
+    Returns the number of users we attempted to message. Failures are
+    swallowed per-user so one Telegram error never blocks the operator
+    flow.
+    """
+    if ctx is None:
+        return 0
+    try:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT telegram_user_id FROM users "
+                "WHERE auto_trade_on = TRUE OR access_tier >= 2"
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("killswitch broadcast user lookup failed: %s", exc)
+        return 0
+
+    sent = 0
+    for r in rows:
+        try:
+            await notifications.send(int(r["telegram_user_id"]), message)
+            sent += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "killswitch broadcast send failed user=%s err=%s",
+                r["telegram_user_id"], exc,
+            )
+    return sent
+
+
+async def _apply_killswitch_action(
+    action: str,
+    *,
+    actor_id: int | None,
+    reply,
+    broadcast_via_ctx: ContextTypes.DEFAULT_TYPE | None,
+) -> None:
+    """Shared implementation for ``/killswitch`` and the inline buttons."""
+    try:
+        result = await ops_kill_switch.set_active(
+            action=action, actor_id=actor_id,
+        )
+    except ValueError as exc:
+        if reply is not None:
+            await reply(f"❌ {exc}")
+        return
+    except Exception as exc:  # noqa: BLE001
+        logger.error("killswitch %s failed: %s", action, exc)
+        if reply is not None:
+            await reply(f"❌ killswitch {action} failed: {exc}")
+        return
+
+    await audit.write(
+        actor_role="operator",
+        action=f"kill_switch_{action}",
+        payload={"actor_id": actor_id, "result": result},
+    )
+
+    if action == "pause":
+        if reply is not None:
+            await reply(
+                "🔴 Kill switch *ACTIVE*. Auto-trade paused (≤30s "
+                "propagation). Use `/killswitch resume` to re-open.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        await _broadcast_pause(
+            broadcast_via_ctx,
+            "🛑 Auto-trade paused by operator. New trades are blocked. "
+            "Existing positions remain open until you close them.",
+        )
+    elif action == "resume":
+        if reply is not None:
+            await reply(
+                "🟢 Kill switch deactivated. Auto-trade resumed.",
+            )
+    elif action == "lock":
+        if reply is not None:
+            await reply(
+                "🔒 Kill switch *LOCKED*. "
+                f"{result['users_disabled']} users had auto-trade disabled. "
+                "Run `/killswitch resume` after the incident is addressed; "
+                "users must re-opt-in individually.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        await _broadcast_pause(
+            broadcast_via_ctx,
+            "🔒 Auto-trade has been locked by the operator due to an "
+            "incident. Your auto-trade has been turned OFF — re-enable "
+            "from /dashboard once the operator confirms it is safe.",
+        )
+
+
+async def killswitch_command(update: Update,
+                             ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """``/killswitch <pause|resume|lock>``."""
+    if not _is_operator(update) or update.message is None:
+        await _reject_silently(update)
+        return
+    args: Iterable[str] = ctx.args or []
+    args_list = list(args)
+    if not args_list:
+        await update.message.reply_text(_KS_USAGE,
+                                        parse_mode=ParseMode.MARKDOWN)
+        return
+    action = args_list[0].strip().lower()
+    if action not in {"pause", "resume", "lock"}:
+        await update.message.reply_text(_KS_USAGE,
+                                        parse_mode=ParseMode.MARKDOWN)
+        return
+    await _apply_killswitch_action(
+        action,
+        actor_id=update.effective_user.id if update.effective_user else None,
+        reply=update.message.reply_text,
+        broadcast_via_ctx=ctx,
+    )
+
+
+# --------------------------------------------------------------------------
+# /jobs
+# --------------------------------------------------------------------------
+
+DEFAULT_JOB_LIMIT = 10
+DEFAULT_AUDIT_LIMIT = 20
+MAX_OPS_LIMIT = 50
+
+
+def _parse_limit(args: list[str], default: int) -> tuple[int, bool]:
+    """Return ``(limit, only_failed)`` from ``/jobs`` style args.
+
+    ``args`` may be empty, a single integer, the literal ``failed``, or
+    both (``failed 5``). Anything else falls back to ``(default, False)``.
+    """
+    only_failed = False
+    limit = default
+    for tok in args:
+        t = tok.strip().lower()
+        if t == "failed":
+            only_failed = True
+            continue
+        try:
+            limit = max(1, min(MAX_OPS_LIMIT, int(t)))
+        except ValueError:
+            continue
+    return limit, only_failed
+
+
+def _render_jobs(rows: list[dict], only_failed: bool) -> str:
+    if not rows:
+        return ("_No matching job runs._" if only_failed
+                else "_No job runs recorded yet._")
+    head = "*Recent failed job runs*" if only_failed else "*Recent job runs*"
+    lines = [head, ""]
+    for r in rows:
+        status = "✅" if r["status"] == "success" else "❌"
+        ts = r["started_at"].strftime("%m-%d %H:%M:%S") \
+            if r.get("started_at") else "—"
+        duration = _format_duration_ms(r.get("started_at"),
+                                       r.get("finished_at"))
+        err = _truncate(r.get("error"), 80)
+        line = f"{status} `{r['job_name']}` · {ts} · {duration}"
+        if err:
+            line += f"\n    └ _{err}_"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+async def jobs_command(update: Update,
+                       ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """``/jobs [n] [failed]`` — last N (default 10) scheduler runs."""
+    if not _is_operator(update) or update.message is None:
+        await _reject_silently(update)
+        return
+    limit, only_failed = _parse_limit(list(ctx.args or []), DEFAULT_JOB_LIMIT)
+    try:
+        rows = await job_tracker.fetch_recent(
+            limit=limit, only_failed=only_failed,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("/jobs query failed: %s", exc)
+        await update.message.reply_text(f"❌ /jobs query failed: {exc}")
+        return
+    await update.message.reply_text(
+        _render_jobs(rows, only_failed), parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+# --------------------------------------------------------------------------
+# /auditlog
+# --------------------------------------------------------------------------
+
+async def _fetch_audit_tail(limit: int) -> list[dict]:
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT ts, actor_role, action, user_id "
+            "FROM audit.log ORDER BY ts DESC LIMIT $1",
+            limit,
+        )
+    return [dict(r) for r in rows]
+
+
+def _render_auditlog(rows: list[dict]) -> str:
+    if not rows:
+        return "_Audit log is empty._"
+    lines = ["*Audit log (most recent first)*", ""]
+    for r in rows:
+        ts = (r["ts"].astimezone(timezone.utc).strftime("%m-%d %H:%M:%S")
+              if r.get("ts") else "—")
+        user = _truncate(str(r.get("user_id") or ""), 8)
+        actor = r.get("actor_role") or "?"
+        action = _truncate(r.get("action"), 40)
+        lines.append(f"`{ts}` · {actor} · {action} · {user or '—'}")
+    return "\n".join(lines)
+
+
+async def auditlog_command(update: Update,
+                           ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """``/auditlog [n]`` — last N (default 20) audit.log rows. Read-only."""
+    if not _is_operator(update) or update.message is None:
+        await _reject_silently(update)
+        return
+    limit, _ = _parse_limit(list(ctx.args or []), DEFAULT_AUDIT_LIMIT)
+    try:
+        rows = await _fetch_audit_tail(limit)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("/auditlog query failed: %s", exc)
+        await update.message.reply_text(f"❌ /auditlog query failed: {exc}")
+        return
+    await update.message.reply_text(
+        _render_auditlog(rows), parse_mode=ParseMode.MARKDOWN,
     )

--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -233,8 +233,13 @@ async def _collect_dashboard_snapshot() -> dict[str, Any]:
         "open_positions": None,
         "total_usdc": None,
         "auto_trade_users": None,
-        "kill_switch_active": False,
-        "lock_mode": False,
+        # ``None`` = state could not be read. The renderer surfaces this
+        # as "❓ unknown" so the operator never sees a misleading
+        # "🟢 inactive" during a DB outage (Codex P2 follow-up on
+        # PR #874). The risk gate itself fails SAFE on the same error
+        # — see ``domain.ops.kill_switch.is_active``.
+        "kill_switch_active": None,
+        "lock_mode": None,
         "recent_jobs": [],
         "errors": [],
     }
@@ -271,7 +276,15 @@ async def _collect_dashboard_snapshot() -> dict[str, Any]:
 
 
 def _render_dashboard(snapshot: dict[str, Any]) -> str:
-    kill_state = "🔴 ACTIVE" if snapshot["kill_switch_active"] else "🟢 inactive"
+    ks = snapshot.get("kill_switch_active")
+    if ks is None:
+        # Snapshot fetch failed before the kill-switch read — never lie
+        # to the operator with "🟢 inactive" in this state.
+        kill_state = "❓ unknown (DB unreachable)"
+    elif ks:
+        kill_state = "🔴 ACTIVE"
+    else:
+        kill_state = "🟢 inactive"
     lock = " (LOCK)" if snapshot.get("lock_mode") else ""
     db = "✅" if snapshot["db_ok"] else "❌"
 

--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -200,6 +200,22 @@ def _truncate(value: str | None, limit: int) -> str:
     return value if len(value) <= limit else value[: max(0, limit - 1)] + "…"
 
 
+# Telegram's legacy Markdown parser treats ``_ * ` [`` as formatting
+# metacharacters. Failed job errors and audit actions routinely contain
+# at least underscores (``kill_switch_pause``) and backticks (Python
+# repr fragments), which would cause Telegram to reject the whole
+# message with a "can't parse entities" error and leave the operator
+# blind exactly when something is broken. Escape every dynamic field
+# that lands in a MARKDOWN-mode reply.
+def _md_escape(text: str | None) -> str:
+    if not text:
+        return ""
+    out = text.replace("\\", "\\\\")
+    for ch in ("_", "*", "`", "["):
+        out = out.replace(ch, "\\" + ch)
+    return out
+
+
 async def _collect_dashboard_snapshot() -> dict[str, Any]:
     """Pull every datum the operator dashboard needs.
 
@@ -272,7 +288,7 @@ def _render_dashboard(snapshot: dict[str, Any]) -> str:
         "*⚙️ Operator Dashboard*",
         "",
         f"Uptime: {_format_uptime(snapshot['uptime_seconds'])}",
-        f"Host:   `{snapshot['hostname']}`",
+        f"Host:   `{_md_escape(snapshot['hostname'])}`",
         f"DB:     {db}",
         "",
         f"Active users (Tier 2+): {_val('active_users')}",
@@ -293,7 +309,7 @@ def _render_dashboard(snapshot: dict[str, Any]) -> str:
             duration = _format_duration_ms(j.get("started_at"),
                                            j.get("finished_at"))
             lines.append(
-                f"  {status} `{j['job_name']}` · {duration}"
+                f"  {status} `{_md_escape(j['job_name'])}` · {duration}"
             )
     else:
         lines.append("")
@@ -303,7 +319,7 @@ def _render_dashboard(snapshot: dict[str, Any]) -> str:
         lines.append("")
         lines.append(
             "_Some fields unavailable: "
-            + "; ".join(snapshot["errors"][:3]) + "_"
+            + _md_escape("; ".join(snapshot["errors"][:3])) + "_"
         )
     return "\n".join(lines)
 
@@ -532,9 +548,10 @@ def _render_jobs(rows: list[dict], only_failed: bool) -> str:
         duration = _format_duration_ms(r.get("started_at"),
                                        r.get("finished_at"))
         err = _truncate(r.get("error"), 80)
-        line = f"{status} `{r['job_name']}` · {ts} · {duration}"
+        line = (f"{status} `{_md_escape(r['job_name'])}` · "
+                f"{ts} · {duration}")
         if err:
-            line += f"\n    └ _{err}_"
+            line += f"\n    └ _{_md_escape(err)}_"
         lines.append(line)
     return "\n".join(lines)
 
@@ -584,7 +601,10 @@ def _render_auditlog(rows: list[dict]) -> str:
         user = _truncate(str(r.get("user_id") or ""), 8)
         actor = r.get("actor_role") or "?"
         action = _truncate(r.get("action"), 40)
-        lines.append(f"`{ts}` · {actor} · {action} · {user or '—'}")
+        lines.append(
+            f"`{ts}` · {_md_escape(actor)} · {_md_escape(action)} · "
+            f"{_md_escape(user) or '—'}"
+        )
     return "\n".join(lines)
 
 

--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -317,9 +317,11 @@ def _render_dashboard(snapshot: dict[str, Any]) -> str:
 
     if snapshot.get("errors"):
         lines.append("")
+        # Plain (escaped) text — same legacy-MARKDOWN entity caveat as
+        # the /jobs error line above.
         lines.append(
-            "_Some fields unavailable: "
-            + _md_escape("; ".join(snapshot["errors"][:3])) + "_"
+            "Some fields unavailable: "
+            + _md_escape("; ".join(snapshot["errors"][:3]))
         )
     return "\n".join(lines)
 
@@ -551,7 +553,12 @@ def _render_jobs(rows: list[dict], only_failed: bool) -> str:
         line = (f"{status} `{_md_escape(r['job_name'])}` · "
                 f"{ts} · {duration}")
         if err:
-            line += f"\n    └ _{_md_escape(err)}_"
+            # Render the error as plain (escaped) text — legacy
+            # ParseMode.MARKDOWN does NOT honour backslash escapes
+            # inside an entity span, so wrapping the escaped err in
+            # ``_..._`` could still fail to parse on common error
+            # strings (Codex follow-up review on PR #874).
+            line += f"\n    └ {_md_escape(err)}"
         lines.append(line)
     return "\n".join(lines)
 

--- a/projects/polymarket/crusaderbot/bot/keyboards/admin.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/admin.py
@@ -1,0 +1,41 @@
+"""Admin/Ops-plane inline keyboards (R12f operator dashboard).
+
+Kept in its own module to keep the legacy ``admin_menu`` (in
+``keyboards/__init__.py``) stable while the new dashboard surface gets
+its own callback prefix (``ops:``) and renderer-specific buttons.
+"""
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+def ops_dashboard_keyboard(kill_active: bool) -> InlineKeyboardMarkup:
+    """Refresh + quick-action keyboard rendered under /ops_dashboard.
+
+    Buttons:
+        - Refresh (re-fetches the snapshot)
+        - Pause / Resume (single button — label flips with current state)
+        - Lock (always present; destructive — separate row to avoid
+          accidental taps).
+    """
+    flip_label = "▶️ Resume" if kill_active else "⏸ Pause"
+    flip_action = "ops:resume" if kill_active else "ops:pause"
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton("🔄 Refresh", callback_data="ops:refresh")],
+        [InlineKeyboardButton(flip_label, callback_data=flip_action)],
+        [InlineKeyboardButton("🔒 Lock (force users off)",
+                              callback_data="ops:lock")],
+    ])
+
+
+def killswitch_confirm_keyboard(action: str) -> InlineKeyboardMarkup:
+    """Yes/No confirm for destructive killswitch actions (lock).
+
+    ``action`` is the ops verb being confirmed (``pause`` / ``resume`` /
+    ``lock``); the callback payload encodes it so the handler does not
+    need a context-stash.
+    """
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton("✅ Confirm", callback_data=f"ops:confirm:{action}"),
+        InlineKeyboardButton("❌ Cancel", callback_data="ops:cancel"),
+    ]])

--- a/projects/polymarket/crusaderbot/database.py
+++ b/projects/polymarket/crusaderbot/database.py
@@ -68,18 +68,35 @@ async def ping() -> bool:
 
 
 async def is_kill_switch_active() -> bool:
-    pool = get_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            "SELECT active FROM kill_switch ORDER BY id DESC LIMIT 1"
-        )
-        return bool(row and row["active"])
+    """Compatibility wrapper around the R12f kill-switch domain module.
+
+    R12f introduced ``system_settings.kill_switch_active`` as the single
+    source of truth (cached 30s on the hot path). Existing callers
+    (``api/admin.py``, the legacy admin inline-keyboard callback) keep
+    working through this wrapper without bypassing the cache or the
+    history table.
+    """
+    from .domain.ops.kill_switch import is_active as _is_active
+
+    return await _is_active()
 
 
 async def set_kill_switch(active: bool, reason: str | None, changed_by) -> None:
-    pool = get_pool()
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "INSERT INTO kill_switch (active, reason, changed_by) VALUES ($1, $2, $3)",
-            active, reason, changed_by,
-        )
+    """Compatibility wrapper that routes through ops.kill_switch.set_active.
+
+    The legacy ``kill_switch`` table is no longer authoritative — flips
+    persist to ``system_settings`` and a row is appended to
+    ``kill_switch_history``. ``changed_by`` is preserved as the actor id
+    when it is an int-like (Telegram user id); otherwise it is dropped.
+    """
+    from .domain.ops.kill_switch import set_active
+
+    actor_id: int | None = None
+    if isinstance(changed_by, int):
+        actor_id = changed_by
+
+    await set_active(
+        action="pause" if active else "resume",
+        actor_id=actor_id,
+        reason=reason,
+    )

--- a/projects/polymarket/crusaderbot/domain/ops/__init__.py
+++ b/projects/polymarket/crusaderbot/domain/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Ops-plane domain modules: kill switch, job tracking, operator state."""

--- a/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
+++ b/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
@@ -1,0 +1,86 @@
+"""APScheduler -> job_runs bridge.
+
+A single listener is registered on the scheduler in ``setup_scheduler``.
+Every job execution writes one row to ``job_runs`` with status, duration,
+and (on failure) the truncated error message. The /jobs operator command
+reads from this table directly — no in-memory state.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ...database import get_pool
+
+logger = logging.getLogger(__name__)
+
+
+# Per-job-id start timestamps captured in the scheduler's ``_job_submitted``
+# callback so the listener can compute duration without depending on
+# APScheduler's internal scheduled_run_time vs. wallclock skew. Keys are
+# job ids; values are aware UTC datetimes.
+_started_at: dict[str, datetime] = {}
+
+
+def mark_job_submitted(job_id: str) -> None:
+    """Record the wallclock start of a job execution.
+
+    Called from a scheduler ``EVENT_JOB_SUBMITTED`` listener so that
+    ``record_job_event`` can compute an accurate duration even when
+    APScheduler's ``scheduled_run_time`` is shifted by misfires or
+    coalescing.
+    """
+    _started_at[job_id] = datetime.now(timezone.utc)
+
+
+async def record_job_event(
+    *,
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    started_at: Optional[datetime] = None,
+    finished_at: Optional[datetime] = None,
+) -> None:
+    """Persist a single job execution outcome.
+
+    Failure to write must NEVER bubble up — observability cannot break
+    the trading loop. ``error`` is truncated to 500 chars to bound the
+    row size; the operator dashboard further truncates to 80 chars when
+    rendering.
+    """
+    started = started_at or _started_at.pop(job_id, None) or datetime.now(timezone.utc)
+    finished = finished_at or datetime.now(timezone.utc)
+    status = "success" if success else "failed"
+    err = (error or "")[:500] if not success else None
+    try:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO job_runs (job_name, status, started_at, "
+                "finished_at, error) VALUES ($1, $2, $3, $4, $5)",
+                job_id, status, started, finished, err,
+            )
+    except Exception as exc:
+        # Don't crash the scheduler loop because the ops table is down.
+        logger.error("job_runs write failed for %s: %s", job_id, exc)
+    finally:
+        # Pop is defensive — already removed via ``or _started_at.pop``,
+        # but a no-record-found path would leave a dangling key.
+        _started_at.pop(job_id, None)
+
+
+async def fetch_recent(limit: int = 10, *, only_failed: bool = False) -> list[dict[str, Any]]:
+    """Return the most recent job runs, newest first."""
+    if limit <= 0:
+        return []
+    pool = get_pool()
+    where = "WHERE status='failed' " if only_failed else ""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"SELECT job_name, status, started_at, finished_at, error "
+            f"FROM job_runs {where}"
+            f"ORDER BY started_at DESC LIMIT $1",
+            limit,
+        )
+    return [dict(r) for r in rows]

--- a/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
+++ b/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
@@ -20,18 +20,32 @@ logger = logging.getLogger(__name__)
 # callback so the listener can compute duration without depending on
 # APScheduler's internal scheduled_run_time vs. wallclock skew. Keys are
 # job ids; values are aware UTC datetimes.
+#
+# The listener pops this value SYNCHRONOUSLY on EVENT_JOB_EXECUTED /
+# EVENT_JOB_ERROR and forwards it as a parameter to ``record_job_event``
+# (which is dispatched via ``loop.create_task``). The synchronous pop
+# avoids a race where a fresh SUBMITTED event for the same job_id
+# overwrites the slot before the prior completion's create_task gets to
+# read it — APScheduler's ``max_instances=1, coalesce=True`` only
+# guarantees serial execution; the EVENT delivery + create_task
+# scheduling boundary is still racy.
 _started_at: dict[str, datetime] = {}
 
 
 def mark_job_submitted(job_id: str) -> None:
-    """Record the wallclock start of a job execution.
-
-    Called from a scheduler ``EVENT_JOB_SUBMITTED`` listener so that
-    ``record_job_event`` can compute an accurate duration even when
-    APScheduler's ``scheduled_run_time`` is shifted by misfires or
-    coalescing.
-    """
+    """Record the wallclock start of a job execution."""
     _started_at[job_id] = datetime.now(timezone.utc)
+
+
+def pop_job_start(job_id: str) -> Optional[datetime]:
+    """Synchronous pop of the SUBMITTED-time wallclock for a job id.
+
+    Returned to the scheduler listener so the start timestamp is
+    captured at EXECUTED-event delivery (before the next SUBMITTED can
+    overwrite the slot). The returned value is then passed into
+    ``record_job_event`` as the ``started_at`` parameter.
+    """
+    return _started_at.pop(job_id, None)
 
 
 async def record_job_event(
@@ -49,7 +63,16 @@ async def record_job_event(
     row size; the operator dashboard further truncates to 80 chars when
     rendering.
     """
-    started = started_at or _started_at.pop(job_id, None) or datetime.now(timezone.utc)
+    # ``started_at`` is normally captured synchronously by the scheduler
+    # listener via ``pop_job_start`` to defeat the SUBMITTED-overwrite
+    # race. We still fall back to the dict + wallclock so a direct
+    # caller (e.g. unit tests, or a future code path) that omits the
+    # parameter degrades gracefully rather than crashing.
+    started = (
+        started_at
+        or _started_at.pop(job_id, None)
+        or datetime.now(timezone.utc)
+    )
     finished = finished_at or datetime.now(timezone.utc)
     status = "success" if success else "failed"
     err = (error or "")[:500] if not success else None

--- a/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
+++ b/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
@@ -87,10 +87,14 @@ async def record_job_event(
     except Exception as exc:
         # Don't crash the scheduler loop because the ops table is down.
         logger.error("job_runs write failed for %s: %s", job_id, exc)
-    finally:
-        # Pop is defensive — already removed via ``or _started_at.pop``,
-        # but a no-record-found path would leave a dangling key.
-        _started_at.pop(job_id, None)
+    # NOTE: no finally cleanup of ``_started_at[job_id]``. The scheduler
+    # listener already pops via ``pop_job_start`` on EXECUTED/ERROR
+    # delivery, and the test-direct fallback above pops as part of the
+    # ``or`` chain. A late cleanup here was racy — a fresh SUBMITTED for
+    # the same job_id could arrive before this async DB write finishes,
+    # writing the new run's timestamp into the slot, and the cleanup
+    # would then erase the next run's start time (Codex P1 follow-up
+    # on PR #874).
 
 
 async def fetch_recent(limit: int = 10, *, only_failed: bool = False) -> list[dict[str, Any]]:

--- a/projects/polymarket/crusaderbot/domain/ops/kill_switch.py
+++ b/projects/polymarket/crusaderbot/domain/ops/kill_switch.py
@@ -214,6 +214,8 @@ async def set_active(
 
     pool = get_pool()
     users_disabled = 0
+    new_active = False
+    new_lock = False
     async with pool.acquire() as conn:
         async with conn.transaction():
             if action == ACTION_PAUSE:
@@ -243,10 +245,16 @@ async def set_active(
             await record_history(
                 conn, action=action, actor_id=actor_id, reason=reason,
             )
+            # Read both flags back inside the transaction so the returned
+            # payload mirrors actual DB state. ``pause`` intentionally
+            # leaves lock_mode untouched, so a pause on an already-locked
+            # system must report lock_mode=true — computing the value
+            # from ``action`` alone would mis-report the audit payload
+            # written by the caller.
+            new_active = await _fetch_flag(conn, "kill_switch_active")
+            new_lock = await _fetch_flag(conn, "kill_switch_lock_mode")
 
     invalidate_cache()
-    new_active = action in (ACTION_PAUSE, ACTION_LOCK)
-    new_lock = action == ACTION_LOCK
     return {
         "active": new_active,
         "lock_mode": new_lock,

--- a/projects/polymarket/crusaderbot/domain/ops/kill_switch.py
+++ b/projects/polymarket/crusaderbot/domain/ops/kill_switch.py
@@ -1,0 +1,268 @@
+"""Operator kill switch — the single source of truth for trade halts.
+
+State lives in ``system_settings`` (key ``kill_switch_active``,
+``kill_switch_lock_mode``) and is read on the hot path by the risk gate
+(step [1]). Reads are cached in-process for ``CACHE_TTL_SECONDS`` so a
+busy gate does not slam the DB on every signal.
+
+The cache is intentionally simple — a single asyncio.Lock around a
+timestamp+value tuple. No Redis, no shared state. A 30-second propagation
+window after the operator flips the switch is acceptable and explicitly
+documented in the R12f task brief; ``invalidate()`` is called from
+``set_active()`` so an operator action is reflected immediately on the
+process that handled the command.
+
+The history table (``kill_switch_history``) is append-only. Every
+``set_active()`` writes one row. The general audit.log also receives a
+matching ``kill_switch_*`` event via ``audit.write`` from the caller
+(admin handler) — this module only owns the ops-plane history table.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import asyncpg
+
+from ...database import get_pool
+
+logger = logging.getLogger(__name__)
+
+
+CACHE_TTL_SECONDS: float = 30.0
+
+ACTION_PAUSE = "pause"
+ACTION_RESUME = "resume"
+ACTION_LOCK = "lock"
+_VALID_ACTIONS = {ACTION_PAUSE, ACTION_RESUME, ACTION_LOCK}
+
+
+class _Cache:
+    """Tiny TTL cache for the kill-switch flag.
+
+    Holds (expires_at_monotonic, value). ``read`` returns ``None`` when
+    the entry is missing or stale; the caller then re-fetches from DB
+    and writes back via ``store``. A single ``asyncio.Lock`` keeps
+    concurrent gate evaluations from issuing parallel SELECTs on a cold
+    cache — they coalesce on the lock and the second waiter sees a warm
+    entry.
+    """
+
+    def __init__(self) -> None:
+        self._expires: float = 0.0
+        self._value: bool = False
+        self._has_value: bool = False
+        self._lock = asyncio.Lock()
+
+    def read(self) -> Optional[bool]:
+        if not self._has_value:
+            return None
+        if time.monotonic() >= self._expires:
+            return None
+        return self._value
+
+    def store(self, value: bool) -> None:
+        self._value = value
+        self._expires = time.monotonic() + CACHE_TTL_SECONDS
+        self._has_value = True
+
+    def invalidate(self) -> None:
+        self._has_value = False
+        self._expires = 0.0
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        return self._lock
+
+
+_cache = _Cache()
+
+
+def invalidate_cache() -> None:
+    """Force the next ``is_active`` call to re-read from DB.
+
+    Exposed for tests and for any caller that needs to bypass the TTL
+    immediately after an operator-driven mutation that did not go
+    through ``set_active`` (for example, a direct DB tweak from a
+    migration or a CLI tool).
+    """
+    _cache.invalidate()
+
+
+async def _fetch_flag(conn: asyncpg.Connection, key: str) -> bool:
+    row = await conn.fetchrow(
+        "SELECT value FROM system_settings WHERE key=$1", key,
+    )
+    if row is None:
+        return False
+    raw = (row["value"] or "").strip().lower()
+    return raw in {"true", "1", "yes", "on"}
+
+
+async def is_active(conn: Optional[asyncpg.Connection] = None) -> bool:
+    """Return True when the operator has paused trading.
+
+    Cached for ``CACHE_TTL_SECONDS``. Pass ``conn`` only when the caller
+    is already inside a transaction it wants the read to share — risk
+    gate step [1] passes ``None`` so it picks up a short-lived
+    connection from the pool.
+    """
+    cached = _cache.read()
+    if cached is not None:
+        return cached
+
+    async with _cache.lock:
+        cached = _cache.read()
+        if cached is not None:
+            return cached
+        try:
+            if conn is not None:
+                value = await _fetch_flag(conn, "kill_switch_active")
+            else:
+                pool = get_pool()
+                async with pool.acquire() as c:
+                    value = await _fetch_flag(c, "kill_switch_active")
+        except Exception as exc:
+            # On a DB blip we fail SAFE: assume the switch is ACTIVE so
+            # no new trades route, log loudly, and let the next call
+            # try again. A risk gate that opens the floodgates because
+            # the read failed would be the worst possible default.
+            logger.error("kill_switch is_active read failed: %s", exc)
+            return True
+        _cache.store(value)
+        return value
+
+
+async def get_lock_mode(conn: Optional[asyncpg.Connection] = None) -> bool:
+    """Return True when the kill switch is in lock-mode.
+
+    Lock mode means a /killswitch resume alone will not bring auto-trade
+    back online — every user has had ``users.auto_trade_on`` flipped to
+    FALSE and must re-enable manually. ``set_active(False)`` does not
+    clear lock mode; the operator must call that explicitly.
+    """
+    try:
+        if conn is not None:
+            return await _fetch_flag(conn, "kill_switch_lock_mode")
+        pool = get_pool()
+        async with pool.acquire() as c:
+            return await _fetch_flag(c, "kill_switch_lock_mode")
+    except Exception as exc:
+        logger.error("kill_switch get_lock_mode read failed: %s", exc)
+        return False
+
+
+async def _upsert(conn: asyncpg.Connection, key: str, value: bool) -> None:
+    await conn.execute(
+        "INSERT INTO system_settings (key, value, updated_at) "
+        "VALUES ($1, $2, NOW()) "
+        "ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value, "
+        "updated_at=NOW()",
+        key, "true" if value else "false",
+    )
+
+
+async def record_history(
+    conn: asyncpg.Connection,
+    *,
+    action: str,
+    actor_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> None:
+    """Append a row to ``kill_switch_history``.
+
+    Validates ``action`` against the allowed set so a typo can never
+    produce a bogus entry that would later confuse the audit reviewer.
+    """
+    if action not in _VALID_ACTIONS:
+        raise ValueError(f"invalid kill switch action: {action!r}")
+    await conn.execute(
+        "INSERT INTO kill_switch_history (action, actor_id, reason) "
+        "VALUES ($1, $2, $3)",
+        action, actor_id, reason,
+    )
+
+
+async def set_active(
+    *,
+    action: str,
+    actor_id: Optional[int] = None,
+    reason: Optional[str] = None,
+    deactivate_users: bool = False,
+) -> dict:
+    """Flip the operator kill switch and record history in one transaction.
+
+    ``action`` must be one of ``pause`` / ``resume`` / ``lock``.
+
+    * ``pause``  -> kill_switch_active=true, lock_mode unchanged.
+    * ``resume`` -> kill_switch_active=false, lock_mode=false. Risk gate
+                    re-opens. Users with ``auto_trade_on=true`` resume
+                    on their next signal.
+    * ``lock``   -> kill_switch_active=true, lock_mode=true, AND every
+                    user's ``users.auto_trade_on`` is forced to false.
+                    Resuming requires the operator to call /killswitch
+                    resume AND each user must re-opt-in.
+
+    Returns a small dict with the resulting state and (for ``lock``) the
+    number of user rows touched, so the caller can shape its operator
+    reply.
+    """
+    if action not in _VALID_ACTIONS:
+        raise ValueError(f"invalid kill switch action: {action!r}")
+
+    pool = get_pool()
+    users_disabled = 0
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            if action == ACTION_PAUSE:
+                await _upsert(conn, "kill_switch_active", True)
+            elif action == ACTION_RESUME:
+                await _upsert(conn, "kill_switch_active", False)
+                await _upsert(conn, "kill_switch_lock_mode", False)
+            elif action == ACTION_LOCK:
+                await _upsert(conn, "kill_switch_active", True)
+                await _upsert(conn, "kill_switch_lock_mode", True)
+                # Force every user out of auto-trade. The status field on
+                # users is ``auto_trade_on`` (see migrations/001_init.sql).
+                # We capture the affected count so the operator reply can
+                # report exactly how many users were paused.
+                users_disabled = int(await conn.fetchval(
+                    "WITH affected AS ("
+                    "  UPDATE users SET auto_trade_on=FALSE "
+                    "  WHERE auto_trade_on=TRUE RETURNING 1"
+                    ") SELECT COUNT(*) FROM affected"
+                ) or 0)
+                if deactivate_users and users_disabled == 0:
+                    # Optional explicit-zero hint kept for symmetry with
+                    # callers that want to log a no-op lock action.
+                    logger.info(
+                        "kill_switch lock: no users had auto_trade_on=true"
+                    )
+            await record_history(
+                conn, action=action, actor_id=actor_id, reason=reason,
+            )
+
+    invalidate_cache()
+    new_active = action in (ACTION_PAUSE, ACTION_LOCK)
+    new_lock = action == ACTION_LOCK
+    return {
+        "active": new_active,
+        "lock_mode": new_lock,
+        "users_disabled": users_disabled,
+    }
+
+
+async def fetch_history(limit: int = 10) -> list[dict]:
+    """Return the most recent ``kill_switch_history`` rows."""
+    if limit <= 0:
+        return []
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT action, actor_id, reason, ts "
+            "FROM kill_switch_history ORDER BY ts DESC LIMIT $1",
+            limit,
+        )
+    return [dict(r) for r in rows]

--- a/projects/polymarket/crusaderbot/domain/risk/gate.py
+++ b/projects/polymarket/crusaderbot/domain/risk/gate.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from ...database import get_pool, is_kill_switch_active
+from ...database import get_pool
 from ...wallet.ledger import daily_pnl, get_balance
+from ..ops.kill_switch import is_active as kill_switch_is_active
 from . import constants as K
 
 logger = logging.getLogger(__name__)
@@ -146,8 +147,9 @@ async def evaluate(ctx: GateContext) -> GateResult:
     settings = get_settings()
     profile = K.profile_or_default(ctx.risk_profile)
 
-    # 1. Kill switch
-    if await is_kill_switch_active():
+    # 1. Kill switch — read goes through the domain module so we hit the
+    # 30s in-process cache instead of the DB on every signal evaluation.
+    if await kill_switch_is_active():
         await _log(ctx.user_id, ctx.market_id, 1, False, "kill_switch_active")
         return GateResult(False, "kill_switch_active", 1)
     await _log(ctx.user_id, ctx.market_id, 1, True, "ok")

--- a/projects/polymarket/crusaderbot/migrations/007_ops.sql
+++ b/projects/polymarket/crusaderbot/migrations/007_ops.sql
@@ -26,15 +26,40 @@ CREATE TABLE IF NOT EXISTS system_settings (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Seed the kill-switch keys exactly once. INSERT … ON CONFLICT DO NOTHING
--- keeps the migration idempotent and never overwrites an active state on
--- redeploy: if the operator paused the switch before a deploy, the post-deploy
--- run must not silently flip it back to inactive.
-INSERT INTO system_settings (key, value)
-VALUES
-    ('kill_switch_active', 'false'),
-    ('kill_switch_lock_mode', 'false')
-ON CONFLICT (key) DO NOTHING;
+-- Seed the kill-switch keys exactly once. The block is idempotent — on
+-- re-run it does nothing because the keys already exist — AND it
+-- backfills from the legacy ``kill_switch`` table on first migration so
+-- a deploy onto a DB where the operator had paused via the pre-R12f
+-- code path inherits the paused state instead of silently re-opening
+-- trading. The latest row in ``kill_switch`` (ORDER BY id DESC LIMIT 1)
+-- is the authoritative legacy state.
+DO $$
+DECLARE
+    legacy_active BOOLEAN := FALSE;
+    has_legacy_table BOOLEAN;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM system_settings WHERE key = 'kill_switch_active'
+    ) THEN
+        SELECT to_regclass('public.kill_switch') IS NOT NULL
+          INTO has_legacy_table;
+        IF has_legacy_table THEN
+            SELECT COALESCE(active, FALSE) INTO legacy_active
+              FROM kill_switch ORDER BY id DESC LIMIT 1;
+        END IF;
+        INSERT INTO system_settings (key, value) VALUES (
+            'kill_switch_active',
+            CASE WHEN legacy_active THEN 'true' ELSE 'false' END
+        );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM system_settings WHERE key = 'kill_switch_lock_mode'
+    ) THEN
+        INSERT INTO system_settings (key, value)
+        VALUES ('kill_switch_lock_mode', 'false');
+    END IF;
+END $$;
 
 CREATE TABLE IF NOT EXISTS kill_switch_history (
     id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/projects/polymarket/crusaderbot/migrations/007_ops.sql
+++ b/projects/polymarket/crusaderbot/migrations/007_ops.sql
@@ -1,0 +1,63 @@
+-- 007_ops.sql — R12f operator-dashboard / kill-switch / job-monitor backplane.
+--
+-- Three additive tables, all idempotent:
+--
+--   system_settings      Key/value bag for operator-flipped runtime flags.
+--                        Single row per key. Risk gate step [1] reads
+--                        ('kill_switch_active','true'|'false') from here on
+--                        every gate evaluation (cached 30s in process to keep
+--                        the read non-blocking).
+--
+--   kill_switch_history  Append-only history of every pause / resume / lock
+--                        operator action. INSERT-only from the app — never
+--                        UPDATE, never DELETE. Lets WARP🔹CMD reconstruct who
+--                        flipped the switch and when, without touching the
+--                        general-purpose audit.log.
+--
+--   job_runs             Last-N scheduler job outcomes. Populated by the
+--                        APScheduler listener registered in setup_scheduler().
+--                        /ops_dashboard surfaces the most recent rows so the
+--                        operator can see whether market_sync, deposit_watch,
+--                        signal_scan, exit_watch, and redeem are healthy.
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    key        VARCHAR(100) PRIMARY KEY,
+    value      TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the kill-switch keys exactly once. INSERT … ON CONFLICT DO NOTHING
+-- keeps the migration idempotent and never overwrites an active state on
+-- redeploy: if the operator paused the switch before a deploy, the post-deploy
+-- run must not silently flip it back to inactive.
+INSERT INTO system_settings (key, value)
+VALUES
+    ('kill_switch_active', 'false'),
+    ('kill_switch_lock_mode', 'false')
+ON CONFLICT (key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS kill_switch_history (
+    id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    action    VARCHAR(20) NOT NULL,
+    actor_id  BIGINT,
+    reason    TEXT,
+    ts        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kill_switch_history_ts
+    ON kill_switch_history(ts DESC);
+
+CREATE TABLE IF NOT EXISTS job_runs (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_name    VARCHAR(100) NOT NULL,
+    status      VARCHAR(20) NOT NULL,
+    started_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at TIMESTAMPTZ,
+    error       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_runs_started_at
+    ON job_runs(started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_job_runs_status
+    ON job_runs(status, started_at DESC);

--- a/projects/polymarket/crusaderbot/migrations/007_ops.sql
+++ b/projects/polymarket/crusaderbot/migrations/007_ops.sql
@@ -33,6 +33,12 @@ CREATE TABLE IF NOT EXISTS system_settings (
 -- code path inherits the paused state instead of silently re-opening
 -- trading. The latest row in ``kill_switch`` (ORDER BY id DESC LIMIT 1)
 -- is the authoritative legacy state.
+-- Two-instance rolling deploys can race on this seed. Both transactions
+-- pass the IF NOT EXISTS check, then the second INSERT raises a unique-
+-- key error and aborts startup. ``ON CONFLICT (key) DO NOTHING`` makes
+-- the seed idempotent under concurrency. The IF NOT EXISTS guard is
+-- still useful — it skips the (cheap) backfill SELECT against the
+-- legacy ``kill_switch`` table on every redeploy after the first.
 DO $$
 DECLARE
     legacy_active BOOLEAN := FALSE;
@@ -50,15 +56,13 @@ BEGIN
         INSERT INTO system_settings (key, value) VALUES (
             'kill_switch_active',
             CASE WHEN legacy_active THEN 'true' ELSE 'false' END
-        );
+        )
+        ON CONFLICT (key) DO NOTHING;
     END IF;
 
-    IF NOT EXISTS (
-        SELECT 1 FROM system_settings WHERE key = 'kill_switch_lock_mode'
-    ) THEN
-        INSERT INTO system_settings (key, value)
-        VALUES ('kill_switch_lock_mode', 'false');
-    END IF;
+    INSERT INTO system_settings (key, value)
+    VALUES ('kill_switch_lock_mode', 'false')
+    ON CONFLICT (key) DO NOTHING;
 END $$;
 
 CREATE TABLE IF NOT EXISTS kill_switch_history (

--- a/projects/polymarket/crusaderbot/reports/forge/r12f-operator-dashboard.md
+++ b/projects/polymarket/crusaderbot/reports/forge/r12f-operator-dashboard.md
@@ -1,0 +1,234 @@
+# WARP•FORGE Report — R12f Operator Dashboard + Kill Switch
+
+Lane: `WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD`
+Date: 2026-05-05 (Asia/Jakarta)
+Validation Tier: STANDARD
+Claim Level: OPERATOR TOOLING ONLY — no new execution path; kill switch
+integrates at risk gate step [1] only.
+Validation Target: operator-only Telegram surface (`/ops_dashboard`,
+`/killswitch`, `/jobs`, `/auditlog`), kill-switch state machine,
+job-runs observability.
+Not in Scope: trading logic, risk constants, execution path, user-facing
+handlers, multi-operator support, email-verify unlock, on-chain sweep.
+Suggested Next Step: WARP🔹CMD review and merge — STANDARD tier; no
+SENTINEL audit required per task brief.
+
+---
+
+## 1. What was built
+
+### `/ops_dashboard`
+Operator-only system snapshot in Telegram. One reply with:
+
+- App uptime + Fly.io machine id (or hostname fallback)
+- DB ping result
+- Active users (Tier 2+) count
+- Open positions count (all users)
+- Total USDC balance across all sub-account wallets
+- Auto-trade enabled users count
+- Kill switch state (ACTIVE / inactive, plus LOCK marker if lock-mode)
+- Last 3 job runs with status icon and duration
+
+Refresh + Pause/Resume + Lock buttons attached to the reply via the new
+`ops:` callback prefix. Each field degrades to `N/A` (or an error footer)
+if the underlying read fails — the snapshot never crashes the operator
+flow.
+
+### `/killswitch <pause|resume|lock>`
+Single-operator command that flips the kill switch through one
+authoritative path:
+
+- `pause`  — sets `system_settings.kill_switch_active=true`. Risk gate
+  step [1] starts rejecting new trades within ≤30s (the cache TTL).
+  All Tier 2+ users get a Telegram broadcast.
+- `resume` — sets `kill_switch_active=false` and clears
+  `kill_switch_lock_mode`. Operator gets a confirmation reply.
+- `lock`   — sets both flags true AND flips every `users.auto_trade_on`
+  to FALSE in a single SQL statement. Reports the count of affected
+  users. Operator must run `/killswitch resume` separately to unlock;
+  users must re-opt-in.
+
+Every flip writes one row to `kill_switch_history` AND one row to
+`audit.log` (action `kill_switch_pause` / `_resume` / `_lock`).
+
+### `/jobs [n] [failed]`
+Tail of `job_runs`, default 10, max 50 (`MAX_OPS_LIMIT`). `failed`
+filters to status='failed'. Errors are truncated to 80 chars in the
+output.
+
+### `/auditlog [n]`
+Read-only tail of `audit.log`, default 20, max 50. Renders ts /
+actor_role / action / truncated user_id. No write or delete code path
+exists in the new module — only `SELECT`.
+
+### Kill-switch domain module (`domain/ops/kill_switch.py`)
+Single source of truth for the operator pause flag.
+- `is_active(conn=None)` — cached read with 30s TTL. Cold-cache
+  contention is coalesced through one `asyncio.Lock`. Fails SAFE: a
+  DB read error returns `True` so the gate stays closed.
+- `set_active(action, actor_id, reason)` — transactional upsert into
+  `system_settings` + history append + cache invalidation. Lock action
+  also flips `users.auto_trade_on=FALSE`.
+- `record_history(...)`, `fetch_history(limit)`, `get_lock_mode(...)`,
+  `invalidate_cache()` — supporting helpers.
+
+### Job-runs tracker (`domain/ops/job_tracker.py` + scheduler listener)
+APScheduler `EVENT_JOB_SUBMITTED | EXECUTED | ERROR` listener writes
+one `job_runs` row per scheduled job execution. Captures wallclock
+start in the SUBMITTED handler so duration is accurate even when a
+misfire shifts `scheduled_run_time`. DB write failures are logged but
+never block scheduler progress.
+
+### Risk gate integration (single line)
+`domain/risk/gate.py` step [1] now imports
+`domain.ops.kill_switch.is_active` instead of the old uncached
+`database.is_kill_switch_active`. The legacy database helper is now a
+compatibility wrapper that delegates to the new module so the legacy
+inline-keyboard callback (`bot/handlers/admin.py:admin_callback`) and
+the REST API (`api/admin.py`) stay on the same source of truth.
+
+### Migration `007_ops.sql`
+Three new tables — `system_settings`, `kill_switch_history`, `job_runs`
+— all `IF NOT EXISTS`. Seed rows for `kill_switch_active=false` and
+`kill_switch_lock_mode=false` written via `ON CONFLICT DO NOTHING` so a
+re-run on a paused production DB never silently flips the switch back
+to inactive. Indexes on `kill_switch_history(ts DESC)` and
+`job_runs(started_at DESC)` + `(status, started_at DESC)` keep tail
+reads cheap.
+
+---
+
+## 2. Current system architecture
+
+```
+Telegram operator
+    │
+    ▼
+bot/handlers/admin.py
+  /ops_dashboard ── _collect_dashboard_snapshot() ──► DB + job_tracker.fetch_recent
+  /killswitch    ── _apply_killswitch_action()    ──► domain.ops.kill_switch.set_active
+                                                       └─► system_settings (upsert)
+                                                       └─► kill_switch_history (insert)
+                                                       └─► users.auto_trade_on (lock only)
+                                                       └─► audit.log (audit.write)
+                                                       └─► broadcast to users (notifications.send)
+  /jobs          ── job_tracker.fetch_recent()    ──► job_runs SELECT
+  /auditlog      ── _fetch_audit_tail()           ──► audit.log SELECT (read-only)
+
+scheduler.py
+  setup_scheduler()
+    └── add_listener(_job_tracker_listener,
+                     EVENT_JOB_SUBMITTED | EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
+              └─► job_tracker.mark_job_submitted / record_job_event ── job_runs INSERT
+
+domain/risk/gate.py step [1]
+    └── domain.ops.kill_switch.is_active()  (30s TTL cache)
+              └─► system_settings SELECT (cold cache only)
+
+database.py
+  is_kill_switch_active() / set_kill_switch()
+    └── thin wrappers delegating to domain.ops.kill_switch  (single source of truth)
+```
+
+---
+
+## 3. Files created / modified (full repo-root paths)
+
+### Created
+- `projects/polymarket/crusaderbot/migrations/007_ops.sql`
+- `projects/polymarket/crusaderbot/domain/ops/__init__.py`
+- `projects/polymarket/crusaderbot/domain/ops/kill_switch.py`
+- `projects/polymarket/crusaderbot/domain/ops/job_tracker.py`
+- `projects/polymarket/crusaderbot/bot/keyboards/admin.py`
+- `projects/polymarket/crusaderbot/tests/test_kill_switch.py`
+- `projects/polymarket/crusaderbot/tests/test_admin_handlers.py`
+- `projects/polymarket/crusaderbot/reports/forge/r12f-operator-dashboard.md`
+
+### Modified
+- `projects/polymarket/crusaderbot/bot/handlers/admin.py` — added
+  `_format_uptime`, `_format_duration_ms`, `_truncate`, `_parse_limit`,
+  `_collect_dashboard_snapshot`, `_render_dashboard`, `_render_jobs`,
+  `_render_auditlog`, `_apply_killswitch_action`, `_broadcast_pause`,
+  `_fetch_audit_tail`, `ops_dashboard_command`, `ops_dashboard_callback`,
+  `killswitch_command`, `jobs_command`, `auditlog_command`. Promoted
+  `notifications` import to module scope.
+- `projects/polymarket/crusaderbot/bot/dispatcher.py` — registered
+  `/ops_dashboard`, `/killswitch`, `/jobs`, `/auditlog` command handlers
+  and the `^ops:` callback handler.
+- `projects/polymarket/crusaderbot/database.py` — converted
+  `is_kill_switch_active()` and `set_kill_switch()` to thin wrappers
+  around the new domain module (single source of truth).
+- `projects/polymarket/crusaderbot/domain/risk/gate.py` — step [1] now
+  calls `domain.ops.kill_switch.is_active` (cached 30s).
+- `projects/polymarket/crusaderbot/scheduler.py` — registered the
+  APScheduler listener on `setup_scheduler()`. No trading logic changed.
+- `projects/polymarket/crusaderbot/state/PROJECT_STATE.md`,
+  `state/WORKTODO.md`, `state/CHANGELOG.md` — surgical state sync.
+
+### Note on path naming
+Task brief specified `infra/migrations/007_ops.sql`. The repo's existing
+convention is `projects/polymarket/crusaderbot/migrations/` (where
+001–006 already live and where `database.run_migrations()` reads from).
+The migration was placed there to remain idempotent with the existing
+`run_migrations` glob.
+
+---
+
+## 4. What is working
+
+- All 51 new tests pass; full CrusaderBot suite 140 / 140 green.
+  Coverage:
+  - `is_active`: cold-cache, warm-cache, fail-safe-on-error, conn pass-through
+  - `set_active`: pause / resume / lock paths, history row, cache invalidation
+  - `record_history` validation, `fetch_history` limit handling
+  - All four R12f commands silently reject non-operators
+  - Operator gate happy paths: dashboard renders, killswitch usage / pause /
+    resume / lock replies, /jobs default + failed filter, /auditlog default
+  - All pure formatters: uptime, duration (ms / s / m), truncate, parse_limit
+  - Dashboard renderer: kill-switch active vs. inactive, lock marker,
+    missing-field N/A path, error footer
+- Kill switch read on the hot path is non-blocking: warm cache returns
+  immediately; cold cache coalesces under a single asyncio lock so a
+  burst of signals does not produce parallel SELECTs.
+- `database.is_kill_switch_active()` and `set_kill_switch()` keep their
+  signatures; the legacy admin inline-keyboard callback and `api/admin.py`
+  REST endpoint continue to work without code changes on their side and
+  share the new source of truth.
+- Migration is idempotent: re-running on a DB whose
+  `kill_switch_active=true` does not silently revert it (ON CONFLICT
+  DO NOTHING on seed inserts; CREATE TABLE IF NOT EXISTS for tables;
+  CREATE INDEX IF NOT EXISTS).
+
+---
+
+## 5. Known issues
+
+- Up to 30 seconds of propagation between `/killswitch pause` and the
+  risk gate seeing it on a *different* process. On the same process the
+  set_active call invalidates the cache immediately, so the operator's
+  acknowledgement is consistent with the local gate. Multi-instance
+  deployments will see ≤30s skew between machines — accepted per the
+  task brief.
+- `/killswitch lock` does not yet require email verification to unlock;
+  unlock is operator-manual via `/killswitch resume`. Email-verify path
+  was explicitly deferred in the task brief.
+- The legacy `kill_switch` table (created in `001_init.sql`) is no
+  longer authoritative but is left in place to avoid a cross-cutting
+  drop migration. No code path reads from it after this lane.
+- `_broadcast_pause` fans out per-user `notifications.send` calls
+  serially. For >1k users a Tier-2+ pause broadcast will take a few
+  seconds; acceptable for an operator-triggered event.
+- F401 warnings on the file's pre-existing imports remain unchanged
+  from the deferred cleanup lane noted in WORKTODO.
+
+---
+
+## 6. What is next
+
+- WARP🔹CMD review of this PR (STANDARD tier — no SENTINEL required).
+- Open lanes that R12f does NOT block:
+  - R12c exit-watcher merge (PR #865) — independent.
+  - R12a CI/CD pipeline merge — independent.
+  - R12d live opt-in checklist (MAJOR) — separate gate.
+- Future lane (deferred): email-verify unlock for `/killswitch lock`,
+  multi-machine cache invalidation via Redis pub/sub.

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -424,8 +424,14 @@ def _job_tracker_listener(event) -> None:
         exc = getattr(event, "exception", None)
         if exc is not None:
             err = f"{type(exc).__name__}: {exc}"
+    # Pop the start timestamp SYNCHRONOUSLY here so the next SUBMITTED
+    # event for the same job_id cannot overwrite it before our
+    # create_task'd record_job_event reads it. This closes the race
+    # Codex flagged on PR #874 (job_tracker.py:34).
+    started_at = job_tracker.pop_job_start(event.job_id)
     coro = job_tracker.record_job_event(
         job_id=event.job_id, success=success, error=err,
+        started_at=started_at,
     )
     try:
         loop = asyncio.get_running_loop()

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -6,6 +6,10 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+import asyncio
+from apscheduler.events import (
+    EVENT_JOB_ERROR, EVENT_JOB_EXECUTED, EVENT_JOB_SUBMITTED,
+)
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from . import audit, notifications
@@ -13,6 +17,7 @@ from .config import get_settings
 from .database import get_pool
 from .domain.execution import exit_watcher
 from .domain.execution.router import execute as router_execute
+from .domain.ops import job_tracker
 from .domain.risk.gate import GateContext, evaluate
 from .domain.signal.copy_trade import CopyTradeStrategy
 from .integrations import polygon, polymarket
@@ -396,6 +401,45 @@ async def sweep_deposits() -> None:
     logger.info("sweep_deposits: %s deposits marked", n)
 
 
+def _job_tracker_listener(event) -> None:
+    """APScheduler listener that mirrors job outcomes into ``job_runs``.
+
+    Three event classes feed into a single sink:
+      * EVENT_JOB_SUBMITTED - capture a wallclock start so duration is
+        accurate even when ``scheduled_run_time`` is shifted by a misfire.
+      * EVENT_JOB_EXECUTED  - happy-path terminal event.
+      * EVENT_JOB_ERROR     - failure terminal event with exception text.
+
+    The DB write is dispatched onto the running event loop because
+    APScheduler invokes listeners synchronously. ``call_soon_threadsafe``
+    is used defensively in case APScheduler ever upgrades to a thread
+    pool — today the AsyncIO scheduler runs listeners on the loop thread.
+    """
+    if event.code == EVENT_JOB_SUBMITTED:
+        job_tracker.mark_job_submitted(event.job_id)
+        return
+    success = event.code == EVENT_JOB_EXECUTED
+    err = None
+    if not success:
+        exc = getattr(event, "exception", None)
+        if exc is not None:
+            err = f"{type(exc).__name__}: {exc}"
+    coro = job_tracker.record_job_event(
+        job_id=event.job_id, success=success, error=err,
+    )
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop (shouldn't happen with AsyncIOScheduler) — fire
+        # a fresh task so the write still lands.
+        try:
+            asyncio.run(coro)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("job_runs sync write failed: %s", exc)
+        return
+    loop.create_task(coro)
+
+
 def setup_scheduler() -> AsyncIOScheduler:
     s = get_settings()
     sched = AsyncIOScheduler(timezone=s.TIMEZONE)
@@ -412,4 +456,8 @@ def setup_scheduler() -> AsyncIOScheduler:
     sched.add_job(check_resolutions, "interval", seconds=s.RESOLUTION_CHECK_INTERVAL,
                   id="resolution", max_instances=1, coalesce=True)
     sched.add_job(sweep_deposits, "cron", hour=3, id="sweep", max_instances=1)
+    sched.add_listener(
+        _job_tracker_listener,
+        EVENT_JOB_SUBMITTED | EVENT_JOB_EXECUTED | EVENT_JOB_ERROR,
+    )
     return sched

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,5 @@
+2026-05-05 19:10 UTC | WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD | R12f operator dashboard built: /ops_dashboard, /killswitch (pause|resume|lock), /jobs, /auditlog. New domain.ops.kill_switch (30s cached non-blocking is_active), domain.ops.job_tracker + APScheduler listener, migration 007_ops.sql (system_settings + kill_switch_history + job_runs, idempotent). Risk gate step [1] now reads via the cached module; legacy database.is_kill_switch_active delegates. Operator-only gate (silent reject). 51 new tests, 140/140 suite green. Tier: STANDARD. Claim: OPERATOR TOOLING ONLY.
+
 2026-05-05 07:49 UTC | #869 feat(crusaderbot): R12e auto-redeem system — 7f8af0b90993 | SENTINEL APPROVED 92/100, 0 critical. NARROW INTEGRATION: instant+hourly workers, redeem_queue, Settings UI, 87/87 tests. EXECUTION_PATH_VALIDATED gate maintained.
 
 ---

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-05 07:49 UTC
-Status       : R12e auto-redeem MERGED ✔ (PR #869, SHA 7f8af0b90993). SENTINEL APPROVED 92/100, 0 critical. R12c exit watcher (PR #865) CLEAN, awaiting CMD merge. R12a CI/CD PR open. Paper-default. EXECUTION_PATH_VALIDATED NOT SET.
+Last Updated : 2026-05-05 19:10 UTC
+Status       : R12f operator dashboard + kill switch lane built — PR open: WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD, STANDARD tier, awaiting WARP🔹CMD review. R12e auto-redeem MERGED ✔ (PR #869). R12c exit watcher (PR #865) CLEAN, awaiting CMD merge. R12a CI/CD PR open. Paper-default. EXECUTION_PATH_VALIDATED NOT SET.
 
 [COMPLETED]
 - PR #852 — feat(crusaderbot): import full Replit build R1-R11
@@ -18,6 +18,7 @@ Status       : R12e auto-redeem MERGED ✔ (PR #869, SHA 7f8af0b90993). SENTINEL
 - R12c — Auto-Close / Take-Profit — PR open: WARP/CRUSADERBOT-R12C-EXIT-WATCHER — MAJOR tier, SENTINEL audit required before merge
 - R12d — Telegram Position UX (live position monitor + per-position force close) — PR #868 MERGED (4f5e12201964) — STANDARD tier
 - R12e — Auto-Redeem System (instant + hourly workers + redeem_queue + Settings UI) — PR #869 MERGED (7f8af0b90993) — MAJOR tier, SENTINEL APPROVED 92/100
+- R12f — Operator Dashboard + Kill Switch + Job Monitor + Audit Log — PR open: WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD — STANDARD tier, awaiting WARP🔹CMD review
 
 [NOT STARTED]
 - R12d — Live Opt-In Checklist (MAJOR — hard gate before EXE)
@@ -26,9 +27,9 @@ Status       : R12e auto-redeem MERGED ✔ (PR #869, SHA 7f8af0b90993). SENTINEL
 - R12 — Deployment (Fly.io) — final (MAJOR)
 
 [NEXT PRIORITY]
+- WARP🔹CMD review required for R12f operator dashboard + kill switch. Source: projects/polymarket/crusaderbot/reports/forge/r12f-operator-dashboard.md. Tier: STANDARD. Branch: WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD.
 - R12c exit watcher (PR #865) CLEAN — WARP🔹CMD merge decision pending. Tier: MAJOR, SENTINEL required. Branch: WARP/CRUSADERBOT-R12C-EXIT-WATCHER.
 - WARP•SENTINEL validation required for R12c exit watcher before merge. Source: projects/polymarket/crusaderbot/reports/forge/r12c-exit-watcher.md. Tier: MAJOR. Branch: WARP/CRUSADERBOT-R12C-EXIT-WATCHER.
-- WARP🔹CMD review required for R12d Telegram position UX. Source: projects/polymarket/crusaderbot/reports/forge/r12d-telegram-position-ux.md. Tier: STANDARD. Branch: WARP/CRUSADERBOT-R12D-TELEGRAM-POSITION-UX.
 
 [KNOWN ISSUES]
 - /deposit no tier gate (intentional, non-blocking)

--- a/projects/polymarket/crusaderbot/state/WORKTODO.md
+++ b/projects/polymarket/crusaderbot/state/WORKTODO.md
@@ -1,14 +1,14 @@
 # CrusaderBot — WORKTODO
 
 **Project:** projects/polymarket/crusaderbot
-**Last Updated:** 2026-05-05 18:30 UTC
+**Last Updated:** 2026-05-05 19:10 UTC
 
 ---
 
 ## Right Now
 
-Active lane: WARP/CRUSADERBOT-R12C-EXIT-WATCHER (PR #865) — MAJOR tier, CLEAN, CMD merge pending.
-Next: WARP🔹CMD merge decision on R12c exit watcher (PR #865). R12a CI/CD PR review pending.
+Active lane: WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD — STANDARD tier, PR open, awaiting WARP🔹CMD review.
+Next: WARP🔹CMD review of R12f, then merge decisions on R12c exit watcher (PR #865) and R12a CI/CD.
 
 ---
 
@@ -22,6 +22,7 @@ Next: WARP🔹CMD merge decision on R12c exit watcher (PR #865). R12a CI/CD PR r
 - [x] R12e — Auto-Redeem System — MERGED PR #869 (7f8af0b90993), SENTINEL APPROVED 92/100
 - [ ] R12e — Live → Paper Auto-Fallback — NOT STARTED (MAJOR)
 - [ ] R12f — Daily P&L Summary — NOT STARTED (STANDARD)
+- [ ] R12f — Operator Dashboard + Kill Switch + Job Monitor + Audit Log — IN PROGRESS: WARP/CRUSADERBOT-R12F-OPERATOR-DASHBOARD open, STANDARD — awaiting WARP🔹CMD review
 - [ ] R12 — Deployment (Fly.io) final — NOT STARTED (MAJOR — blocked on R12a-R12f all merged)
 
 Done condition: All R12a-R12f merged + activation guards reviewed by WARP🔹CMD before final R12 deployment.

--- a/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
+++ b/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
@@ -176,6 +176,9 @@ def test_render_dashboard_handles_missing_fields():
     assert "❌" in out  # DB down
     assert "N/A" in out
     assert "Some fields unavailable" in out
+    # The "Some fields unavailable" line must NOT be wrapped in ``_..._``
+    # — legacy MARKDOWN rejects escapes inside entity spans.
+    assert "_Some fields unavailable:" not in out
 
 
 def test_render_jobs_empty_default():
@@ -247,8 +250,11 @@ def test_render_jobs_escapes_error_metacharacters():
     assert "bad\\_value" in out
     assert "\\`xyz\\`" in out
     assert "\\[step 2]" in out
-    # The unescaped form must NOT appear inside the rendered italic span.
-    assert "_bad_value_" not in out
+    # The error must be rendered as plain (escaped) text, NOT wrapped
+    # in an italic span — legacy MARKDOWN rejects escapes inside
+    # entities, so a `_..._` wrap would still fail on common errors.
+    assert "└ ValueError" in out
+    assert "_ValueError" not in out
 
 
 # ---------- Operator gate ---------------------------------------------------

--- a/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
+++ b/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
@@ -133,7 +133,8 @@ def test_render_dashboard_kill_switch_inactive():
     assert "🟢 inactive" in out
     assert "1m" in out  # uptime
     assert "$1,234.50" in out
-    assert "market_sync" in out
+    # Job name underscores are escaped for Telegram MARKDOWN safety.
+    assert "market\\_sync" in out
     assert "(LOCK)" not in out
 
 
@@ -208,9 +209,46 @@ def test_render_auditlog_truncates_user_id():
     }]
     out = admin._render_auditlog(rows)
     assert "operator" in out
-    assert "kill_switch_pause" in out
+    # Action contains underscores — must be escaped so Telegram MARKDOWN
+    # parses cleanly (Codex P2 fix).
+    assert "kill\\_switch\\_pause" in out
+    assert "kill_switch_pause" not in out
     # user_id truncated to 8 chars + ellipsis = 8 chars
     assert "abcdefg…" in out
+
+
+# ---------- Markdown escape ------------------------------------------------
+
+
+def test_md_escape_escapes_metacharacters():
+    out = admin._md_escape("a_b*c`d[e")
+    assert out == "a\\_b\\*c\\`d\\[e"
+
+
+def test_md_escape_handles_none_and_empty():
+    assert admin._md_escape(None) == ""
+    assert admin._md_escape("") == ""
+
+
+def test_md_escape_doubles_backslashes_first():
+    # The order matters: backslash must be doubled BEFORE escaping the
+    # other metacharacters, otherwise an _md_escape("_") produces ``\\_``
+    # which then becomes ``\\\\_`` on a re-escape pass.
+    out = admin._md_escape("\\_")
+    assert out == "\\\\\\_"
+
+
+def test_render_jobs_escapes_error_metacharacters():
+    # Failed job error contains underscores, backticks, and brackets —
+    # raw injection would break Telegram MARKDOWN parsing.
+    err = "ValueError: bad_value `xyz` at [step 2]"
+    rows = [_job_row("redeem", "failed", error=err)]
+    out = admin._render_jobs(rows, only_failed=True)
+    assert "bad\\_value" in out
+    assert "\\`xyz\\`" in out
+    assert "\\[step 2]" in out
+    # The unescaped form must NOT appear inside the rendered italic span.
+    assert "_bad_value_" not in out
 
 
 # ---------- Operator gate ---------------------------------------------------
@@ -399,4 +437,5 @@ def test_auditlog_default_limit():
         asyncio.run(admin.auditlog_command(update, ctx))
     fetch.assert_awaited_once_with(admin.DEFAULT_AUDIT_LIMIT)
     args, _ = update.message.reply_text.call_args
-    assert "kill_switch_pause" in args[0]
+    # Action underscores escaped for Telegram MARKDOWN safety.
+    assert "kill\\_switch\\_pause" in args[0]

--- a/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
+++ b/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
@@ -167,8 +167,10 @@ def test_render_dashboard_handles_missing_fields():
         "open_positions": None,
         "total_usdc": None,
         "auto_trade_users": None,
-        "kill_switch_active": False,
-        "lock_mode": False,
+        # DB read failed — kill switch state is genuinely unknown.
+        # The renderer must surface that, not lie with "🟢 inactive".
+        "kill_switch_active": None,
+        "lock_mode": None,
         "recent_jobs": [],
         "errors": ["db: down"],
     }
@@ -179,6 +181,9 @@ def test_render_dashboard_handles_missing_fields():
     # The "Some fields unavailable" line must NOT be wrapped in ``_..._``
     # — legacy MARKDOWN rejects escapes inside entity spans.
     assert "_Some fields unavailable:" not in out
+    # Kill switch state must be reported as unknown, never inactive.
+    assert "❓ unknown" in out
+    assert "🟢 inactive" not in out
 
 
 def test_render_jobs_empty_default():

--- a/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
+++ b/projects/polymarket/crusaderbot/tests/test_admin_handlers.py
@@ -1,0 +1,402 @@
+"""Hermetic tests for the R12f operator-dashboard handlers.
+
+Exercises the pure formatters (``_render_dashboard``, ``_render_jobs``,
+``_render_auditlog``, ``_format_uptime``, ``_truncate``,
+``_parse_limit``) directly, plus the operator-gate wiring on the four
+new commands using ``ContextTypes``-style doubles. No DB, no Telegram
+network calls.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from projects.polymarket.crusaderbot.bot.handlers import admin
+
+
+# ---------- Pure helpers ----------------------------------------------------
+
+
+def test_format_uptime_minutes():
+    assert admin._format_uptime(0) == "0m"
+    assert admin._format_uptime(59) == "0m"
+    assert admin._format_uptime(125) == "2m"
+
+
+def test_format_uptime_hours():
+    assert admin._format_uptime(3 * 3600 + 12 * 60) == "3h 12m"
+
+
+def test_format_uptime_days():
+    assert admin._format_uptime(2 * 86400 + 4 * 3600 + 30 * 60) == "2d 4h 30m"
+
+
+def test_format_duration_handles_none():
+    assert admin._format_duration_ms(None, None) == "—"
+    now = datetime.now(timezone.utc)
+    assert admin._format_duration_ms(now, None) == "—"
+
+
+def test_format_duration_milliseconds():
+    start = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    out = admin._format_duration_ms(start, start + timedelta(milliseconds=350))
+    assert out == "350ms"
+
+
+def test_format_duration_seconds():
+    start = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    out = admin._format_duration_ms(start, start + timedelta(seconds=12.4))
+    assert out == "12.4s"
+
+
+def test_format_duration_minutes():
+    start = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    out = admin._format_duration_ms(start, start + timedelta(seconds=125))
+    assert out == "2.1m"
+
+
+def test_truncate_passthrough_under_limit():
+    assert admin._truncate("hello", 80) == "hello"
+
+
+def test_truncate_appends_ellipsis_over_limit():
+    out = admin._truncate("x" * 200, 80)
+    assert len(out) == 80 and out.endswith("…")
+
+
+def test_truncate_handles_none():
+    assert admin._truncate(None, 80) == ""
+
+
+# ---------- _parse_limit ----------------------------------------------------
+
+
+def test_parse_limit_default_when_no_args():
+    assert admin._parse_limit([], 10) == (10, False)
+
+
+def test_parse_limit_picks_integer():
+    assert admin._parse_limit(["5"], 10) == (5, False)
+
+
+def test_parse_limit_recognises_failed_token():
+    assert admin._parse_limit(["failed"], 10) == (10, True)
+
+
+def test_parse_limit_combines_failed_and_n():
+    assert admin._parse_limit(["failed", "7"], 10) == (7, True)
+
+
+def test_parse_limit_clamps_to_max():
+    assert admin._parse_limit(["999"], 10) == (admin.MAX_OPS_LIMIT, False)
+
+
+def test_parse_limit_ignores_garbage():
+    assert admin._parse_limit(["nope"], 10) == (10, False)
+
+
+# ---------- Renderers -------------------------------------------------------
+
+
+def _job_row(name: str, status: str, *, error: str | None = None,
+             duration_ms: int = 100) -> dict:
+    start = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    return {
+        "job_name": name,
+        "status": status,
+        "started_at": start,
+        "finished_at": start + timedelta(milliseconds=duration_ms),
+        "error": error,
+    }
+
+
+def test_render_dashboard_kill_switch_inactive():
+    snapshot = {
+        "uptime_seconds": 90,
+        "hostname": "fly-machine-abc",
+        "db_ok": True,
+        "active_users": 12,
+        "open_positions": 3,
+        "total_usdc": 1234.5,
+        "auto_trade_users": 7,
+        "kill_switch_active": False,
+        "lock_mode": False,
+        "recent_jobs": [_job_row("market_sync", "success")],
+        "errors": [],
+    }
+    out = admin._render_dashboard(snapshot)
+    assert "Operator Dashboard" in out
+    assert "🟢 inactive" in out
+    assert "1m" in out  # uptime
+    assert "$1,234.50" in out
+    assert "market_sync" in out
+    assert "(LOCK)" not in out
+
+
+def test_render_dashboard_kill_switch_locked():
+    snapshot = {
+        "uptime_seconds": 0,
+        "hostname": "h",
+        "db_ok": True,
+        "active_users": 0,
+        "open_positions": 0,
+        "total_usdc": 0,
+        "auto_trade_users": 0,
+        "kill_switch_active": True,
+        "lock_mode": True,
+        "recent_jobs": [],
+        "errors": [],
+    }
+    out = admin._render_dashboard(snapshot)
+    assert "🔴 ACTIVE" in out
+    assert "(LOCK)" in out
+    assert "_No recent job runs recorded._" in out
+
+
+def test_render_dashboard_handles_missing_fields():
+    snapshot = {
+        "uptime_seconds": 0,
+        "hostname": "h",
+        "db_ok": False,
+        "active_users": None,
+        "open_positions": None,
+        "total_usdc": None,
+        "auto_trade_users": None,
+        "kill_switch_active": False,
+        "lock_mode": False,
+        "recent_jobs": [],
+        "errors": ["db: down"],
+    }
+    out = admin._render_dashboard(snapshot)
+    assert "❌" in out  # DB down
+    assert "N/A" in out
+    assert "Some fields unavailable" in out
+
+
+def test_render_jobs_empty_default():
+    assert "_No job runs recorded yet._" in admin._render_jobs([], False)
+
+
+def test_render_jobs_empty_failed_filter_message():
+    assert "_No matching job runs._" in admin._render_jobs([], True)
+
+
+def test_render_jobs_truncates_long_errors():
+    long_err = "Boom! " + "x" * 500
+    rows = [_job_row("redeem", "failed", error=long_err)]
+    out = admin._render_jobs(rows, only_failed=True)
+    assert "Recent failed job runs" in out
+    assert "❌" in out
+    # Error fragment is truncated to 80 chars in the renderer.
+    assert "…" in out
+
+
+def test_render_auditlog_empty():
+    assert "_Audit log is empty._" in admin._render_auditlog([])
+
+
+def test_render_auditlog_truncates_user_id():
+    rows = [{
+        "ts": datetime(2026, 5, 5, 12, 30, 0, tzinfo=timezone.utc),
+        "actor_role": "operator",
+        "action": "kill_switch_pause",
+        "user_id": "abcdefghijklmno",
+    }]
+    out = admin._render_auditlog(rows)
+    assert "operator" in out
+    assert "kill_switch_pause" in out
+    # user_id truncated to 8 chars + ellipsis = 8 chars
+    assert "abcdefg…" in out
+
+
+# ---------- Operator gate ---------------------------------------------------
+
+
+def _fake_settings(operator_id: int = 42):
+    return SimpleNamespace(OPERATOR_CHAT_ID=operator_id)
+
+
+def _fake_update(user_id: int, *, command_args: list[str] | None = None,
+                 message: bool = True):
+    msg = SimpleNamespace(reply_text=AsyncMock())
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        message=msg if message else None,
+        callback_query=None,
+    )
+
+
+def _fake_ctx(args: list[str] | None = None):
+    return SimpleNamespace(args=args or [])
+
+
+def test_ops_dashboard_rejects_non_operator_silently():
+    update = _fake_update(user_id=999)  # not the operator
+    ctx = _fake_ctx()
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.ops_dashboard_command(update, ctx))
+    update.message.reply_text.assert_not_called()
+
+
+def test_killswitch_rejects_non_operator_silently():
+    update = _fake_update(user_id=999)
+    ctx = _fake_ctx(args=["pause"])
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    update.message.reply_text.assert_not_called()
+
+
+def test_jobs_rejects_non_operator_silently():
+    update = _fake_update(user_id=999)
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.jobs_command(update, _fake_ctx()))
+    update.message.reply_text.assert_not_called()
+
+
+def test_auditlog_rejects_non_operator_silently():
+    update = _fake_update(user_id=999)
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.auditlog_command(update, _fake_ctx()))
+    update.message.reply_text.assert_not_called()
+
+
+# ---------- Operator happy paths -------------------------------------------
+
+
+def test_ops_dashboard_renders_for_operator():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx()
+    snapshot = {
+        "uptime_seconds": 60,
+        "hostname": "h",
+        "db_ok": True,
+        "active_users": 1,
+        "open_positions": 0,
+        "total_usdc": 0,
+        "auto_trade_users": 0,
+        "kill_switch_active": False,
+        "lock_mode": False,
+        "recent_jobs": [],
+        "errors": [],
+    }
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin, "_collect_dashboard_snapshot",
+                      AsyncMock(return_value=snapshot)):
+        asyncio.run(admin.ops_dashboard_command(update, ctx))
+    update.message.reply_text.assert_awaited_once()
+    args, kwargs = update.message.reply_text.call_args
+    assert "Operator Dashboard" in args[0]
+    assert kwargs["reply_markup"] is not None
+
+
+def test_killswitch_usage_with_no_args():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=[])
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    args, _ = update.message.reply_text.call_args
+    assert "Usage" in args[0]
+
+
+def test_killswitch_invalid_action_shows_usage():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=["nuke"])
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    args, _ = update.message.reply_text.call_args
+    assert "Usage" in args[0]
+
+
+def test_killswitch_pause_calls_set_active_and_replies():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=["pause"])
+    set_active = AsyncMock(return_value={
+        "active": True, "lock_mode": False, "users_disabled": 0,
+    })
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin.ops_kill_switch, "set_active", set_active), \
+         patch.object(admin.audit, "write", AsyncMock()), \
+         patch.object(admin, "_broadcast_pause", AsyncMock(return_value=3)):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    set_active.assert_awaited_once()
+    kwargs = set_active.await_args.kwargs
+    assert kwargs["action"] == "pause"
+    assert kwargs["actor_id"] == 42
+    args, _ = update.message.reply_text.call_args
+    assert "ACTIVE" in args[0]
+
+
+def test_killswitch_resume_calls_set_active_and_replies():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=["resume"])
+    set_active = AsyncMock(return_value={
+        "active": False, "lock_mode": False, "users_disabled": 0,
+    })
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin.ops_kill_switch, "set_active", set_active), \
+         patch.object(admin.audit, "write", AsyncMock()):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    set_active.assert_awaited_once()
+    args, _ = update.message.reply_text.call_args
+    assert "deactivated" in args[0].lower()
+
+
+def test_killswitch_lock_disables_users_and_replies():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=["lock"])
+    set_active = AsyncMock(return_value={
+        "active": True, "lock_mode": True, "users_disabled": 5,
+    })
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin.ops_kill_switch, "set_active", set_active), \
+         patch.object(admin.audit, "write", AsyncMock()), \
+         patch.object(admin, "_broadcast_pause", AsyncMock(return_value=5)):
+        asyncio.run(admin.killswitch_command(update, ctx))
+    args, _ = update.message.reply_text.call_args
+    assert "LOCKED" in args[0]
+    assert "5 users" in args[0]
+
+
+def test_jobs_invokes_tracker_with_default_limit():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=[])
+    fetch = AsyncMock(return_value=[_job_row("market_sync", "success")])
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin.job_tracker, "fetch_recent", fetch):
+        asyncio.run(admin.jobs_command(update, ctx))
+    fetch.assert_awaited_once()
+    kwargs = fetch.await_args.kwargs
+    assert kwargs["limit"] == admin.DEFAULT_JOB_LIMIT
+    assert kwargs["only_failed"] is False
+
+
+def test_jobs_failed_filter_passes_through():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=["failed"])
+    fetch = AsyncMock(return_value=[])
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin.job_tracker, "fetch_recent", fetch):
+        asyncio.run(admin.jobs_command(update, ctx))
+    fetch.assert_awaited_once()
+    assert fetch.await_args.kwargs["only_failed"] is True
+
+
+def test_auditlog_default_limit():
+    update = _fake_update(user_id=42)
+    ctx = _fake_ctx(args=[])
+    rows = [{
+        "ts": datetime(2026, 5, 5, tzinfo=timezone.utc),
+        "actor_role": "operator", "action": "kill_switch_pause",
+        "user_id": "abc",
+    }]
+    fetch = AsyncMock(return_value=rows)
+    with patch.object(admin, "get_settings", return_value=_fake_settings(42)), \
+         patch.object(admin, "_fetch_audit_tail", fetch):
+        asyncio.run(admin.auditlog_command(update, ctx))
+    fetch.assert_awaited_once_with(admin.DEFAULT_AUDIT_LIMIT)
+    args, _ = update.message.reply_text.call_args
+    assert "kill_switch_pause" in args[0]

--- a/projects/polymarket/crusaderbot/tests/test_job_tracker.py
+++ b/projects/polymarket/crusaderbot/tests/test_job_tracker.py
@@ -87,6 +87,45 @@ def test_record_job_event_uses_explicit_started_at():
     assert args[4] is None  # error
 
 
+def test_record_job_event_does_not_clobber_next_runs_start():
+    """Regression for Codex P1 follow-up on PR #874.
+
+    After the listener pops and forwards started_at, a fresh
+    SUBMITTED for the same job_id arrives before record_job_event's
+    DB write finishes. The old code popped ``_started_at[job_id]`` in
+    a ``finally`` block, erasing the new run's slot. This test
+    pre-loads the slot with a "next-run" timestamp and asserts that
+    record_job_event leaves it intact.
+    """
+    job_tracker._started_at.clear()
+    next_run_started = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+    job_tracker._started_at["redeem"] = next_run_started
+
+    class FakeConn:
+        async def execute(self, *_):
+            return None
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *_):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    with patch.object(job_tracker, "get_pool", return_value=FakePool()):
+        asyncio.run(job_tracker.record_job_event(
+            job_id="redeem", success=True,
+            started_at=datetime(2026, 5, 5, 11, 59, 0, tzinfo=timezone.utc),
+            finished_at=datetime(2026, 5, 5, 11, 59, 30, tzinfo=timezone.utc),
+        ))
+    # The next run's slot must still be intact.
+    assert job_tracker._started_at.get("redeem") == next_run_started
+
+
 def test_record_job_event_swallows_db_errors():
     class BoomPool:
         def acquire(self):

--- a/projects/polymarket/crusaderbot/tests/test_job_tracker.py
+++ b/projects/polymarket/crusaderbot/tests/test_job_tracker.py
@@ -1,0 +1,106 @@
+"""Hermetic tests for the R12f job_tracker module.
+
+Covers the SUBMITTED/EXECUTED race fix Codex flagged on PR #874:
+``pop_job_start`` removes the slot so a fresh SUBMITTED for the same
+job_id cannot cross-contaminate the next completion's started_at.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from projects.polymarket.crusaderbot.domain.ops import job_tracker
+
+
+def test_mark_and_pop_round_trip():
+    job_tracker._started_at.clear()
+    job_tracker.mark_job_submitted("market_sync")
+    popped = job_tracker.pop_job_start("market_sync")
+    assert isinstance(popped, datetime)
+    # Pop is destructive — second pop returns None.
+    assert job_tracker.pop_job_start("market_sync") is None
+
+
+def test_pop_isolates_concurrent_executions():
+    """After pop, a fresh SUBMITTED creates an independent slot.
+
+    This is the regression test for the race Codex flagged: a second
+    SUBMITTED that arrives while the prior EXECUTED's create_task is
+    still queued must NOT corrupt the prior run's started_at.
+    """
+    job_tracker._started_at.clear()
+    job_tracker.mark_job_submitted("redeem")
+    first = job_tracker.pop_job_start("redeem")
+    # Listener forwarded ``first`` into record_job_event already; the
+    # next SUBMITTED arrives and writes a fresh slot.
+    job_tracker.mark_job_submitted("redeem")
+    second = job_tracker.pop_job_start("redeem")
+    assert first is not None and second is not None
+    # The two timestamps are independent — first run's value is intact.
+    assert second >= first
+
+
+def test_pop_returns_none_when_nothing_marked():
+    job_tracker._started_at.clear()
+    assert job_tracker.pop_job_start("never-marked") is None
+
+
+def test_record_job_event_uses_explicit_started_at():
+    """When the listener forwards started_at, record uses it verbatim."""
+    captured: list[tuple] = []
+
+    async def fake_execute(self, query, *args):
+        captured.append((query, args))
+        return None
+
+    class FakeConn:
+        async def execute(self, query, *args):
+            captured.append((query, args))
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *_):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    started = datetime(2026, 5, 5, 0, 0, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 5, 5, 0, 0, 1, tzinfo=timezone.utc)
+    with patch.object(job_tracker, "get_pool", return_value=FakePool()):
+        asyncio.run(job_tracker.record_job_event(
+            job_id="market_sync", success=True,
+            started_at=started, finished_at=finished,
+        ))
+    # Exactly one INSERT with our explicit timestamps in args.
+    inserts = [c for c in captured if "INSERT INTO job_runs" in c[0]]
+    assert len(inserts) == 1
+    args = inserts[0][1]
+    assert args[0] == "market_sync"
+    assert args[1] == "success"
+    assert args[2] == started
+    assert args[3] == finished
+    assert args[4] is None  # error
+
+
+def test_record_job_event_swallows_db_errors():
+    class BoomPool:
+        def acquire(self):
+            raise RuntimeError("DB blip")
+
+    with patch.object(job_tracker, "get_pool", return_value=BoomPool()):
+        # Must not raise — observability cannot break the scheduler.
+        asyncio.run(job_tracker.record_job_event(
+            job_id="redeem", success=False, error="x",
+        ))
+
+
+def test_fetch_recent_zero_limit_returns_empty():
+    with patch.object(job_tracker, "get_pool",
+                      side_effect=AssertionError("pool must not be hit")):
+        out = asyncio.run(job_tracker.fetch_recent(0))
+    assert out == []

--- a/projects/polymarket/crusaderbot/tests/test_kill_switch.py
+++ b/projects/polymarket/crusaderbot/tests/test_kill_switch.py
@@ -179,6 +179,21 @@ def test_set_active_pause_upserts_and_writes_history():
     assert actor_id == 42
 
 
+def test_set_active_pause_preserves_existing_lock_mode():
+    # Codex P2 fix: pause must not silently report lock_mode=False when
+    # the system is already locked. The returned payload mirrors actual
+    # DB state, not a value computed from the action verb.
+    conn = FakeConn(settings={
+        "kill_switch_active": "true",
+        "kill_switch_lock_mode": "true",
+    })
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.set_active(action="pause", actor_id=42))
+    assert result["lock_mode"] is True
+    # Lock mode must remain set in DB after a pause on a locked system.
+    assert conn.settings["kill_switch_lock_mode"] == "true"
+
+
 def test_set_active_resume_clears_lock_mode():
     conn = FakeConn(settings={
         "kill_switch_active": "true",
@@ -217,14 +232,15 @@ def test_set_active_invalidates_cache():
     with patch.object(ks, "get_pool", return_value=FakePool(conn)):
         # Warm cache with FALSE.
         assert asyncio.run(ks.is_active()) is False
-        assert len(conn.fetchrow_calls) == 1
-        # Now flip to pause; the cache must be cleared so the next is_active
+        # Flip to pause; cache must be cleared so the next is_active
         # re-reads the DB.
         asyncio.run(ks.set_active(action="pause"))
-        # Update simulated DB so the post-pause read returns the new value.
+        # Simulate DB state for the post-set read.
         conn.settings["kill_switch_active"] = "true"
+        before_n = len(conn.fetchrow_calls)
         assert asyncio.run(ks.is_active()) is True
-        assert len(conn.fetchrow_calls) == 2
+        # A fresh fetchrow must have happened — proves cache was cold.
+        assert len(conn.fetchrow_calls) > before_n
 
 
 # ---------- record_history --------------------------------------------------

--- a/projects/polymarket/crusaderbot/tests/test_kill_switch.py
+++ b/projects/polymarket/crusaderbot/tests/test_kill_switch.py
@@ -1,0 +1,262 @@
+"""Hermetic tests for the R12f kill-switch domain module.
+
+No real DB. ``asyncpg.Pool`` and ``asyncpg.Connection`` are replaced
+with async-context-manager doubles so the test suite exercises:
+
+    * is_active() returns DB value when cache is cold
+    * is_active() returns cached value within TTL (no DB hit)
+    * is_active() fails SAFE (returns True) when the DB read raises
+    * set_active("pause") upserts true and writes one history row
+    * set_active("resume") upserts false and clears lock_mode
+    * set_active("lock") upserts true+true AND flips users.auto_trade_on
+    * set_active() invalidates the cache so the next read re-fetches
+    * record_history() rejects unknown actions
+    * fetch_history() returns the rows asyncpg gave it as plain dicts
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from projects.polymarket.crusaderbot.domain.ops import kill_switch as ks
+
+
+# ---------- Fake asyncpg machinery ------------------------------------------
+
+
+class FakeConn:
+    """asyncpg.Connection stand-in capturing every SQL call."""
+
+    def __init__(self, *, settings: dict[str, str] | None = None,
+                 lock_mode: bool = False,
+                 raise_on_fetchrow: bool = False) -> None:
+        self.settings = dict(settings or {})
+        self.lock_mode = lock_mode
+        self.raise_on_fetchrow = raise_on_fetchrow
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+        self.fetchval_calls: list[tuple[str, tuple]] = []
+        self.history_rows: list[tuple] = []
+        self.users_disabled = 0
+
+    async def fetchrow(self, query: str, *args: Any):
+        if self.raise_on_fetchrow:
+            raise RuntimeError("DB blip")
+        self.fetchrow_calls.append((query, args))
+        if "system_settings" in query and "key=$1" in query:
+            key = args[0]
+            if key in self.settings:
+                return {"value": self.settings[key]}
+            return None
+        return None
+
+    async def fetchval(self, query: str, *args: Any):
+        self.fetchval_calls.append((query, args))
+        if "auto_trade_on=FALSE" in query and "auto_trade_on=TRUE" in query:
+            return self.users_disabled
+        return 0
+
+    async def execute(self, query: str, *args: Any):
+        self.execute_calls.append((query, args))
+        if "INSERT INTO system_settings" in query:
+            key, val = args
+            self.settings[key] = val
+        elif "INSERT INTO kill_switch_history" in query:
+            self.history_rows.append(args)
+        return "INSERT 0 1"
+
+    async def fetch(self, query: str, *args: Any):
+        # used by fetch_history
+        return [
+            {"action": "pause", "actor_id": 42, "reason": None,
+             "ts": "2026-05-05T00:00:00+00:00"},
+        ]
+
+    def transaction(self):
+        conn = self
+
+        class _Txn:
+            async def __aenter__(self_inner):
+                return conn
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _Txn()
+
+
+class FakeAcquire:
+    def __init__(self, conn: FakeConn) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> FakeConn:
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakePool:
+    def __init__(self, conn: FakeConn) -> None:
+        self.conn = conn
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self.conn)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    ks.invalidate_cache()
+    yield
+    ks.invalidate_cache()
+
+
+# ---------- is_active() -----------------------------------------------------
+
+
+def test_is_active_returns_db_value_on_cold_cache():
+    conn = FakeConn(settings={"kill_switch_active": "true"})
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.is_active())
+    assert result is True
+    # Exactly one fetchrow against system_settings.
+    assert len(conn.fetchrow_calls) == 1
+
+
+def test_is_active_returns_false_when_setting_missing():
+    conn = FakeConn(settings={})
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.is_active())
+    assert result is False
+
+
+def test_is_active_uses_cache_within_ttl():
+    conn = FakeConn(settings={"kill_switch_active": "false"})
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        first = asyncio.run(ks.is_active())
+        second = asyncio.run(ks.is_active())
+        third = asyncio.run(ks.is_active())
+    assert (first, second, third) == (False, False, False)
+    # Only the first call should have hit the DB.
+    assert len(conn.fetchrow_calls) == 1
+
+
+def test_is_active_fails_safe_on_db_error():
+    conn = FakeConn(raise_on_fetchrow=True)
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.is_active())
+    # Fail SAFE: when the DB read errors, the gate must assume ACTIVE so
+    # no new trades route until the issue is resolved.
+    assert result is True
+
+
+def test_is_active_uses_provided_conn_without_pool():
+    conn = FakeConn(settings={"kill_switch_active": "true"})
+    # If is_active reaches into get_pool when a conn is supplied, this
+    # patch will assert via NotImplementedError.
+    with patch.object(ks, "get_pool",
+                      side_effect=AssertionError("pool must not be used")):
+        result = asyncio.run(ks.is_active(conn))
+    assert result is True
+
+
+# ---------- set_active() ----------------------------------------------------
+
+
+def test_set_active_pause_upserts_and_writes_history():
+    conn = FakeConn(settings={"kill_switch_active": "false"})
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.set_active(action="pause", actor_id=42))
+    assert result == {"active": True, "lock_mode": False, "users_disabled": 0}
+    assert conn.settings["kill_switch_active"] == "true"
+    # Exactly one history row written.
+    assert len(conn.history_rows) == 1
+    action, actor_id, _reason = conn.history_rows[0]
+    assert action == "pause"
+    assert actor_id == 42
+
+
+def test_set_active_resume_clears_lock_mode():
+    conn = FakeConn(settings={
+        "kill_switch_active": "true",
+        "kill_switch_lock_mode": "true",
+    })
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.set_active(action="resume", actor_id=7))
+    assert result == {"active": False, "lock_mode": False, "users_disabled": 0}
+    assert conn.settings["kill_switch_active"] == "false"
+    assert conn.settings["kill_switch_lock_mode"] == "false"
+
+
+def test_set_active_lock_disables_users():
+    conn = FakeConn(settings={"kill_switch_active": "false"})
+    conn.users_disabled = 5
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        result = asyncio.run(ks.set_active(action="lock", actor_id=99))
+    assert result == {"active": True, "lock_mode": True, "users_disabled": 5}
+    assert conn.settings["kill_switch_active"] == "true"
+    assert conn.settings["kill_switch_lock_mode"] == "true"
+    # The auto_trade UPDATE must have run.
+    matched = [
+        q for q, _ in conn.fetchval_calls
+        if "auto_trade_on=FALSE" in q and "auto_trade_on=TRUE" in q
+    ]
+    assert matched, "lock action must flip every user's auto_trade_on"
+
+
+def test_set_active_rejects_invalid_action():
+    with pytest.raises(ValueError):
+        asyncio.run(ks.set_active(action="nuke", actor_id=1))
+
+
+def test_set_active_invalidates_cache():
+    conn = FakeConn(settings={"kill_switch_active": "false"})
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        # Warm cache with FALSE.
+        assert asyncio.run(ks.is_active()) is False
+        assert len(conn.fetchrow_calls) == 1
+        # Now flip to pause; the cache must be cleared so the next is_active
+        # re-reads the DB.
+        asyncio.run(ks.set_active(action="pause"))
+        # Update simulated DB so the post-pause read returns the new value.
+        conn.settings["kill_switch_active"] = "true"
+        assert asyncio.run(ks.is_active()) is True
+        assert len(conn.fetchrow_calls) == 2
+
+
+# ---------- record_history --------------------------------------------------
+
+
+def test_record_history_rejects_unknown_action():
+    conn = FakeConn()
+    with pytest.raises(ValueError):
+        asyncio.run(ks.record_history(conn, action="explode", actor_id=1))
+
+
+def test_record_history_writes_one_row():
+    conn = FakeConn()
+    asyncio.run(ks.record_history(
+        conn, action="pause", actor_id=7, reason="incident",
+    ))
+    assert conn.history_rows == [("pause", 7, "incident")]
+
+
+# ---------- fetch_history ---------------------------------------------------
+
+
+def test_fetch_history_zero_limit_returns_empty():
+    conn = FakeConn()
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        out = asyncio.run(ks.fetch_history(0))
+    assert out == []
+
+
+def test_fetch_history_returns_dicts():
+    conn = FakeConn()
+    with patch.object(ks, "get_pool", return_value=FakePool(conn)):
+        out = asyncio.run(ks.fetch_history(5))
+    assert out == [{"action": "pause", "actor_id": 42, "reason": None,
+                    "ts": "2026-05-05T00:00:00+00:00"}]


### PR DESCRIPTION
## Summary

R12f operator/Ops-plane Telegram surface — kill-switch controls, system snapshot, job monitor, and audit log tail. All commands are operator-only (`update.effective_user.id == OPERATOR_CHAT_ID`) with silent reject for non-operators.

**New commands:**
- `/ops_dashboard` — uptime, host, DB ping, active users (Tier 2+), open positions, pool USDC, auto-trade users, kill-switch state, last 3 job runs. Refresh + Pause/Resume + Lock buttons.
- `/killswitch <pause|resume|lock>` — flips `system_settings.kill_switch_active`, writes to `kill_switch_history` and `audit.log`. `lock` also flips every `users.auto_trade_on=FALSE` and broadcasts to active users.
- `/jobs [n] [failed]` — last N (default 10) scheduler runs from `job_runs`.
- `/auditlog [n]` — last N (default 20) `audit.log` rows. Read-only.

**New domain modules:**
- `domain/ops/kill_switch.py` — single source of truth. `is_active()` is cached 30s in-process with cold-cache lock coalescing. Fails SAFE: a DB read error returns `True` (gate stays closed). `set_active()` is transactional (upsert + history + cache invalidation in one txn).
- `domain/ops/job_tracker.py` + APScheduler `EVENT_JOB_SUBMITTED|EXECUTED|ERROR` listener — every scheduled job execution writes one row to `job_runs`.

**Risk gate integration:** `domain/risk/gate.py` step [1] now calls the cached module instead of a per-query DB SELECT. The legacy `database.is_kill_switch_active()` is now a thin wrapper, so `api/admin.py` and the existing inline-keyboard callback share the new source of truth without changes.

**Migration `007_ops.sql`:** `system_settings`, `kill_switch_history`, `job_runs` — all `IF NOT EXISTS`. Seeds use `ON CONFLICT DO NOTHING` so re-running on a paused production DB never silently flips the switch back to inactive.

**Validation Tier:** STANDARD
**Claim Level:** OPERATOR TOOLING ONLY — no new execution path, kill switch integrates at risk gate step [1] only.

## Test plan
- [x] 51 new tests added (`test_kill_switch.py` 14, `test_admin_handlers.py` 37)
- [x] Full CrusaderBot suite green: 140 / 140
- [x] Coverage: cold/warm cache, fail-safe-on-DB-error, set_active pause/resume/lock, history rows, cache invalidation, formatters (uptime / duration / truncate / parse_limit), operator-gate silent reject for non-operators, command happy paths (dashboard, killswitch usage/pause/resume/lock, /jobs default + failed filter, /auditlog default)
- [ ] Manual smoke once deployed: `/ops_dashboard` returns snapshot, `/killswitch pause` propagates to risk gate within 30s, `/jobs` and `/auditlog` render

**Report:** `projects/polymarket/crusaderbot/reports/forge/r12f-operator-dashboard.md`
**State:** `PROJECT_STATE.md` / `WORKTODO.md` / `CHANGELOG.md` updated
**Next gate:** WARP🔹CMD review — STANDARD tier, no SENTINEL required.


---
_Generated by [Claude Code](https://claude.ai/code/session_014khjkkhLVGFfCSRosprCwo)_