### PR TITLE
Public HTML status landing page at `/` and tests

### DIFF
--- a/projects/polymarket/crusaderbot/main.py
+++ b/projects/polymarket/crusaderbot/main.py
@@ -7,6 +7,7 @@ import secrets
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response
+from fastapi.responses import HTMLResponse
 from telegram import Update
 from telegram.ext import Application
 
@@ -221,7 +222,41 @@ app.include_router(api_ops.router)
 
 @app.get("/")
 async def root():
-    return {"service": "crusaderbot", "status": "running"}
+    settings = get_settings()
+
+    def _pill(value: str) -> str:
+        lowered = value.lower()
+        if lowered in {"ok", "online", "running"}:
+            cls = "ok"
+        elif lowered in {"degraded", "warn", "warning"}:
+            cls = "warn"
+        else:
+            cls = "fail"
+        return f'<span class="pill {cls}">{value}</span>'
+
+    guards_msg = "OFF / NOT SET"
+    body = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CrusaderBot Status</title>
+<style>
+body{{margin:0;background:#0b1020;color:#d6deff;font-family:Inter,system-ui,sans-serif}} .wrap{{max-width:980px;margin:0 auto;padding:20px}}
+.grid{{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}} .card{{background:#141a31;border:1px solid #283153;border-radius:12px;padding:14px}}
+.pill{{padding:2px 8px;border-radius:999px;font-size:12px;font-weight:700}} .ok{{background:#10361f;color:#7cf0a0}} .warn{{background:#3a2c0a;color:#ffd36d}} .fail{{background:#3d1320;color:#ff8ca7}}
+a.btn{{display:inline-block;padding:10px 14px;background:#253463;color:#d6deff;text-decoration:none;border-radius:10px}}
+h1{{margin:0 0 6px}} .muted{{color:#9fabd2;font-size:14px}}
+</style></head>
+<body><div class="wrap"><h1>CrusaderBot</h1>
+<p class="muted">Public status landing page for production posture and service health.</p>
+<div class="grid">
+<section class="card"><h3>Server Status</h3><p>App reachable: {_pill('online')}</p><p>Environment: Fly.io</p><p>Timestamp: N/A (public-safe view)</p></section>
+<section class="card"><h3>Health</h3><p>Overall: {_pill('N/A')}</p><p>Database: {_pill('N/A')}</p><p>Telegram: {_pill('N/A')}</p><p class="muted">Use <a href="/health">/health</a> for machine-readable probe status.</p></section>
+<section class="card"><h3>Runtime</h3><p>Service: CrusaderBot</p><p>Mode: PAPER ONLY ({settings.APP_ENV.upper()})</p><p>Live trading: Disabled unless explicitly enabled by owner decision.</p></section>
+<section class="card"><h3>Activation Guards</h3>
+<p>ENABLE_LIVE_TRADING: {guards_msg}</p><p>EXECUTION_PATH_VALIDATED: {guards_msg}</p><p>CAPITAL_MODE_CONFIRMED: {guards_msg}</p><p>RISK_CONTROLS_VALIDATED: {guards_msg}</p></section>
+</div>
+<p style="margin-top:14px"><a class="btn" href="/health">Open /health</a></p>
+<p class="muted">Disclaimer: Not financial advice. Paper trading only.</p></div></body></html>"""
+    return HTMLResponse(content=body, status_code=200)
 
 
 @app.post("/telegram/webhook")

--- a/projects/polymarket/crusaderbot/reports/forge/public-status-landing-page.md
+++ b/projects/polymarket/crusaderbot/reports/forge/public-status-landing-page.md
@@ -1,0 +1,26 @@
+# Forge Report — public-status-landing-page
+
+- Branch: WARP/public-status-landing-page
+- Validation Tier: STANDARD
+- Claim Level: NARROW INTEGRATION
+- Validation Target: Public landing/status page on `/` and `/health` contract stability.
+- Not in Scope: Trading logic, risk constants, capital logic, activation guard state changes, CLOB/order execution, Telegram behavior.
+
+## Changes
+
+- CMD hold fix: public `/` no longer calls `api_health.health()`; landing page now uses public-safe static `N/A` health snapshot and keeps `/health` as machine-readable probe endpoint only.
+- Replaced root `/` response in `main.py` from JSON heartbeat to read-only public HTML landing page.
+- Landing page renders dark mobile-first card layout with Server Status, Health, Runtime, Activation Guards.
+- Added `/health` link CTA and paper-trading/not-financial-advice disclaimer.
+- Health card renders public-safe `N/A` values on `/`; machine-readable health remains available on `/health`.
+- Added targeted tests for `/` HTML contract and `/health` machine-readable JSON contract.
+
+## Validation
+- `python3 -m py_compile projects/polymarket/crusaderbot/main.py projects/polymarket/crusaderbot/tests/test_public_landing.py`
+- `pytest -q projects/polymarket/crusaderbot/tests/test_public_landing.py`
+- `pytest -q projects/polymarket/crusaderbot/tests/test_health.py projects/polymarket/crusaderbot/tests/test_api_ops.py`
+
+## Safety Notes
+- Activation guard values unchanged (OFF / NOT SET posture retained).
+- `/health` machine-readable behavior preserved.
+- No trading/runtime safety path modifications.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-14 15:41 | WARP/public-status-landing-page | PR #1038 HOLD fix: removed alerting health-route call from public `/`; landing now renders public-safe static health values and keeps `/health` as machine-readable probe endpoint; STANDARD, NARROW INTEGRATION
 2026-05-14 12:00 | WARP/telegram-ux-polish | Telegram UX polish: Dashboard button main reply keyboard, edit_message_text nav (no message spam), W/L moved to Stats section (clarity), portfolio/auto-trade keyboard dedup Back+Home, activity_nav_kb(), empty state action buttons, settings hub real risk profile; STANDARD, NARROW INTEGRATION
 2026-05-14 09:03 | warp/redesign-telegram-ux-for-crusaderbot | PR #1036 gate fix: positions.py portfolio stats always visible (split stats/footer), settings.py f-string Python 3.11 compat (mode_clean var), branch traceability drift fixed; ruff PASS
 2026-05-14 06:20 | WARP/crusaderbot-telegram-redesign-v2 | PR #1036 fix task: restored canonical preset callback IDs, fixed conservative risk callback token, fixed portfolio summary ternary output; STANDARD, NARROW INTEGRATION
@@ -100,3 +101,5 @@ fully operational in paper mode on Fly.io IAD. Idempotency keys active.
 2026-05-13 19:00 | warp/fix-telegram-mvp-ux-readability-regression | Traceability/state sync for PR #1032: aligned branch string across forge report/state artifacts and removed stale PR #1029-open references; STANDARD, NARROW INTEGRATION
 
 2026-05-13 20:30 | WARP/telegram-lightweight-tree-ui-hotfix | telegram-lightweight-tree-ui-hotfix: final lightweight tree UI pass — removed all standalone │ rails and ├──/└── heavy arms from dashboard/presets/positions/settings/signals/onboarding; added explicit Back/Home nav row to preset_picker (dashboard:main only, no noop:refresh); STANDARD, NARROW INTEGRATION
+
+2026-05-14 11:56 | WARP/public-status-landing-page | Public `/` status landing page (HTML dark mobile-first cards) + targeted route tests; `/health` contract preserved; STANDARD, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-05-14 11:56
+Last Updated : 2026-05-14 15:45
 Status       : telegram-ux-polish UX cleanup complete (edit nav, dashboard text, keyboard cleanup, settings risk fix); PR open on WARP/telegram-ux-polish awaiting WARP🔹CMD review. Production PAPER ONLY. Activation guards remain OFF / NOT SET.
 
 [COMPLETED]

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,4 +1,4 @@
-Last Updated : 2026-05-14 12:00
+Last Updated : 2026-05-14 11:56
 Status       : telegram-ux-polish UX cleanup complete (edit nav, dashboard text, keyboard cleanup, settings risk fix); PR open on WARP/telegram-ux-polish awaiting WARP🔹CMD review. Production PAPER ONLY. Activation guards remain OFF / NOT SET.
 
 [COMPLETED]
@@ -19,6 +19,7 @@ Status       : telegram-ux-polish UX cleanup complete (edit nav, dashboard text,
 - Fast Track Week 2 Track F -- Live Opt-In Gate MERGED PR #970 (2026-05-12). /enable_live 3-step gate, mode_change_events audit log, auto-fallback monitor; activation guards remain OFF.
 
 [IN PROGRESS]
+- public-status-landing-page: root `/` public status landing page shipped (HTML cards, paper posture, activation guards, /health link) + targeted tests; branch WARP/public-status-landing-page; STANDARD, NARROW INTEGRATION. Source: projects/polymarket/crusaderbot/reports/forge/public-status-landing-page.md
 - telegram-ux-polish: UX cleanup — Dashboard button main menu, edit vs reply nav, dashboard text W/L clarity, keyboard nav dedup, activity nav keyboard, settings risk display fix; PR open on WARP/telegram-ux-polish; STANDARD, NARROW INTEGRATION. Source: projects/polymarket/crusaderbot/reports/forge/telegram-ux-polish.md
 - crusaderbot-telegram-redesign-v2: Gate fixes applied — positions.py stats clarity fix, settings.py Python 3.11 f-string lint fix; PR #1036 on warp/redesign-telegram-ux-for-crusaderbot; ruff PASS; STANDARD, NARROW INTEGRATION. Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-telegram-redesign-v2.md
 - crusaderbot-mvp-reset-v1: Telegram MVP UX reset complete; PR open on WARP/crusaderbot-mvp-reset-v1 awaiting WARP🔹CMD review; STANDARD, NARROW INTEGRATION. Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-reset-v1.md

--- a/projects/polymarket/crusaderbot/state/WORKTODO.md
+++ b/projects/polymarket/crusaderbot/state/WORKTODO.md
@@ -1,11 +1,12 @@
 # CrusaderBot -- WORKTODO
 
 **Project:** projects/polymarket/crusaderbot
-**Last Updated: 2026-05-14 06:20 WIB
+**Last Updated: 2026-05-14 11:56 WIB
 
 ---
 
 ## Right Now
+- public-status-landing-page lane complete (2026-05-14). Root `/` now serves public status landing page with health/runtime/guard cards; targeted route tests added; `/health` contract preserved.
 - crusaderbot-telegram-redesign-v2 lane complete (2026-05-14). Telegram-native card UX v2 implemented; PR pending WARP🔹CMD review on WARP/crusaderbot-telegram-redesign-v2.
 - crusaderbot-mvp-reset-v1 lane complete (2026-05-14). Telegram MVP UX reset: 5-button nav, clean onboarding, MVP screens. PR open on WARP/crusaderbot-mvp-reset-v1 awaiting WARP🔹CMD review.
 - PR #1032 merged (warp/fix-telegram-mvp-ux-readability-regression, 2026-05-13). Compact hierarchy readability regression fix.

--- a/projects/polymarket/crusaderbot/tests/test_public_landing.py
+++ b/projects/polymarket/crusaderbot/tests/test_public_landing.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from projects.polymarket.crusaderbot import main as app_main
+from projects.polymarket.crusaderbot.api import admin as api_admin
+from projects.polymarket.crusaderbot.api import health as api_health
+from projects.polymarket.crusaderbot.api import ops as api_ops
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_health.router)
+    app.include_router(api_admin.router)
+    app.include_router(api_ops.router)
+    app.add_api_route("/", app_main.root, methods=["GET"])
+    return app
+
+
+def test_public_landing_page_contract():
+    client = TestClient(_build_app())
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+
+    body = r.text
+    for token in [
+        "CrusaderBot",
+        "PAPER ONLY",
+        "Fly.io",
+        "Health",
+        "Server Status",
+        "Activation Guards",
+        "ENABLE_LIVE_TRADING",
+        "EXECUTION_PATH_VALIDATED",
+        "CAPITAL_MODE_CONFIRMED",
+        "RISK_CONTROLS_VALIDATED",
+        "Not financial advice",
+        "/health",
+        "N/A",
+    ]:
+        assert token in body
+
+
+def test_health_contract_remains_machine_readable(monkeypatch):
+    async def _fake_checks():
+        return {
+            "status": "ok",
+            "service": "CrusaderBot",
+            "checks": {
+                "database": "ok",
+                "telegram": "ok",
+                "alchemy_rpc": "ok",
+                "alchemy_ws": "ok",
+            },
+            "ready": True,
+        }
+
+    monkeypatch.setattr(api_health, "run_health_checks", _fake_checks)
+
+    client = TestClient(_build_app())
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert "application/json" in r.headers.get("content-type", "")
+
+    data = r.json()
+    assert set(data.keys()) == {
+        "status",
+        "uptime_seconds",
+        "version",
+        "mode",
+        "timestamp",
+        "service",
+        "checks",
+        "ready",
+    }


### PR DESCRIPTION
### Motivation
- Replace the public root heartbeat response with a read-only, public-safe status landing page to avoid exposing internal probe data and to keep `/health` as the machine-readable probe endpoint.
- Provide a simple, branded HTML surface for ops and users that does not surface activation guard or sensitive runtime details.

### Description
- Replaced JSON heartbeat in `root()` with an HTML landing page returned via `HTMLResponse` that renders Server Status, Health (public-safe `N/A`), Runtime, and Activation Guards cards and a CTA to `/health`.
- Added helper `_pill()` to style status tokens and used `get_settings()` to render `APP_ENV` in the Runtime card while keeping guard values intentionally static (`OFF / NOT SET`).
- Preserved existing machine-readable health contract at `/health` and removed any direct call to `api_health.health()` from the public root path to avoid alerting behavior.
- Added `projects/polymarket/crusaderbot/tests/test_public_landing.py` to assert the HTML contract for `/` and to verify `/health` remains JSON machine-readable; updated changelog, project state, worktodo, and added a Forge report file documenting the change.

### Testing
- Ran `python3 -m py_compile projects/polymarket/crusaderbot/main.py projects/polymarket/crusaderbot/tests/test_public_landing.py` which completed without syntax errors.
- Ran `pytest -q projects/polymarket/crusaderbot/tests/test_public_landing.py` which passed.
- Ran `pytest -q projects/polymarket/crusaderbot/tests/test_health.py projects/polymarket/crusaderbot/tests/test_api_ops.py` which passed and confirmed `/health` contract stability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05547c1638832eb6aa3ccd3de05e0c)