### PR TITLE
fix(migrations): WARP-49 — remove stale access_tier UPDATE from 031

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql
+++ b/projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql
@@ -69,7 +69,6 @@ AND NOT EXISTS (
        AND s.unsubscribed_at IS NULL
 );
 
--- 5. Align access_tier with role model — paper is open to all users
-UPDATE users SET access_tier = 3 WHERE access_tier < 3;
+-- 5. access_tier removed — role-based scope (admin/user) handles access. No action needed.
 
 COMMIT;

--- a/projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql
+++ b/projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql
@@ -1,7 +1,7 @@
 -- Migration 031: Signal Scanner — backfill feed seeds + user enrollment
 -- Fixes: demo/live feeds missing if 024/025 ran on empty DB;
---        users created after 024 not enrolled or subscribed;
---        access_tier < 3 blocking paper-mode signal scan.
+--        users created after 024 not enrolled or subscribed.
+-- Note:  access_tier handling removed; access is now role-based (admin/user).
 -- Idempotent: all writes use ON CONFLICT DO NOTHING or WHERE NOT EXISTS.
 -- Apply after 030_job_runs_metadata.sql
 

--- a/projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
@@ -1,0 +1,95 @@
+# WARP•FORGE REPORT — fix-migrations-warp49
+
+**Validation Tier:** MINOR
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** migrations/027–031 SQL files only
+**Not in Scope:** Python code, frontend, new schema changes, migration 024 (already applied)
+
+---
+
+## 1. What Was Built
+
+Audit of migrations 027–031 for stale `access_tier` references. One blocker found and patched in-place in 031. No structural changes to any migration.
+
+---
+
+## 2. Current System Architecture
+
+No architecture changes. Migration pipeline unchanged. Latest applied migration: 043. Migrations 027–031 are pending Supabase production application.
+
+Schema truth established from migrations 032–043: no migration in that range touches `users.access_tier` or `users.role`. The column removal occurred outside the migration files (directly in Supabase).
+
+---
+
+## 3. Files Created / Modified
+
+| Action   | File |
+|----------|------|
+| PATCHED  | `projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql` |
+| CREATED  | `projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md` |
+
+---
+
+## 4. Per-Migration Status
+
+| Migration | Status    | Detail |
+|-----------|-----------|--------|
+| 027       | CONFIRMED CLEAN | Adds `notifications_on` BOOLEAN to `user_settings`. No `access_tier` reference. |
+| 028       | OUT OF SCOPE | Not in audit range (027/029/030/031 per issue). |
+| 029       | CONFIRMED CLEAN | Creates `portfolio_snapshots`, `system_alerts`, and NOTIFY triggers. No `access_tier` reference. |
+| 030       | CONFIRMED CLEAN | Adds `metadata` JSONB to `job_runs`. No `access_tier` reference. |
+| 031       | PATCHED | Step 5 removed (see below). Steps 1–4 verified CLEAN. |
+
+---
+
+## 5. What Is Working
+
+**Migration 031 — patch detail**
+
+Removed (hard blocker):
+```sql
+-- 5. Align access_tier with role model — paper is open to all users
+UPDATE users SET access_tier = 3 WHERE access_tier < 3;
+```
+
+Replaced with:
+```sql
+-- 5. access_tier removed — role-based scope (admin/user) handles access. No action needed.
+```
+
+`role` column nullability was NOT confirmed from migrations 032–043 (no migration in that range adds or alters `users.role`). Per issue instructions: no `UPDATE users SET role = ...` added.
+
+**Migration 031 Steps 1–4 — schema verification**
+
+Step 1 & 2 — `signal_feeds` INSERT:
+- Columns used: `id, name, slug, operator_id, status, description, subscriber_count, is_demo, created_at, updated_at`
+- All present: `id/name/slug/operator_id/status/description/subscriber_count/created_at/updated_at` from 010, `is_demo` from 014 ✓
+
+Step 3 — `user_strategies` INSERT:
+- Columns used: `user_id, strategy_name, weight, enabled, created_at`
+- Identical pattern used in 024 step 5 (already applied without issue) ✓
+
+Step 4 — `user_signal_subscriptions` INSERT:
+- Columns used: `user_id, feed_id, subscribed_at, is_demo`
+- `unsubscribed_at IS NULL` guard column present from 010 ✓
+- `is_demo` added by 014 ✓
+
+---
+
+## 6. Known Issues
+
+**024 step 4 has an identical `access_tier` UPDATE** (`UPDATE users SET access_tier = 3 WHERE access_tier < 3`). This is outside the declared scope (027–031) and was already applied. Flagged for WARP🔹CMD awareness — if 024 ever needs to be replayed, it will hit the same blocker.
+
+No other issues found.
+
+---
+
+## 7. What Is Next
+
+```
+WARP🔹CMD review required.
+Source: projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
+Tier: MINOR
+```
+
+GATE + Mr. Walker handle Supabase execution of 027–031. No further FORGE action required on this lane.

--- a/projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
@@ -86,7 +86,7 @@ No other issues found.
 
 ## 7. What Is Next
 
-```
+```text
 WARP🔹CMD review required.
 Source: projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md
 Tier: MINOR


### PR DESCRIPTION
Closes #1215

## Summary

Audited migrations 027–031 for stale `access_tier` references. One blocker found in 031 step 5; patched in-place.

**Validation Tier:** MINOR
**Claim Level:** NARROW INTEGRATION

## Per-Migration Status

| Migration | Status | Detail |
|-----------|--------|--------|
| 027 | CONFIRMED CLEAN | `notifications_on` column on `user_settings`. No `access_tier`. |
| 029 | CONFIRMED CLEAN | `portfolio_snapshots` + `system_alerts` + NOTIFY triggers. No `access_tier`. |
| 030 | CONFIRMED CLEAN | `metadata` JSONB on `job_runs`. No `access_tier`. |
| 031 | PATCHED | Step 5 `UPDATE users SET access_tier = 3` removed, replaced with comment. Steps 1–4 schema-verified. |

## 031 Steps 1–4 Schema Verification

- Step 1/2 (`signal_feeds` INSERT): all columns confirmed via 010 + 014.
- Step 3 (`user_strategies` INSERT): pattern identical to 024 step 5 (already applied).
- Step 4 (`user_signal_subscriptions` INSERT + `unsubscribed_at` guard): columns from 010 + 014.

## Notes for WARP🔹CMD

- `role` column nullability NOT confirmed from migrations 032–043 (no migration in that range touches `users.role`). Per issue instructions: no `UPDATE users SET role = ...` added.
- Migration 024 step 4 contains the **same** `access_tier` UPDATE. Out of scope here (already applied) — flagged in forge report for awareness if 024 ever needs replay.

## Files Changed

- `projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql` — step 5 patched
- `projects/polymarket/crusaderbot/reports/forge/fix-migrations-warp49.md` — forge report (created)

## State Files

Not modified by FORGE — GATE handles post-merge sync per issue spec.

## Test Plan

- [ ] GATE / Mr. Walker apply 027–031 to Supabase production
- [ ] Confirm 031 completes without `column "access_tier" does not exist` error
- [ ] Confirm demo + live feeds seeded, users enrolled in `signal_following`, demo subscriptions created

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLKi6EabbwvwGq1P9hwxWz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Audited database migrations to align with the current role-based access approach.
  * Removed legacy access-tier update steps from migrations to prevent outdated backfills.

* **Documentation**
  * Added an internal report documenting the migration audit, verifications performed, and a noted migration anomaly for follow-up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->