### PR TITLE
wire notification_service.register_handlers() into main.py startup

### DIFF
--- a/projects/polymarket/crusaderbot/main.py
+++ b/projects/polymarket/crusaderbot/main.py
@@ -20,6 +20,7 @@ from .api import admin as api_admin, health as api_health, ops as api_ops
 from .webtrader.backend import sse as webtrader_sse
 from .webtrader.backend.router import router as web_router
 from .bot.dispatcher import register as register_handlers
+from .services.notification_service import register_handlers as register_notification_handlers
 from .cache import close_cache, get_cache, init_cache, set_cache
 from .config import get_settings, validate_required_env
 from .database import close_pool, init_pool, run_migrations
@@ -88,6 +89,7 @@ async def lifespan(_: FastAPI):
 
     await bot_app.initialize()
     await bot_app.start()
+    register_notification_handlers()
 
     if use_webhook:
         # Always enforce secret validation in webhook mode.

--- a/projects/polymarket/crusaderbot/reports/forge/wire-notification-handlers.md
+++ b/projects/polymarket/crusaderbot/reports/forge/wire-notification-handlers.md
@@ -1,0 +1,46 @@
+# WARP•FORGE Report — wire-notification-handlers
+
+Validation Tier: MINOR
+Claim Level: NARROW INTEGRATION
+Validation Target: main.py lifespan — register_notification_handlers() wiring
+Not in Scope: notification_service logic, event_bus implementation, Telegram delivery
+Suggested Next Step: WARP🔹CMD review and merge
+
+---
+
+## 1. What was built
+
+Wired `notification_service.register_handlers()` into the bot startup lifespan in `main.py`.
+Call site: after `await bot_app.start()`, before polling/webhook block.
+This activates the three event-bus subscriptions — `position.opened`, `position.closed`,
+`copy_trade.executed` — so Telegram trade receipts fire on every trade event.
+
+## 2. Current system architecture
+
+`notification_service.register_handlers()` calls `subscribe()` from `core.event_bus`
+for each of the three trade events. Handlers are async and use `notifications.send()`.
+`notifications.set_bot()` is called at line 87, before `register_notification_handlers()`
+at line 91, so the bot reference is always ready when a handler fires.
+
+Pipeline: event emitter → event_bus.publish() → subscribed handler → `_send_safe()` → `notifications.send()` → Telegram.
+
+## 3. Files created / modified
+
+- Modified: `projects/polymarket/crusaderbot/main.py`
+  - Line 23: added `from .services.notification_service import register_handlers as register_notification_handlers`
+  - Line 91: added `register_notification_handlers()` call after `await bot_app.start()`
+
+## 4. What is working
+
+- `python3 -m compileall projects/polymarket/crusaderbot` — clean, zero errors
+- `ruff check projects/polymarket/crusaderbot/main.py` — All checks passed
+- Import uses alias `register_notification_handlers` to avoid name collision with
+  the existing `register_handlers` alias from `bot.dispatcher` (line 22)
+
+## 5. Known issues
+
+None.
+
+## 6. What is next
+
+WARP🔹CMD review and merge. No SENTINEL required (Tier: MINOR).

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-17 22:30 | WARP/CRUSADERBOT-FAST-TRADE-NOTIFS-WIRE | wire-notification-handlers: register_notification_handlers() called in main.py lifespan after bot_app.start(); MINOR, NARROW INTEGRATION
 2026-05-17 22:00 | WARP/CRUSADERBOT-FAST-TRADE-ENGINE | Track A: signal-to-order + TP/SL pipeline audit; EXIT_WATCH_INTERVAL 60→30s; TestSchedulerWiring added; 49 hermetic tests pass; MAJOR, FULL RUNTIME INTEGRATION
 2026-05-17 20:00 | WARP/CRUSADERBOT-FAST-TRADE-NOTIFS | Track C: core/event_bus.py + services/notification_service.py — position.opened/closed + copy_trade.executed receipts; STANDARD, NARROW INTEGRATION
 2026-05-17 20:00 | WARP/CRUSADERBOT-SIGNAL-ENGINE-FIX | signal-engine-fix: edge_finder demo path widened (edge scoring replaces price<0.15 threshold), SCANNER_MIN_LIQUIDITY lowered to 5k, idempotency key date-scoped (prevents duplicate positions), structlog per-market logging added; STANDARD, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-17 22:00
-Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs open. Track A awaiting WARP•SENTINEL. Track C merges after Track A. Production PAPER ONLY.
+Last Updated : 2026-05-17 22:30
+Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs open. notification_service.register_handlers() wired into main.py startup. Production PAPER ONLY.
 
 [COMPLETED]
 - WARP/CRUSADERBOT-MVP-RUNTIME-V1 MERGED PR #1089 (2026-05-17). Autonomous trading bot MVP runtime: Phase 0 audit (P0_RUNTIME_MAP.md) + skip_deposit_cb preset activation fix + auto_trade_on=True on onboarding + allowlist_command migrated to is_admin(). MAJOR, FULL RUNTIME INTEGRATION.
@@ -17,6 +17,7 @@ Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs ope
 - WARP/CRUSADERBOT-FAST-TRADE-ENGINE: Track A signal-to-order + TP/SL. PR open. SENTINEL validation required before merge.
 - WARP/CRUSADERBOT-MVP-BUGFIX-ROUND1: handler audit fixes PR open, awaiting WARP🔹CMD merge decision.
 - WARP/CRUSADERBOT-FAST-TRADE-NOTIFS: Track C event bus + notification service PR open. Awaiting Track A merge first.
+- WARP/CRUSADERBOT-FAST-TRADE-NOTIFS-WIRE: notification_service.register_handlers() wired into main.py. PR open, awaiting WARP🔹CMD merge.
 - Closed beta observation / paper-mode runtime monitoring active.
 - Current production posture: Telegram @CrusaderPolybot live, Fly.io app running, PAPER ONLY.
 - Activation guards remain OFF: ENABLE_LIVE_TRADING=false, EXECUTION_PATH_VALIDATED=false, CAPITAL_MODE_CONFIRMED=false, RISK_CONTROLS_VALIDATED=false.
@@ -35,6 +36,7 @@ Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs ope
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
+- WARP🔹CMD review required for wire-notification-handlers (register_handlers() wired into main.py). Source: projects/polymarket/crusaderbot/reports/forge/wire-notification-handlers.md. Tier: MINOR.
 - WARP•SENTINEL validation required for fast-trade-engine (Track A: signal-to-order + TP/SL). Source: projects/polymarket/crusaderbot/reports/forge/fast-trade-engine.md. Tier: MAJOR. Track B (copy trade) blocked until this merges.
 - WARP🔹CMD review required for trade-notifications Track C (event bus + notification service). Source: projects/polymarket/crusaderbot/reports/forge/trade-notifications.md. Tier: STANDARD. Merge after Track A.
 - WARP🔹CMD review required for crusaderbot-mvp-bugfix-round1 (9 handler bugs fixed). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-mvp-bugfix-round1.md. Tier: STANDARD.


### PR DESCRIPTION
## Summary

- Imports `register_handlers` from `services.notification_service` with alias `register_notification_handlers` (avoids collision with existing `bot.dispatcher` alias on line 22)
- Calls `register_notification_handlers()` in the lifespan after `await bot_app.start()`, before the polling/webhook block — satisfying the "after bot initialized, before polling starts" constraint
- Activates the three event-bus subscriptions: `position.opened`, `position.closed`, `copy_trade.executed`

## Validation

- `python3 -m compileall projects/polymarket/crusaderbot` — clean
- `ruff check projects/polymarket/crusaderbot/main.py` — All checks passed

## Tier

MINOR — no WARP•SENTINEL required. WARP🔹CMD review and merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvKfqNhQ2LuwimwvP1e7f8)_