### PR TITLE
fix: WARP•GATE dispatch exits 0 when secrets not configured

### DIFF
--- a/.github/workflows/warp-gate-events.yml
+++ b/.github/workflows/warp-gate-events.yml
@@ -87,12 +87,9 @@ actor   = os.environ.get("WARP_ACTOR", "")
 api_key = os.environ.get("BASE44_API_KEY", "")
 secret  = os.environ.get("WARP_WEBHOOK_SECRET", "")
 
-if not api_key:
-    print("ERROR: BASE44_API_KEY not set", file=sys.stderr)
-    sys.exit(1)
-if not secret:
-    print("ERROR: WARP_WEBHOOK_SECRET not set", file=sys.stderr)
-    sys.exit(1)
+if not api_key or not secret:
+    print("WARN: BASE44_API_KEY or WARP_WEBHOOK_SECRET not configured — dispatch skipped")
+    sys.exit(0)
 
 # ── pull_request ─────────────────────────────────────────────────────────────
 if ev == "pull_request":

--- a/scripts/warp_gate_dispatcher.py
+++ b/scripts/warp_gate_dispatcher.py
@@ -212,8 +212,8 @@ def main() -> int:
     secret  = os.environ.get("WARP_WEBHOOK_SECRET", "")
 
     if not api_key or not secret:
-        print("ERROR: BASE44_API_KEY or WARP_WEBHOOK_SECRET not set.", file=sys.stderr)
-        return 1
+        print("WARN: BASE44_API_KEY or WARP_WEBHOOK_SECRET not configured — dispatch skipped")
+        return 0
 
     envelope = build_envelope()
     message  = human_message(envelope)


### PR DESCRIPTION
## Summary

- `sys.exit(1)` on missing `BASE44_API_KEY` / `WARP_WEBHOOK_SECRET` caused every dispatch step to show as failed in CI, even with `continue-on-error: true` set at both step and job level
- Changed to `sys.exit(0)` with a `WARN` print — the step now skips cleanly when secrets are not configured (e.g. forks, fresh repos, pre-secret setup)
- Same fix applied to `scripts/warp_gate_dispatcher.py` for consistency

## Files changed

- `.github/workflows/warp-gate-events.yml` — inline Python: `sys.exit(1)` → `sys.exit(0)` on missing secrets
- `scripts/warp_gate_dispatcher.py` — `return 1` → `return 0` on missing secrets

## Test plan

- [ ] Merge and verify next PR/issue event triggers the workflow with green status
- [ ] Confirm dispatch still fires correctly when `BASE44_API_KEY` + `WARP_WEBHOOK_SECRET` are set

https://claude.ai/code/session_01Rxifue7SohcmCMFHZQP1KT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxifue7SohcmCMFHZQP1KT)_