### PR TITLE
fix: kill_switch_exec system_flags → system_settings (WARP-17)

### DIFF
--- a/projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py
+++ b/projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py
@@ -23,7 +23,7 @@ async def _set_system_flag(key: str, value: str) -> None:
     pool = get_pool()
     async with pool.acquire() as conn:
         await conn.execute(
-            "INSERT INTO system_flags (key, value, updated_at) VALUES ($1, $2, NOW()) "
+            "INSERT INTO system_settings (key, value, updated_at) VALUES ($1, $2, NOW()) "
             "ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value, updated_at=NOW()",
             key, value,
         )
@@ -80,7 +80,7 @@ async def execute_kill_switch(reason: str, triggered_by: str) -> None:
     except Exception as exc:
         logger.error("kill_switch_exec: pending order cancel failed: %s", exc)
 
-    # 3. Set system_flags record (Track D flag table)
+    # 3. Set system_settings record (kill_switch_active key)
     try:
         await _set_system_flag("kill_switch_active", "true")
     except Exception as exc:

--- a/projects/polymarket/crusaderbot/reports/forge/fix-warpforge-kill-switch.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-warpforge-kill-switch.md
@@ -1,0 +1,66 @@
+# WARP•FORGE — fix-warpforge-kill-switch
+
+## 1. What was built
+
+Fixed `_set_system_flag()` in `domain/risk/kill_switch_exec.py` to reference the correct
+database table `system_settings` instead of the non-existent `system_flags` table.
+The `INSERT ... ON CONFLICT (key)` query is now aligned with the canonical table used
+throughout `domain/ops/kill_switch.py`. Inline comment updated for accuracy.
+
+## 2. Current system architecture (relevant slice)
+
+Kill switch activation converges on three paths, all calling `execute_kill_switch()`:
+
+```
+Path 1  Telegram /kill command   → bot/handlers/admin.py        → execute_kill_switch()
+Path 2  DB flag checked per tick → jobs/market_signal_scanner.py → execute_kill_switch()
+Path 3  Env KILL_SWITCH=true     → main.py startup              → execute_kill_switch()
+```
+
+Inside `execute_kill_switch()` (kill_switch_exec.py):
+1. `ops_kill_switch.set_active(action="pause")` — writes kill_switch_active to `system_settings` (canonical, via ops module)
+2. Cancel pending orders — `orders` table
+3. **[FIXED]** `_set_system_flag("kill_switch_active", "true")` — now targets `system_settings`
+4. Audit row — `audit_log` table
+5. Telegram admin notify — best-effort, non-blocking
+
+`domain/ops/kill_switch.py` is the canonical writer for `system_settings`. Step 3 now
+correctly mirrors that table rather than targeting a non-existent `system_flags` table.
+
+## 3. Files created / modified
+
+Modified:
+- `projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py`
+  - line 27: `system_flags` → `system_settings` in INSERT query
+  - line 83: comment updated — "system_flags record (Track D flag table)" → "system_settings record (kill_switch_active key)"
+
+## 4. What is working
+
+- `_set_system_flag()` now targets `system_settings` — the table that actually exists and
+  holds kill switch state
+- `ON CONFLICT (key)` clause is valid — `system_settings.key` has a UNIQUE constraint,
+  confirmed by identical upsert pattern in `domain/ops/kill_switch.py:159`
+- Value type consistency: both ops module and `_set_system_flag()` write string "true"/"false"
+  to the `value TEXT` column — no type mismatch
+- No silent failure: `_set_system_flag()` propagates exceptions; callers in
+  `execute_kill_switch()` and `reset_kill_switch()` catch and log via `logger.error()` —
+  non-silent by design
+- `py_compile` passes on modified file
+
+## 5. Known issues
+
+- Branch `claude/fix-warpforge-kill-switch-4A9Gy` does not conform to `WARP/{feature}`
+  naming rule (GATE 1 P0 in automated review). Branch was harness-assigned for this session.
+  WARP🔹CMD should rename or re-target to a compliant branch before merge.
+
+## 6. What is next
+
+```
+Validation Tier   : MAJOR
+Claim Level       : FULL RUNTIME INTEGRATION
+Validation Target : _set_system_flag() + execute_kill_switch() + reset_kill_switch()
+                    write to system_settings; kill switch activation path end-to-end
+Not in Scope      : kill_switch_history table, audit_log writes, Telegram notify path,
+                    order cancellation path, ops/kill_switch.py (unchanged)
+Suggested Next    : WARP•SENTINEL validation required before merge (MAJOR tier)
+```

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -27,3 +27,4 @@
 2026-05-17 18:30 | WARP/CRUSADERBOT-PRICE-FETCH-FIX | get_live_market_price 422 fix: Gamma ?conditionId= query param + CLOB /price primary source + Gamma outcomePrices fallback; STANDARD, NARROW INTEGRATION
 2026-05-17 18:00 | WARP/CRUSADERBOT-SSE-AUTH-FIX | SSE auth query-param confirmed wired; useSSE returns { connected }; SSEStatusContext + TopBar green/red dot; MINOR, NARROW INTEGRATION
 2026-05-17 17:30 | WARP/CRUSADERBOT-WEBTRADER-WS | SSE real-time push: polling removed from DashboardPage + PortfolioPage; event_bus bridge wired to SSE broadcaster (position.opened/closed/scanner.tick); four new SSE event types; scanner.tick emit added to market_signal_scanner; STANDARD, NARROW INTEGRATION
