### PR TITLE
UI: Relabel “👥 Copy Wallet” → “📡 Signal Feeds”, hide portfolio force-close CTAs, and sync tests

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/presets.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/presets.py
@@ -411,7 +411,7 @@ CUSTOM_INPUT = 4
 
 _MENU_BUTTONS_CUSTOMIZE = {
     "🏠 Dashboard", "💼 Portfolio", "🤖 Auto Trade",
-    "👥 Copy Wallet", "📊 Insights", "⚙️ Settings", "🛑 Stop Bot",
+    "📡 Signal Feeds", "📊 Insights", "⚙️ Settings", "🛑 Stop Bot",
 }
 
 

--- a/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
@@ -29,7 +29,7 @@ def main_menu() -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(
         [
             [KeyboardButton("🏠 Dashboard"),   KeyboardButton("💼 Portfolio")],
-            [KeyboardButton("🤖 Auto Trade"),  KeyboardButton("👥 Copy Wallet")],
+            [KeyboardButton("🤖 Auto Trade"),  KeyboardButton("📡 Signal Feeds")],
             [KeyboardButton("📊 Insights"),    KeyboardButton("⚙️ Settings")],
             [KeyboardButton("🛑 Stop Bot")],
         ],
@@ -42,7 +42,7 @@ def dashboard_kb(cta_btn: InlineKeyboardButton) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([
         [
             InlineKeyboardButton("🤖 Auto Trade",  callback_data="dashboard:auto"),
-            InlineKeyboardButton("👥 Copy Wallet", callback_data="dashboard:signals"),
+            InlineKeyboardButton("📡 Signal Feeds", callback_data="dashboard:signals"),
         ],
         [
             InlineKeyboardButton("💼 Portfolio",   callback_data="dashboard:portfolio"),

--- a/projects/polymarket/crusaderbot/bot/keyboards/positions.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/positions.py
@@ -1,18 +1,8 @@
-"""Inline keyboards for the live position monitor and per-position
-force-close flow (R12d).
+"""Inline keyboards for the live position monitor (R12d).
 
-Layout:
-  * positions_list_kb    — one row per open position with a
-                           [🛑 Force Close] button keyed by position UUID
-  * force_close_confirm_kb — two-button confirm dialog keyed by position UUID
-
-Callback prefixes (registered in bot.dispatcher):
-  position:fc_ask:<uuid>      — user tapped 🛑 Force Close on row
-  position:fc_yes:<uuid>      — user confirmed
-  position:fc_no:<uuid>       — user cancelled
-
-The UUID is round-tripped through callback_data so the confirm step does not
-have to re-query the DB to know which position the user is acting on.
+MVP UX hides manual force-close controls from standard user surfaces.
+The force-close confirmation keyboard remains available for internal/admin
+callback paths, but positions_list_kb renders navigation-only controls.
 """
 from __future__ import annotations
 
@@ -23,16 +13,9 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 
 def positions_list_kb(position_ids: Iterable[UUID | str]) -> InlineKeyboardMarkup:
-    """One [🛑 Force Close] button per open position + Back/Home nav."""
-    rows = [
-        [
-            InlineKeyboardButton(
-                f"🛑 Force Close {str(pid)[:6]}",
-                callback_data=f"position:fc_ask:{pid}",
-            )
-        ]
-        for pid in position_ids
-    ]
+    """Navigation-only keyboard for portfolio surfaces (no manual close CTA)."""
+    _ = list(position_ids)  # keep signature stable for existing call sites
+    rows: list[list[InlineKeyboardButton]] = []
     rows.append([
         InlineKeyboardButton("⬅ Back", callback_data="portfolio:portfolio"),
         InlineKeyboardButton("🏠 Home", callback_data="dashboard:main"),

--- a/projects/polymarket/crusaderbot/bot/menus/main.py
+++ b/projects/polymarket/crusaderbot/bot/menus/main.py
@@ -9,7 +9,7 @@ one-line change here.
 MVP UX v1 layout (hierarchy tree style):
 
   🏠 Dashboard   💼 Portfolio
-  🤖 Auto Trade  👥 Copy Wallet
+  🤖 Auto Trade  📡 Signal Feeds
   📊 Insights    ⚙️ Settings
   🛑 Stop Bot
 """
@@ -35,7 +35,7 @@ MAIN_MENU_ROUTES: dict[str, HandlerFn] = {
     "🏠 Dashboard":   dashboard.dashboard,
     "💼 Portfolio":   positions.show_portfolio,
     "🤖 Auto Trade":  presets.show_preset_picker,
-    "👥 Copy Wallet": signal_following.signals_command,
+    "📡 Signal Feeds": signal_following.signals_command,
     "📊 Insights":    pnl_insights_h.pnl_insights_command,
     "⚙️ Settings":    settings_handler.settings_hub_root,
     "🛑 Stop Bot":    emergency.emergency_root,

--- a/projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-ux-v1.md
+++ b/projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-ux-v1.md
@@ -12,7 +12,7 @@ Rebuilt CrusaderBot Telegram UI from "Premium Hybrid Luxury" style (`━━━`,
 
 Scope: message template text + keyboard labels only. No callback_data values, routing logic, function signatures, DB queries, or execution paths were modified.
 
-11 handler/keyboard files changed. 4 test files updated to match new text/label assertions. 3 state files updated. 1 report created.
+11 handler/keyboard files changed (+ blocker follow-up relabel + force-close hide). 5 test files updated. 3 state files updated. 1 report created.
 
 ---
 
@@ -24,13 +24,13 @@ Telegram User
     ├── Reply Keyboard (ReplyKeyboardMarkup)
     │   └── bot/keyboards/__init__.py → main_menu()
     │       Labels: 🏠 Dashboard │ 💼 Portfolio │ 🤖 Auto Trade
-    │              👥 Copy Wallet │ 📊 Insights │ ⚙️ Settings │ 🛑 Stop Bot
+    │              📡 Signal Feeds │ 📊 Insights │ ⚙️ Settings │ 🛑 Stop Bot
     │
     ├── Message Handlers (bot/handlers/)
     │   ├── dashboard.py        → 🏠 Dashboard tree (Bot Status / Today / Auto Trade / Portfolio)
     │   ├── positions.py        → 💼 Portfolio + 📌 Open Positions tree
     │   ├── presets.py          → 🤖 Auto Trade wizard (picker/confirm/status/customize)
-    │   ├── signal_following.py → 👥 Copy Wallet menu entry; screen shows Signal Feeds hub
+    │   ├── signal_following.py → 📡 Signal Feeds menu entry; screen shows signal feed hub
     │   ├── settings.py         → ⚙️ Settings hub tree (Account / Mode / Tier)
     │   └── onboarding.py       → 🚀 Quick Start tree
     │
@@ -65,7 +65,7 @@ Pipeline layers (untouched): STRATEGY → RISK → EXECUTION → MONITORING.
 | `projects/polymarket/crusaderbot/bot/keyboards/settings.py` | `↩️ Back to Settings` → `⬅ Back`; `Custom` → `✏️ Custom` |
 | `projects/polymarket/crusaderbot/bot/handlers/onboarding.py` | `_WELCOME_TEXT` + `_PAPER_COMPLETE_TEXT` → tree format |
 
-### Test files updated (4)
+### Test files updated (5)
 
 | File | Change |
 |------|--------|
@@ -74,6 +74,7 @@ Pipeline layers (untouched): STRATEGY → RISK → EXECUTION → MONITORING.
 | `projects/polymarket/crusaderbot/tests/test_phase5i_my_trades.py` | Route key updated |
 | `projects/polymarket/crusaderbot/tests/test_phase5h_onboarding.py` | Onboarding confirmation text updated |
 | `projects/polymarket/crusaderbot/tests/test_preset_system.py` | Status card assertions updated for tree format |
+| `projects/polymarket/crusaderbot/tests/test_positions_handler.py` | Portfolio keyboard coverage updated for Back/Home nav footer row |
 
 ### State / report files (4)
 
@@ -109,8 +110,8 @@ Pipeline layers (untouched): STRATEGY → RISK → EXECUTION → MONITORING.
 - `pnl_insights.py`, `copy_trade.py`, `portfolio_chart.py` still contain `━━━` — out of scope for this lane. Separate cleanup lane required.
 - Help (`/help`) and Markets screens deferred — adding them requires new callback routing registrations (not UI-only).
 - `_LIVE_REDIRECT_TEXT` in `onboarding.py` not updated (single-line redirect, no tree structure applicable).
-- `positions_list_kb()` retains existing `🛑 Force Close` buttons from original implementation. These are pre-existing safety/admin controls, not trade entry CTAs. No new manual execution CTA was added in this lane.
-- `👥 Copy Wallet` menu label applied per blueprint. Underlying screen (`_build_signals_screen`) displays signal feed subscriptions under the header "📡 Signal Feeds". Wallet address mirroring functionality is deferred to a separate lane and requires storage/routing changes outside this UI-only scope.
+- `positions_list_kb()` retains existing `🛑 Force Close` buttons from original implementation. These are pre-existing safety/admin controls, not trade entry CTAs. Manual force-close CTA is now hidden from portfolio keyboard in this lane; confirm callbacks remain internal/admin-capable.
+- Main menu/route label now uses `📡 Signal Feeds` to match actual signal-subscription behavior. Wallet address mirroring remains deferred to a separate lane requiring storage/routing changes.
 
 ---
 
@@ -129,7 +130,7 @@ Pipeline layers (untouched): STRATEGY → RISK → EXECUTION → MONITORING.
 Validation Tier   : STANDARD
 Claim Level       : NARROW INTEGRATION — Telegram UI text + keyboard labels only
 Validation Target : bot/handlers/ and bot/keyboards/ message templates and keyboard labels (11 files)
-                    + test assertions updated to match new text format (4 test files)
+                    + test assertions updated to match new text format (5 test files)
 Not in Scope      : callback_data values, routing logic, DB, execution, risk, migrations, fly.toml,
                     pnl_insights.py, copy_trade.py, portfolio_chart.py (out-of-scope prohibited chars),
                     help.py, markets.py (deferred — require routing changes),

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-13 17:10 WIB | WARP/CRUSADERBOT-MVP-UX-V1 | PR #1029 blocker fix pass: relabeled misleading "👥 Copy Wallet" surfaces to "📡 Signal Feeds" across main menu/routes/dashboard, removed user-facing force-close buttons from portfolio keyboard (nav only), updated related tests; STANDARD, NARROW INTEGRATION
 2026-05-13 17:00 WIB | WARP/CRUSADERBOT-MVP-UX-V1 | Hierarchy Tree Terminal UI rebuild — 11 files; Premium Hybrid Luxury → tree format; blueprint emoji system; STANDARD, NARROW INTEGRATION; Closes #1028
 2026-05-13 14:32 WIB | WARP/relax-branch-prefix-rule | AGENTS.md branch prefix relaxed — WARP/ and warp/ both accepted; GATE 1 and pre-flight updated; Closes #1018
 2026-05-13 12:20 WIB | PR #1024 MERGED | edceaa07 | Telegram UX v3 — 7-button menu, dashboard v3, portfolio screen, signals tap-hub, settings hub v3, onboarding v3, nav_row(), notify_order_filled() | STANDARD NARROW INTEGRATION | Closes #1020

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-13 18:30 WIB
-Status       : crusaderbot-mvp-ux-v1 STANDARD lane open — PR #1029 under WARP🔹CMD gate review, CI fixes in progress. Production PAPER ONLY. Activation guards remain OFF / NOT SET.
+Last Updated : 2026-05-13 17:10 WIB
+Status       : crusaderbot-mvp-ux-v1 STANDARD lane open — PR #1029 blocker fixes pushed (Signal Feeds relabel + force-close hide + tests green), awaiting WARP🔹CMD re-review. Production PAPER ONLY. Activation guards remain OFF / NOT SET.
 
 [COMPLETED]
 - Premium UX v4 (Hybrid Luxury) — PR #1026 merged bd8fe42d
@@ -17,7 +17,7 @@ Status       : crusaderbot-mvp-ux-v1 STANDARD lane open — PR #1029 under WARP�
 - Fast Track Week 2 Track F -- Live Opt-In Gate MERGED PR #970 (2026-05-12). /enable_live 3-step gate, mode_change_events audit log, auto-fallback monitor; activation guards remain OFF.
 
 [IN PROGRESS]
-- crusaderbot-mvp-ux-v1: Hierarchy Tree Terminal UI rebuild; PR #1029 open, gate review NEEDS FIX — CI fixes pushed, awaiting re-review. Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-ux-v1.md
+- crusaderbot-mvp-ux-v1: Hierarchy Tree Terminal UI rebuild; PR #1029 open, gate review blockers addressed — Signal Feeds route contract aligned, manual force-close surface hidden, targeted tests passing; awaiting re-review. Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-ux-v1.md
 - relax-branch-prefix-rule: AGENTS.md updated; PR open, awaiting WARP🔹CMD review. Source: projects/polymarket/crusaderbot/reports/forge/relax-branch-prefix-rule.md
 - live-execution-user-id-guards: WARP•SENTINEL APPROVED 97/100. PR #1021 open. Awaiting WARP🔹CMD merge decision. Source: projects/polymarket/crusaderbot/reports/sentinel/live-execution-user-id-guards.md
 - Observation / runtime monitoring remains active in paper mode.

--- a/projects/polymarket/crusaderbot/state/WORKTODO.md
+++ b/projects/polymarket/crusaderbot/state/WORKTODO.md
@@ -1,12 +1,12 @@
 # CrusaderBot -- WORKTODO
 
 **Project:** projects/polymarket/crusaderbot
-**Last Updated: 2026-05-13T14:16 WIB
+**Last Updated: 2026-05-13 17:10 WIB
 
 ---
 
 ## Right Now
-- WARP/CRUSADERBOT-MVP-UX-V1 PR open (2026-05-13). Hierarchy Tree Terminal UI rebuild — 11 files; awaiting WARP🔹CMD review.
+- WARP/CRUSADERBOT-MVP-UX-V1 PR open (2026-05-13). Hierarchy Tree Terminal UI rebuild + blocker fix pass (Signal Feeds contract restore, manual force-close hide, tests green); awaiting WARP🔹CMD re-review.
 - [x] crusaderbot-mvp-ux-v1 — Hierarchy Tree Terminal UI rebuild complete, PR open, STANDARD NARROW INTEGRATION
 - Telegram UX v3 MERGED PR #1024 (2026-05-13). 7-button menu, dashboard v3, signals tap-hub, portfolio screen, nav_row, notifications utility.
 - [x] Telegram UX v3 MERGED PR #1024 — 7-button menu, dashboard v3, signals tap-hub, nav_row, notifications utility

--- a/projects/polymarket/crusaderbot/tests/test_phase5d_grid_menu_split.py
+++ b/projects/polymarket/crusaderbot/tests/test_phase5d_grid_menu_split.py
@@ -57,7 +57,7 @@ V3_BUTTONS = {
     "🏠 Dashboard",
     "💼 Portfolio",
     "🤖 Auto Trade",
-    "👥 Copy Wallet",
+    "📡 Signal Feeds",
     "📊 Insights",
     "⚙️ Settings",
     "🛑 Stop Bot",
@@ -96,7 +96,7 @@ def test_main_menu_expected_v3_buttons():
 def test_main_menu_contains_signals_button():
     kb = main_menu()
     labels = [btn.text for row in kb.keyboard for btn in row]
-    assert "👥 Copy Wallet" in labels
+    assert "📡 Signal Feeds" in labels
 
 
 def test_main_menu_contains_portfolio_button():
@@ -120,7 +120,7 @@ def test_main_menu_contains_stop_bot_button():
 # ---------- MAIN_MENU_ROUTES v3 --------------------------------------------
 
 def test_signals_route_registered():
-    assert "👥 Copy Wallet" in MAIN_MENU_ROUTES
+    assert "📡 Signal Feeds" in MAIN_MENU_ROUTES
 
 
 def test_portfolio_route_registered():
@@ -138,13 +138,13 @@ def test_auto_mode_route_registered():
 def test_all_seven_main_menu_routes_present():
     expected = {
         "🏠 Dashboard", "💼 Portfolio", "🤖 Auto Trade",
-        "👥 Copy Wallet", "📊 Insights", "⚙️ Settings", "🛑 Stop Bot",
+        "📡 Signal Feeds", "📊 Insights", "⚙️ Settings", "🛑 Stop Bot",
     }
     assert expected <= set(MAIN_MENU_ROUTES.keys())
 
 
 def test_signals_and_portfolio_are_different_handlers():
-    signals_handler = MAIN_MENU_ROUTES["👥 Copy Wallet"]
+    signals_handler = MAIN_MENU_ROUTES["📡 Signal Feeds"]
     portfolio_handler = MAIN_MENU_ROUTES["💼 Portfolio"]
     assert signals_handler is not portfolio_handler
 

--- a/projects/polymarket/crusaderbot/tests/test_positions_handler.py
+++ b/projects/polymarket/crusaderbot/tests/test_positions_handler.py
@@ -133,15 +133,13 @@ def test_fetch_mark_price_one_side_only():
 
 # ---------- Keyboard builders -----------------------------------------------
 
-def test_positions_list_kb_one_button_per_row():
+def test_positions_list_kb_nav_only_no_force_close_rows():
     pids = [uuid4() for _ in range(3)]
     kb = positions_list_kb(pids)
     rows = kb.inline_keyboard
-    assert len(rows) == 4  # 3 position rows + 1 nav footer (⬅ Back / 🏠 Home)
-    for row, pid in zip(rows, pids):
-        assert len(row) == 1
-        assert row[0].callback_data == f"position:fc_ask:{pid}"
-        assert "🛑" in row[0].text
+    assert len(rows) == 1
+    assert [btn.text for btn in rows[0]] == ["⬅ Back", "🏠 Home"]
+    assert [btn.callback_data for btn in rows[0]] == ["portfolio:portfolio", "dashboard:main"]
 
 
 def test_force_close_confirm_kb_yes_no_pair():

--- a/projects/polymarket/crusaderbot/tests/test_ux_overhaul.py
+++ b/projects/polymarket/crusaderbot/tests/test_ux_overhaul.py
@@ -71,10 +71,10 @@ def test_main_menu_has_stop_bot_not_emergency():
 
 def test_main_menu_v3_second_row():
     kb = main_menu()
-    # MVP v1: second row is Auto Trade + Copy Wallet
+    # MVP v1: second row is Auto Trade + Signal Feeds
     row2 = [btn.text for btn in kb.keyboard[1]]
     assert "🤖 Auto Trade" in row2
-    assert "👥 Copy Wallet" in row2
+    assert "📡 Signal Feeds" in row2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Align top-level menu label with the actual feature surface (signal subscriptions) by replacing the misleading `👥 Copy Wallet` label with `📡 Signal Feeds` across reply keyboards and menu routes.
- Reduce user-facing risk surface by removing manual force-close CTA rows from the portfolio positions keyboard and exposing only navigation (Back/Home), while keeping the confirm keyboard for internal/admin callbacks.
- Ensure all message templates, keyboard labels, and tests remain consistent after the UX vocabulary change.

### Description
- Replaced `👥 Copy Wallet` with `📡 Signal Feeds` in `bot/keyboards/__init__.py`, `bot/menus/main.py`, `bot/handlers/presets.py` and related handler/keyboard files to keep `main_menu()` and `MAIN_MENU_ROUTES` in sync.
- Updated `positions_list_kb` in `bot/keyboards/positions.py` to render a navigation-only keyboard (⬅ Back / 🏠 Home) and retained `force_close_confirm_kb` for confirm flows.
- Updated report and project state files (`reports/forge/...`, `state/CHANGELOG.md`, `state/PROJECT_STATE.md`, `state/WORKTODO.md`) to document the relabel and blocker-fix pass.
- Updated unit tests to match the new labels and behavior (`projects/polymarket/crusaderbot/tests/*`) and preserved all `callback_data` and function signatures unchanged.

### Testing
- Static checks and compilation succeeded (`python3 -m compileall` passes and `ruff` linting passes) on all changed files.
- Updated 5 unit tests to assert the new `📡 Signal Feeds` label and the modified portfolio keyboard layout, and the updated tests passed locally. 
- Verified that `positions_list_kb` now returns nav-only row with callbacks `portfolio:portfolio` and `dashboard:main` as asserted by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044ac68dac832ebd9dbf1058e9fe80)