### PR TITLE
fix(folio): show current position value instead of raw pnl_usdc + apply migrations 030/031

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/PositionCard.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/PositionCard.tsx
@@ -5,7 +5,7 @@ export type PositionSide = "yes" | "no" | "exp" | "credit" | "debit";
 
 type Props = {
   market: string;
-  pnl: { value: string; tone: "zero" | "up" | "dn" };
+  positionValue: { value: string; tone: "zero" | "up" | "dn" };
   side: PositionSide;
   /** Primary meta items shown in essential + advanced. */
   meta: ReactNode[];
@@ -44,7 +44,7 @@ const PNL_TONE = {
   dn:   "text-red",
 } as const;
 
-export function PositionCard({ market, pnl, side, meta, metaAdvanced, onClick }: Props) {
+export function PositionCard({ market, positionValue, side, meta, metaAdvanced, onClick }: Props) {
   return (
     <div
       role={onClick ? "button" : undefined}
@@ -64,8 +64,8 @@ export function PositionCard({ market, pnl, side, meta, metaAdvanced, onClick }:
         <div className="font-sans text-[13px] font-semibold leading-[1.3] text-ink-1 flex-1">
           {market}
         </div>
-        <div className={`font-mono text-[13px] font-bold whitespace-nowrap ${PNL_TONE[pnl.tone]}`}>
-          {pnl.value}
+        <div className={`font-mono text-[13px] font-bold whitespace-nowrap ${PNL_TONE[positionValue.tone]}`}>
+          {positionValue.value}
         </div>
       </div>
       <div className="flex gap-3 items-center font-mono text-[10px] text-ink-3 tracking-[0.5px]">

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -97,14 +97,14 @@ function PositionRow({ p }: { p: PositionItem }) {
   const diff = curVal - p.size_usdc;
   const tone: "zero" | "up" | "dn" =
     Math.abs(diff) < 0.005 ? "zero" : diff > 0 ? "up" : "dn";
-  const pnl = { value: `$${curVal.toFixed(2)}`, tone };
+  const positionValue = { value: `$${curVal.toFixed(2)}`, tone };
   const side =
     p.status === "expired" ? "exp" : p.side === "no" ? "no" : "yes";
 
   return (
     <PositionCard
       market={p.market_question ?? `${p.market_id.slice(0, 18)}…`}
-      pnl={pnl}
+      positionValue={positionValue}
       side={side}
       meta={[
         <>${p.size_usdc.toFixed(2)}</>,

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -84,11 +84,20 @@ export function PortfolioPage() {
 }
 
 function PositionRow({ p }: { p: PositionItem }) {
-  const v = p.pnl_usdc ?? 0;
+  // Show current market value of the position, not raw PnL.
+  // Open: (current_price ?? entry_price) / entry_price * size_usdc
+  // Closed/expired: cost + realized pnl_usdc (what was actually returned)
+  const curVal = (() => {
+    if (p.status === "open") {
+      const price = p.current_price ?? p.entry_price;
+      return p.entry_price > 0 ? (price / p.entry_price) * p.size_usdc : p.size_usdc;
+    }
+    return p.size_usdc + (p.pnl_usdc ?? 0);
+  })();
+  const diff = curVal - p.size_usdc;
   const tone: "zero" | "up" | "dn" =
-    Math.abs(v) < 0.005 ? "zero" : v >= 0 ? "up" : "dn";
-  const sign = tone === "zero" ? "" : v >= 0 ? "+" : "−";
-  const pnl = { value: tone === "zero" ? "$0.00" : `${sign}$${Math.abs(v).toFixed(2)}`, tone };
+    Math.abs(diff) < 0.005 ? "zero" : diff > 0 ? "up" : "dn";
+  const pnl = { value: `$${curVal.toFixed(2)}`, tone };
   const side =
     p.status === "expired" ? "exp" : p.side === "no" ? "no" : "yes";
 


### PR DESCRIPTION
## Summary

- Applied migration 030: adds `metadata JSONB` column to `job_runs` for structured per-tick RunResult output
- Applied migration 031: backfills demo/live signal feeds, enrolls all users in `signal_following` strategy, subscribes users to demo feed, aligns `access_tier >= 3` for paper-mode access
- Fixed webtrader FOLIO tab showing `$0.00` for all positions

## Root cause (webtrader $0.00)

`PortfolioPage.tsx` was rendering `pnl_usdc` as the right-side metric. The DB has `pnl_usdc = NULL` for open positions (exit_watcher writes it on the next price-update tick) and `pnl_usdc = 0.000000` for positions that closed at entry price. Both cases collapsed to `$0.00` via `p.pnl_usdc ?? 0`.

## Fix

Switch the right-side card metric from raw `pnl_usdc` to **current market value** of the position:

| Status | Formula |
|---|---|
| open | `(current_price ?? entry_price) / entry_price × size_usdc` |
| closed / expired | `size_usdc + (pnl_usdc ?? 0)` |

- Flat open position (price unchanged): shows `$10.00` instead of `$0.00`
- Losing position: value drops below cost → red tone
- Winning position: value rises above cost → green tone
- Closed at break-even: `$10.00` (cost returned)
- Expired worthless: `$0.00` (correct — total loss)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7bhwNHiyMb5yYQrihk6J1)_