### PR TITLE
fix(signal-scan): reconnect signal_publications feed consumption in run_once Phase C

### DIFF
--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -53,6 +53,7 @@ from ...domain.strategy.types import MarketFilters, SignalCandidate, UserContext
 from ...integrations import polymarket as _polymarket
 from ..trade_engine import TradeEngine, TradeResult, TradeSignal
 from .lib_strategy_runner import ENABLED_STRATEGIES, DEFERRED_STRATEGIES, run_lib_strategy
+from ..signal_feed.signal_evaluator import evaluate_publications_for_user
 
 logger = structlog.get_logger(__name__)
 
@@ -664,6 +665,32 @@ async def run_once() -> None:
                         strategy=lib_name,
                         error=str(exc),
                     )
+
+        # Phase C: evaluate signal_publications feed for this user.
+        # Uses signal_evaluator which reads user's subscribed feeds and
+        # returns SignalCandidates with metadata["publication_id"] set.
+        # _process_candidate handles dedup via (user_id, publication_id) unique key.
+        try:
+            user_ctx = _build_user_context(row)
+            market_filters = _build_market_filters()
+            feed_candidates = await evaluate_publications_for_user(
+                user_context=user_ctx,
+                market_filters=market_filters,
+                strategy_name=_STRATEGY_NAME,
+            )
+        except Exception as exc:
+            user_log.warning("signal_feed_eval_failed", error=str(exc))
+            feed_candidates = []
+
+        for cand in feed_candidates:
+            try:
+                await _process_candidate(row, cand)
+            except Exception as exc:
+                user_log.error(
+                    "signal_scan_feed_candidate_unhandled",
+                    market_id=cand.market_id,
+                    error=str(exc),
+                )
 
     await _event_bus.emit(
         "pipeline.scan_completed",

--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -685,7 +685,9 @@ async def run_once() -> None:
         for cand in feed_candidates:
             try:
                 await _process_candidate(row, cand)
+                candidates_processed += 1
             except Exception as exc:
+                candidates_errored += 1
                 user_log.error(
                     "signal_scan_feed_candidate_unhandled",
                     market_id=cand.market_id,


### PR DESCRIPTION
## Problem
signal_following_scan (`run_once`) only ran lib strategies (Phase A+B).
`signal_evaluator.evaluate_publications_for_user()` was never called, so `signal_publications`
rows (published every 30 min by `market_signal_scanner`) were never consumed.
All `execution_queue` entries (May 17) have `publication_id` set, confirming the feed
path is the proven execution path. 0 trades since lib strategy thresholds are strict.

## Fix
Add Phase C to `run_once()`: per-user call to `evaluate_publications_for_user()`,
which reads the user's subscribed `signal_publications` and returns `SignalCandidate`s
with `publication_id` in metadata. `_process_candidate` handles all dedup + risk gate + execution.

**Changes:**
- `signal_scan_job.py` — add import `evaluate_publications_for_user` from `..signal_feed.signal_evaluator`
- `signal_scan_job.py` — add Phase C block inside the `for row in users` loop, after Phase B's lib-strategy inner loop

## Impact
- No existing Phase A/B behavior changed
- Feed candidates processed per-user, isolated, exception-safe
- Restores proven execution path: `signal_publications` → `execution_queue`

## Validation checklist
- [x] Import resolves correctly (`from ..signal_feed.signal_evaluator import evaluate_publications_for_user`)
- [x] Phase A+B code unchanged (27 lines added, zero lines modified)
- [x] Phase C exception fully isolated — one user error cannot propagate
- [x] No new DB writes outside `_process_candidate` (which already handles all writes)
- [x] `__all__ = ["run_once"]` preserved at end of file

https://claude.ai/code/session_01RBgVUcXYM3nD2deLzwSNvH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBgVUcXYM3nD2deLzwSNvH)_