### PR TITLE
fix: responsive layout — login centering, right-col clipping, tablet breakpoint

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
@@ -105,11 +105,19 @@ function AppShell() {
       {showChrome && <DesktopSidebar />}
 
       {/* Content: mobile-centered up to 440px; desktop full-width offset from sidebar */}
-      <div className="flex justify-center md:block relative" style={{ zIndex: 1 }}>
+      <div
+        className={[
+          "relative",
+          showChrome ? "flex justify-center md:block" : "flex justify-center",
+        ].join(" ")}
+        style={{ zIndex: 1 }}
+      >
         <div
           className={[
-            "w-full max-w-mobile",
-            showChrome ? "md:max-w-none md:ml-[220px] pb-24 md:pb-0" : "",
+            "w-full",
+            showChrome
+              ? "max-w-mobile md:max-w-none md:ml-[180px] lg:ml-[220px] md:overflow-x-hidden pb-24 md:pb-0"
+              : "max-w-mobile md:max-w-none",
           ].join(" ")}
         >
           <Routes>

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DesktopSidebar.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DesktopSidebar.tsx
@@ -18,7 +18,7 @@ export function DesktopSidebar() {
 
   return (
     <aside
-      className="hidden md:flex fixed top-0 left-0 bottom-0 w-[220px] flex-col z-[150] overflow-y-auto py-5"
+      className="hidden md:flex fixed top-0 left-0 bottom-0 w-[180px] lg:w-[220px] flex-col z-[150] overflow-y-auto py-5"
       style={{
         background: "rgba(2,5,11,0.98)",
         borderRight: "1px solid rgba(245,200,66,0.14)",

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
@@ -138,10 +138,10 @@ export function DashboardPage() {
         )}
 
         {/* Desktop: 2-column grid — Left: Hero + Stats | Right: Scanner + Activity */}
-        <div className="md:grid md:grid-cols-2 md:gap-5 md:items-start">
+        <div className="md:grid md:grid-cols-1 lg:grid-cols-2 md:gap-5 md:items-start min-w-0 overflow-x-hidden">
 
           {/* LEFT COLUMN: Hero card + Stats */}
-          <div>
+          <div className="md:min-w-0 md:overflow-hidden">
             <HeroCard
               label="Equity"
               value={equityWhole}
@@ -219,7 +219,7 @@ export function DashboardPage() {
           </div>
 
           {/* RIGHT COLUMN: Scanner terminal + Recent Activity */}
-          <div>
+          <div className="md:min-w-0 md:overflow-hidden">
             <AdvancedOnly>
               <Terminal lines={buildScannerLines(alerts, data)} />
             </AdvancedOnly>


### PR DESCRIPTION
## Summary

- **Fix 1 — Login centering**: When `!showChrome` (auth route), the outer wrapper no longer switches to `md:block`, so it stays `flex justify-center` on all viewports. `AuthPage`'s own `min-h-screen flex items-center justify-center` then correctly centers the form on desktop without any sidebar offset. Inner div gets `md:max-w-none` so it isn't capped at mobile width on desktop.
- **Fix 2 — Right column clipping**: Main content wrapper gains `md:overflow-x-hidden`. Dashboard grid and both column divs get `min-w-0 overflow-hidden` / `md:min-w-0 md:overflow-hidden` to prevent flex/grid children from overflowing the viewport.
- **Fix 3 — Tablet breakpoints (768–1023px)**: Sidebar shrinks from `w-[220px]` to `w-[180px]` at `md:` and `lg:w-[220px]` at 1024px+. Main content margin tracks this with `md:ml-[180px] lg:ml-[220px]`. Dashboard grid stays single-column (`md:grid-cols-1`) at 768–1023px and switches to 2-col only at `lg:grid-cols-2` (1024px+).

## Files changed

- `webtrader/frontend/src/App.tsx`
- `webtrader/frontend/src/components/DesktopSidebar.tsx`
- `webtrader/frontend/src/pages/DashboardPage.tsx`

## Test plan

- [ ] Login page: full-viewport centered on desktop, no sidebar offset or left-shift
- [ ] Dashboard right column: no horizontal scroll, content fully visible at 1024px+
- [ ] 768–1023px: single-column layout, sidebar 180px, no clipping
- [ ] 1024px+: 2-column grid, sidebar 220px
- [ ] Mobile (<768px): unchanged — bottom nav, no sidebar
- [ ] `npm run build` exits clean ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdQot76QhX2AWE4Hj6jF9z)_