### PR TITLE
warp-forge: cek-pr-flow-update — extend cek pr to full review+execute cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,7 +447,7 @@ Detailed behavior for each shortcut lives in `COMMANDER.md`.
 | `start work` | Read repo truth, identify active lane, return summary + recommended action |
 | `sync and continue` | Run project sync then proceed into next lane |
 | `project sync` | Check drift across state files, return sync status and required actions |
-| `cek pr` | List all open PRs with current status |
+| `cek pr` / `cek` / `recheck` / `cek all` | Full PR+Issue review cycle: fetch (limit 5 each), decide, execute (merge/close/fix-comment), return summary |
 | `merge pr` | Inspect PR, evaluate gates, merge if clean |
 | `close pr` | Inspect PR, close if justified, post reason |
 | `degen mode on` | Activate degen mode (Mr. Walker only) |

--- a/COMMANDER.md
+++ b/COMMANDER.md
@@ -427,9 +427,26 @@ Skills are execution helpers only, not authority sources, and never a justificat
   - Check reports older than 7 days and trigger archive if needed
   - Return sync status, exact drift, exact files needing update, recommended sync action
 
-- cek pr
-  - List all open PRs with current status, tier, and gate state
-  - Flag any traceability or state drift visible from PR context
+- cek pr / cek / recheck / cek all
+  - Aliases: all four trigger the same flow.
+  - Full PR+Issue review cycle:
+    1. Fetch all open PRs (limit 5) + all open issues (limit 5)
+    2. For each PR: read metadata, files, tier, gate state. Run pre-review drift check. WARP🔹CMD decides: MERGE / CLOSE / NEEDS-FIX / HOLD
+    3. For each decision:
+       - MERGE: execute merge immediately + close linked issue
+       - CLOSE: execute close immediately + close linked issue + post reason
+       - NEEDS-FIX: post fix-task comment to PR (per PR COMMENT AUTO-POST RULE)
+       - HOLD: state reason, move to next
+    4. Orphan issues (no linked PR):
+       - stale or superseded: close with reason
+       - valid but unstarted: flag as pending
+    5. Return consolidated summary: merged / closed / needs-fix / held / orphan issues
+  - Rules:
+    - Limit 5 PRs + 5 issues per run
+    - Execute decisions immediately
+    - Merge gate rules still apply (AUTO PR ACTION RULE)
+    - MAJOR without SENTINEL verdict: HOLD, flag to Mr. Walker
+    - Post-merge sync after each merge
 
 - merge pr
   - Inspect PR against all merge gates
@@ -511,6 +528,7 @@ Examples:
 - continue work = resume current valid lane
 - next lane = choose next best grouped execution lane
 - sync and continue = sync truth files then continue execution
+- cek pr / cek / recheck / cek all = full PR+issue review cycle: fetch open PRs+issues (limit 5 each), decide per item, execute immediately (merge/close/comment), return consolidated summary
 - merge pr = inspect, decide, merge if gate-clean, then sync
 - close pr = inspect, decide, close if justified, then reroute
 

