### PR TITLE
fix(tg): WARP-25 — Telegram functional routing fix (positions callback, Close buttons, preset picker)

### DIFF
--- a/projects/polymarket/crusaderbot/bot/dispatcher.py
+++ b/projects/polymarket/crusaderbot/bot/dispatcher.py
@@ -24,7 +24,7 @@ from .handlers import (
 )
 from .handlers.autotrade import autotrade_callback, show_autotrade
 from .handlers.dashboard import (
-    autotrade_toggle_cb, close_position_cb, dashboard, dashboard_nav_cb,
+    autotrade_toggle_cb, dashboard, dashboard_nav_cb,
     show_dashboard_for_cb, activity,
 )
 from .handlers.emergency import emergency_callback, emergency_root, emergency_root_cb
@@ -60,6 +60,10 @@ async def _menu_nav_cb(update, ctx) -> None:
         # pre-answer below to avoid double-ACK (BadRequest from Telegram).
         from .handlers.positions import show_portfolio
         await show_portfolio(update, ctx)
+        return
+    if sub == "positions":
+        # show_positions answers internally on the callback path.
+        await positions.show_positions(update, ctx)
         return
     await q.answer()
     if sub == "dashboard":

--- a/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
@@ -384,7 +384,7 @@ def preset_picker() -> InlineKeyboardMarkup:
     from ...domain.preset import RECOMMENDED_PRESET, list_presets
     rows: list[list] = []
     for p in list_presets():
-        name = p.name if len(p.name) <= 20 else p.name.split()[0]
+        name = p.name if len(p.name) <= 20 else p.name[:20]
         label = f"{p.emoji} {name}"
         if p.key == RECOMMENDED_PRESET:
             label = f"{label} ⭐"

--- a/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
+++ b/projects/polymarket/crusaderbot/bot/keyboards/__init__.py
@@ -381,17 +381,16 @@ def p5_dashboard_kb(has_preset: bool = False) -> InlineKeyboardMarkup:
 
 
 def preset_picker() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup([
-        [InlineKeyboardButton("🐋 Whale Mirror",   callback_data="p5:preset:whale_mirror")],
-        [InlineKeyboardButton("📈 Trend Breakout", callback_data="p5:preset:trend_breakout")],
-        [InlineKeyboardButton("🔄 Contrarian",     callback_data="p5:preset:contrarian")],
-        [InlineKeyboardButton("🎯 Value Hunter",   callback_data="p5:preset:value_hunter")],
-        [InlineKeyboardButton("⏰ Close Sweep",    callback_data="p5:preset:close_sweep")],
-        [InlineKeyboardButton("💰 Pair Arb",       callback_data="p5:preset:pair_arb")],
-        [InlineKeyboardButton("🤖 Ensemble",       callback_data="p5:preset:ensemble")],
-        [InlineKeyboardButton("🚀 Full Auto",      callback_data="p5:preset:full_auto")],
-        [InlineKeyboardButton("← Back",            callback_data="auto_trade:back")],
-    ])
+    from ...domain.preset import RECOMMENDED_PRESET, list_presets
+    rows: list[list] = []
+    for p in list_presets():
+        name = p.name if len(p.name) <= 20 else p.name.split()[0]
+        label = f"{p.emoji} {name}"
+        if p.key == RECOMMENDED_PRESET:
+            label = f"{label} ⭐"
+        rows.append([InlineKeyboardButton(label, callback_data=f"p5:preset:{p.key}")])
+    rows.append([InlineKeyboardButton("← Back", callback_data="auto_trade:back")])
+    return InlineKeyboardMarkup(rows)
 
 
 def preset_confirm_kb() -> InlineKeyboardMarkup:

