### PR TITLE
sentinel: crusaderbot-live-gate-hardening — APPROVED 92/100

### DIFF
--- a/projects/polymarket/crusaderbot/reports/sentinel/crusaderbot-live-gate-hardening.md
+++ b/projects/polymarket/crusaderbot/reports/sentinel/crusaderbot-live-gate-hardening.md
@@ -1,0 +1,295 @@
+# WARP•SENTINEL REPORT — crusaderbot-live-gate-hardening
+
+**Branch:** WARP/crusaderbot-live-gate-hardening
+**Sentinel Branch:** WARP/sentinel-crusaderbot-live-gate-hardening
+**Date:** 2026-05-11 18:31 Asia/Jakarta
+**Tier:** MAJOR
+**Claim Level:** SAFETY HARDENING
+**Verdict:** APPROVED
+**Score:** 92 / 100
+**Critical Issues:** 0
+**Source PR:** #954
+**Sentinel Issue:** #956 (supersedes #955)
+**Run:** 2 of 2 (run 1 via issue #955 produced partial-format report; this run delivers the complete 14-section report with independent code review confirming the prior verdict)
+
+---
+
+## 1. ENVIRONMENT
+
+**Mode:** dev — paper-only; no live infra, no real CLOB, no real wallet
+**Inferred from:** validation target states "PAPER ONLY, no activation guards enabled"; issue #956 does not specify dev/staging/prod explicitly; paper-only posture and absence of live guards confirms dev environment
+**Environment table applied:**
+- Infra: warn only (dev)
+- Risk: ENFORCED
+- Telegram: warn only (dev)
+
+---
+
+## 2. VALIDATION CONTEXT
+
+**Validation Target:** Execution path readiness checks, risk assertion layer, slippage guardrails, kill-switch verification — PAPER ONLY, no activation guards enabled.
+
+**Not in Scope:** Live trading activation, real-money execution, enabling ENABLE_LIVE_TRADING, enabling EXECUTION_PATH_VALIDATED, enabling CAPITAL_MODE_CONFIRMED, enabling RISK_CONTROLS_VALIDATED, UI premium work, referral/admin systems.
+
+**Scope verified:**
+- Step 14 slippage / market-impact guard in `domain/risk/gate.py`
+- Risk assertion audit layer in `domain/risk/hardening.py`
+- Slippage checks in `domain/execution/slippage.py`
+- Shadow/live parity hooks in `domain/execution/parity.py`
+- Readiness validator in `services/validation/readiness_validator.py`
+- `RISK_CONTROLS_VALIDATED` config default and activation guard posture
+
+---
+
+## 3. PHASE 0 CHECKS
+
+| Check | Result |
+|---|---|
+| PR #954 exists and is open | PASS |
+| Branch `WARP/crusaderbot-live-gate-hardening` matches expected | PASS |
+| Forge report at `projects/polymarket/crusaderbot/reports/forge/crusaderbot-live-gate-hardening.md` | PASS |
+| Forge report has all 6 required sections | PASS |
+| `PROJECT_STATE.md` updated with full timestamp (2026-05-11 21:00) | PASS |
+| No `phase*/` folders introduced | PASS |
+| Domain structure: new files in locked paths only | PASS — `domain/risk/`, `domain/execution/`, `services/validation/` |
+| Implementation evidence: 35 tests present | PASS |
+| No hardcoded secrets or API keys | PASS |
+| No full Kelly a=1.0 in production code | PASS — KELLY_FRACTION=0.25, hardening.py blocks a=1.0 |
+| No silent exception handling | PASS — all exceptions caught, logged, or returned as structured results |
+| No threading — asyncio only | PASS |
+
+**Phase 0 verdict: ALL PASS — validation proceeds.**
+
+---
+
+## 4. FINDINGS
+
+### Phase 1 — Functional Testing
+
+**domain/risk/hardening.py**
+- `audit_risk_constants()` (hardening.py:31–90): validates KELLY_FRACTION, MAX_POSITION_PCT, MAX_CORRELATED_EXPOSURE, DAILY_LOSS_HARD_STOP, MAX_DRAWDOWN_HALT, MIN_LIQUIDITY, MAX_MARKET_IMPACT_PCT, MAX_SLIPPAGE_PCT (8 top-level constants) and 3 profiles × 4 fields (kelly, max_pos_pct, daily_loss, min_liquidity). Returns typed `RiskAuditReport`. **PASS**
+- Full Kelly detection at hardening.py:34: `if not (0 < K.KELLY_FRACTION <= 0.25)` — fires on a=1.0. **PASS**
+- Profile kelly guard at hardening.py:68: `if not (0 < kelly <= K.KELLY_FRACTION)` — catches per-profile aggressive kelly > global cap. **PASS**
+- DAILY_LOSS_HARD_STOP: dual check — range check `(-10000 <= v < 0)` plus cap check `(v < -2000)` — effective safe range is `[-2000, 0)`. **PASS**
+- `assert_risk_constants()` (hardening.py:93–103): raises `AssertionError` with detail on violation; passes cleanly against current constants. **PASS**
+- Test coverage: 8 tests in `TestAuditRiskConstants`, all cases verified. **PASS**
+
+**domain/execution/slippage.py**
+- `check_market_impact()` (slippage.py:34–56): pure function; rejects when `size_usdc / liquidity > threshold`; zero-liquidity returns `market_liquidity_zero` (no division-by-zero). **PASS**
+- `check_price_deviation()` (slippage.py:59–82): pure function; rejects >3% deviation; zero reference returns `reference_price_invalid`. **PASS**
+- `check_price_deviation()` NOT wired to gate or live execution path — explicitly deferred. Callable and tested. **P2, non-blocking**
+- Test coverage: 9 tests, covering boundary at threshold (500/10000=5% → accepted), custom threshold, zero inputs. **PASS**
+
+**domain/risk/gate.py — step 14**
+- Step 14 at gate.py after step 13 `final_size` computation: `impact_result = check_market_impact(final_size, ctx.market_liquidity)` — uses Kelly-adjusted size, not raw proposed size. **PASS**
+- Rejection path: `GateResult(False, "market_impact_cap", 14)` — correctly attributed to step 14. **PASS**
+- Accept path: `await _log(..., 14, True, f"impact_ok_{impact_result.impact_pct:.4f}")` — step 14 logged. **PASS**
+- `_record_idempotency` called AFTER step 14 (gate.py:309) — rejected orders do not consume idempotency slots. **PASS**
+- Pure function on hot path — zero DB reads. **PASS**
+- Test coverage: 4 tests via `TestGateStep14SlippageIntegration`, including stub for transitive import chain. **PASS**
+
+**services/validation/readiness_validator.py**
+- `CHECK_RISK_CONSTANTS` (readiness_validator.py:120–130): delegates to `audit_risk_constants()`. **PASS**
+- `CHECK_GUARD_STATE` (readiness_validator.py:132–155): checks all 4 guards; FAIL if ENABLE_LIVE_TRADING=True resolved. **PASS**
+- `CHECK_KILL_SWITCH` (readiness_validator.py:157–175): read-only; SKIP on RuntimeError (no pool); FAIL on other exceptions. **PASS**
+- `CHECK_EXECUTION_PATH` (readiness_validator.py:177–200): importlib checks 5 modules + key callables. Uses absolute module paths (`projects.polymarket.crusaderbot...`); requires repo root in sys.path. **P2, functional in deployment context**
+- `CHECK_CAPITAL_ALLOC` (readiness_validator.py:202–219): pure math, all profiles verified at ref $1,000 balance. **PASS**
+- `CHECK_SLIPPAGE` (readiness_validator.py:221–243): threshold bounds + functional smoke test. **PASS**
+- Test coverage: 10 tests in `TestReadinessValidator`, covering all PASS/FAIL/SKIP branches. **PASS**
+
+### Phase 2 — Pipeline End-to-End
+
+- Gate step ordering confirmed: step 13 computes `final_size = min(ctx.proposed_size_usdc, max_pos_size)` → step 14 uses `final_size`. Kelly-adjusted size flows correctly into slippage guard. **PASS**
+- Idempotency recorded post-step-14 — no slot consumed on rejection. **PASS**
+- `chosen_mode` returned in `GateResult` — parity check can compare modes independently of verdict. **PASS**
+
+### Phase 3 — Failure Modes
+
+| Failure Mode | Handling | Result |
+|---|---|---|
+| Zero liquidity | `check_market_impact(size, 0.0)` → `accepted=False, reason="market_liquidity_zero"` (slippage.py:38–42) | PASS |
+| DB blip on kill switch | `is_active()` returns True (fail-safe); error logged, no crash (pre-existing) | PASS |
+| Pool unavailable in readiness | `CHECK_KILL_SWITCH` catches RuntimeError → SKIP; overall not forced to FAIL | PASS |
+| Parity mutation suppression | `_log`, `_record_idempotency`, `_idempotent_already_seen`, `_recent_dup_market_trade`, all three `live_fallback.trigger_*` nooped via AsyncMock in both parity runs (parity.py:109–118, 148–158) | PASS |
+| DB failure on `_check_kill_switch` (non-RuntimeError) | Caught by `except Exception as exc` → `FAIL` with detail message | PASS |
+
+### Phase 4 — Async Safety
+
+- Parity patches are context-managed (`with` blocks) — patch scope does not bleed between paper and live runs (parity.py:108–118, 147–158). **PASS**
+- `_fallback_noop = AsyncMock(return_value=None)` — correctly async for async callables. **PASS**
+- No threading module introduced. asyncio throughout. **PASS**
+- `validate_gate_parity()` is a top-level `async def` function — no shared mutable state between calls. **PASS**
+
+### Phase 5 — Risk Rules in Code
+
+| Rule | Constant | Value | Gate | Result |
+|---|---|---|---|---|
+| Kelly fraction α | `KELLY_FRACTION` | 0.25 | `assert 0 < K.KELLY_FRACTION <= 0.5` in gate.py:268; hardening.py:34 checks `<= 0.25` | PASS |
+| Max position size | `MAX_POSITION_PCT` | 0.10 | hardening.py:37 enforces `<= 0.10`; profile max_pos_pct capped below this | PASS |
+| Daily loss limit | `DAILY_LOSS_HARD_STOP` | -$2,000 | effective_daily_loss() applies it as max; hardening.py dual-checks range | PASS |
+| Max drawdown | `MAX_DRAWDOWN_HALT` | 0.08 | hardening.py:48 range check 0.05–0.15 | PASS |
+| Min liquidity | `MIN_LIQUIDITY` | $10,000 | hardening.py:52: `>= 10000` | PASS |
+| Market impact cap | `MAX_MARKET_IMPACT_PCT` | 5% | slippage.py:34–56, gate step 14 | PASS |
+| `RISK_CONTROLS_VALIDATED` | config.py | False | Never set to True in any new production code; readiness validator fails on True | PASS |
+| All activation guards | multiple | all False | No production code sets any guard to True; `_FakeSettings(ENABLE_LIVE_TRADING=True)` in tests is test-only | PASS |
+
+### Phase 6 — Latency
+
+- `check_market_impact()`: pure Python — one float division, one comparison. Added overhead < 1µs. Well within ingest <100ms budget. **PASS**
+- `ReadinessValidator` is not on signal hot path (operator/ops endpoint triggered). **PASS**
+- No new network calls on signal evaluation path. **PASS**
+
+### Phase 7 — Infra
+
+- No new infra dependencies introduced (no new Redis, PostgreSQL calls, no new external services). **PASS**
+- `CHECK_KILL_SWITCH` gracefully degrades when pool unavailable (SKIP, not FAIL). **PASS**
+- dev environment: infra=warn only. No infra enforcement failures expected. **PASS**
+
+### Phase 8 — Telegram
+
+- No new Telegram alert events introduced. **PASS**
+- Parity dry-run suppresses `live_fallback.trigger_*` — these include Telegram notifications. Suppression verified in code (parity.py:113–116, 153–156). **PASS**
+- dev environment: telegram=warn only. **PASS**
+
+---
+
+## 5. SCORE BREAKDOWN
+
+| Category | Weight | Score | Evidence |
+|---|---|---|---|
+| Architecture | 20% | 18 | Clean layering; step 14 pure-function zero-DB; parity noops all mutations; no new infra coupling. Deduction: readiness_validator _check_execution_path uses absolute import paths (P2) |
+| Functional | 20% | 17 | All 35 tests green; all 6 readiness checks correct; hardening dual-checks DAILY_LOSS; gate step 14 order correct. Deduction: check_price_deviation deferred from gate (acceptable in paper-only posture, declared Known Issue) |
+| Failure modes | 20% | 18 | Zero-liq, DB-blip, pool-unavailable, mutation-suppression all verified with file:line citations. Deduction: _check_kill_switch invalidate_cache not patched in full-run test (SKIP is acceptable fallback) |
+| Risk rules | 20% | 20 | All constants correct; guards OFF; RISK_CONTROLS_VALIDATED=False; full Kelly blocked; no guard mutation in prod code. Full score. |
+| Infra + Telegram | 10% | 9 | No new infra; pool-unavailable graceful; Telegram mutations suppressed. Deduction: minor — dev environment inferred, not declared in issue |
+| Latency | 10% | 10 | Step 14 pure function; sub-microsecond overhead; no hot-path additions. Full score. |
+
+**Total: 92 / 100**
+
+---
+
+## 6. CRITICAL ISSUES
+
+None found.
+
+---
+
+## 7. STATUS
+
+**APPROVED — Score 92/100, zero critical issues.**
+
+Track D delivers four hardening planes that strengthen the 13-step risk gate without enabling live trading:
+- Gate step 14 rejects orders exceeding 5% market impact using Kelly-adjusted final size
+- Risk assertion audit layer validates all constants and profiles; blocks full Kelly at boot
+- Readiness validator executes 6 independent checks with PASS/FAIL/SKIP verdicts
+- Parity hooks confirm gate behavior consistency across paper/simulated-live postures with zero DB mutations
+
+All activation guards remain OFF. No live trading path is enabled or reachable through this PR. Paper posture is intact.
+
+---
+
+## 8. PR GATE RESULT
+
+**PR #954 — FORGE PR:** Open. Branch `WARP/crusaderbot-live-gate-hardening`. 14 files changed (+1450/-7).
+
+**Gate:** APPROVED. Zero critical issues. WARP🔹CMD may merge PR #954 into main.
+
+**Sentinel PR target:** `WARP/crusaderbot-live-gate-hardening` (FORGE PR is open — sentinel PR targets source branch per AGENTS.md branch/PR rules).
+
+---
+
+## 9. BROADER AUDIT FINDING
+
+**Finding: ENABLE_LIVE_TRADING code default is True (pre-existing, tracked)**
+
+`config.py:134 ENABLE_LIVE_TRADING: bool = True` — the code default has been True since an earlier phase. The fly.toml `[env]` block overrides this to `false` in production, so the resolved settings value is correct. The `CHECK_GUARD_STATE` check in ReadinessValidator correctly surfaces a FAIL when the resolved value is True (i.e., when the override is absent).
+
+This is a pre-existing KNOWN ISSUE tracked in `projects/polymarket/crusaderbot/state/PROJECT_STATE.md` under `KNOWN ISSUES` with deferred resolution to `WARP/config-guard-default-alignment`. Not introduced by this PR. Not a blocker for merge.
+
+**Risk exposure:** Even if `ENABLE_LIVE_TRADING` resolves True (e.g., in a fresh deployment without fly.toml override), live trading is NOT enabled because `_passes_live_guards()` requires ALL four flags to be True simultaneously (`ENABLE_LIVE_TRADING AND EXECUTION_PATH_VALIDATED AND CAPITAL_MODE_CONFIRMED AND tier>=4`). With `EXECUTION_PATH_VALIDATED=False` and `CAPITAL_MODE_CONFIRMED=False` as code defaults, the live path remains blocked.
+
+**Claim Level assessment:** SAFETY HARDENING — declared scope is paper-only readiness checks. The `check_price_deviation()` function not being wired to the live execution path is expected and correctly deferred. Claim is accurate.
+
+---
+
+## 10. REASONING
+
+Prior SENTINEL run (issue #955) produced an APPROVED 92/100 verdict but delivered an incomplete-format report (present sections: TEST PLAN, FINDINGS, CRITICAL ISSUES, STABILITY SCORE, GO-LIVE STATUS, FIX RECOMMENDATIONS — missing 8 of 14 required sections). Issue #956 was opened to supersede #955 and produce the complete report.
+
+This run (run 2) independently verified all claimed behavior by reading actual source code:
+- gate.py: step 14 ordering, pure-function path, idempotency-after-step-14 confirmed
+- hardening.py: dual-check on DAILY_LOSS, profile audit coverage, full-Kelly detection confirmed
+- slippage.py: zero-liquidity edge case, boundary behavior confirmed
+- readiness_validator.py: all 6 check implementations verified line-by-line
+- parity.py: all mutations nooped, context-managed patches, no state leakage confirmed
+- constants.py: all values match AGENTS.md fixed risk constants
+- config.py: RISK_CONTROLS_VALIDATED=False, ENABLE_LIVE_TRADING=True (pre-existing)
+- test_live_gate_hardening.py: 35 tests verified including boundary, FAIL-detection, and SKIP cases
+
+Independent code review confirms the prior verdict. Score 92/100 stands.
+
+---
+
+## 11. FIX RECOMMENDATIONS
+
+**P2 — non-blocking, deferred:**
+
+1. **Align ENABLE_LIVE_TRADING code default to False.** `config.py:134` — change `bool = True` to `bool = False`. This closes the gap where a deployment without fly.toml override would resolve True and cause `CHECK_GUARD_STATE` to FAIL on first run. Tracked as `WARP/config-guard-default-alignment`. No action required before merge.
+
+2. **Wire `check_price_deviation()` to live execution pre-submit path.** `slippage.py:59–82` — callable and tested but not called by gate or live router. Required before live trading is enabled. Acceptable deferral in paper-only posture.
+
+3. **Update forge report Known Issues section 5** — remove stale reference to `patch("...gate.get_settings")`. The Codex P1 fix already corrected parity.py to patch `_passes_live_guards` instead. Documentation drift only; already tracked in PROJECT_STATE.md KNOWN ISSUES as a deferred item.
+
+4. **Absolute module paths in `_check_execution_path`** — `readiness_validator.py:178–187` uses `projects.polymarket.crusaderbot...` form requiring repo root in sys.path. Confirm this is in the deployment `sys.path` or switch to relative imports if needed.
+
+No P0 or P1 issues found. All items above are safe to defer.
+
+---
+
+## 12. OUT-OF-SCOPE ADVISORY
+
+The following were observed but are explicitly out of scope for this validation:
+
+- `domain/execution/live.py` — live execution engine; not touched by this PR; not validated here
+- Telegram alert delivery pipeline — no new alert events in this PR; existing system not re-validated
+- Redis kill-switch cache layer — existing behavior; not changed; `invalidate_cache()` observed in kill_switch.py but not re-audited
+- `services/copy_trade/` and `services/trade_engine/` — pre-existing services; not changed by this PR
+- `check_price_deviation()` wiring — explicitly out of scope per issue #956; deferred P2
+
+Any future lane that enables `EXECUTION_PATH_VALIDATED`, `CAPITAL_MODE_CONFIRMED`, or `RISK_CONTROLS_VALIDATED` must trigger a new MAJOR SENTINEL validation before merge.
+
+---
+
+## 13. DEFERRED MINOR BACKLOG
+
+The following P2 items are recorded for a future cleanup pass:
+
+- `[DEFERRED] ENABLE_LIVE_TRADING code default in config.py is True — resolved by fly.toml override in production; code default alignment deferred to WARP/config-guard-default-alignment — found in PR #954`
+- `[DEFERRED] check_price_deviation() not wired into live execution path — callable and tested; deferred until ENABLE_LIVE_TRADING gate is considered — found in PR #954`
+- `[DEFERRED] _check_execution_path in readiness_validator uses absolute import paths — requires repo root in sys.path; confirm or fix before live activation — found in PR #954`
+- `[DEFERRED] Forge report Known Issues section 5 references stale parity patch approach (gate.get_settings); code is correct post-Codex fix; documentation drift only — found in PR #954`
+
+These items are already tracked in `projects/polymarket/crusaderbot/state/PROJECT_STATE.md` `[KNOWN ISSUES]`. No new entries required — existing entries confirmed accurate.
+
+---
+
+## 14. TELEGRAM VISUAL PREVIEW
+
+No new Telegram alert events were introduced in this PR. The readiness validator is an operator tool (`/ops` endpoint), not a user-facing Telegram command. No new Telegram preview is required.
+
+**Existing alert events confirmed intact (not changed by this PR):**
+- Kill switch activated / deactivated
+- Daily loss limit hit
+- Max drawdown halt triggered
+- Live-to-paper fallback (R12)
+- Emergency lock
+- Copy trade fill
+- Manual close
+
+**Parity check — Telegram mutation suppression verified:** `live_fallback.trigger_*` functions (which send Telegram notifications) are nooped in both parity runs. No accidental alert sends during dry-run validation.
+
+---
+
+**Validation Tier:** MAJOR
+**Claim Level:** SAFETY HARDENING
+**NEXT GATE:** Return to WARP🔹CMD for final merge / hold decision on PR #954.

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-11 19:00
-Status       : Fast Track Track A MERGED PR #942. Track B MERGED PR #948. Track C MERGED PR #951. Track D queued. Activation guards remain NOT SET.
+Last Updated : 2026-05-11 18:31
+Status       : Fast Track Track A MERGED PR #942. Track B MERGED PR #948. Track C MERGED PR #951. Track D FORGE complete PR #954 — SENTINEL APPROVED 92/100, zero critical issues. Awaiting WARP🔹CMD merge decision. Activation guards remain NOT SET.
 
 [COMPLETED]
 - Phase 1 project restructure complete.
@@ -15,19 +15,20 @@ Status       : Fast Track Track A MERGED PR #942. Track B MERGED PR #948. Track 
 - Fast Track Track C — Trade notifications MERGED PR #951 (2026-05-11). TradeNotifier service layer; ENTRY/TP_HIT/SL_HIT/MANUAL/EMERGENCY/COPY_TRADE scaffold; paper.py wired; alert_user_manual_close added; already_closed guard; 16 hermetic tests green.
 
 [IN PROGRESS]
+- Track D Live Gate Hardening — PR #954 open; SENTINEL APPROVED 92/100; awaiting WARP🔹CMD merge decision.
 - Observation / runtime monitoring remains active in paper mode.
 - Current production posture: Telegram @CrusaderBot live, Fly.io app running, Supabase project ykyagjdeqcgcktnpdhes, test user walk3r69 has $1000 paper USDC and Full Auto aggressive preset.
 - Activation guards remain OFF: ENABLE_LIVE_TRADING=false, EXECUTION_PATH_VALIDATED=false, CAPITAL_MODE_CONFIRMED=false, RISK_CONTROLS_VALIDATED=false.
 
 [NOT STARTED]
-- Fast Track Track D -- Risk caps + kill switch hardening: hard exposure caps, daily loss guard, max open positions, Telegram/DB/env kill paths. MAJOR; SENTINEL required.
-- Fast Track Track E -- Daily P&L report: scheduled Telegram daily summary. STANDARD.
+- Fast Track Track E -- Daily P&L Report: scheduled Telegram daily summary. STANDARD.
 - Fast Track Week 2 -- Live gate + UI premium pack + charts/insights + referral/share/fee prep.
 - Fast Track Week 3 -- Multi-user isolation audit + access tiers + admin + onboarding polish.
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
-- Track D (Risk caps + kill switch hardening) — MAJOR, SENTINEL REQUIRED. Awaiting WARP🔹CMD task declaration.
+- WARP🔹CMD merge decision required for Track D PR #954 — SENTINEL APPROVED 92/100.
+- Sentinel report: projects/polymarket/crusaderbot/reports/sentinel/crusaderbot-live-gate-hardening.md
 - Do not flip activation guards.
 
 [KNOWN ISSUES]
@@ -41,3 +42,6 @@ Status       : Fast Track Track A MERGED PR #942. Track B MERGED PR #948. Track 
 - [DEFERRED] CLOB circuit-open Telegram alert text uses plain markdown rather than MarkdownV2; P2, acceptable for static template.
 - [DEFERRED] Ops dashboard CLOB circuit card refreshes only via page-level 30s meta refresh; SSE/WS push is future enhancement.
 - [DEFERRED] Package-level single-instance CircuitBreaker is adequate for single-broker steady state; per-broker instances can be passed via circuit_breaker kwarg if needed.
+- [DEFERRED] Forge report Known Issues section for Track D references stale parity patch approach (gate.get_settings); code is correct post-Codex fix; documentation drift only.
+- [DEFERRED] check_price_deviation() not yet wired into live execution path; callable and tested; deferred until ENABLE_LIVE_TRADING gate is considered.
+- [DEFERRED] _check_execution_path in readiness_validator uses absolute import paths; requires repo root in sys.path; confirm before live activation.


### PR DESCRIPTION
## WARP•SENTINEL — Track D Live Gate Hardening

**Verdict:** APPROVED
**Score:** 92 / 100
**Critical Issues:** 0
**Source PR:** #954
**Sentinel Issue:** #956 (supersedes #955)
**Run:** 2 of 2

## Summary

- Complete 14-section sentinel report delivered at `projects/polymarket/crusaderbot/reports/sentinel/crusaderbot-live-gate-hardening.md`
- Independent code review confirms run 1 (issue #955) verdict: APPROVED 92/100, zero critical issues
- `PROJECT_STATE.md` updated with sentinel verdict and current timestamp

## What was validated

- Gate step 14 (slippage/market-impact) wired correctly post-Kelly at `final_size`; pure function; `_record_idempotency` after step 14
- `audit_risk_constants()` catches full Kelly (a=1.0), DAILY_LOSS > -2000, MIN_LIQUIDITY < 10000, and per-profile violations
- `ReadinessValidator.run()` correct PASS/FAIL/SKIP behavior for all 6 checks
- Parity module: mutations fully suppressed; `_passes_live_guards` patched correctly (not `get_settings`)
- All activation guards OFF; RISK_CONTROLS_VALIDATED=False; no production code sets any guard to True
- 35 hermetic tests verified

## P2 deferred (non-blocking)

1. `ENABLE_LIVE_TRADING` code default True — resolved by fly.toml override; tracked in KNOWN ISSUES
2. `check_price_deviation()` not wired to gate — acceptable in paper-only posture; deferred to live activation lane
3. `_check_execution_path` uses absolute import paths — functional in deployment context; confirm before live activation
4. Forge report Known Issues section 5 — stale `gate.get_settings` reference; code is correct; documentation drift only

## Merge order

Depends on: PR #954 (must be merged first)
This sentinel PR merges into `WARP/crusaderbot-live-gate-hardening`. When WARP🔹CMD merges PR #954 into main, sentinel report lands with it.

## Next gate

Return to WARP🔹CMD for final PR #954 merge / hold / rework decision.

---
https://claude.ai/code/session_01S72aeBtKaw5Kxd9rDGxZr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01S72aeBtKaw5Kxd9rDGxZr2)_