### PR TITLE
WARP-26: copy trade engine sync + reasoning injection + CI fix (rebase, supersedes #1168)

### DIFF
--- a/projects/polymarket/crusaderbot/domain/strategy/strategies/copy_trade.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/strategies/copy_trade.py
@@ -134,20 +134,31 @@ class CopyTradeStrategy(BaseStrategy):
 
                 if copy_mode == "proportional":
                     pct = _coerce_float(target.get("copy_pct"))
-                    if pct > 0:
-                        sized = min(
-                            user_context.available_balance_usdc * float(pct),
-                            cap_usdc,
+                    if pct <= 0:
+                        logger.warning(
+                            "copy_trade scan: invalid copy_pct=%s task=%s — skipping",
+                            target.get("copy_pct"), target.get("id"),
                         )
-                    else:
-                        sized = mirror_size_direct(
-                            leader_size=leader_size_usdc,
-                            user_available=user_context.available_balance_usdc,
-                            max_position_pct=user_context.capital_allocation_pct,
-                        )
-                else:
+                        continue
+                    sized = min(
+                        user_context.available_balance_usdc * pct,
+                        cap_usdc,
+                    )
+                elif copy_mode == "rm_mirror":
+                    sized = mirror_size_direct(
+                        leader_size=leader_size_usdc,
+                        user_available=user_context.available_balance_usdc,
+                        max_position_pct=user_context.capital_allocation_pct,
+                    )
+                elif copy_mode == "fixed":
                     fixed_amount = _coerce_float(target.get("copy_amount") or 5.0)
                     sized = min(fixed_amount, cap_usdc) if fixed_amount > 0 else 0.0
+                else:
+                    logger.warning(
+                        "copy_trade scan: unknown copy_mode=%s task=%s — skipping",
+                        copy_mode, target.get("id"),
+                    )
+                    continue
 
                 min_size = _coerce_float(target.get("min_trade_size") or 0.50)
                 if sized <= 0.0 or sized < min_size:
@@ -404,10 +415,13 @@ def _normalise_side(
     side = (trade.get("side") or "").upper()
     outcome = (trade.get("outcome") or "").upper()
 
+    if side not in ("BUY", "SELL"):
+        return None
+    if copy_direction not in ("buys_only", "buys_and_sells"):
+        return None
+
     if copy_direction == "buys_only":
-        if side and side != "BUY":
-            return None
-        return outcome if outcome in ("YES", "NO") else None
+        return outcome if side == "BUY" and outcome in ("YES", "NO") else None
 
     # buys_and_sells: invert side for SELL trades
     if side == "SELL":

--- a/projects/polymarket/crusaderbot/domain/strategy/strategies/signal_following.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/strategies/signal_following.py
@@ -107,7 +107,7 @@ class SignalFollowingStrategy(BaseStrategy):
                     signal_ts=c.signal_ts,
                     metadata=c.metadata,
                     reasoning=(
-                        f"Signal: Heisenberg feed breakout — "
+                        f"Signal: {c.metadata.get('feed_name', 'feed')} candidate — "
                         f"market {c.market_id[:8]}… "
                         f"conf={c.confidence:.0%}."
                     ),

--- a/projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md
+++ b/projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md
@@ -39,7 +39,7 @@ Full divider standardization complete.
 
 ## 2. Current System Architecture
 
-```
+```text
 copy_trade_tasks (DB) ←── NEW source for CopyTradeStrategy
     │  wallet_address, copy_mode, copy_amount, copy_pct,
     │  copy_direction, min_trade_size, status='active'
@@ -109,6 +109,31 @@ Modified:
   (historical rows, no FK violation). Cleanup deferred to a dedicated
   schema migration lane.
 - Reasoning strings are English-only. i18n is post-MVP scope.
+
+### Post-merge CI fixes (same branch)
+
+- `test_copy_trade.py` — 8 test functions used legacy `target_row` schema
+  (`target_wallet_address`, `scale_factor`, `trades_mirrored`); `_already_mirrored`
+  calls used 2-arg signature; metadata assertions checked `copy_target_id`.
+  All updated to new schema (`wallet_address`, `copy_mode`, `copy_amount`, etc.)
+  and 3-arg `_already_mirrored(user_id, task_id, tx_hash)`.
+- `test_signal_following.py` — `test_strategy_scan_delegates_to_evaluator`
+  built expected candidate without `reasoning`; updated to include the injected
+  reasoning string so the equality assertion holds. Subsequent CI pass revealed
+  the expected string `"Signal: Heisenberg feed breakout …"` did not match the
+  code template (`"{feed_name} candidate"`). Corrected to
+  `"Signal: feed candidate — market mkt_1… conf=70%."` (metadata carries no
+  `feed_name` key → default `'feed'` fallback applies).
+- `copy_trade.py` — `rm_mirror` mode (persisted by Telegram wizard and WebTrader
+  router) fell into the fixed-amount else branch, ignoring leader trade size.
+  Added explicit `rm_mirror` path: uses `mirror_size_direct` (same as proportional
+  with no pct), capping at the user's position cap. Unknown modes now log a warning
+  and skip rather than silently mis-sizing.
+- `copy_trade.py` — `proportional` mode with `copy_pct=0` or `None` fell through
+  to the else branch and would have triggered the unknown-mode warning. Now
+  explicitly validated: skips with a warning when `pct <= 0`.
+- `_normalise_side` — unvalidated `side` and `copy_direction` inputs could produce
+  silent incorrect routing. Now guards both fields before any logic executes.
 
 ---
 

--- a/projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md
+++ b/projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md
@@ -25,7 +25,7 @@ Sizing logic replaced: `leader_bankroll_estimate` / `scale_size` removed;
 `SignalCandidate` gains `reasoning: str = ""` field (backward-compatible
 default). All three active strategies populate it:
 - CopyTrade: "CopyTrade: Mirroring {task_name} ({wallet[:8]}…). Mode=…, Size=$…."
-- SignalFollowing: "Signal: Heisenberg feed breakout — market {id[:8]}… conf=X%."
+- SignalFollowing: "Signal: {feed_name} candidate — market {id[:8]}… conf=X%." (feed_name fallback = 'feed')
 - MomentumReversal: "Momentum: YES oversold — 24h drop X%, price Y, conf=Z%."
 Note: `confidence` already existed as a required field on `SignalCandidate`
 (added in an earlier phase). Only `reasoning` was missing; no duplicate added.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-19 10:30 | WARP/master-cleanup-v5-beta | WARP-26 follow-up: test_copy_trade.py + test_signal_following.py aligned to new schema; rm_mirror sizing regression fixed (mirror_size_direct); unknown mode guard added
 2026-05-19 09:21 | WARP/master-cleanup-v5-beta | WARP-26: copy_trade.py reads copy_trade_tasks + copy_trade_idempotency dedup; SignalCandidate.reasoning added; all 3 strategies injected; messages.py 32-char dividers; MAJOR, FULL RUNTIME INTEGRATION
 2026-05-19 08:55 | WARP-28/dashboard-corruption-fix | EMERGENCY: restored 3 Base64-corrupted Python files + DIV 26→32 in messages.py; compileall clean; deployment blocker resolved
 2026-05-18 23:45 | WARP/telegram-functional-routing-fix | WARP-25: show_positions() callback fix + Positions Close buttons + Trades history-only nav + preset label shortening; STANDARD, FULL RUNTIME INTEGRATION

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,8 +1,8 @@
-Last Updated : 2026-05-19 09:21
-Status       : WARP-26 master-cleanup-v5-beta PR open — copy trade engine sync + reasoning injection + DIV 32 standardization. MAJOR, FULL RUNTIME INTEGRATION. WARP•SENTINEL required before merge.
+Last Updated : 2026-05-19 10:22
+Status       : WARP-26 PR open (rebase branch) — copy trade engine sync + reasoning injection + DIV 32 + rm_mirror sizing fix + CI test alignment. MAJOR, FULL RUNTIME INTEGRATION. WARP•SENTINEL required before merge.
 
 [COMPLETED]
-- WARP-26 master-cleanup-v5-beta PR open: copy_trade.py reads copy_trade_tasks (was copy_targets), dedup via copy_trade_idempotency, copy_direction + sizing via copy_mode. SignalCandidate.reasoning added; all 3 strategies populate it. messages.py all dividers 32-char. compileall clean. MAJOR, FULL RUNTIME INTEGRATION.
+- WARP-26 copy trade engine sync + reasoning injection: copy_trade.py reads copy_trade_tasks (was copy_targets), dedup via copy_trade_idempotency, copy_direction + sizing via copy_mode + rm_mirror explicit sizing path (mirror_size_direct, unknown mode guard). SignalCandidate.reasoning added; all 3 strategies populate it. messages.py all dividers 32-char. test_copy_trade.py + test_signal_following.py aligned to new schema. compileall clean. MAJOR, FULL RUNTIME INTEGRATION.
 - WARP-28 dashboard-corruption-fix: repaired 3 Base64-corrupted files (dashboard.py 351L, copy_trade.py 462L, types.py 138L) + messages.py DIV 26→32. compileall clean. STANDARD, NARROW INTEGRATION.
 - WARP-17 WARP/fix-kill-switch-db-table: fixed kill_switch_exec.py _set_system_flag() to target system_settings (was system_flags); MAJOR, FULL RUNTIME INTEGRATION. SENTINEL APPROVED 93/100.
 - WARP/crusaderbot-realtime-pipeline-runtime MERGED PR #1141 (2026-05-18 23:55): pipeline MONITORING events (scan_started/strategy_scan_done/scan_completed/risk_gate_evaluated), /status endpoint, 14/14 hermetic pipeline ordering tests, WebTrader TopBar dynamic trading_mode pill, Paper Mode banners, analytics trust guard, config IA reorder, mobile nav readability, leaderboard data source note; Promise.allSettled AutoTrade load decoupled from dashboard failures. SENTINEL APPROVED 89/100. MAJOR, FULL RUNTIME INTEGRATION.
@@ -59,7 +59,8 @@ Status       : WARP-26 master-cleanup-v5-beta PR open — copy trade engine sync
 - Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
-- WARP•SENTINEL validation required for WARP-26 master-cleanup-v5-beta (copy trade engine sync + reasoning injection). Source: projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md. Tier: MAJOR.
+- WARP•SENTINEL validation required for WARP-26 rebase PR (copy trade engine sync + reasoning injection + rm_mirror fix + CI test alignment). Source: projects/polymarket/crusaderbot/reports/forge/master-cleanup-v5-beta.md. Tier: MAJOR.
+- WARP🔹CMD: close old PR #1168 (conflict — superseded by rebase PR). New PR is clean forward-only diff from main.
 - WARP🔹CMD review + URGENT MERGE required for WARP-28 dashboard-corruption-fix (deployment blocker). Source: projects/polymarket/crusaderbot/reports/forge/dashboard-corruption-fix.md. Tier: STANDARD. After merge: Fly.io redeploy required.
 - WARP🔹CMD review required for WARP-25 telegram-functional-routing-fix (Positions callback fix + Close buttons + Trades history separation + preset label fix). Source: projects/polymarket/crusaderbot/reports/forge/telegram-functional-routing-fix.md. Tier: STANDARD.
 - WARP🔹CMD review required for WARP/expand-webtrader-pagination (WARP-19: Load More pagination — Live Market Feed, Leaderboard, Closed Trades, Orders). Source: projects/polymarket/crusaderbot/reports/forge/expand-webtrader-pagination.md. Tier: STANDARD. No migration required.
@@ -86,7 +87,7 @@ Status       : WARP-26 master-cleanup-v5-beta PR open — copy trade engine sync
 - WARP🔹CMD review required for WARP/CRUSADERBOT-TG-KB-CLEANUP (inline KB ghost fix). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-tg-kb-cleanup.md. Tier: STANDARD.
 - WARP🔹CMD review required for WARP/CRUSADERBOT-SCANNER-SYNC-FIX (skipped_market_not_synced fix). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-scanner-sync-fix.md. Tier: STANDARD.
 - WARP🔹CMD review required for WARP/CRUSADERBOT-PRICE-FETCH-FIX (get_live_market_price 422 fix). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-price-fetch-fix.md. Tier: STANDARD.
-- WARP🔹CMD review required for WARP/CRUSADERBOT-SSE-AUTH-FIX (SSE status dot + auth confirmed). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-sse-auth-fix.md. Tier: MINOR.
+- WARP🔹CMD review required for WARP/CRUSADERBOT-SSE-AUTH-FIX (SSE status dot + auth confirmed). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-sse-auth-fix.md. Tier: STANDARD.
 - WARP🔹CMD review required for crusaderbot-webtrader-ws (SSE push + polling removal). Source: projects/polymarket/crusaderbot/reports/forge/crusaderbot-webtrader-ws.md. Tier: STANDARD.
 - WARP🔹CMD review required for webtrader-build-fix (pipeline verified + BottomNav label fix). Source: projects/polymarket/crusaderbot/reports/forge/webtrader-build-fix.md. Tier: MINOR.
 - WARP🔹CMD production deploy decision required: apply pending migrations (030, 031, 034, 035) to production DB, then deploy main to Fly.io.

--- a/projects/polymarket/crusaderbot/tests/test_copy_trade.py
+++ b/projects/polymarket/crusaderbot/tests/test_copy_trade.py
@@ -482,9 +482,9 @@ def test_scan_emits_signal_for_fresh_buy():
     target_row = {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
     }
     fresh_trade = {
@@ -520,12 +520,12 @@ def test_scan_emits_signal_for_fresh_buy():
     assert sig.confidence == 0.75
     assert sig.suggested_size_usdc > 0.0
     assert sig.metadata["source_tx_hash"] == fresh_trade["transactionHash"]
-    assert sig.metadata["copy_target_id"] == str(_TARGET_UUID)
-    assert sig.metadata["leader_wallet"] == target_row["target_wallet_address"]
+    assert sig.metadata["copy_task_id"] == str(_TARGET_UUID)
+    assert sig.metadata["leader_wallet"] == target_row["wallet_address"]
 
 
 def test_already_mirrored_scopes_query_per_follower():
-    """The dedup query must filter on (copy_target_id, source_tx_hash) so the
+    """The dedup query must filter on (user_id, task_id, leader_trade_id) so the
     same leader transaction can be mirrored independently by every follower."""
     from projects.polymarket.crusaderbot.domain.strategy.strategies import (
         copy_trade as ct_mod,
@@ -554,15 +554,17 @@ def test_already_mirrored_scopes_query_per_follower():
 
     with patch.object(ct_mod, "get_pool", return_value=_CapturingPool()):
         out = asyncio.run(
-            ct_mod._already_mirrored(_TARGET_UUID, "0x" + "a" * 64),
+            ct_mod._already_mirrored(_USER_UUID, _TARGET_UUID, "0x" + "a" * 64),
         )
     assert out is False
-    assert "copy_target_id = $1" in captured["sql"]
-    assert "source_tx_hash = $2" in captured["sql"]
+    assert "user_id = $1" in captured["sql"]
+    assert "task_id = $2" in captured["sql"]
+    assert "leader_trade_id = $3" in captured["sql"]
     # asyncpg coerces the UUID at the protocol layer; the strategy passes the
     # parsed UUID, not the raw string, so the queries can use the index.
-    assert captured["args"][0] == _TARGET_UUID
-    assert captured["args"][1] == "0x" + "a" * 64
+    assert captured["args"][0] == _USER_UUID
+    assert captured["args"][1] == _TARGET_UUID
+    assert captured["args"][2] == "0x" + "a" * 64
 
 
 def test_already_mirrored_returns_false_on_blank_inputs():
@@ -570,9 +572,9 @@ def test_already_mirrored_returns_false_on_blank_inputs():
         copy_trade as ct_mod,
     )
 
-    out = asyncio.run(ct_mod._already_mirrored(None, "0xabc"))
+    out = asyncio.run(ct_mod._already_mirrored(None, None, "0xabc"))
     assert out is False
-    out = asyncio.run(ct_mod._already_mirrored(_TARGET_UUID, ""))
+    out = asyncio.run(ct_mod._already_mirrored(_USER_UUID, _TARGET_UUID, ""))
     assert out is False
 
 
@@ -580,9 +582,9 @@ def test_scan_dedupes_already_mirrored_trades():
     target_row = {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
     }
     seen_trade = {
@@ -617,9 +619,9 @@ def test_scan_drops_stale_trades_outside_window():
     target_row = {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
     }
     stale = {
@@ -658,9 +660,9 @@ def test_scan_skips_trade_when_size_below_floor():
     target_row = {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
     }
     fresh = {
@@ -829,9 +831,9 @@ def _build_target_row():
     return {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
         # leader_bankroll_estimate is intentionally absent — column not yet
         # backfilled. The strategy must fall back to mirror_size_direct.
@@ -1103,9 +1105,9 @@ def test_scan_blacklisted_market_id_yields_no_signal():
     target_row = {
         "id": _TARGET_UUID,
         "user_id": _USER_UUID,
-        "target_wallet_address": "0x" + "a" * 40,
-        "scale_factor": 1.0,
-        "trades_mirrored": 0,
+        "wallet_address": "0x" + "a" * 40,
+        "copy_mode": "rm_mirror",
+        "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
     }
     fresh_trade = {

--- a/projects/polymarket/crusaderbot/tests/test_copy_trade.py
+++ b/projects/polymarket/crusaderbot/tests/test_copy_trade.py
@@ -835,8 +835,7 @@ def _build_target_row():
         "copy_mode": "rm_mirror",
         "copy_amount": None, "copy_pct": None, "copy_direction": "buys_only", "min_trade_size": 0.5,
         "created_at": datetime.now(timezone.utc),
-        # leader_bankroll_estimate is intentionally absent — column not yet
-        # backfilled. The strategy must fall back to mirror_size_direct.
+        # leader_bankroll_estimate absent by design; copy_mode="rm_mirror" takes the explicit rm_mirror path via mirror_size_direct.
     }
 
 

--- a/projects/polymarket/crusaderbot/tests/test_signal_following.py
+++ b/projects/polymarket/crusaderbot/tests/test_signal_following.py
@@ -565,11 +565,24 @@ def test_strategy_scan_delegates_to_evaluator():
         metadata={"feed_id": str(_FEED_UUID),
                   "publication_id": str(_PUB_UUID),
                   "market_id": "mkt_1"},
+        reasoning="Signal: feed candidate — market mkt_1… conf=70%.",
     )
 
     async def fake_eval(**kwargs):
         assert kwargs["strategy_name"] == "signal_following"
-        return [expected]
+        # Return a candidate without reasoning so scan() injects it.
+        from projects.polymarket.crusaderbot.domain.strategy.types import SignalCandidate as SC
+        bare = SC(
+            market_id=expected.market_id,
+            condition_id=expected.condition_id,
+            side=expected.side,
+            confidence=expected.confidence,
+            suggested_size_usdc=expected.suggested_size_usdc,
+            strategy_name=expected.strategy_name,
+            signal_ts=expected.signal_ts,
+            metadata=expected.metadata,
+        )
+        return [bare]
 
     # Patch the symbol that signal_following.py imported, not the source
     # module — function references are bound at import time.


### PR DESCRIPTION
## Summary

Clean rebase of WARP-26 from main's HEAD (`09a1b89`) — supersedes PR #1168 which had merge conflicts from in-flight WARP-26 chunks landing on main while the PR was open. This branch is a forward-only diff with no three-way conflict.

### What's in this PR

**Copy Trade Engine Sync (CRITICAL)**
- `_load_active_copy_targets`: queries `copy_trade_tasks` (not legacy `copy_targets`); correct field mapping (`wallet_address`, `copy_mode`, `copy_amount`, `copy_pct`, `copy_direction`, `min_trade_size`)
- `_already_mirrored(user_id, task_id, tx_hash)`: 3-arg signature; dedup via `copy_trade_idempotency`
- Sizing: `fixed` / `proportional` / `rm_mirror` all have explicit paths; unknown mode logs + skips; `copy_pct <= 0` guard on proportional
- `_normalise_side`: validates both `side` and `copy_direction` before any routing logic

**SignalCandidate.reasoning on all 3 strategies**
- `CopyTrade`: `"CopyTrade: Mirroring {task_name} ({wallet[:8]}…). Mode=…, Size=$…."`
- `SignalFollowing`: `"Signal: {feed_name} candidate — market {id[:8]}… conf=X%."` (feed_name fallback = `'feed'`)
- `MomentumReversal`: set at SignalCandidate construction

**CI test fixes**
- `test_signal_following.py` line 568: corrected expected reasoning string to match actual template output (`"Signal: feed candidate — market mkt_1… conf=70%."`)
- `test_copy_trade.py`: all 8 test functions aligned to new `copy_trade_tasks` schema; 3-arg `_already_mirrored` calls; `rm_mirror` mode coverage; mirror size regression test

## Files Changed

- `domain/strategy/strategies/copy_trade.py`
- `domain/strategy/strategies/signal_following.py`
- `tests/test_copy_trade.py`
- `tests/test_signal_following.py`
- `reports/forge/master-cleanup-v5-beta.md`
- `state/PROJECT_STATE.md`
- `state/CHANGELOG.md`

## Validation

Validation Tier   : MAJOR
Claim Level       : FULL RUNTIME INTEGRATION
Validation Target : Copy Trade scan loop reads copy_trade_tasks; dedup via copy_trade_idempotency; SignalCandidate.reasoning populated on all three active strategies; messages.py divider width 32-char throughout.
Not in Scope      : signal_evaluator.py reasoning injection, copy_targets DB cleanup, copy_trade_idempotency backfill migration, i18n of reasoning strings.

## Notes for WARP🔹CMD

- Close old PR #1168 (`WARP/master-cleanup-v5-beta`) — superseded by this clean rebase
- Do NOT merge until WARP•SENTINEL validation passes

https://claude.ai/code/session_01EEQUhSxEWZcUTaZvXcbtuU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mirror sizing regression and added guards for unknown sizing modes
  * Tightened validation to skip invalid trades (invalid side/direction and non-positive proportional pct)

* **New Features**
  * Explicit trade sizing modes (proportional, fixed, rm_mirror) with clearer behavior
  * Signal reasoning now injects feed name and uses a generic "candidate" label

* **Chores**
  * Updated docs, changelog, and project state; aligned tests to new schema and metadata contract

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->