### PR TITLE
forge: WARP-35+WARP-37 Linear status sync — issues closed to Done

### DIFF
--- a/projects/polymarket/crusaderbot/reports/forge/fix-active-issues.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-active-issues.md
@@ -1,0 +1,60 @@
+# WARP•FORGE REPORT — fix-active-issues
+
+**Branch:** WARP/fix-active-issues
+**Date:** 2026-05-20 15:30 WIB
+**Validation Tier:** MINOR
+**Claim Level:** FOUNDATION
+**Validation Target:** Linear issue status sync for WARP-35 and WARP-37
+**Not in Scope:** Code changes, migrations, runtime behavior
+
+---
+
+## 1. What Was Built
+
+State sync lane: verified that WARP-35 and WARP-37 fixes are present in `main`, then closed both Linear issues from `In Progress` → `Done` with completed task checklists.
+
+---
+
+## 2. Current System Architecture
+
+No architecture changes. CrusaderBot runtime unchanged.
+
+---
+
+## 3. Files Created / Modified
+
+- `projects/polymarket/crusaderbot/reports/forge/fix-active-issues.md` — this report (created)
+- `projects/polymarket/crusaderbot/state/CHANGELOG.md` — lane closure entry appended
+- Linear WARP-35 — status updated to Done, description updated with fix details and checked tasks
+- Linear WARP-37 — status updated to Done, description updated with fix details and checked tasks
+
+---
+
+## 4. What Is Working
+
+**WARP-35** — DataError: date string to asyncpg (1-min job)
+- Root: `copy_trade_monitor.run_once` (COPY_TRADE_MONITOR_INTERVAL=60s)
+- Functions: `_get_daily_spend` / `_record_spend` in `services/copy_trade/monitor.py`
+- Fix in main: `date.today()` returns `datetime.date` — correct, no `.isoformat()` call
+- Regression tests in `tests/test_copy_trade.py` (commit `7f14c42d`, direct-apply 2026-05-19)
+- Linear WARP-35: Done ✓
+
+**WARP-37** — BadRequest: Telegram edit_message_text no-op
+- Root: `bot/handlers/setup.py → set_risk` and 5 other inline-edit handlers
+- Fix in main: `except BadRequest as e: if "not modified" not in str(e).lower(): raise` guard in all 6 handlers
+  - `setup.py` ×5: `set_risk` (line 269), `set_category` (line 295), `set_mode` (line 329) + 2 others
+  - `settings.py` ×1: `_render_hub` (line 128)
+- Commits `088bad4` + `843bb6c` (direct-apply 2026-05-19/20)
+- Linear WARP-37: Done ✓
+
+---
+
+## 5. Known Issues
+
+None introduced by this lane.
+
+---
+
+## 6. What Is Next
+
+**Suggested Next Step:** WARP🔹CMD review of open WARP-45 PR (fix-sentry-p1-runtime-bugs) — asyncpg JSONB-as-str fix for signal_scan_job.py. Redeploy on Fly.io after merge.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -1,3 +1,4 @@
+2026-05-20 15:30 | WARP/fix-active-issues | WARP-35+WARP-37: Linear status sync — both issues closed to Done; fixes confirmed in main (7f14c42d, 088bad4, 843bb6c); no code changes in this lane. MINOR, FOUNDATION
 2026-05-20 14:52 | WARP/feat-pagination-warp19 | WARP-19 MERGED (2fc2929d): Load More pagination audit — all 4 surfaces confirmed (Market Feed, Leaderboard, Closed Trades, Orders); ScannerContext + TopBar last_scan display wired; vite build clean. STANDARD, NARROW INTEGRATION
 2026-05-20 14:04 | WARP/fix-webtrader-sse-warp21 | WARP-21 MERGED (97e7d25a): Pre-audit 5/6 deliverables present; gap patched (scanner.tick→TopBar display via ScannerContext + useScannerStatus hook). STANDARD, NARROW INTEGRATION
 2026-05-20 13:20 | WARP/fix-sentry-p1-runtime-bugs | WARP-45: _coerce_jsonb() added to signal_scan_job.py; asyncpg JSONB-as-str ValueError fixed (Sentry DAWN-SNOWFLAKE-1729-1Q); STANDARD, NARROW INTEGRATION


### PR DESCRIPTION
## Summary

- Verified WARP-35 (DataError: date string to asyncpg) fix is in `main` — commit `7f14c42d`
- Verified WARP-37 (BadRequest: Telegram no-op edit) fix is in `main` — commits `088bad4` + `843bb6c`
- Closed both Linear issues from `In Progress` → `Done` with completed task checklists

## Details

**WARP-35** — `_get_daily_spend` / `_record_spend` in `services/copy_trade/monitor.py` correctly pass `datetime.date` (not ISO string) to asyncpg. Regression tests in `tests/test_copy_trade.py` confirm type contract.

**WARP-37** — `not modified` BadRequest guard present in all 6 inline-edit handlers: `setup.py` (×5) and `settings.py` (×1).

## Test plan

- [ ] No code changes — state sync lane only
- [ ] Forge report at `projects/polymarket/crusaderbot/reports/forge/fix-active-issues.md`
- [ ] CHANGELOG.md appended

**Validation Tier:** MINOR
**Claim Level:** FOUNDATION

https://claude.ai/code/session_01Rxifue7SohcmCMFHZQP1KT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxifue7SohcmCMFHZQP1KT)_