### PR TITLE
hotfix: 022b migration — recover partial 022, fix referral_events schema

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/022b_fix_partial_022.sql
+++ b/projects/polymarket/crusaderbot/migrations/022b_fix_partial_022.sql
@@ -1,35 +1,47 @@
 -- 022b: Fix partial migration 022
--- Safe to run: uses IF NOT EXISTS and IF EXISTS checks
+-- Safe to run: uses IF NOT EXISTS and conditional DO blocks
 
--- referral_events (missing)
+-- Fix referral_events if previously created with wrong BIGINT schema
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'referral_events'
+          AND column_name = 'referrer_user_id'
+    ) THEN
+        -- DROP COLUMN also drops any indexes on those columns automatically
+        ALTER TABLE referral_events DROP COLUMN referrer_user_id;
+        ALTER TABLE referral_events DROP COLUMN referred_user_id;
+        ALTER TABLE referral_events ADD COLUMN referrer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+        ALTER TABLE referral_events ADD COLUMN referred_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+        ALTER TABLE referral_events ADD CONSTRAINT referral_events_referred_unique UNIQUE (referred_id);
+    END IF;
+END $$;
+
+-- referral_events: create with correct UUID schema if missing
 CREATE TABLE IF NOT EXISTS referral_events (
-    id BIGSERIAL PRIMARY KEY,
-    referrer_user_id BIGINT NOT NULL,
-    referred_user_id BIGINT NOT NULL,
-    code VARCHAR(12) NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT NOW()
+    id          BIGSERIAL   PRIMARY KEY,
+    referrer_id UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    referred_id UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code        VARCHAR(12) NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT referral_events_referred_unique UNIQUE (referred_id)
 );
 CREATE INDEX IF NOT EXISTS idx_referral_events_referrer
-    ON referral_events(referrer_user_id);
-CREATE INDEX IF NOT EXISTS idx_referral_events_referred
-    ON referral_events(referred_user_id);
+    ON referral_events (referrer_id, created_at DESC);
 
 -- fee_config (missing)
 CREATE TABLE IF NOT EXISTS fee_config (
-    id SERIAL PRIMARY KEY,
-    fee_pct DECIMAL(5,4) NOT NULL DEFAULT 0.10,
-    updated_at TIMESTAMPTZ DEFAULT NOW()
+    id         SERIAL      PRIMARY KEY,
+    fee_pct    DECIMAL(5,4) NOT NULL DEFAULT 0.10,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 INSERT INTO fee_config (fee_pct)
     SELECT 0.10 WHERE NOT EXISTS (SELECT 1 FROM fee_config);
 
 -- fees table conflict: add missing columns if not present
-ALTER TABLE fees ADD COLUMN IF NOT EXISTS gross_pnl DECIMAL(20,8);
-ALTER TABLE fees ADD COLUMN IF NOT EXISTS fee_amount DECIMAL(20,8);
-ALTER TABLE fees ADD COLUMN IF NOT EXISTS net_pnl DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS gross_pnl    DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS fee_amount   DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS net_pnl      DECIMAL(20,8);
 ALTER TABLE fees ADD COLUMN IF NOT EXISTS collected_at TIMESTAMPTZ DEFAULT NOW();
-
--- Record in schema_migrations
-INSERT INTO schema_migrations (version, applied_at)
-    VALUES ('022b', NOW())
-    ON CONFLICT (version) DO NOTHING;

--- a/projects/polymarket/crusaderbot/migrations/022b_fix_partial_022.sql
+++ b/projects/polymarket/crusaderbot/migrations/022b_fix_partial_022.sql
@@ -1,0 +1,35 @@
+-- 022b: Fix partial migration 022
+-- Safe to run: uses IF NOT EXISTS and IF EXISTS checks
+
+-- referral_events (missing)
+CREATE TABLE IF NOT EXISTS referral_events (
+    id BIGSERIAL PRIMARY KEY,
+    referrer_user_id BIGINT NOT NULL,
+    referred_user_id BIGINT NOT NULL,
+    code VARCHAR(12) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_referral_events_referrer
+    ON referral_events(referrer_user_id);
+CREATE INDEX IF NOT EXISTS idx_referral_events_referred
+    ON referral_events(referred_user_id);
+
+-- fee_config (missing)
+CREATE TABLE IF NOT EXISTS fee_config (
+    id SERIAL PRIMARY KEY,
+    fee_pct DECIMAL(5,4) NOT NULL DEFAULT 0.10,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+INSERT INTO fee_config (fee_pct)
+    SELECT 0.10 WHERE NOT EXISTS (SELECT 1 FROM fee_config);
+
+-- fees table conflict: add missing columns if not present
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS gross_pnl DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS fee_amount DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS net_pnl DECIMAL(20,8);
+ALTER TABLE fees ADD COLUMN IF NOT EXISTS collected_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Record in schema_migrations
+INSERT INTO schema_migrations (version, applied_at)
+    VALUES ('022b', NOW())
+    ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
Supersedes #982 (wrong branch name).

## What was done

Migration 022 ran partially during Fly.io deploy due to asyncpg connection resets (Sentry #7474092076). This migration recovers the missing schema and fixes a schema error introduced in the first 022b apply.

## Changes applied to production (CrusaderBot Supabase, us-east-1)

1. **`referral_events`** — created with correct UUID schema (`referrer_id`, `referred_id`). Wrong BIGINT columns from initial 022b apply were dropped and replaced. Index `idx_referral_events_referrer (referrer_id, created_at DESC)` created.
2. **`fee_config`** — created, seeded with `fee_pct = 0.10`.
3. **`fees`** — four columns added: `gross_pnl`, `fee_amount`, `net_pnl`, `collected_at`.

## P1 fixes in this file vs initial 022b apply

- **`referral_events` schema**: original 022b used `BIGINT` — incompatible with `referral_service.py:118-119,154-155` which writes/reads `referrer_id`/`referred_id` as UUID. Fixed to match original 022 design and code expectations.
- **`schema_migrations` INSERT**: removed — table does not exist in this DB; unconditional insert caused `undefined_table` on every startup migration run.

## Migration file is idempotent

- DO block detects and repairs wrong-schema `referral_events` (BIGINT → UUID) on re-run
- All CREATE TABLE use IF NOT EXISTS
- All ALTER TABLE ADD COLUMN use IF NOT EXISTS
- fee_config seed uses `WHERE NOT EXISTS`

## Test plan

- [ ] Confirm `referral_events` columns: `referrer_id UUID`, `referred_id UUID`
- [ ] Confirm `fee_config` has one row, `fee_pct = 0.10`
- [ ] Confirm `fees` has `gross_pnl`, `fee_amount`, `net_pnl`, `collected_at`
- [ ] Bot `/start` and `/status` respond normally via Telegram
- [ ] `mode_change_events` still clean (zero `AUTO_FALLBACK` rows)

## Open items (separate tasks)

- `schema_migrations` tracking table does not exist DB-wide — no guard against future partial applies
- `fee_config` lacks single-row CHECK constraint from original 022 design

https://claude.ai/code/session_01WMbrCw8MB2stiEQeDwSpVM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMbrCw8MB2stiEQeDwSpVM)_