### PR TITLE
guard: ENABLE_LIVE_TRADING check in _on_slippage_retry

### DIFF
--- a/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
+++ b/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
@@ -615,6 +615,14 @@ class OrderLifecycleManager:
         one tick in the aggressive direction, and re-submits. Sets
         slippage_retry_count=1 so the next timeout triggers _on_slippage_cancel.
         """
+        s = get_settings()
+        if not s.ENABLE_LIVE_TRADING:
+            logger.warning(
+                "lifecycle slippage_retry skipped: ENABLE_LIVE_TRADING=false "
+                "order=%s — retry deferred until live gate is active",
+                order["id"],
+            )
+            return
         broker_id = str(order.get("polymarket_order_id") or "")
         if broker_id:
             try:


### PR DESCRIPTION
## Summary

- Adds `ENABLE_LIVE_TRADING` guard at the top of `_on_slippage_retry()` in `domain/execution/lifecycle.py`
- Prevents live CLOB cancel+resubmit when `USE_REAL_CLOB=True` but `ENABLE_LIVE_TRADING=False`
- Logs a warning and returns early; no broker call is made when the live gate is inactive
- No new imports — `get_settings` was already imported at module level

## Validation

- `python3 -m py_compile` passes clean
- Guard inserted after docstring, before first broker call (`client.cancel_order`)
- No other files modified

## Scope

Single targeted fix — MINOR tier. No report update required per task spec.

---

**Validation Tier:** MINOR
**Claim Level:** NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_01T864vtieizoEHdn3AwpegP)_