### PR TITLE
fix(ui): all sections default open + clear SHOW/HIDE toggle + pagination scope

### DIFF
--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-19 | WARP/CRUSADERBOT-UI-COLLAPSIBLE-FIX | all CollapsibleSection defaultOpen=true; SHOW/HIDE labeled toggle button; pagination scoped to ledger + market list only; STANDARD, NARROW INTEGRATION
 2026-05-19 | WARP/CRUSADERBOT-UI-FEED-CASHOUT | Dashboard Recent Activity replaced with Live Market Feed (signal_publications, 30s refresh); Cash Out button green=profit / red=loss; STANDARD, NARROW INTEGRATION
 2026-05-19 | WARP/CRUSADERBOT-SPA-AUTH-FIX | SPAStaticFiles 404→index.html fallback; navigate("/") post-login redirect; upsert_user replaces 403 gate — webtrader login works without prior /start; STANDARD, NARROW
 2026-05-19 | WARP/CRUSADERBOT-MARKET-SYNC-FIX | market_sync 1800s→300s; paper fill now uses get_live_market_price() matching exit_watcher source — eliminates entry/exit price gap that caused instant TP; live_price_override is-not-None guard (handles price=0.0); STANDARD, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/CollapsibleSection.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/CollapsibleSection.tsx
@@ -42,7 +42,7 @@ export function CollapsibleSection({
         <button
           type="button"
           onClick={toggle}
-          className="flex items-center gap-2 cursor-pointer"
+          className="flex items-center gap-2 cursor-pointer group"
           aria-expanded={open}
         >
           <span className="w-3 h-px bg-gold flex-shrink-0" aria-hidden />
@@ -50,11 +50,15 @@ export function CollapsibleSection({
             {label}
           </span>
           <span
-            className="text-ink-3 text-[10px] transition-transform duration-150 flex-shrink-0"
-            style={{ display: "inline-block", transform: open ? "rotate(0deg)" : "rotate(-90deg)" }}
-            aria-hidden
+            className={[
+              "font-hud text-[8px] font-bold tracking-[1.5px] uppercase px-1.5 py-0.5",
+              "rounded border transition-colors ml-1",
+              open
+                ? "text-ink-3 border-border-2 bg-surface-2 group-hover:border-ink-3"
+                : "text-gold border-gold/40 bg-gold/10 group-hover:bg-gold/20",
+            ].join(" ")}
           >
-            ▾
+            {open ? "HIDE" : "SHOW"}
           </span>
         </button>
         {action && <div>{action}</div>}

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -468,7 +468,7 @@ export function AutoTradePage() {
         </div>
 
         {/* ── SECTION C: Market Filter ── */}
-        <CollapsibleSection id="autotrade_market_filter" label="Market Filter" defaultOpen={false}>
+        <CollapsibleSection id="autotrade_market_filter" label="Market Filter" defaultOpen={true}>
         <p className="text-ink-3 text-xs font-mono mb-3 mx-0.5">
           Choose which market categories and liquidity thresholds the bot scans.
         </p>


### PR DESCRIPTION
## Summary

- **CollapsibleSection**: chevron (▾) replaced with labeled SHOW/HIDE pill button — gold styling when closed, muted when open, `group-hover` transitions
- **AutoTradePage market filter**: `defaultOpen={false}` → `defaultOpen={true}` — filter section open on load
- **CHANGELOG**: 1 line prepended, 0 deleted

## git diff main --stat

```
 .../frontend/src/components/CollapsibleSection.tsx |  14 +++++++++-----
 .../webtrader/frontend/src/pages/AutoTradePage.tsx |   2 +-
 projects/polymarket/crusaderbot/state/CHANGELOG.md |   1 +
 3 files changed, 12 insertions(+), 5 deletions(-)
```

## Validation Checklist

- [x] `git diff main --stat` = 3 files only
- [x] AutoTradePage market filter `defaultOpen={true}`
- [x] All other CollapsibleSection instances already default open (no explicit `defaultOpen={false}` elsewhere)
- [x] CollapsibleSection toggle shows `HIDE` (muted) when open, `SHOW` (gold) when closed
- [x] WalletPage ledger pagination untouched
- [x] DiscoverPage market limit untouched
- [x] No Load More in PortfolioPage / CopyTradePage / DashboardPage — confirmed clean
- [x] CHANGELOG: 1 line prepended, 0 deleted

Validation Tier: STANDARD, NARROW INTEGRATION — WARP🔹CMD review required.

https://claude.ai/code/session_01H3i9D2wZvkrHvY19JMVfiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3i9D2wZvkrHvY19JMVfiu)_