### PR TITLE
fix: WebTrader bot username CrusaderBot → CrusaderPolybot

### DIFF
--- a/projects/polymarket/crusaderbot/Dockerfile
+++ b/projects/polymarket/crusaderbot/Dockerfile
@@ -5,7 +5,7 @@ COPY webtrader/frontend/package.json webtrader/frontend/package-lock.json ./
 RUN npm ci
 COPY webtrader/frontend/ ./
 # Bot username injected at build time; defaults to CrusaderBot
-ARG VITE_BOT_USERNAME=CrusaderBot
+ARG VITE_BOT_USERNAME=CrusaderPolybot
 ENV VITE_BOT_USERNAME=$VITE_BOT_USERNAME
 RUN npm run build
 # Output: /build/dist/

--- a/projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md
+++ b/projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md
@@ -1,0 +1,63 @@
+# WARP•FORGE Report — webtrader-botusername-fix
+
+Validation Tier: MINOR
+Claim Level: NARROW INTEGRATION
+Validation Target: WebTrader Telegram Login Widget bot username
+Not in Scope: backend auth logic, Fly.io deploy, other frontend components
+Suggested Next Step: WARP🔹CMD review → merge → fly deploy with --build-arg
+
+---
+
+## 1. What Was Built
+
+Fixed incorrect default bot username (`CrusaderBot`) in two locations so the
+Telegram Login Widget resolves to `@CrusaderPolybot` at build time.
+
+---
+
+## 2. Current System Architecture
+
+WebTrader uses a Vite/React frontend compiled inside a Docker multi-stage build.
+`VITE_BOT_USERNAME` is injected as a Docker build ARG → Vite ENV → compiled into
+the JS bundle at `import.meta.env.VITE_BOT_USERNAME`. The `data-telegram-login`
+attribute on the Telegram widget script tag reads this value; Telegram validates
+the attribute against the registered bot domain. A mismatch causes "Bot domain
+invalid".
+
+---
+
+## 3. Files Created / Modified
+
+Modified:
+- `projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx`
+  Line 10: fallback `"CrusaderBot"` → `"CrusaderPolybot"`
+- `projects/polymarket/crusaderbot/Dockerfile`
+  Line 8: `ARG VITE_BOT_USERNAME=CrusaderBot` → `ARG VITE_BOT_USERNAME=CrusaderPolybot`
+
+Created:
+- `projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md` (this file)
+
+---
+
+## 4. What Is Working
+
+- `TelegramAuth.tsx` already read from `import.meta.env.VITE_BOT_USERNAME` (not
+  hardcoded). The fallback was the only incorrect value; now corrected.
+- Dockerfile ARG default now matches production bot username. `fly deploy` without
+  an explicit `--build-arg` will also produce the correct widget.
+
+---
+
+## 5. Known Issues
+
+None. Deploy step (`fly deploy --build-arg VITE_BOT_USERNAME=CrusaderPolybot -a crusaderbot`)
+remains a manual post-merge action by WARP🔹CMD.
+
+---
+
+## 6. What Is Next
+
+1. WARP🔹CMD merges PR
+2. Run: `fly deploy --build-arg VITE_BOT_USERNAME=CrusaderPolybot -a crusaderbot`
+3. Verify `crusaderbot.fly.dev/dashboard` shows "Log in with Telegram" widget with no domain error
+4. Login with walk3r69 → confirm redirect to dashboard

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx
@@ -7,7 +7,7 @@ declare global {
   }
 }
 
-const BOT_USERNAME = import.meta.env.VITE_BOT_USERNAME ?? "CrusaderBot";
+const BOT_USERNAME = import.meta.env.VITE_BOT_USERNAME ?? "CrusaderPolybot";
 
 export function TelegramAuth() {
   const ref = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

- `Dockerfile`: ARG default `VITE_BOT_USERNAME=CrusaderBot` → `CrusaderPolybot`
- `TelegramAuth.tsx`: fallback value `"CrusaderBot"` → `"CrusaderPolybot"`
- Forge report: `projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md`

The Telegram Login Widget was resolving `data-telegram-login` to `CrusaderBot` (incorrect bot username), causing "Bot domain invalid". Both the Dockerfile build ARG default and the in-code fallback now reference `@CrusaderPolybot`.

## Test plan

- [ ] Merge PR
- [ ] `fly deploy --build-arg VITE_BOT_USERNAME=CrusaderPolybot -a crusaderbot`
- [ ] `crusaderbot.fly.dev/dashboard` loads without "Bot domain invalid"
- [ ] Telegram Login Widget displays "Log in with Telegram" button
- [ ] Login with walk3r69 succeeds and redirects to dashboard

Validation Tier: MINOR

https://claude.ai/code/session_01T6KhkuBVopMgUxdi2YfA7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6KhkuBVopMgUxdi2YfA7K)_