### PR TITLE
hotfix(P0): export seed_defaults from domain/strategy

### DIFF
--- a/projects/polymarket/crusaderbot/domain/strategy/__init__.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/__init__.py
@@ -10,7 +10,7 @@ Public surface (foundation-only):
 """
 
 from .base import BaseStrategy
-from .registry import StrategyRegistry, bootstrap_default_strategies
+from .registry import StrategyRegistry, bootstrap_default_strategies, seed_defaults
 from .types import (
     ExitDecision,
     MarketFilters,
@@ -22,6 +22,7 @@ __all__ = [
     "BaseStrategy",
     "StrategyRegistry",
     "bootstrap_default_strategies",
+    "seed_defaults",
     "SignalCandidate",
     "ExitDecision",
     "MarketFilters",


### PR DESCRIPTION
## Summary

- Add `seed_defaults` to import in `projects/polymarket/crusaderbot/domain/strategy/__init__.py`
- Add `"seed_defaults"` to `__all__`

## Impact

Fixes P0 bot crash loop caused by missing `seed_defaults` export from the strategy plane public surface.

## Validation

- `python3 -m py_compile domain/strategy/__init__.py` — OK
- `from domain.strategy import seed_defaults` — OK

## Files Modified

- `projects/polymarket/crusaderbot/domain/strategy/__init__.py`

Validation Tier: MINOR
Claim Level: NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFc6wK6TPcM2oYnoZMGMDf)_