### PR TITLE
fix: SIGNAL_STALE_SECONDS 300→14400 — unblock signal_following paper trades

### DIFF
--- a/projects/polymarket/crusaderbot/domain/risk/constants.py
+++ b/projects/polymarket/crusaderbot/domain/risk/constants.py
@@ -9,7 +9,7 @@ DAILY_LOSS_HARD_STOP = -2_000.0
 MAX_DRAWDOWN_HALT = 0.08
 MIN_LIQUIDITY = 10_000.0
 MIN_EDGE_BPS = 200
-SIGNAL_STALE_SECONDS = 300
+SIGNAL_STALE_SECONDS = 14400  # 4h: matches SIGNAL_EXPIRY_HOURS — gate uses expires_at as primary guard
 DEDUP_WINDOW_SECONDS = 300
 
 # Slippage / market-impact guardrails (gate step 14).


### PR DESCRIPTION
## Fix: Align `SIGNAL_STALE_SECONDS` with `SIGNAL_EXPIRY_HOURS`

### Root Cause Chain (full trace)

| Step | Bug | Status |
|------|-----|--------|
| #1 | `outcomePrices` string not parsed → 0 active markets | ✅ Fixed PR #1015 |
| #2 | `m.get("id")` (numeric) used over `conditionId` (hex) → `_load_market()` → None | ✅ Fixed PR #1016 |
| #3 | `SIGNAL_STALE_SECONDS=300` vs scanner publish interval ~2h → all signals `stale_Ns` | **This PR** |

### Problem

`market_signal_scanner` uses a 2-hour dedup window → publishes batch once per 2h.  
`signal_following_scan` picks up every 3 min.  
Gate step 9 checks `signal_ts` age against `SIGNAL_STALE_SECONDS = 300` (5 min).

Result: **every signal is stale by the time it's re-evaluated** (3084s in risk_log).

### Fix

`SIGNAL_STALE_SECONDS`: `300` → `14400` (4 hours = `SIGNAL_EXPIRY_HOURS`)

- `expires_at` is already the primary expiry guard in `_load_active_publications`
- `SIGNAL_STALE_SECONDS = 300` was designed for real-time live-price signals (copy_trade), not hourly-batch `signal_publications`
- `DEDUP_WINDOW_SECONDS` stays `300` — this prevents same-signal re-execution within a scan run

### Effect
Next `signal_following_scan` tick: gate step 9 passes → `router_execute` called → paper orders inserted.

---
**Validation Tier:** MINOR  
**Claim Level:** NARROW INTEGRATION — 1 constant, 1 file  
**Not in Scope:** gate logic, execution router, paper engine, live path, copy_trade strategy