### PR TITLE
fix: 3 Sentry production blockers — migration crash + job_runs dict + schema

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/dashboard.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/dashboard.py
@@ -103,7 +103,7 @@ async def _fetch_last_trade_action(user_id) -> str:
                     p.status,
                     m.question AS market_question,
                     CASE WHEN p.status = 'open'
-                         THEN p.created_at
+                         THEN p.opened_at
                          ELSE p.closed_at
                     END AS action_time
                 FROM positions p

--- a/projects/polymarket/crusaderbot/bot/handlers/share_card.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/share_card.py
@@ -28,7 +28,7 @@ async def _fetch_trade(trade_id: str) -> dict | None:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT m.question AS market_question, p.market_id, p.pnl_usdc, p.size_usdc, p.exit_price
+            SELECT m.question AS market_question, p.market_id, p.pnl_usdc, p.size_usdc
             FROM positions p
             LEFT JOIN markets m ON m.id = p.market_id
             WHERE p.id=$1 AND p.status='closed'

--- a/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
+++ b/projects/polymarket/crusaderbot/domain/ops/job_tracker.py
@@ -7,6 +7,7 @@ reads from this table directly — no in-memory state.
 """
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -84,7 +85,8 @@ async def record_job_event(
             await conn.execute(
                 "INSERT INTO job_runs (job_name, status, started_at, "
                 "finished_at, error, metadata) VALUES ($1, $2, $3, $4, $5, $6)",
-                job_id, status, started, finished, err, metadata,
+                job_id, status, started, finished, err,
+                json.dumps(metadata) if metadata is not None else None,
             )
     except Exception as exc:
         # Don't crash the scheduler loop because the ops table is down.

--- a/projects/polymarket/crusaderbot/migrations/032_copy_trade_events.sql
+++ b/projects/polymarket/crusaderbot/migrations/032_copy_trade_events.sql
@@ -3,20 +3,32 @@
 -- opened via the copy-trade monitor so callers can query what has been
 -- mirrored without scanning idempotency rows.
 --
--- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- copy_trade_events was created in 009_copy_trade.sql with columns:
+--   id, copy_target_id, source_tx_hash, mirrored_order_id, created_at
+-- This migration adds the monitor-audit columns idempotently via ALTER TABLE.
+-- CREATE TABLE IF NOT EXISTS would be a no-op (table already exists) and
+-- the subsequent CREATE INDEX on user_id would crash with
+-- "column user_id does not exist" — hence ALTER TABLE approach here.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
 -- Safe to replay.
 
 BEGIN;
 
-CREATE TABLE IF NOT EXISTS copy_trade_events (
-    id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id        UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    position_id    UUID         REFERENCES positions(id),
-    target_wallet  VARCHAR(100) NOT NULL,
-    market_id      VARCHAR(100) NOT NULL,
-    size_usdc      NUMERIC(18,6),
-    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
-);
+ALTER TABLE copy_trade_events
+    ADD COLUMN IF NOT EXISTS user_id       UUID         REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE copy_trade_events
+    ADD COLUMN IF NOT EXISTS position_id   UUID         REFERENCES positions(id);
+
+ALTER TABLE copy_trade_events
+    ADD COLUMN IF NOT EXISTS target_wallet VARCHAR(100);
+
+ALTER TABLE copy_trade_events
+    ADD COLUMN IF NOT EXISTS market_id     VARCHAR(100);
+
+ALTER TABLE copy_trade_events
+    ADD COLUMN IF NOT EXISTS size_usdc     NUMERIC(18,6);
 
 CREATE INDEX IF NOT EXISTS idx_copy_trade_events_user_id
     ON copy_trade_events (user_id);

--- a/projects/polymarket/crusaderbot/migrations/034_positions_denorm_columns.sql
+++ b/projects/polymarket/crusaderbot/migrations/034_positions_denorm_columns.sql
@@ -1,0 +1,20 @@
+-- Migration 034: add denormalised columns to positions for direct reads.
+--
+-- Sentry DAWN-SNOWFLAKE-1729-1A: column "market_question" does not exist
+-- Sentry DAWN-SNOWFLAKE-1729-10: column "strategy_type" does not exist
+--
+-- Queries that access these columns directly on positions (without JOIN) fail
+-- when the columns are absent.  Adding them as nullable TEXT/VARCHAR with
+-- IF NOT EXISTS makes every such query safe; existing JOIN-aliased reads
+-- continue to return the live markets.question value and are unaffected.
+--
+-- strategy_type on orders is already handled by 026_add_strategy_type_to_orders.sql.
+-- This migration covers positions so the column is available there too.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. Safe to replay on every startup.
+
+ALTER TABLE positions
+    ADD COLUMN IF NOT EXISTS market_question TEXT;
+
+ALTER TABLE positions
+    ADD COLUMN IF NOT EXISTS strategy_type   VARCHAR(50);

--- a/projects/polymarket/crusaderbot/reports/forge/crusaderbot-sentry-hotfix-p0.md
+++ b/projects/polymarket/crusaderbot/reports/forge/crusaderbot-sentry-hotfix-p0.md
@@ -1,0 +1,81 @@
+# WARP•FORGE Report — crusaderbot-sentry-hotfix-p0
+
+**Branch:** WARP/CRUSADERBOT-SENTRY-HOTFIX-P0
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** Migration runner crash fix + job_runs serialization + schema gap fills
+**Not in Scope:** New features, live trading, architecture changes
+**Suggested Next Step:** WARP🔹CMD review → merge → Fly.io redeploy
+
+---
+
+## 1. What was built
+
+Three targeted fixes for Sentry production blockers:
+
+**FIX 1 — P0 startup crash (DAWN-SNOWFLAKE-1729-1K)**
+Migration 032 crash: `copy_trade_events` was created in migration 009 without a `user_id` column. Migration 032 used `CREATE TABLE IF NOT EXISTS` (no-op since table exists) then tried `CREATE INDEX ON copy_trade_events (user_id)` — fails with "column user_id does not exist". Bot could not start.
+
+Fix: Rewrote migration 032 to use `ALTER TABLE copy_trade_events ADD COLUMN IF NOT EXISTS` for each new column (`user_id`, `position_id`, `target_wallet`, `market_id`, `size_usdc`). Indexes now created on columns that actually exist.
+
+**FIX 2 — P1 high (DAWN-SNOWFLAKE-1729-5 — 5383 events)**
+`job_tracker.record_job_event` passed `metadata` (Python `dict`) as `$6` to asyncpg for a `JSONB` column. asyncpg does not auto-serialize Python dicts; it raises "expected str, got dict".
+
+Fix: `json.dumps(metadata) if metadata is not None else None` before passing to the INSERT.
+
+**FIX 3 — P3 schema (DAWN-SNOWFLAKE-1729-1A + DAWN-SNOWFLAKE-1729-10)**
+Two schema gaps and two query bugs:
+- Migration 034 added: `ALTER TABLE positions ADD COLUMN IF NOT EXISTS market_question TEXT` and `ALTER TABLE positions ADD COLUMN IF NOT EXISTS strategy_type VARCHAR(50)`. Queries that access these columns directly on positions (without JOIN) now return NULL instead of crashing.
+- `share_card.py`: Removed `p.exit_price` from SELECT — column does not exist on positions (never migrated), and the fetched value was never used downstream.
+- `dashboard.py`: Fixed `p.created_at` → `p.opened_at` in `_fetch_last_trade_action` CASE expression. Positions table uses `opened_at`, not `created_at`; the exception was silently caught but caused log noise.
+
+---
+
+## 2. Current system architecture
+
+Migration runner (`database.run_migrations`) reads all `.sql` files in sorted order and executes them on every restart. All migrations must be idempotent. No change to this architecture.
+
+The `job_tracker` module writes one row per scheduler job execution to `job_runs`. `metadata` is a JSONB column (added by migration 030) used by the exit_watch job to store RunResult counts.
+
+---
+
+## 3. Files created / modified
+
+| Action | Path |
+|--------|------|
+| Modified | `projects/polymarket/crusaderbot/migrations/032_copy_trade_events.sql` |
+| Created | `projects/polymarket/crusaderbot/migrations/034_positions_denorm_columns.sql` |
+| Modified | `projects/polymarket/crusaderbot/domain/ops/job_tracker.py` |
+| Modified | `projects/polymarket/crusaderbot/bot/handlers/share_card.py` |
+| Modified | `projects/polymarket/crusaderbot/bot/handlers/dashboard.py` |
+| Created | `projects/polymarket/crusaderbot/reports/forge/crusaderbot-sentry-hotfix-p0.md` |
+| Modified | `projects/polymarket/crusaderbot/state/PROJECT_STATE.md` |
+
+---
+
+## 4. What is working
+
+- `python3 -m compileall projects/polymarket/crusaderbot/ -q` — clean, no output
+- `ruff check projects/polymarket/crusaderbot/` — All checks passed
+- Migration 032 is now idempotent: uses `ALTER TABLE ADD COLUMN IF NOT EXISTS` throughout; will not crash on a database where `copy_trade_events` already exists from migration 009
+- Migration 034 adds missing `market_question` and `strategy_type` to positions safely
+- `job_tracker.py` now serializes dict to JSON string before INSERT
+- `share_card.py` no longer references `p.exit_price` (non-existent column)
+- `dashboard.py` no longer references `p.created_at` (positions uses `opened_at`)
+
+---
+
+## 5. Known issues
+
+- Migration 026 (`ALTER TABLE orders ADD COLUMN IF NOT EXISTS strategy_type VARCHAR(50)`) already exists and handles the orders table. The new migration 034 handles positions.
+- `positions.market_question` and `positions.strategy_type` are nullable columns with no backfill — existing rows will show NULL. JOIN-based queries that alias `m.question AS market_question` continue to work correctly and are unaffected.
+- Bot has not been tested against a live PostgreSQL instance in this cloud environment (no DB connection available). Migration SQL is syntactically correct and idempotent by design.
+
+---
+
+## 6. What is next
+
+- WARP🔹CMD review → merge → Fly.io redeploy
+- Apply migrations 032, 033, 034 to production DB (idempotent — safe on running DB)
+- Verify Sentry issues 1K, 5, 1A, 10 close after deploy
+- Backfill `positions.market_question` from `markets.question` JOIN if dashboard queries require populated values (separate lane, not blocking)

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-18 00:15 | WARP/CRUSADERBOT-SENTRY-HOTFIX-P0 | FIX1: migration 032 rewrite (ALTER TABLE copy_trade_events); FIX2: job_tracker json.dumps(metadata); FIX3: migration 034 positions schema + share_card exit_price + dashboard created_at; STANDARD, NARROW INTEGRATION
 2026-05-17 23:59 | WARP/CRUSADERBOT-FAST-RISK-SAFETY | Track D: validate_risk_caps (10%/80%/-$50/20 caps) + unified kill switch executor (3 paths → execute_kill_switch) + migration 032 system_flags + audit_log; MAJOR, FULL RUNTIME INTEGRATION
 2026-05-17 23:55 | WARP/CRUSADERBOT-FAST-COPY-EXEC | Track B: copy_trade_events table (migration 032) + copy_trade.executed event emission in monitor.py; MAJOR, FULL RUNTIME INTEGRATION
 2026-05-17 22:30 | WARP/CRUSADERBOT-FAST-TRADE-NOTIFS-WIRE | wire-notification-handlers: register_notification_handlers() called in main.py lifespan after bot_app.start(); MINOR, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -2,8 +2,8 @@ Last Updated : 2026-05-17 23:15
 Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs open. Track E (daily P&L report) PR open. notification_service.register_handlers() wired into main.py startup. Production PAPER ONLY.
 Last Updated : 2026-05-17 23:59
 Status       : Track D (FAST-RISK-SAFETY) PR open. Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs open. Production PAPER ONLY.
-Last Updated : 2026-05-17 23:55
-Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs open. Track B copy_trade.executed event + copy_trade_events table delivered (PR pending SENTINEL). Production PAPER ONLY.
+Last Updated : 2026-05-18 00:15
+Status       : SENTRY-HOTFIX-P0 in progress. Migration 032 crash + job_runs dict serialization + positions schema fixes. Production PAPER ONLY.
 
 [COMPLETED]
 - WARP/CRUSADERBOT-MVP-RUNTIME-V1 MERGED PR #1089 (2026-05-17). Autonomous trading bot MVP runtime: Phase 0 audit (P0_RUNTIME_MAP.md) + skip_deposit_cb preset activation fix + auto_trade_on=True on onboarding + allowlist_command migrated to is_admin(). MAJOR, FULL RUNTIME INTEGRATION.
@@ -18,6 +18,7 @@ Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs ope
 - trading-unblock MERGED PR #1065 (2026-05-16). exit_watcher two-phase MARKET_EXPIRED sweep: Phase A None-price retry, Phase B list_open_on_resolved_markets(); close_as_expired() atomic tx; alert_user_market_expired(); RunResult; signal scan next_run_time=now; job_runs metadata JSONB. MAJOR, NARROW INTEGRATION.
 
 [IN PROGRESS]
+- WARP/CRUSADERBOT-SENTRY-HOTFIX-P0: P0 startup crash (migration 032 ALTER TABLE fix) + P1 job_runs dict serialization (json.dumps) + P3 schema (positions market_question/strategy_type + share_card exit_price + dashboard created_at). PR open. WARP🔹CMD review required. Tier: STANDARD.
 - WARP/CRUSADERBOT-FAST-RISK-SAFETY: Track D risk caps + kill switch. PR open. SENTINEL validation required before merge.
 - WARP/CRUSADERBOT-FAST-TRADE-ENGINE: Track A signal-to-order + TP/SL. PR open. SENTINEL validation required before merge.
 - WARP/CRUSADERBOT-MVP-BUGFIX-ROUND1: handler audit fixes PR open, awaiting WARP🔹CMD merge decision.
@@ -43,6 +44,7 @@ Status       : Track A (FAST-TRADE-ENGINE) + Track C (FAST-TRADE-NOTIFS) PRs ope
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
+- WARP🔹CMD review required for CRUSADERBOT-SENTRY-HOTFIX-P0 (3 Sentry blockers: migration 032 crash + job_runs serialization + schema). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-sentry-hotfix-p0.md. Tier: STANDARD.
 - WARP🔹CMD review required for crusaderbot-fast-daily-pnl (Track E daily P&L report service). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-fast-daily-pnl.md. Tier: STANDARD.
 - WARP•SENTINEL validation required for risk-caps-kill-switch (Track D: validate_risk_caps + 3-path kill switch). Source: projects/polymarket/crusaderbot/reports/forge/risk-caps-kill-switch.md. Tier: MAJOR.
 - WARP🔹CMD review required for wire-notification-handlers (register_handlers() wired into main.py). Source: projects/polymarket/crusaderbot/reports/forge/wire-notification-handlers.md. Tier: MINOR.


### PR DESCRIPTION
## Summary

- **FIX 1 — P0 startup crash** (DAWN-SNOWFLAKE-1729-1K): Migration 032 used `CREATE TABLE IF NOT EXISTS copy_trade_events` which is a no-op (table exists since migration 009), then tried `CREATE INDEX ON copy_trade_events (user_id)` — column didn't exist → bot crash on every restart. Rewrote 032 to use `ALTER TABLE ADD COLUMN IF NOT EXISTS` for all new columns before creating indexes.
- **FIX 2 — P1 high / 5383 events** (DAWN-SNOWFLAKE-1729-5): `job_tracker.record_job_event` passed Python `dict` as `$6` to asyncpg JSONB column. asyncpg requires a JSON string. Fixed with `json.dumps(metadata)`.
- **FIX 3 — P3 schema** (DAWN-SNOWFLAKE-1729-1A + 10): Added migration 034 `ALTER TABLE positions ADD COLUMN IF NOT EXISTS market_question TEXT / strategy_type VARCHAR(50)`. Also removed `p.exit_price` from `share_card.py` (column doesn't exist on positions) and fixed `p.created_at` → `p.opened_at` in `dashboard.py`.

## Files changed

| File | Change |
|------|--------|
| `migrations/032_copy_trade_events.sql` | Rewrite: CREATE TABLE → ALTER TABLE ADD COLUMN IF NOT EXISTS |
| `migrations/034_positions_denorm_columns.sql` | New: add market_question + strategy_type to positions |
| `domain/ops/job_tracker.py` | json.dumps(metadata) before asyncpg INSERT |
| `bot/handlers/share_card.py` | Remove p.exit_price from SELECT |
| `bot/handlers/dashboard.py` | p.created_at → p.opened_at |

## Test plan

- [ ] `python3 -m compileall projects/polymarket/crusaderbot/ -q` — clean (no output)
- [ ] `ruff check projects/polymarket/crusaderbot/` — All checks passed
- [ ] Migrate production DB: migrations 032, 033, 034 are idempotent — safe on running DB
- [ ] Verify Sentry issues 1K, 5, 1A, 10 close after Fly.io redeploy
- [ ] Bot starts without crash (migration runner completes all 34 migrations)

## Constraints

- `ENABLE_LIVE_TRADING` guard untouched
- No new features — fix only
- Validation Tier: STANDARD
- Claim Level: NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_0179X9AyjjzrSUe79FXqfJx1)_