### PR TITLE
hotfix: clamp leaderboard numeric fields to schema bounds

### DIFF
--- a/projects/polymarket/crusaderbot/services/copy_trade/leaderboard_sync.py
+++ b/projects/polymarket/crusaderbot/services/copy_trade/leaderboard_sync.py
@@ -117,6 +117,20 @@ async def sync_leaderboard(pool: Any) -> None:
         if roi_pct is not None and roi_pct > 1.0:
             roi_pct = roi_pct / 100.0
         volume_usdc = _safe_float(r.get("total_volume_15d"))
+
+        _pre_roi, _pre_pnl, _pre_vol = roi_pct, total_pnl, volume_usdc
+        if roi_pct is not None:
+            roi_pct = max(-9999.9999, min(9999.9999, roi_pct))
+        if total_pnl is not None:
+            total_pnl = max(-999999999999.0, min(999999999999.0, total_pnl))
+        if volume_usdc is not None:
+            volume_usdc = max(0.0, min(999999999999.0, volume_usdc))
+        if roi_pct != _pre_roi or total_pnl != _pre_pnl or volume_usdc != _pre_vol:
+            log.warning(
+                "leaderboard sync: clamped extreme value wallet=%s roi_pct=%s total_pnl=%s volume_usdc=%s",
+                wallet, roi_pct, total_pnl, volume_usdc,
+            )
+
         tier = r.get("tier")
         badge = _badge_from_tier(tier, win_rate, total_pnl)
         rows.append((wallet, None, win_rate, total_pnl, volume_usdc, roi_pct, badge))


### PR DESCRIPTION
## Summary

- Adds upper/lower bound clamps for `roi_pct`, `total_pnl`, and `volume_usdc` in the leaderboard upsert loop to prevent `NumericValueOutOfRangeError` when Falcon API returns extreme values
- Clamp bounds match the DB schema from migration 038: `NUMERIC(8,4)`, `NUMERIC(18,6)`, `NUMERIC(18,6)`
- Emits a `log.warning` (only when at least one field was actually clamped) for observability
- Existing `win_rate` clamp (0.0–1.0) is untouched

## Clamp bounds applied

| Field | Schema | Min | Max |
|---|---|---|---|
| `roi_pct` | `NUMERIC(8,4)` | -9999.9999 | 9999.9999 |
| `total_pnl` | `NUMERIC(18,6)` | -999999999999.0 | 999999999999.0 |
| `volume_usdc` | `NUMERIC(18,6)` | 0.0 | 999999999999.0 |

## Test plan

- [ ] Falcon API returns `roi_pct_15d=1500000` → after `/100` = 15000 → clamped to 9999.9999, warning logged
- [ ] Falcon API returns `total_pnl_15d=1e15` → clamped to 999999999999.0, warning logged
- [ ] Falcon API returns normal values → no clamp, no warning
- [ ] `volume_usdc` negative input → clamped to 0.0
- [ ] Upsert completes without `NumericValueOutOfRangeError`

https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF)_