### PR TITLE
WARP-25: Telegram functional routing fix — Positions/Trades separation + preset labels

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/positions.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/positions.py
@@ -245,14 +245,32 @@ async def portfolio_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> 
 
 
 async def show_positions(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    """Render the live position monitor (Tier 2+)."""
+    """Render the live position monitor — handles both Message and CallbackQuery."""
+    is_cb = update.callback_query is not None
+    if is_cb:
+        await update.callback_query.answer()
+
     user, ok = await _ensure_tier(update)
-    if not ok or update.message is None:
+    if not ok:
+        return
+    if not is_cb and update.message is None:
         return
 
     positions = await _load_open_positions(user["id"])
+
     if not positions:
-        await update.message.reply_text("No open positions.")
+        text = "No open positions."
+        kb = positions_list_kb([])
+        if is_cb:
+            try:
+                await update.callback_query.edit_message_text(
+                    text, reply_markup=kb,
+                )
+            except BadRequest as exc:
+                if "Message is not modified" not in str(exc):
+                    await update.callback_query.message.reply_text(text, reply_markup=kb)
+        else:
+            await update.message.reply_text(text, reply_markup=kb)
         return
 
     # Fetch mark prices in parallel — total wall-clock capped at the per-call
@@ -288,11 +306,23 @@ async def show_positions(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None
             f"  P&amp;L {pnl_str} · {tp_sl}"
         )
 
-    await update.message.reply_text(
-        "\n\n".join(lines),
-        parse_mode=ParseMode.HTML,
-        reply_markup=positions_list_kb([p["id"] for p in positions]),
-    )
+    text = "\n\n".join(lines)
+    kb = positions_list_kb([p["id"] for p in positions])
+
+    if is_cb:
+        try:
+            await update.callback_query.edit_message_text(
+                text, parse_mode=ParseMode.HTML, reply_markup=kb,
+            )
+        except BadRequest as exc:
+            if "Message is not modified" not in str(exc):
+                await update.callback_query.message.reply_text(
+                    text, parse_mode=ParseMode.HTML, reply_markup=kb,
+                )
+    else:
+        await update.message.reply_text(
+            text, parse_mode=ParseMode.HTML, reply_markup=kb,
+        )
 
 
 async def my_trades(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:

--- a/projects/polymarket/crusaderbot/bot/handlers/trades.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/trades.py
@@ -80,21 +80,12 @@ async def show_trades(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     # Build the main trades text
     text = trades_text(open_pos, recent_closed)
 
-    # Build keyboard: per-position [🛑 Close] rows + nav row
+    # Trades screen: history view only — no Close buttons (those live in Positions)
     from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-    rows = []
-    for pos in open_pos:
-        pos_id = str(pos.get("id", ""))
-        q_text = (pos.get("market_question") or "Position")[:40]
-        rows.append([InlineKeyboardButton(
-            f"🛑 Close: {q_text}",
-            callback_data=f"close_position:{pos_id}",
-        )])
-    rows.append([
+    kb = InlineKeyboardMarkup([[
         InlineKeyboardButton("📋 Full History", callback_data="p5:trades:history"),
-        InlineKeyboardButton("📊 Dashboard",    callback_data="menu:dashboard"),
-    ])
-    kb = InlineKeyboardMarkup(rows)
+        InlineKeyboardButton("⬅ Portfolio",     callback_data="portfolio:portfolio"),
+    ]])
 
     q = update.callback_query
     if q is not None and q.message is not None:

--- a/projects/polymarket/crusaderbot/bot/keyboards/positions.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/positions.py
@@ -15,9 +15,12 @@ from ._common import confirm_cancel_row, home_back_row
 
 
 def positions_list_kb(position_ids: Iterable[UUID | str]) -> InlineKeyboardMarkup:
-    """Navigation-only keyboard for portfolio surfaces (no manual close CTA)."""
-    _ = list(position_ids)  # keep signature stable for existing call sites
+    """Per-position [🛑 Close] rows + back/home nav row."""
     rows: list[list[InlineKeyboardButton]] = []
+    for pid in position_ids:
+        rows.append([InlineKeyboardButton(
+            "🛑 Close", callback_data=f"close_position:{pid}",
+        )])
     rows.append(home_back_row("portfolio:portfolio"))
     return InlineKeyboardMarkup(rows)
 

--- a/projects/polymarket/crusaderbot/bot/keyboards/presets.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/presets.py
@@ -11,11 +11,14 @@ from ._common import home_back_row
 def preset_picker() -> InlineKeyboardMarkup:
     """Render presets in a 2-column grid; recommended preset gets a ⭐ tag.
 
-    Button label: Emoji + Name + Risk badge (not capital %).
+    Label uses first word of name + badge emoji only to avoid truncation on
+    mobile 375px grids.
     """
     buttons = []
     for p in list_presets():
-        label = f"{p.emoji} {p.name} · {p.badge.value}"
+        short_name = p.name.split()[0]
+        badge_emoji = p.badge.value.split()[0]
+        label = f"{p.emoji} {short_name} · {badge_emoji}"
         if p.key == RECOMMENDED_PRESET:
             label = f"{label} ⭐"
         buttons.append(InlineKeyboardButton(

--- a/projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md
+++ b/projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md
@@ -1,0 +1,80 @@
+# WARP•FORGE Report — telegram-functional-routing-fix
+
+**Validation Tier:** STANDARD
+**Claim Level:** FULL RUNTIME INTEGRATION
+**Validation Target:** Telegram Portfolio → Positions routing; Positions vs Trades logic separation; preset picker label overflow
+**Not in Scope:** Message dispatcher registration, close flow execution engine, trades_text() copy, messages.py
+
+---
+
+## 1. What Was Built
+
+Four targeted fixes to the Telegram bot UX:
+
+1. **`show_positions()` callback fix** — function now handles both `Message` (command trigger) and `CallbackQuery` (portfolio:positions tap) paths. Uses `edit_message_text` in-place when triggered via callback, eliminating the ghost-message problem where the portfolio screen stayed visible behind a new reply.
+
+2. **Positions screen: Close buttons restored** — `positions_list_kb()` now emits one `[🛑 Close]` button row per position using the `close_position:{id}` pattern, routed to the existing `close_ask_cb` handler in `trades.py`. The Back row points to `portfolio:portfolio` for smooth in-place navigation.
+
+3. **Trades screen: Close buttons removed** — `show_trades()` keyboard was stripped of the per-position `[🛑 Close: ...]` rows. The Trades screen now shows closed trade history with a `[📋 Full History] [⬅ Portfolio]` nav row only, separating the concerns cleanly.
+
+4. **Preset picker label shortening** — `preset_picker()` labels changed from `{emoji} {full_name} · {full_badge_text}` to `{emoji} {first_word} · {badge_emoji}`. Example: `🐋 Whale Mirror · 🟡 Balanced ⭐` → `🐋 Whale · 🟡 ⭐`. Fits a 2-column mobile grid at 375px without truncation.
+
+---
+
+## 2. Current System Architecture
+
+```
+Portfolio screen (portfolio_callback)
+  ├── portfolio:positions  → show_positions()   [active P&L + Close buttons]
+  ├── portfolio:trades     → my_trades_cb()     [history only, no Close]
+  ├── portfolio:chart      → chart_command()
+  └── portfolio:insights   → pnl_insights_command()
+
+show_positions() path:
+  CallbackQuery → answer() → edit_message_text()   [in-place]
+  Message       → reply_text()                     [fresh reply]
+
+Close flow (unchanged):
+  close_position:{id} → close_ask_cb() → confirmation → close_confirm_cb()
+```
+
+---
+
+## 3. Files Created / Modified
+
+| Action   | Path |
+|----------|------|
+| Modified | `projects/polymarket/crusaderbot/bot/handlers/positions.py` |
+| Modified | `projects/polymarket/crusaderbot/bot/handlers/trades.py` |
+| Modified | `projects/polymarket/crusaderbot/bot/keyboards/positions.py` |
+| Modified | `projects/polymarket/crusaderbot/bot/keyboards/presets.py` |
+| Created  | `projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md` |
+
+---
+
+## 4. What Is Working
+
+- `show_positions()` handles both Message and CallbackQuery; in-place edit on callback path; graceful BadRequest fallback to reply_text.
+- `positions_list_kb()` emits one `[🛑 Close]` row per position ID + Back/Home nav row.
+- `show_trades()` keyboard no longer contains per-position close rows; nav row is `[Full History] [⬅ Portfolio]`.
+- Preset picker labels are ≤ ~16 chars: `🐋 Whale · 🟡 ⭐`, `📡 Signal · 🟢`, `🐋📡 Hybrid · 🟡`, `🎯 Value · 🟡`, `🚀 Full · 🔴`.
+- `py_compile` clean on all 4 files.
+- No `phase*/` folders introduced.
+
+---
+
+## 5. Known Issues
+
+- Close buttons in Positions screen route to `close_position:{id}` which calls `close_ask_cb` in `trades.py`. That handler already exists and is dispatcher-registered; no new wiring needed.
+- `trades_text()` in `messages.py` still renders the open positions block at the top of the Trades screen (text shows position count + entries). This is cosmetically inconsistent with the "history-focused" intent but is outside scope — separate pass needed if WARP🔹CMD wants the Trades text copy revised too.
+- `positions_list_kb()` emits one close button per position with no position label. For >5 positions this creates a long button list. Truncated label variant deferred to a follow-up if UX feedback warrants it.
+
+---
+
+## 6. What Is Next
+
+WARP🔹CMD review required.
+Source: `projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md`
+Tier: STANDARD
+
+Optional follow-up: revise `trades_text()` in `messages.py` to lead with closed history rather than open positions summary, aligning text copy with the keyboard intent.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,4 +1,4 @@
-2026-05-18 23:45 | claude/telegram-routing-fix-gvE8Z | WARP-25: show_positions() callback fix + Positions Close buttons + Trades history-only nav + preset label shortening; STANDARD, FULL RUNTIME INTEGRATION
+2026-05-18 23:45 | WARP/telegram-functional-routing-fix | WARP-25: show_positions() callback fix + Positions Close buttons + Trades history-only nav + preset label shortening; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-18 23:30 | WARP/expand-webtrader-pagination | WARP-19: Load More pagination (offset-based) for Live Market Feed, Leaderboard, Closed Trades, Orders; api.ts offset param added; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-18 21:00 | WARP/truth-integration-mock-cleanup | WARP-21: Live Market Feed 30s poll→SSE, scanner.tick ts payload, Discover case-insensitive category + SSE refresh, mock audit clean; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-19 | WARP/CRUSADERBOT-UI-COLLAPSIBLE-FIX | all CollapsibleSection defaultOpen=true; SHOW/HIDE labeled toggle button; pagination scoped to ledger + market list only; STANDARD, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-18 23:45 | claude/telegram-routing-fix-gvE8Z | WARP-25: show_positions() callback fix + Positions Close buttons + Trades history-only nav + preset label shortening; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-18 23:30 | WARP/expand-webtrader-pagination | WARP-19: Load More pagination (offset-based) for Live Market Feed, Leaderboard, Closed Trades, Orders; api.ts offset param added; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-18 21:00 | WARP/truth-integration-mock-cleanup | WARP-21: Live Market Feed 30s poll→SSE, scanner.tick ts payload, Discover case-insensitive category + SSE refresh, mock audit clean; STANDARD, FULL RUNTIME INTEGRATION
 2026-05-19 | WARP/CRUSADERBOT-UI-COLLAPSIBLE-FIX | all CollapsibleSection defaultOpen=true; SHOW/HIDE labeled toggle button; pagination scoped to ledger + market list only; STANDARD, NARROW INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-18 23:30
-Status       : Multiple PRs open. WARP/expand-webtrader-pagination (WARP-19: Load More pagination for Live Market Feed, Leaderboard, Closed Trades, Orders) open for WARP🔹CMD review. WARP/tg-ux-redesign (WARP-24) and others awaiting WARP🔹CMD review.
+Last Updated : 2026-05-18 23:45
+Status       : Multiple PRs open. WARP-25 telegram-functional-routing-fix PR open for WARP🔹CMD review. WARP/expand-webtrader-pagination (WARP-19) and others also awaiting review.
 
 [COMPLETED]
 - WARP-17 WARP/fix-kill-switch-db-table: fixed kill_switch_exec.py _set_system_flag() to target system_settings (was system_flags); MAJOR, FULL RUNTIME INTEGRATION. SENTINEL APPROVED 93/100.
@@ -14,6 +14,7 @@ Status       : Multiple PRs open. WARP/expand-webtrader-pagination (WARP-19: Loa
 - crusaderbot-mvp-runtime-v1 MERGED PR #1080 (2026-05-17). Tier gates removed from all paper paths: scheduler (deposit auto-bump + run_signal_scan filter), signal_scan_job (_load_enrolled_users filter), daily_pnl_summary (access_tier >= 2), weekly_insights (access_tier >= 2), tier_gate.py (no-op passthrough), admin.py (status counts + active_users + broadcast). MAJOR, FULL RUNTIME INTEGRATION.
 
 [IN PROGRESS]
+- WARP-25 telegram-functional-routing-fix PR open — show_positions() callback fix + Positions [🛑 Close] buttons + Trades history-only keyboard + preset picker short labels. STANDARD, FULL RUNTIME INTEGRATION. Awaiting WARP🔹CMD review.
 - WARP/expand-webtrader-pagination PR open — WARP-19: Load More pagination for Live Market Feed (DashboardPage), Leaderboard Rankings (CopyTradePage), Closed Trades (PortfolioPage), Orders (PortfolioPage). offset param added to getRecentSignals, getLeaderboard, getPositions, getOrders in api.ts. STANDARD, FULL RUNTIME INTEGRATION. Awaiting WARP🔹CMD review.
 - WARP/tg-ux-redesign PR open — WARP-24: Dashboard HUD redesigned as tactical terminal (<pre> blocks + DIV dividers + Last Scan heartbeat + 🟢/🔴 P&L indicator). Auto Mode wizard: compact picker grid → in-place detail view → Back/Home nav. Main menu 🤖 Auto Mode routes directly to preset picker. STANDARD, FULL RUNTIME INTEGRATION. Awaiting WARP🔹CMD review.
 - WARP/truth-integration-mock-cleanup PR open — WARP-21: Live Market Feed 30s poll→SSE, scanner.tick ts broadcast, Discover case-insensitive category + SSE auto-refresh, mock audit (clean). STANDARD, FULL RUNTIME INTEGRATION. Awaiting WARP🔹CMD review.
@@ -56,6 +57,7 @@ Status       : Multiple PRs open. WARP/expand-webtrader-pagination (WARP-19: Loa
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
+- WARP🔹CMD review required for WARP-25 telegram-functional-routing-fix (Positions callback fix + Close buttons + Trades history separation + preset label fix). Source: projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md. Tier: STANDARD.
 - WARP🔹CMD review required for WARP/expand-webtrader-pagination (WARP-19: Load More pagination — Live Market Feed, Leaderboard, Closed Trades, Orders). Source: projects/polymarket/crusaderbot/reports/forge/expand-webtrader-pagination.md. Tier: STANDARD. No migration required.
 - WARP🔹CMD review required for WARP/tg-ux-redesign (WARP-24: Dashboard HUD redesign + Auto Mode wizard). Source: projects/polymarket/crusaderbot/reports/forge/tg-ux-redesign.md. Tier: STANDARD. No migration required.
 - WARP🔹CMD review required for WARP/truth-integration-mock-cleanup (WARP-21: SSE feed migration, scanner heartbeat, Discover category fix). Source: projects/polymarket/crusaderbot/reports/forge/truth-integration-mock-cleanup.md. Tier: STANDARD. No migration required.

--- a/projects/polymarket/crusaderbot/tests/test_positions_handler.py
+++ b/projects/polymarket/crusaderbot/tests/test_positions_handler.py
@@ -133,13 +133,17 @@ def test_fetch_mark_price_one_side_only():
 
 # ---------- Keyboard builders -----------------------------------------------
 
-def test_positions_list_kb_nav_only_no_force_close_rows():
+def test_positions_list_kb_close_rows_plus_nav():
     pids = [uuid4() for _ in range(3)]
     kb = positions_list_kb(pids)
     rows = kb.inline_keyboard
-    assert len(rows) == 1
-    assert [btn.text for btn in rows[0]] == ["⬅ Back", "🏠 Home"]
-    assert [btn.callback_data for btn in rows[0]] == ["portfolio:portfolio", "nav:home"]
+    # One close-button row per position + one back/home nav row
+    assert len(rows) == 4
+    for i, pid in enumerate(pids):
+        assert rows[i][0].text == "🛑 Close"
+        assert rows[i][0].callback_data == f"close_position:{pid}"
+    assert [btn.text for btn in rows[-1]] == ["⬅ Back", "🏠 Home"]
+    assert [btn.callback_data for btn in rows[-1]] == ["portfolio:portfolio", "nav:home"]
 
 
 def test_force_close_confirm_kb_yes_no_pair():


### PR DESCRIPTION
## Summary

- **`show_positions()` callback fix**: handles both `Message` and `CallbackQuery` paths. Uses `edit_message_text` in-place when triggered via `portfolio:positions` callback — eliminates ghost message stacking.
- **Positions screen: `[🛑 Close]` buttons restored**: `positions_list_kb()` emits one close button row per position using `close_position:{id}`, routed to existing `close_ask_cb`. Back button returns to `portfolio:portfolio` in-place.
- **Trades screen: Close buttons removed**: `show_trades()` keyboard stripped of per-position close rows. Nav is now `[📋 Full History] [⬅ Portfolio]` — history-focused, no action CTAs.
- **Preset picker label shortening**: labels changed from `🐋 Whale Mirror · 🟡 Balanced ⭐` to `🐋 Whale · 🟡 ⭐` (first word + badge emoji only), fits 375px mobile grid without truncation.

## Files Changed

| File | Change |
|------|--------|
| `bot/handlers/positions.py` | `show_positions()` — callback detection + in-place edit + Close button keyboard |
| `bot/handlers/trades.py` | `show_trades()` — remove Close button rows, add Portfolio back nav |
| `bot/keyboards/positions.py` | `positions_list_kb()` — per-position Close rows + Back/Home nav |
| `bot/keyboards/presets.py` | `preset_picker()` — short labels (first word + badge emoji) |
| `tests/test_positions_handler.py` | Updated test to assert new close-button behavior (1493 pass) |

## Validation

- Validation Tier: STANDARD
- Claim Level: FULL RUNTIME INTEGRATION
- `py_compile` clean on all 4 files
- Full test suite: **1493 passed, 1 skipped**
- Report: `projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md`

## Test Plan

- [ ] Tap Portfolio → Positions from Telegram: message edits in-place (no ghost reply)
- [ ] Positions screen shows `[🛑 Close]` per active position + Back button
- [ ] Tap Close → confirmation dialog appears (existing flow)
- [ ] Portfolio → Trades: no Close buttons, only Full History + Portfolio nav
- [ ] Auto Trade preset picker: labels fit without truncation on 375px mobile

https://claude.ai/code/session_01P85bHkBJtJsZWCf78YH4BA

---
_Generated by [Claude Code](https://claude.ai/code/session_01P85bHkBJtJsZWCf78YH4BA)_