### PR TITLE
fix: WalletPage layout overflow — truncate tx hash, fix amount column

### DIFF
--- a/projects/polymarket/crusaderbot/Dockerfile
+++ b/projects/polymarket/crusaderbot/Dockerfile
@@ -5,7 +5,7 @@ COPY webtrader/frontend/package.json webtrader/frontend/package-lock.json ./
 RUN npm ci
 COPY webtrader/frontend/ ./
 # Bot username injected at build time; defaults to CrusaderBot
-ARG VITE_BOT_USERNAME=CrusaderBot
+ARG VITE_BOT_USERNAME=CrusaderPolybot
 ENV VITE_BOT_USERNAME=$VITE_BOT_USERNAME
 RUN npm run build
 # Output: /build/dist/

--- a/projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md
+++ b/projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md
@@ -1,0 +1,63 @@
+# WARP•FORGE Report — webtrader-botusername-fix
+
+Validation Tier: MINOR
+Claim Level: NARROW INTEGRATION
+Validation Target: WebTrader Telegram Login Widget bot username
+Not in Scope: backend auth logic, Fly.io deploy, other frontend components
+Suggested Next Step: WARP🔹CMD review → merge → fly deploy with --build-arg
+
+---
+
+## 1. What Was Built
+
+Fixed incorrect default bot username (`CrusaderBot`) in two locations so the
+Telegram Login Widget resolves to `@CrusaderPolybot` at build time.
+
+---
+
+## 2. Current System Architecture
+
+WebTrader uses a Vite/React frontend compiled inside a Docker multi-stage build.
+`VITE_BOT_USERNAME` is injected as a Docker build ARG → Vite ENV → compiled into
+the JS bundle at `import.meta.env.VITE_BOT_USERNAME`. The `data-telegram-login`
+attribute on the Telegram widget script tag reads this value; Telegram validates
+the attribute against the registered bot domain. A mismatch causes "Bot domain
+invalid".
+
+---
+
+## 3. Files Created / Modified
+
+Modified:
+- `projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx`
+  Line 10: fallback `"CrusaderBot"` → `"CrusaderPolybot"`
+- `projects/polymarket/crusaderbot/Dockerfile`
+  Line 8: `ARG VITE_BOT_USERNAME=CrusaderBot` → `ARG VITE_BOT_USERNAME=CrusaderPolybot`
+
+Created:
+- `projects/polymarket/crusaderbot/reports/forge/webtrader-botusername-fix.md` (this file)
+
+---
+
+## 4. What Is Working
+
+- `TelegramAuth.tsx` already read from `import.meta.env.VITE_BOT_USERNAME` (not
+  hardcoded). The fallback was the only incorrect value; now corrected.
+- Dockerfile ARG default now matches production bot username. `fly deploy` without
+  an explicit `--build-arg` will also produce the correct widget.
+
+---
+
+## 5. Known Issues
+
+None. Deploy step (`fly deploy --build-arg VITE_BOT_USERNAME=CrusaderPolybot -a crusaderbot`)
+remains a manual post-merge action by WARP🔹CMD.
+
+---
+
+## 6. What Is Next
+
+1. WARP🔹CMD merges PR
+2. Run: `fly deploy --build-arg VITE_BOT_USERNAME=CrusaderPolybot -a crusaderbot`
+3. Verify `crusaderbot.fly.dev/dashboard` shows "Log in with Telegram" widget with no domain error
+4. Login with walk3r69 → confirm redirect to dashboard

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TelegramAuth.tsx
@@ -7,7 +7,7 @@ declare global {
   }
 }
 
