### PR TITLE
docs: mark P3d done and cleanup pre-flight docs

### DIFF
--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,33 +1,23 @@
-Last Updated : 2026-05-08 05:30 Asia/Jakarta
-Status       : Pre-flight cleanup lane open on WARP/CRUSADERBOT-PREFLIGHT-CLEANUP (STANDARD, reclassified from MINOR — migration 013 changes copy_trade_events FK referential action). PR #899 awaiting WARP🔹CMD review. P3d MERGED (PR #897). 464/464 tests green at last green CI. Awaiting R12 final Fly.io deployment.
+Last Updated : 2026-05-08 06:04 Asia/Jakarta
+Status       : Pre-flight cleanup MERGED (PR #899, STANDARD). Strategy plane complete (P3a-P3d). 464/464 tests green. Awaiting R12 final Fly.io deployment — activation guards review required before any live flag set.
 
 [COMPLETED]
-- PR #852 — feat(crusaderbot): import full Replit build R1-R11
-- PR #853 — sentinel: crusaderbot-replit-import PASS (post-fix)
-- C1 resolved: KELLY_FRACTION applied, capital_alloc_pct capped <1.0
-- C2 resolved: migrations/004 idempotent DO $$ blocks
-- C3 resolved: Tier 3 promotion gated on MIN_DEPOSIT_USDC
-- R12b — Fly.io health probes + operator alerts + JSON logging (PR #856 merged)
-- PR #857 — chore: state sync post-PR #856
-- PR #858 — chore: state sync post-PR #857
-- PR #860 — chore: ROADMAP R12b drift fix + WORKTODO init (STANDARD, merged)
-- R12a — CI/CD Pipeline GitHub Actions + Fly.io — PR #855 MERGED 2026-05-04 (STANDARD)
 - R12c — Auto-Close / Take-Profit exit watcher — PR #865 MERGED 2026-05-05 (MAJOR, SENTINEL APPROVED 95/100)
 - R12d — Telegram Position UX (live monitor + force close) — PR #868 MERGED 4f5e12201964 (STANDARD)
 - R12e — Auto-Redeem System — PR #869 MERGED 7f8af0b90993 (MAJOR, SENTINEL CONDITIONAL 64/100 — conditions resolved PR #879)
 - R12f — Operator Dashboard + Kill Switch + Job Monitor — PR #874 MERGED 2026-05-05 (STANDARD)
-- P3a — Strategy Registry Foundation (BaseStrategy ABC + StrategyRegistry + migration 008) — PR #876 MERGED 2026-05-05 (STANDARD, FOUNDATION)
-- P3b — Copy Trade strategy (CopyTradeStrategy + scaler + wallet_watcher + migration 009 + /copytrade Telegram + registry bootstrap) — PR #877 MERGED 2026-05-06 a369129d (MAJOR, SENTINEL CONDITIONAL 71/100 resolved)
-- R12 Live Readiness batch — Live Opt-In Checklist + Live→Paper Auto-Fallback + Daily P&L Summary — PR #883 MERGED 5a9cb22a (STANDARD, NARROW INTEGRATION)
-- Cleanup legacy polyquantbot directory — PR #891 MERGED (MINOR, Issue #890 closed)
+- P3a — Strategy Registry Foundation — PR #876 MERGED 2026-05-05 (STANDARD, FOUNDATION)
+- P3b — Copy Trade strategy — PR #877 MERGED 2026-05-06 a369129d (MAJOR, SENTINEL CONDITIONAL 71/100 resolved)
+- R12 Live Readiness batch — Live Opt-In Checklist + Live->Paper Auto-Fallback + Daily P&L Summary — PR #883 MERGED 5a9cb22a (STANDARD, NARROW INTEGRATION)
 - P3c — Signal Following strategy — PR #892 MERGED (5ee8487e), MAJOR, SENTINEL APPROVED 100/100
-- P3d — Per-user signal scan loop + execution queue wiring — PR #897 MERGED (bb08092), MAJOR, SENTINEL APPROVED 94/100. Crash-recovery resume path, subscribe/unsubscribe enrollment, dual-layer dedup, migration 011+012. 464/464 tests green.
+- P3d — Per-user signal scan loop + execution queue wiring — PR #897 MERGED (bb08092), MAJOR, SENTINEL APPROVED 94/100. 464/464 tests green.
+- Pre-flight cleanup (F401 + MIN-01/02/03 + ROADMAP naming) — PR #899 MERGED (STANDARD, NARROW INTEGRATION)
 
 [IN PROGRESS]
-- Pre-flight cleanup lane on WARP/CRUSADERBOT-PREFLIGHT-CLEANUP (STANDARD, NARROW INTEGRATION — reclassified from MINOR per Codex P2 finding; CMD-ratified): 15 F401 cleared across 7 files, MIN-01 user_id annotations on 3 copy_trade handler helpers, MIN-02 dispatcher phase comment, MIN-03 migration 013 (copy_trade_events.copy_target_id FK referential action ON DELETE CASCADE → ON DELETE SET NULL — audit rows survive parent delete), ROADMAP R12d/R12e/R12f naming aligned to actual executed lanes. PR #899.
+- None
 
 [NOT STARTED]
-- R12 — Deployment (Fly.io) final (MAJOR — P3d unblock complete, activation guards review required before live)
+- R12 — Deployment (Fly.io) final (MAJOR — activation guards review required before live)
 
 [NEXT PRIORITY]
 - R12 final Fly.io deployment (MAJOR — last R12 lane). Activation sequence gated on EXECUTION_PATH_VALIDATED + CAPITAL_MODE_CONFIRMED + ENABLE_LIVE_TRADING — review required before any flag is set.
@@ -38,4 +28,4 @@ Status       : Pre-flight cleanup lane open on WARP/CRUSADERBOT-PREFLIGHT-CLEANU
 - check_alchemy_ws is TCP-only (no full WS handshake) — follow-up
 - lib/ F401 leakage (LOW, 5 occurrences across lib/strategies/logic_arb.py, lib/strategies/value_investor.py, lib/strategies/weather_arb.py, lib/strategy_base.py) — pre-existing repo-root ruff failure surfaced by Codex on PR #899; deferred to WARP/LIB-F401-CLEANUP (post-demo MINOR) per WARP🔹CMD scope-boundary hold; cross-project impact requires audit before cleanup
 
-<!-- CD verify: 2026-05-08 00:30 -->
+<!-- CD verify: 2026-05-08 06:04 -->

--- a/projects/polymarket/crusaderbot/state/ROADMAP.md
+++ b/projects/polymarket/crusaderbot/state/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Project:** projects/polymarket/crusaderbot
 **Blueprint:** docs/blueprint/crusaderbot.md (v3.1 LOCKED)
-**Last Updated:** 2026-05-08 03:39 Asia/Jakarta
+**Last Updated:** 2026-05-08 06:04 Asia/Jakarta
 
 ## Build Path (Replit → Claude Code MVP)
 
@@ -123,5 +123,5 @@ Reference: `docs/blueprint/crusaderbot.md` §6 (Risk System), §12 (Activation G
 | P3a | Strategy Registry Foundation | ✅ Done | STANDARD | Merged PR #876 (2026-05-05), FOUNDATION |
 | P3b | Copy Trade strategy | ✅ Done | MAJOR | Merged PR #877 (2026-05-06) a369129d, SENTINEL CONDITIONAL 71/100 resolved |
 | P3c | Signal Following strategy | ✅ Done | MAJOR | Merged PR #892 (5ee8487e), SENTINEL APPROVED 100/100 |
-| P3d | Signal scan loop + execution queue wiring | ❌ Not Started | MAJOR | Wires registry into risk gate |
+| P3d | Signal scan loop + execution queue wiring | ✅ Done | MAJOR | Merged PR #897 (bb08092), SENTINEL APPROVED 94/100. 464/464 tests green. |
 


### PR DESCRIPTION
## Summary

Mark P3d milestone as completed and clean up project state documentation following the recent merge of pre-flight changes.

## Changes

**Documentation (`projects/polymarket/crusaderbot/state/PROJECT_STATE.md`)**

- Mark P3d milestone as completed
- Remove pre-flight cleanup documentation
- Reduce file size and consolidate state information

**Documentation (`projects/polymarket/crusaderbot/state/ROADMAP.md`)**

- Update roadmap to reflect P3d completion status

---

[Chat](https://warp-xgen-2lvqzor3m-wmos-warp.vercel.app/sessions/C5jx4-pEToZ2Q8mQj6Lj2/chats/Rz4OIAP8pksGlaAhhwj5S) - Built with guidance from [BayueWalker](https://github.com/bayuewalker)