### PR TITLE
fix: global visibility — surface-1 token + ink-4 contrast + input borders

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -350,7 +350,7 @@ export function AutoTradePage() {
                 <div>
                   <div className="font-hud text-sm font-bold text-ink-2 flex items-center gap-2">
                     {cs.name}
-                    <span className="text-[9px] font-bold tracking-widest text-ink-3 uppercase px-1.5 py-0.5 rounded border border-ink-4/40 bg-surface-2">
+                    <span className="text-[9px] font-bold tracking-widest text-ink-3 uppercase px-1.5 py-0.5 rounded border border-surface-3/40 bg-surface-2">
                       COMING SOON
                     </span>
                   </div>
@@ -420,7 +420,7 @@ export function AutoTradePage() {
                             max={99}
                             value={val}
                             onChange={e => set(e.target.value)}
-                            className="w-full bg-surface-3 border border-ink-4 rounded px-1.5 py-1 text-xs font-mono text-ink-1 placeholder:text-ink-3 focus:border-gold focus:outline-none"
+                            className="w-full bg-surface-3 border border-surface-3 rounded px-1.5 py-1 text-xs font-mono text-ink-1 placeholder:text-ink-3 focus:border-gold focus:outline-none"
                             style={{ color: "white" }}
                           />
                         </div>
@@ -486,7 +486,7 @@ export function AutoTradePage() {
               <select
                 value={filterLiquidity}
                 onChange={e => setFilterLiquidity(e.target.value)}
-                className="w-full bg-surface-3 border border-ink-4 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
+                className="w-full bg-surface-3 border border-surface-3 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
               >
                 <option value="1000">$1k</option>
                 <option value="5000">$5k</option>
@@ -499,7 +499,7 @@ export function AutoTradePage() {
               <select
                 value={filterResolution}
                 onChange={e => setFilterResolution(e.target.value)}
-                className="w-full bg-surface-3 border border-ink-4 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
+                className="w-full bg-surface-3 border border-surface-3 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
               >
                 <option value="0">Any</option>
                 <option value="1">1 day</option>
@@ -513,7 +513,7 @@ export function AutoTradePage() {
               <select
                 value={filterVolume}
                 onChange={e => setFilterVolume(e.target.value)}
-                className="w-full bg-surface-3 border border-ink-4 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
+                className="w-full bg-surface-3 border border-surface-3 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
               >
                 <option value="100">$100</option>
                 <option value="500">$500</option>
@@ -536,7 +536,7 @@ export function AutoTradePage() {
                 step={0.5}
                 value={filterSlippage}
                 onChange={e => setFilterSlippage(e.target.value)}
-                className="w-20 bg-surface-3 border border-ink-4 rounded px-2 py-1.5 text-xs font-mono text-ink-1 placeholder:text-ink-3 focus:border-gold focus:outline-none"
+                className="w-20 bg-surface-3 border border-surface-3 rounded px-2 py-1.5 text-xs font-mono text-ink-1 placeholder:text-ink-3 focus:border-gold focus:outline-none"
                 style={{ color: "white" }}
                 placeholder="3"
               />

--- a/projects/polymarket/crusaderbot/webtrader/frontend/tailwind.config.ts
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/tailwind.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
         "bg-1":      "#060A14",
         "bg-2":      "#0A0F1C",
         "surface":   "#0D1322",
+        "surface-1": "#101828",
         "surface-2": "#121A2D",
         "surface-3": "#1A2540",
 
@@ -20,7 +21,7 @@ const config: Config = {
         "ink-1": "#F0F5FF",
         "ink-2": "#8FA3C4",
         "ink-3": "#455370",
-        "ink-4": "#2A3550",
+        "ink-4": "#3D5278",
 
         "gold":   "#F5C842",
         "gold-2": "#FFE066",


### PR DESCRIPTION
## Summary

Two config changes + one global class replace fixing all visibility regressions across 6 pages.

**Fix 1 — `tailwind.config.ts`: add missing `surface-1` token**
- `surface-1: #101828` inserted between `surface` (#0D1322) and `surface-2` (#121A2D)
- Fixes transparent backgrounds on all `bg-surface-1` elements across AutoTradePage, CopyTradePage, PortfolioPage, DiscoverPage, SettingsPage, AuthPage

**Fix 2 — `tailwind.config.ts`: increase `ink-4` contrast**
- `ink-4`: `#2A3550` → `#3D5278`
- Makes label text readable on dark surfaces (#0D1322–#1A2540) while staying subtle

**Fix 3 — `AutoTradePage.tsx`: input border visibility**
- Global `border-ink-4` → `border-surface-3` in this file (5 occurrences)
- Applies to: Custom Risk inputs (cap/tp/sl), Min Liquidity, Max Time to Resolution, Min Volume 24h, Slippage

## Impact

No JSX changes needed for fixes 1 & 2 — the config token additions propagate to all 6 affected pages automatically.

## Files changed

- `projects/polymarket/crusaderbot/webtrader/frontend/tailwind.config.ts`
- `projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx`

## Test plan

- [ ] `bg-surface-1` elements render with a visible dark background (#101828), not transparent
- [ ] `ink-4` label text is legible against `surface` / `surface-2` backgrounds
- [ ] Input borders in AutoTradePage are visible at rest (surface-3) and highlight gold on focus
- [ ] No unintended regressions in other pages using the updated tokens

https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpY7row1vHRVSnzbri4foF)_