--- a/projects/polymarket/crusaderbot/reports/forge/fix-telegram-routing-warp25.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-telegram-routing-warp25.md
@@ -1,0 +1,79 @@
+# WARP•FORGE Report — fix-telegram-routing-warp25
+
+**Validation Tier:** STANDARD
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** bot/dispatcher.py, bot/keyboards/__init__.py
+**Not in Scope:** WebTrader, scheduler, DB schema, signal pipeline
+
+---
+
+## 1. What Was Built
+
+Four routing defects diagnosed and resolved:
+
+1. **`menu:positions` routing** — `_menu_nav_cb` had no case for `menu:positions`. Added explicit routing to `positions.show_positions` (answers internally on callback path, matching the `menu:portfolio` pattern).
+
+2. **Dead `close_position_cb` import removed** — `close_position_cb` was imported from `handlers/dashboard.py` in `dispatcher.py` but never registered as a `CallbackQueryHandler`. The correct registration (`close_ask_cb` from `trades.py` for pattern `^close_position:(?!confirm:)`) was already present. Dead import removed; single handler confirmed.
+
+3. **`preset_picker()` in `keyboards/__init__.py` rewritten** — The function had 8 hardcoded stale preset keys (trend_breakout, contrarian, close_sweep, pair_arb, ensemble) that do not exist in `domain/preset/presets.py`. Any tap on those ghost buttons would silently fail the autotrade handler lookup. Replaced with a dynamic builder using `list_presets()` from the domain layer. Labels: `{emoji} {name}` — all ≤ 20 chars for current 5 presets. Recommended preset gets ⭐ badge.
+
+4. **`Back` from Positions → Portfolio verified** — `positions_list_kb()` uses `home_back_row("portfolio:portfolio")`. `home_back_row` emits a Back button with `callback_data="portfolio:portfolio"`. This matches the `^portfolio:` pattern registered in `dispatcher.py` which routes to `portfolio_callback` → `show_portfolio`. No change needed; confirmed working.
+
+---
+
+## 2. Current System Architecture
+
+```
+Telegram user tap
+  │
+  ├─ group=-1 MessageHandler (💼 Trades (N)) → positions.show_positions
+  ├─ group=-1 CallbackQueryHandler (^menu:)  → _menu_nav_cb
+  │     ├─ menu:portfolio  → show_portfolio   [answers internally]
+  │     ├─ menu:positions  → show_positions   [answers internally] ← NEW
+  │     ├─ menu:trades     → show_trades
+  │     └─ menu:dashboard/autotrade/wallet/emergency/settings
+  │
+  ├─ CallbackQueryHandler (^close_position:(?!confirm:)) → close_ask_cb [trades.py]
+  ├─ CallbackQueryHandler (^close_position:confirm:)     → close_confirm_cb [trades.py]
+  │
+  ├─ CallbackQueryHandler (^portfolio:) → portfolio_callback
+  │     └─ portfolio:positions → show_positions
+  │     └─ portfolio:portfolio → show_portfolio [Back from positions]
+  │
+  └─ CallbackQueryHandler (^p5:(preset|confirm|active):|^auto_trade:) → autotrade_callback
+        └─ p5:preset:{key} → looks up domain preset by key [now uses correct keys]
+```
+
+---
+
+## 3. Files Modified
+
+- `projects/polymarket/crusaderbot/bot/dispatcher.py` — removed dead `close_position_cb` import; added `menu:positions` case in `_menu_nav_cb`
+- `projects/polymarket/crusaderbot/bot/keyboards/__init__.py` — rewrote `preset_picker()` to use `list_presets()` from domain layer with validated short labels
+
+---
+
+## 4. What Is Working
+
+- `menu:positions` callback now routes to `show_positions` from any surface
+- `close_position:{id}` has a single registered handler (`close_ask_cb` from `trades.py`); no duplicate registration; dead import gone
+- Preset picker renders only the 5 domain-registered presets (whale_mirror, signal_sniper, hybrid, value_hunter, full_auto) with labels ≤ 20 chars
+- Back from Positions → Portfolio confirmed via `portfolio:portfolio` → `portfolio_callback` → `show_portfolio`
+- `compileall` clean on all modified files
+
+---
+
+## 5. Known Issues
+
+- None introduced by this task
+
+---
+
+## 6. What Is Next
+
+- WARP🔹CMD review and merge decision
+- No migration required; no Fly.io redeploy dependency (routing-only fix)
+
+---
+
+**Suggested Next Step:** WARP🔹CMD review required. Tier: STANDARD — no SENTINEL run needed.


### PR DESCRIPTION
## WARP-25 — Telegram Functional Routing Fix

**Tier:** STANDARD
**Claim Level:** NARROW INTEGRATION
**Validation Target:** bot/dispatcher.py, bot/keyboards/__init__.py
**Not in Scope:** WebTrader, scheduler, DB schema

Closes #1200

---

## Summary

- **`menu:positions` routing wired** — `_menu_nav_cb` had no case for `menu:positions`; added explicit dispatch to `positions.show_positions` (answers internally on callback path, matching the `menu:portfolio` pattern)
- **Dead `close_position_cb` import removed** — imported from `handlers/dashboard.py` but never registered; `close_ask_cb` (trades.py) is the single confirmed handler for `^close_position:` — no duplicate registration
- **`preset_picker()` in `keyboards/__init__.py` rewritten** — had 5 ghost preset keys (trend_breakout, contrarian, close_sweep, pair_arb, ensemble) not present in `domain/preset/presets.py`; replaced with dynamic builder using `list_presets()` with labels ≤ 20 chars
- **Back → Portfolio verified** — `positions_list_kb()` uses `portfolio:portfolio` callback which resolves to `show_portfolio` via the existing `^portfolio:` handler; no change needed

## Test plan

- [ ] Tap any button emitting `menu:positions` → `show_positions` renders open position list with Close buttons
- [ ] Tap `[🔴 Close — …]` on a position → `close_ask_cb` fires confirmation dialog
- [ ] Confirm close → `close_confirm_cb` queues force close intent
- [ ] `⬅ Back` from Positions screen → Portfolio overview renders
- [ ] Preset picker shows 5 presets (Whale Mirror ⭐, Signal Sniper, Hybrid, Value Hunter, Full Auto) — all labels ≤ 20 chars
- [ ] Tapping any preset in the picker → autotrade handler resolves the key correctly
- [ ] `compileall` clean

## Report

`projects/polymarket/crusaderbot/reports/forge/fix-telegram-routing-warp25.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj5pzTuYGChySmKqxGRXUq)_