### PR TITLE
fix(crusaderbot): allow-list signal_following in risk gate STRATEGY_AVAILABILITY

### DIFF
--- a/projects/polymarket/crusaderbot/domain/risk/constants.py
+++ b/projects/polymarket/crusaderbot/domain/risk/constants.py
@@ -33,6 +33,7 @@ PROFILES: dict[str, dict] = {
 STRATEGY_AVAILABILITY: dict[str, list[str]] = {
     "copy_trade": ["conservative", "balanced", "aggressive"],
     "signal":     ["conservative", "balanced", "aggressive"],
+    "signal_following": ["conservative", "balanced", "aggressive"],
     "value":      ["balanced", "aggressive"],   # Phase R6b+
     "momentum":   ["aggressive"],               # Phase R9+
 }


### PR DESCRIPTION
Followup to PR #892 (Codex P2 finding #8).

## Summary

P3c (PR #892) shipped `SignalFollowingStrategy.name = "signal_following"`. `domain/risk/constants.STRATEGY_AVAILABILITY` only allow-listed `"signal"`, so when P3d wires the strategy plane into the risk gate, gate step 4 (`gate.py:179-184`) would reject every `signal_following` candidate as `unknown_strategy`.

## Change

```diff
 STRATEGY_AVAILABILITY: dict[str, list[str]] = {
     "copy_trade": ["conservative", "balanced", "aggressive"],
     "signal":     ["conservative", "balanced", "aggressive"],
+    "signal_following": ["conservative", "balanced", "aggressive"],
     "value":      ["balanced", "aggressive"],   # Phase R6b+
     "momentum":   ["aggressive"],               # Phase R9+
 }
```

Profile compatibility mirrors the existing `"signal"` row and matches `SignalFollowingStrategy.risk_profile_compatibility`. The `"signal"` key is left intact to avoid breaking any legacy `user_strategies` rows that may already use it.

## Validation

- Tier: **MINOR**
- Claim: **FOUNDATION** — pure constant addition, no runtime logic touched.
- Files modified: 1 (`domain/risk/constants.py`)
- No tests, no state files, no report — per WARP🔹CMD scope ("no other files modified").

## Test plan

- [ ] WARP🔹CMD review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATms9f62zxHsz8oTHZrzWb)_