### PR TITLE
fix: SSE routing — debug logging, DB fallback, debug_connected event

### DIFF
--- a/projects/polymarket/crusaderbot/jobs/market_signal_scanner.py
+++ b/projects/polymarket/crusaderbot/jobs/market_signal_scanner.py
@@ -456,6 +456,8 @@ async def run_job() -> tuple[int, int]:
     _scanner_state["published"] = total_published
     _scanner_state["last_tick_ts"] = time.time()
 
+    log.info("scanner.tick: emitting to event_bus",
+             markets=total_scanned, signals=total_published)
     try:
         from ..core import event_bus as _event_bus
         await _event_bus.emit(

--- a/projects/polymarket/crusaderbot/webtrader/backend/sse.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/sse.py
@@ -197,6 +197,21 @@ def _push_broadcast(event_type: str, payload: dict) -> None:
 # event_bus bridge handlers
 # ---------------------------------------------------------------------------
 
+async def _resolve_user_id_by_telegram(telegram_user_id: int) -> str | None:
+    """DB fallback: resolve telegram_user_id → user UUID when not in reverse map."""
+    from ...database import get_pool
+    try:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT id FROM users WHERE telegram_user_id = $1", telegram_user_id
+            )
+        return str(row["id"]) if row else None
+    except Exception as exc:
+        log.warning("SSE: DB user resolution failed telegram_user_id=%d: %s", telegram_user_id, exc)
+        return None
+
+
 async def _on_position_opened_sse(
     *,
     telegram_user_id: int,
@@ -210,6 +225,10 @@ async def _on_position_opened_sse(
 ) -> None:
     user_id = _telegram_to_user_id.get(telegram_user_id)
     if not user_id:
+        log.debug("SSE: position.opened — telegram_user_id=%d not in reverse map, trying DB", telegram_user_id)
+        user_id = await _resolve_user_id_by_telegram(telegram_user_id)
+    if not user_id:
+        log.debug("SSE: position.opened dropped — telegram_user_id=%d has no active WebTrader session", telegram_user_id)
         return
     _push_to_user(user_id, "position_opened", {
         "market_id": market_id,
@@ -234,6 +253,10 @@ async def _on_position_closed_sse(
 ) -> None:
     user_id = _telegram_to_user_id.get(telegram_user_id)
     if not user_id:
+        log.debug("SSE: position.closed — telegram_user_id=%d not in reverse map, trying DB", telegram_user_id)
+        user_id = await _resolve_user_id_by_telegram(telegram_user_id)
+    if not user_id:
+        log.debug("SSE: position.closed dropped — telegram_user_id=%d has no active WebTrader session", telegram_user_id)
         return
     _push_to_user(user_id, "position_closed", {
         "market_id": market_id,
@@ -251,6 +274,7 @@ async def _on_scanner_tick_sse(
     signals: int = 0,
     **_: Any,
 ) -> None:
+    log.info("SSE push: scanner.tick → %d users connected", len(_user_queues))
     _push_broadcast("scanner_tick", {"markets": markets, "signals": signals})
 
 
@@ -302,8 +326,16 @@ async def stream_for_user(
         if telegram_user_id is not None:
             _telegram_to_user_id[telegram_user_id] = user_id
 
+    log.info("SSE: user %s connected (telegram_id=%s), active sessions: %d",
+             user_id, telegram_user_id, len(_user_queues))
+
     try:
         yield {"event": "connected", "data": json.dumps({"user_id": user_id})}
+        # Diagnostic: push test event through the queue to verify end-to-end delivery
+        _push_to_user(user_id, "debug_connected", {
+            "user_id": user_id,
+            "sessions": len(_user_queues),
+        })
         while True:
             try:
                 event = await asyncio.wait_for(queue.get(), timeout=25.0)
@@ -319,3 +351,5 @@ async def stream_for_user(
                 _user_queues.pop(user_id, None)
                 if telegram_user_id is not None:
                     _telegram_to_user_id.pop(telegram_user_id, None)
+        log.info("SSE: user %s disconnected, remaining sessions: %d",
+                 user_id, len(_user_queues))

--- a/projects/polymarket/crusaderbot/webtrader/backend/sse.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/sse.py
@@ -223,6 +223,8 @@ async def _on_position_opened_sse(
     strategy_type: str | None = None,
     **_: Any,
 ) -> None:
+    if not _user_queues:
+        return
     user_id = _telegram_to_user_id.get(telegram_user_id)
     if not user_id:
         log.debug("SSE: position.opened — telegram_user_id=%d not in reverse map, trying DB", telegram_user_id)
@@ -251,6 +253,8 @@ async def _on_position_closed_sse(
     close_reason: str = "MANUAL",
     **_: Any,
 ) -> None:
+    if not _user_queues:
+        return
     user_id = _telegram_to_user_id.get(telegram_user_id)
     if not user_id:
         log.debug("SSE: position.closed — telegram_user_id=%d not in reverse map, trying DB", telegram_user_id)


### PR DESCRIPTION
## Summary

- **`_on_scanner_tick_sse`**: logs `len(_user_queues)` on every broadcast so we can confirm users are registered when the scanner fires
- **`_on_position_opened/closed_sse`**: adds DB fallback (`SELECT id FROM users WHERE telegram_user_id = $1`) when `telegram_user_id` is not in the in-memory reverse map — fixes silent drop when WebTrader session hasn't yet populated `_telegram_to_user_id`
- **`stream_for_user`**: logs connect/disconnect with active session count; immediately pushes `debug_connected` event through the queue on connect to verify the queue→browser delivery path end-to-end
- **`market_signal_scanner.run_job`**: logs before `event_bus.emit("scanner.tick", ...)` to confirm the emit is actually firing

## Investigation findings

| Point | Finding |
|---|---|
| `register_event_bus_handlers()` in lifespan | ✓ Called (main.py:93) |
| `scanner.tick` emitted by scanner | ✓ market_signal_scanner.py:461 |
| `scanner.tick` handler broadcasts to all users | ✓ via `_push_broadcast` |
| Position events routed via `_telegram_to_user_id` map | Map populated on connect IF `telegram_id` in JWT — now has DB fallback |

## Test plan

- [ ] Connect browser to WebTrader — confirm `debug_connected` event received in Network tab (proves queue→browser path is alive)
- [ ] Check logs for `SSE: user ... connected` with session count > 0
- [ ] Wait for scanner tick — check logs for `SSE push: scanner.tick → N users connected`
- [ ] If N=0: user queue registration is broken (investigate generator startup timing)
- [ ] If N>0 but no events in browser: EventSourceResponse iteration issue
- [ ] Open/close a position — confirm position event delivered even when telegram_user_id not in reverse map

## Validation Tier: STANDARD

https://claude.ai/code/session_01BrAkPWBXNp5ttfqTwG1Jq1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrAkPWBXNp5ttfqTwG1Jq1)_