-const BOT_USERNAME = import.meta.env.VITE_BOT_USERNAME ?? "CrusaderBot";
+const BOT_USERNAME = import.meta.env.VITE_BOT_USERNAME ?? "CrusaderPolybot";
 
 export function TelegramAuth() {
   const ref = useRef<HTMLDivElement>(null);

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/WalletPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/WalletPage.tsx
@@ -21,9 +21,9 @@ export function WalletPage() {
 
   if (!wallet) return <div className="p-4 text-muted text-sm">Loading…</div>;
 
-  function truncateHash(hash: string): string {
-    if (hash.length <= 14) return hash;
-    return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+  function truncateHash(note: string): string {
+    if (!note.startsWith("0x") || note.length <= 14) return note;
+    return `${note.slice(0, 6)}…${note.slice(-4)}`;
   }
 
   function formatDate(iso: string): string {

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/WalletPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/WalletPage.tsx
@@ -21,8 +21,18 @@ export function WalletPage() {
 
   if (!wallet) return <div className="p-4 text-muted text-sm">Loading…</div>;
 
+  function truncateHash(hash: string): string {
+    if (hash.length <= 14) return hash;
+    return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+  }
+
+  function formatDate(iso: string): string {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+
   return (
-    <div className="pb-24 px-4">
+    <div className="pb-24 px-4 overflow-x-hidden max-w-full">
       <div className="pt-6 pb-4">
         <h1 className="text-xl font-bold text-primary">Wallet</h1>
       </div>
@@ -57,14 +67,19 @@ export function WalletPage() {
           <p className="text-primary font-medium text-sm mb-3">Recent Transactions</p>
           <div className="space-y-2">
             {wallet.ledger_recent.map((entry, i) => (
-              <div key={i} className="flex items-center justify-between py-2 border-b border-border/50 last:border-0">
-                <div>
-                  <p className="text-primary text-sm capitalize">{entry.type.replace("_", " ")}</p>
-                  {entry.note && <p className="text-muted text-xs">{entry.note}</p>}
+              <div key={i} className="flex items-start justify-between gap-2 py-2 border-b border-border/50 last:border-0 min-w-0">
+                <div className="min-w-0 flex-1">
+                  <p className="text-primary text-sm capitalize truncate">{entry.type.replace("_", " ")}</p>
+                  {entry.note && (
+                    <p className="font-mono text-xs text-muted truncate">{truncateHash(entry.note)}</p>
+                  )}
                 </div>
-                <p className={`text-sm font-medium ${entry.amount_usdc >= 0 ? "text-green" : "text-red"}`}>
-                  {entry.amount_usdc >= 0 ? "+" : ""}${Math.abs(entry.amount_usdc).toFixed(2)}
-                </p>
+                <div className="flex-shrink-0 text-right">
+                  <p className={`text-sm font-medium ${entry.amount_usdc >= 0 ? "text-green" : "text-red"}`}>
+                    {entry.amount_usdc >= 0 ? "+" : ""}${Math.abs(entry.amount_usdc).toFixed(2)}
+                  </p>
+                  <p className="text-muted text-xs">{formatDate(entry.created_at)}</p>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

- Container: added `overflow-x: hidden max-w-full` to prevent horizontal scroll
- Transaction row: `min-w-0 flex-1` on left column so long content truncates instead of overflowing
- Tx hash: rendered via `truncateHash()` → `0x1234…5678` (first 6 + last 4 chars), `font-mono text-xs truncate`
- Amount column: `flex-shrink-0 text-right` so it stays pinned to the right edge at fixed width
- Date column: added below amount using `entry.created_at` formatted as `May 16`

Transaction row layout:
```
[deposit            ]  [+$10.00  ]
[0x1a2b…3c4d, muted]  [May 16   ]
```

## Test plan

- [ ] Long tx hash truncates to `0x1234…5678` — no horizontal overflow
- [ ] Amount column stays right-aligned and fully visible
- [ ] Date appears below amount in muted xs text
- [ ] Page does not scroll horizontally on mobile viewport

Validation Tier: MINOR

https://claude.ai/code/session_01T6KhkuBVopMgUxdi2YfA7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6KhkuBVopMgUxdi2YfA7K)_