### PR TITLE
[WARP•FORGE] Harden live execution position updates with user_id guards

### DIFF
--- a/projects/polymarket/crusaderbot/domain/execution/live.py
+++ b/projects/polymarket/crusaderbot/domain/execution/live.py
@@ -307,8 +307,8 @@ async def close_position(
     async with pool.acquire() as conn:
         claimed = await conn.fetchval(
             "UPDATE positions SET status='closing' "
-            "WHERE id=$1 AND status='open' RETURNING id",
-            position["id"],
+            "WHERE id=$1 AND user_id=$2 AND status='open' RETURNING id",
+            position["id"], position["user_id"],
         )
     if claimed is None:
         logger.info("live close skip — position %s already closing/closed",
@@ -325,8 +325,8 @@ async def close_position(
     except (ClobConfigError, ClobAuthError) as exc:
         async with pool.acquire() as conn:
             await conn.execute(
-                "UPDATE positions SET status='open' WHERE id=$1",
-                position["id"],
+                "UPDATE positions SET status='open' WHERE id=$1 AND user_id=$2",
+                position["id"], position["user_id"],
             )
         raise RuntimeError(f"CLOB client error during close: {exc}") from exc
     try:
@@ -340,8 +340,8 @@ async def close_position(
     except Exception:
         async with pool.acquire() as conn:
             await conn.execute(
-                "UPDATE positions SET status='open' WHERE id=$1",
-                position["id"],
+                "UPDATE positions SET status='open' WHERE id=$1 AND user_id=$2",
+                position["id"], position["user_id"],
             )
         raise
 
@@ -360,8 +360,8 @@ async def close_position(
             updated = await conn.fetchval(
                 "UPDATE positions SET status='closed', exit_reason=$2, "
                 "current_price=$3, pnl_usdc=$4, closed_at=NOW() "
-                "WHERE id=$1 AND status='closing' RETURNING id",
-                position["id"], exit_reason, exit_price, pnl,
+                "WHERE id=$1 AND user_id=$5 AND status='closing' RETURNING id",
+                position["id"], exit_reason, exit_price, pnl, position["user_id"],
             )
             if updated is None:
                 # The claim was ours; status should still be 'closing'. If we

--- a/projects/polymarket/crusaderbot/reports/forge/live-execution-user-id-guards.md
+++ b/projects/polymarket/crusaderbot/reports/forge/live-execution-user-id-guards.md
@@ -1,0 +1,44 @@
+# Forge Report — live-execution-user-id-guards
+
+- Branch: `WARP/live-execution-user-id-guards`
+- Validation Tier: **MAJOR**
+- Claim Level: **NARROW INTEGRATION**
+- Project: `projects/polymarket/crusaderbot`
+- Timestamp (Asia/Jakarta): **2026-05-13 06:01**
+
+## Objective
+Harden live execution persistence updates so position lifecycle UPDATE statements are user-scoped by both `id` and `user_id`.
+
+## Scope
+- `projects/polymarket/crusaderbot/domain/execution/live.py`
+- `projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py`
+- State files and changelog updates in `projects/polymarket/crusaderbot/state/`
+
+## Implementation
+Added `user_id` guards to all scoped live close UPDATE paths:
+1. atomic claim `open -> closing`
+2. rollback `closing -> open` (config error path)
+3. rollback `closing -> open` (submit exception path)
+4. finalize `closing -> closed`
+
+All four now require matching `id` and `user_id`.
+
+## Validation Target
+Verify live execution persistence updates positions only when both `position_id` and `user_id` match.
+
+## Validation Evidence
+- Added unit assertion coverage to verify guarded SQL predicates and bound arguments include `user_id` for claim/finalize paths in close flow.
+- Existing rollback tests still verify status rollback behavior on failure.
+
+## Not in Scope
+- Enabling live trading
+- Changing `ENABLE_LIVE_TRADING`
+- Real CLOB activation
+- Wallet/key handling changes
+- Capital/risk sizing changes
+- Strategy changes
+- Schema migrations
+
+## Risk
+- Runtime behavior impact is limited to authorization/ownership guard on existing UPDATE statements.
+- No changes to strategy, order routing, pricing, or guard flags.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -49,3 +49,5 @@
 2026-05-12 09:07 | claude/fix-forge-task-980-UHdNY | WARP Auto Gate v1 FORGE (STANDARD, NARROW INTEGRATION): warp-auto-gate.yml + warp_auto_gate.py; Gates 1-8 + CI status; idempotent PR comment; no runtime code touched; PR open for WARP🔹CMD review.
 2026-05-12 09:13 | claude/fix-forge-task-980-UHdNY | WARP Auto Gate v1 MERGED PR #996 — warp-auto-gate.yml + warp_auto_gate.py; Gates 1-8 + CI status; idempotent PR comment; STANDARD, NARROW INTEGRATION
 2026-05-12 23:45 | claude/add-strategy-type-column-2slhz | Schema fix orders.strategy_type: migration 026 ADD COLUMN IF NOT EXISTS strategy_type VARCHAR(50); resolves DAWN-SNOWFLAKE-1729-10 and -Z root cause; STANDARD, NARROW INTEGRATION; PR open for WARP🔹CMD review
+
+2026-05-13 06:01 | WARP/live-execution-user-id-guards | Forge lane for issue #1012 (MAJOR, NARROW INTEGRATION): added user_id guards to 4 live close persistence UPDATE statements in domain/execution/live.py (claim, 2 rollback paths, finalize); added SQL guard assertions in test_live_execution_rewire.py; activation guards unchanged; paper-only posture unchanged

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-05-12 23:58
+Last Updated : 2026-05-13 06:01
 Status       : Repo truth synced after PR/issue queue clear (2026-05-12): GitHub open PRs = 0, open issues = 0. Production remains Telegram + Fly.io live, PAPER ONLY. Activation guards remain OFF / NOT SET.
 
 [COMPLETED]
@@ -15,6 +15,7 @@ Status       : Repo truth synced after PR/issue queue clear (2026-05-12): GitHub
 - Fast Track Week 2 Track F -- Live Opt-In Gate MERGED PR #970 (2026-05-12). /enable_live 3-step gate, mode_change_events audit log, auto-fallback monitor; activation guards remain OFF.
 
 [IN PROGRESS]
+- Live execution user_id guards lane started: branch WARP/live-execution-user-id-guards for issue #1012 (MAJOR, NARROW INTEGRATION).
 - No open PR lanes in GitHub queue (open PRs = 0).
 - No open issue lanes in GitHub queue (open issues = 0).
 - Observation / runtime monitoring remains active in paper mode.

--- a/projects/polymarket/crusaderbot/state/ROADMAP.md
+++ b/projects/polymarket/crusaderbot/state/ROADMAP.md
@@ -1,7 +1,7 @@
 # CrusaderBot — Fast Track Roadmap
 
 **Project:** projects/polymarket/crusaderbot
-**Last Updated:** 2026-05-12 23:58 Asia/Jakarta
+**Last Updated:** 2026-05-13 06:01 Asia/Jakarta
 
 ## Current Posture
 
@@ -56,6 +56,7 @@
 - Paper trading stability
 - Performance validation
 - No new feature lanes planned
+- Issue #1012 active hardening lane: live execution user_id guards (MAJOR, NARROW INTEGRATION)
 
 ## Non-Negotiable Rules
 

--- a/projects/polymarket/crusaderbot/state/WORKTODO.md
+++ b/projects/polymarket/crusaderbot/state/WORKTODO.md
@@ -1,13 +1,14 @@
 # CrusaderBot -- WORKTODO
 
 **Project:** projects/polymarket/crusaderbot
-**Last Updated:** 2026-05-12 23:58
+**Last Updated:** 2026-05-13 06:01
 
 ---
 
 ## Right Now
 
-- GitHub queue synced: open PRs = 0, open issues = 0.
+- GitHub queue synced: open PRs = 0, open issues = 1 (issue #1012 open lane).
+- Active FORGE lane: WARP/live-execution-user-id-guards (issue #1012) to harden live position UPDATE user_id guards in domain/execution/live.py.
 - Focus remains closed beta observation and paper-mode runtime monitoring.
 - Production posture unchanged: Telegram + Fly.io live, PAPER ONLY; activation guards remain NOT SET.
 

--- a/projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py
+++ b/projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py
@@ -67,6 +67,7 @@ class FakeConn:
         self.close_claim = close_claim
         self.close_finalize = close_finalize
         self.executed: list[tuple] = []
+        self.fetchval_calls: list[tuple[str, tuple[Any, ...]]] = []
         self._call = 0
 
     async def fetchrow(self, query: str, *args: Any) -> dict | None:
@@ -82,6 +83,7 @@ class FakeConn:
         return None
 
     async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, args))
         if "status='closing'" in query and "RETURNING id" in query:
             return self.close_claim
         if "status='closed'" in query and "RETURNING id" in query:
@@ -493,6 +495,22 @@ def _run_close(
 
 
 class TestClosePosition:
+    def test_close_updates_guard_by_position_and_user_id(self) -> None:
+        conn = FakeConn(close_claim=POSITION_ID, close_finalize=POSITION_ID)
+        s = _settings()
+        client = MockClobClient()
+        _run_close(conn, s, client)
+
+        claim_query, claim_args = conn.fetchval_calls[0]
+        finalize_query, finalize_args = conn.fetchval_calls[-1]
+        assert "WHERE id=$1 AND user_id=$2 AND status='open'" in claim_query
+        assert claim_args == (POSITION_ID, USER_ID)
+        assert "WHERE id=$1 AND user_id=$5 AND status='closing'" in finalize_query
+        assert finalize_args[0] == POSITION_ID
+        assert finalize_args[1] == "tp"
+        assert finalize_args[2] == 0.8
+        assert finalize_args[4] == USER_ID
+
     def test_close_submits_sell_via_clob_client(self) -> None:
         conn = FakeConn(
             close_claim=POSITION_ID,


### PR DESCRIPTION
### Motivation
- Prevent position-update queries in the live close path from affecting another user's rows by requiring both `id` and `user_id` in UPDATE predicates.
- Provide traceable project-state and a forge report for the hardening lane so the change is auditable and matches repo rules.

### Description
- Validation Tier: **MAJOR**; Claim Level: **NARROW INTEGRATION**; Validation Target: verify live close persistence updates only when both `position_id` and `user_id` match; Not in Scope: enabling live trading, guard flips, CLOB activation, wallets, capital/risk, strategies, schema migrations; Closes #1012; Report: `projects/polymarket/crusaderbot/reports/forge/live-execution-user-id-guards.md`; State updated: `PROJECT_STATE.md`, `ROADMAP.md`, `WORKTODO.md`, `CHANGELOG.md`.
- Added `user_id` guards to the live close persistence SQL paths in `projects/polymarket/crusaderbot/domain/execution/live.py` for the atomic claim, both rollback paths, and the finalize update so all four UPDATEs require `id` + `user_id`.
- Extended unit test scaffolding in `projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py` to record `fetchval` calls and assert the guarded SQL predicates and bound arguments include `user_id` for the claim and finalize flows.
- Added the required forge report file `projects/polymarket/crusaderbot/reports/forge/live-execution-user-id-guards.md` and committed all changes on branch `WARP/live-execution-user-id-guards`.

### Testing
- Ran `pytest -q projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py` to exercise the modified close flow, but test collection failed with `ModuleNotFoundError: No module named 'pydantic'` due to a missing test/runtime dependency in the environment.
- Existing rollback and close logic remain covered by the repository's unit test harness changes (assertions added), and a local test run was attempted but blocked by the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b11ea958832ea2548da06b390776)