### PR TITLE
hotfix: leaderboard numeric clamp + set_risk BadRequest guard

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/setup.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/setup.py
@@ -6,6 +6,7 @@ import logging
 
 from telegram import Update
 from telegram.constants import ParseMode
+from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from ...database import get_pool
@@ -255,7 +256,10 @@ async def set_risk(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         )
         return
     await update_settings(user["id"], risk_profile=choice)
-    await q.message.edit_reply_markup(reply_markup=risk_picker(choice))
+    try:
+        await q.message.edit_reply_markup(reply_markup=risk_picker(choice))
+    except BadRequest:
+        pass  # already showing selected choice
 
 
 async def set_category(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:

--- a/projects/polymarket/crusaderbot/services/copy_trade/leaderboard_sync.py
+++ b/projects/polymarket/crusaderbot/services/copy_trade/leaderboard_sync.py
@@ -118,16 +118,27 @@ async def sync_leaderboard(pool: Any) -> None:
             roi_pct = roi_pct / 100.0
         volume_usdc = _safe_float(r.get("total_volume_15d"))
 
-        _pre_roi, _pre_pnl, _pre_vol = roi_pct, total_pnl, volume_usdc
+        # --- schema clamps ---
+        _clamped = False
         if roi_pct is not None:
-            roi_pct = max(-9999.9999, min(9999.9999, roi_pct))
+            capped = max(-9999.9999, min(9999.9999, roi_pct))
+            if capped != roi_pct:
+                _clamped = True
+            roi_pct = capped
         if total_pnl is not None:
-            total_pnl = max(-999999999999.0, min(999999999999.0, total_pnl))
+            capped = max(-999999999999.0, min(999999999999.0, total_pnl))
+            if capped != total_pnl:
+                _clamped = True
+            total_pnl = capped
         if volume_usdc is not None:
-            volume_usdc = max(0.0, min(999999999999.0, volume_usdc))
-        if roi_pct != _pre_roi or total_pnl != _pre_pnl or volume_usdc != _pre_vol:
+            capped = max(0.0, min(999999999999.0, volume_usdc))
+            if capped != volume_usdc:
+                _clamped = True
+            volume_usdc = capped
+        if _clamped:
             log.warning(
-                "leaderboard sync: clamped extreme value wallet=%s roi_pct=%s total_pnl=%s volume_usdc=%s",
+                "leaderboard sync: clamped extreme value wallet=%s roi_pct=%s "
+                "total_pnl=%s volume_usdc=%s",
                 wallet, roi_pct, total_pnl, volume_usdc,
             )
 


### PR DESCRIPTION
## Summary

Two single-file runtime hotfixes.

**Fix 1 — `leaderboard_sync.py`**
- Replaces the interim `_pre_*` comparison pattern (from #1135) with the canonical `_clamped` flag + `capped` variable style
- Clamp bounds unchanged: `roi_pct` → `NUMERIC(8,4)` ±9999.9999, `total_pnl`/`volume_usdc` → `NUMERIC(18,6)` ±999999999999.0 (volume non-negative)
- `log.warning` fires only when at least one field was actually clamped

**Fix 2 — `bot/handlers/setup.py`**
- Adds `from telegram.error import BadRequest` import
- Wraps `edit_reply_markup` in `set_risk` with `try/except BadRequest: pass` to suppress "Message is not modified" when user taps the same risk option twice

## Test plan

- [ ] Falcon API returns `roi_pct_15d=1500000` → after `/100` = 15000 → clamped to 9999.9999, warning logged
- [ ] Falcon API returns normal values → no clamp, no warning
- [ ] User taps same risk profile twice → no `BadRequest` traceback, picker remains visible
- [ ] User taps a different risk profile → markup updates normally

## Files changed

- `projects/polymarket/crusaderbot/services/copy_trade/leaderboard_sync.py`
- `projects/polymarket/crusaderbot/bot/handlers/setup.py`

https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF)_