+2026-05-19 09:01 | claude/fix-warpforge-kill-switch-4A9Gy | WARP-17: fix kill_switch_exec.py _set_system_flag() system_flags → system_settings; MAJOR, FULL RUNTIME INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,7 +1,8 @@
-Last Updated : 2026-05-19 09:00
+Last Updated : 2026-05-19 09:01
 Status       : Multiple PRs open. WARP/CRUSADERBOT-SIGNAL-FRESHNESS-GATE-CLEAN awaiting WARP🔹CMD review. WARP/webtrader-wallet-qr-activity-pagination (wallet QR, deposit/withdraw, collapsibles, pagination) open. WARP/CRUSADERBOT-SENTRY-HOTFIX-BUNDLE and other lanes queued.
 
 [COMPLETED]
+- WARP-17 claude/fix-warpforge-kill-switch-4A9Gy: fixed kill_switch_exec.py _set_system_flag() to target system_settings (was system_flags); MAJOR, FULL RUNTIME INTEGRATION. SENTINEL required before merge.
 - WARP/crusaderbot-realtime-pipeline-runtime MERGED PR #1141 (2026-05-18 23:55): pipeline MONITORING events (scan_started/strategy_scan_done/scan_completed/risk_gate_evaluated), /status endpoint, 14/14 hermetic pipeline ordering tests, WebTrader TopBar dynamic trading_mode pill, Paper Mode banners, analytics trust guard, config IA reorder, mobile nav readability, leaderboard data source note; Promise.allSettled AutoTrade load decoupled from dashboard failures. SENTINEL APPROVED 89/100. MAJOR, FULL RUNTIME INTEGRATION.
 - CRU-12 WARP/CRUSADERBOT-UX-PHASE1 PR open (2026-05-17): 5-item UX bundle — TxHash truncate+copy, CopyTrade input visibility, portfolio chart hover+grid+periods, win rate expired fix (exit_reason IS DISTINCT FROM market_expired), AlertCenter slide-in panel. Vite build clean. STANDARD, NARROW INTEGRATION.
 - WARP/CRUSADERBOT-UI-RESPONSIVE-POLISH MERGED PR #1115 (2026-05-18 02:30): 6-page responsive layout (md: breakpoint), market filter UI (9 categories + 3 dropdowns), auto redeem setting (toggle + mode), copy trade UX (empty state + helper text + stats); migration 036 (min_liquidity, max_resolution_days, min_volume_24h, auto_redeem) applied to Supabase. STANDARD, NARROW INTEGRATION.
@@ -67,6 +68,7 @@ Status       : Multiple PRs open. WARP/CRUSADERBOT-SIGNAL-FRESHNESS-GATE-CLEAN a
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
+- WARP•SENTINEL validation required for fix-warpforge-kill-switch (WARP-17: _set_system_flag system_settings fix). Source: projects/polymarket/crusaderbot/reports/forge/fix-warpforge-kill-switch.md. Tier: MAJOR.
 - WARP🔹CMD review required for WARP/webtrader-wallet-qr-activity-pagination (Deposit/Withdraw flows, QR code, collapsible sections, ledger pagination). Source: projects/polymarket/crusaderbot/reports/forge/webtrader-wallet-qr-activity-pagination.md. Tier: STANDARD. No migration required.
 - WARP🔹CMD review required for signal-freshness-gate (step 1c: reject stale signal_publications older than 30 min). Tier: STANDARD.
 - WARP🔹CMD: apply migration 041 to Supabase production, then review+merge WARP/CRUSADERBOT-SENTRY-HOTFIX-BUNDLE. Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-sentry-hotfix-bundle.md. Tier: STANDARD.


### PR DESCRIPTION
## Summary

- Fixed `_set_system_flag()` in `domain/risk/kill_switch_exec.py` to target `system_settings` table instead of non-existent `system_flags`
- `ON CONFLICT (key)` clause unchanged and valid — `system_settings.key` is UNIQUE (same pattern used by `domain/ops/kill_switch.py`)
- Updated inline comment for accuracy

## What changed

`projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py`
- line 27: `system_flags` → `system_settings` in INSERT query
- line 83: comment updated to reference correct table

## Validation

Validation Tier: MAJOR
Claim Level: FULL RUNTIME INTEGRATION
Validation Target: `_set_system_flag()` + `execute_kill_switch()` + `reset_kill_switch()` write to `system_settings`; kill switch activation path end-to-end
Not in Scope: `kill_switch_history` table, `audit_log` writes, Telegram notify path, order cancellation path

## Note on branch name

Branch `claude/fix-warpforge-kill-switch-4A9Gy` was harness-assigned for this session and does not follow the `WARP/{feature}` naming convention. WARP🔹CMD should rename or re-target to a compliant branch before merge. Per AGENTS.md GATE 1 this will trigger a P0 flag in automated review.

## Forge report

`projects/polymarket/crusaderbot/reports/forge/fix-warpforge-kill-switch.md`

## Next gate

WARP•SENTINEL validation required before merge (MAJOR tier).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGJX7Tgxf8KFLTaAC2jpK1)_