### PR TITLE
fix: prefer conditionId over numeric id — unblock paper trades

### DIFF
--- a/projects/polymarket/crusaderbot/jobs/market_signal_scanner.py
+++ b/projects/polymarket/crusaderbot/jobs/market_signal_scanner.py
@@ -312,7 +312,7 @@ async def run_job() -> tuple[int, int]:
             try:
                 if m.get("closed") or m.get("resolved"):
                     continue
-                mid = str(m.get("id") or m.get("conditionId") or "")
+                mid = str(m.get("conditionId") or m.get("id") or "")  # prefer conditionId (hex) — matches markets.id PK
                 if not mid:
                     continue
                 liq = float(m.get("liquidity") or 0)

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -52,7 +52,7 @@ async def sync_markets() -> None:
     async with pool.acquire() as conn:
         for m in markets:
             try:
-                mid = str(m.get("id") or m.get("conditionId") or "")
+                mid = str(m.get("conditionId") or m.get("id") or "")  # prefer conditionId (hex) — matches markets.id PK
                 if not mid:
                     continue
                 outcomes = m.get("outcomePrices") or m.get("outcome_prices") or [None, None]


### PR DESCRIPTION
## Fix: Prefer `conditionId` over numeric `id` for market PK alignment

### Root Cause
`sync_markets` and `market_signal_scanner` both called:
```python
mid = str(m.get("id") or m.get("conditionId") or "")
```
Polymarket API returns `id` as a **numeric string** (e.g. `"540817"`), while the `markets` table primary key uses `conditionId` (`"0x..."` hex). Since `m.get("id")` is always truthy, `conditionId` was never reached.

Result: 173 signal publications in DB had numeric `market_id` values. `_process_candidate` called `_load_market("562190")` → not found → logged `skipped_market_not_synced` → **zero paper trades executed**, even with 173 active signals.

### Fix
Swapped lookup order in both files:
```python
mid = str(m.get("conditionId") or m.get("id") or "")
```
Now conditionId (hex) is preferred → matches `markets.id` PK → `_load_market()` resolves → trades execute.

### Files Changed
- `scheduler.py` — `sync_markets()` line 55
- `jobs/market_signal_scanner.py` — demo path line 315

---

**Validation Tier:** MINOR  
**Claim Level:** NARROW INTEGRATION — 2 files, 1 line each, no logic change  
**Not in Scope:** live path (Heisenberg), risk gate, execution router, DB schema  
**Effect:** Next scan tick after deploy will publish valid signals with hex market_ids → paper trades will execute