--- a/projects/polymarket/crusaderbot/reports/forge/cek-pr-flow-update.md
+++ b/projects/polymarket/crusaderbot/reports/forge/cek-pr-flow-update.md
@@ -1,0 +1,52 @@
+# WARP•FORGE REPORT — cek-pr-flow-update
+
+Branch            : WARP/cek-pr-flow-update
+Validation Tier   : MINOR
+Claim Level       : FOUNDATION
+Validation Target : shortcut command definitions in COMMANDER.md and AGENTS.md
+Not in Scope      : runtime behavior, state files, CI gate, CLAUDE.md
+Suggested Next Step: WARP🔹CMD review and merge
+
+---
+
+## 1. What was built
+
+Updated shortcut command definitions so `cek`, `recheck`, `cek pr`, and `cek all` all trigger the same full PR+Issue review-and-execute cycle instead of just listing open PRs.
+
+Changes are docs-only — three text edits across two repo-root reference files. No runtime, state, or operational truth touched.
+
+## 2. Current system architecture
+
+Shortcut command authority (unchanged):
+- `AGENTS.md` SHORTCUT COMMANDS (GLOBAL) table is the canonical command index
+- `COMMANDER.md` SHORTCUT COMMANDS section defines per-command operational behavior
+- `COMMANDER.md` SHORTCUT COMMAND INTERPRETATION RULE provides shortcut-only-prompt mapping
+
+After this lane, the `cek pr` family describes a full review-and-execute cycle (fetch → decide → act → summarize) bounded to 5 PRs + 5 issues per run, with merge gate rules (AUTO PR ACTION RULE) and MAJOR-without-SENTINEL hold rule still binding.
+
+## 3. Files created / modified
+
+Modified:
+- `COMMANDER.md` — operational shortcut block for `cek pr` replaced with full flow + aliases
+- `COMMANDER.md` — SHORTCUT COMMAND INTERPRETATION RULE section: added `cek pr / cek / recheck / cek all` mapping
+- `AGENTS.md` — SHORTCUT COMMANDS (GLOBAL) table row for `cek pr` updated with aliases + new description
+
+Created: none.
+
+## 4. What is working
+
+- `cek pr` block in COMMANDER.md now defines a complete review-and-execute cycle with explicit step ordering, decision routing, orphan-issue handling, consolidated summary, and bounded rules
+- `cek`, `recheck`, `cek all` declared as exact aliases of `cek pr` — all four trigger the same flow
+- SHORTCUT COMMAND INTERPRETATION RULE now includes the `cek pr / cek / recheck / cek all` mapping consistent with `merge pr` / `close pr` style
+- AGENTS.md table row syncs aliases and new short description with COMMANDER.md
+- Existing rules preserved verbatim: AUTO PR ACTION RULE, PR COMMENT AUTO-POST RULE, MAJOR-without-SENTINEL hold, post-merge sync
+
+## 5. Known issues
+
+- `COMMANDER.md` contains a duplicate inner `### Interpretation rule for shortcut-only prompts` block (inside the SHORTCUT COMMANDS section) that mirrors the top-level `## SHORTCUT COMMAND INTERPRETATION RULE`. The inner duplicate was not updated in this lane to stay within scope. This is pre-existing drift and out of the declared scope. Flag for a future cleanup lane.
+
+## 6. What is next
+
+- WARP🔹CMD review of this MINOR PR
+- Optional follow-up lane: consolidate the duplicated interpretation-rule block inside COMMANDER.md
+- No state/PROJECT_STATE.md, state/ROADMAP.md, or state/WORKTODO.md update required — docs-only change with no operational truth impact


### PR DESCRIPTION
## Summary

Docs-only update so `cek`, `recheck`, `cek pr`, and `cek all` all trigger the same full PR+Issue review-and-execute cycle (fetch → decide → act → consolidated summary) instead of just listing open PRs.

## Changes

- **COMMANDER.md** — Shortcut commands section: replaced `cek pr` block with full flow (fetch limit 5+5, per-PR decision routing, orphan issue handling, consolidated summary, AUTO PR ACTION RULE binding) + declared `cek` / `recheck` / `cek all` as aliases
- **COMMANDER.md** — SHORTCUT COMMAND INTERPRETATION RULE: added `cek pr / cek / recheck / cek all` mapping consistent with `merge pr` / `close pr` style
- **AGENTS.md** — SHORTCUT COMMANDS (GLOBAL) table: synced aliases and new short description

## Validation

- Validation Tier: **MINOR**
- Claim Level: **FOUNDATION**
- Validation Target: shortcut command definitions in COMMANDER.md and AGENTS.md
- Not in Scope: runtime behavior, state files, CI gate, CLAUDE.md
- No `state/PROJECT_STATE.md` update — docs-only change, no operational truth impact

## Report

`projects/polymarket/crusaderbot/reports/forge/cek-pr-flow-update.md`

## Test plan

- [x] COMMANDER.md shortcut commands section updated
- [x] COMMANDER.md interpretation rule section updated
- [x] AGENTS.md shortcut table synced
- [x] Forge report created
- [x] PR opened from `WARP/cek-pr-flow-update`

## Next gate

- WARP🔹CMD review


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3zFcQN3cWDhth2Psxo94c)_