### PR TITLE
fix(migrations): WARP-50 — add 044 drop access_tier + P1 Python audit

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
+++ b/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
@@ -1,6 +1,8 @@
 -- Migration 044: Drop access_tier column from users table
--- access_tier is obsolete — access control is now role-based (admin/user).
--- Safe to run: column is no longer referenced in any Python code or migration.
--- Idempotent: IF EXISTS guard prevents error on re-run.
+-- access_tier is planned for removal — access control will move to a role-based model.
+-- WARNING: DO NOT APPLY. Column is still referenced in Python code per WARP-50 audit
+--          (see reports/forge/fix-drop-access-tier-warp50.md section 6).
+--          Apply only after the role-based Python migration lane lands.
+-- Idempotent: IF EXISTS guard prevents error on re-run once safe to apply.
 
 ALTER TABLE users DROP COLUMN IF EXISTS access_tier;

--- a/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
+++ b/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
@@ -1,0 +1,6 @@
+-- Migration 044: Drop access_tier column from users table
+-- access_tier is obsolete — access control is now role-based (admin/user).
+-- Safe to run: column is no longer referenced in any Python code or migration.
+-- Idempotent: IF EXISTS guard prevents error on re-run.
+
+ALTER TABLE users DROP COLUMN IF EXISTS access_tier;

--- a/projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md
@@ -1,0 +1,124 @@
+# WARP•FORGE REPORT — fix-drop-access-tier-warp50
+
+**Validation Tier:** MINOR
+**Claim Level:** NARROW INTEGRATION
+**Validation Target:** migrations/ SQL files only
+**Not in Scope:** Python code changes, frontend, new features
+
+---
+
+## 1. What Was Built
+
+- Created `044_drop_access_tier.sql` per issue spec (single `ALTER TABLE users DROP COLUMN IF EXISTS access_tier;` statement).
+- Audited all `.py` files under `projects/polymarket/crusaderbot/` for `access_tier` references.
+- Verified migration 031 step 5 patch (from WARP-49) is still correct.
+
+---
+
+## 2. Current System Architecture
+
+No architecture changes. SQL-only deliverable. Migration pipeline unchanged.
+
+**Apply order:** 031 (already mostly applied; only step 2 live feed pending) → 044.
+
+⚠️ 044 must NOT be applied to Supabase until the Python `access_tier` references listed in section 6 are migrated to the role-based model. Applying 044 against the current codebase will break LIVE TRADING GUARDS, user creation, the risk gate, the admin API, the operator allowlist, and multiple background jobs.
+
+---
+
+## 3. Files Created / Modified
+
+| Action  | File |
+|---------|------|
+| CREATED | `projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql` |
+| CREATED | `projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md` |
+
+No other files modified.
+
+---
+
+## 4. Migration 044 Content (confirmed)
+
+```sql
+-- Migration 044: Drop access_tier column from users table
+-- access_tier is obsolete — access control is now role-based (admin/user).
+-- Safe to run: column is no longer referenced in any Python code or migration.
+-- Idempotent: IF EXISTS guard prevents error on re-run.
+
+ALTER TABLE users DROP COLUMN IF EXISTS access_tier;
+```
+
+---
+
+## 5. Migration 031 Step 5 — confirmed clean
+
+Current content at `projects/polymarket/crusaderbot/migrations/031_signal_scanner_user_enrollment.sql:72`:
+
+```sql
+-- 5. access_tier removed — role-based scope (admin/user) handles access. No action needed.
+```
+
+Patched by WARP-49 (PR #1216, merged). No further action needed on 031.
+
+---
+
+## 6. Python Code Audit — RESULT: **P1 BLOCKERS FOUND**
+
+The issue's preamble for 044 says "column is no longer referenced in any Python code or migration." **This is FALSE.** 30 Python files reference `access_tier`. 16 are production paths (non-test). Dropping the column now will cause runtime failures on user creation, live trading gating, and admin APIs.
+
+### Production code references (P1 — must migrate before applying 044)
+
+| File | Lines | Surface |
+|------|------|---------|
+| `projects/polymarket/crusaderbot/users.py` | 71, 82, 84, 189, 198 | INSERT users + monotonic UPDATEs |
+| `projects/polymarket/crusaderbot/scheduler.py` | 244, 286, 314 | SELECT in scheduler tick + ctx instantiation |
+| `projects/polymarket/crusaderbot/services/tiers.py` | 4 | Docstring (low risk; cosmetic) |
+| `projects/polymarket/crusaderbot/services/user_service.py` | 21, 23, 31, 44, 59, 72, 78, 91, 97 | INSERT/SELECT/UPDATE with audit; `update_access_tier` API |
+| `projects/polymarket/crusaderbot/services/copy_trade/monitor.py` | 290, 481 | SELECT join + ctx field |
+| `projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py` | 143, 398, 490 | Scanner SELECT + ctx instantiation |
+| `projects/polymarket/crusaderbot/services/trade_engine/engine.py` | 77, 184, 288 | `SignalCtx.access_tier: int` dataclass field |
+| `projects/polymarket/crusaderbot/api/admin.py` | 39, 41, 75, 83, 164 | Admin dashboard counts + user create endpoint |
+| `projects/polymarket/crusaderbot/bot/middleware/access_tier.py` | (file-level) | `require_access_tier` decorator; the entire module is built on this |
+| `projects/polymarket/crusaderbot/domain/activation/live_checklist.py` | 187, 191 | `SELECT access_tier FROM users` (live gate check 8) |
+| `projects/polymarket/crusaderbot/domain/risk/gate.py` | 24, 140, 242, 243 | Risk gate `access_tier < 3` block (LIVE mode) |
+| `projects/polymarket/crusaderbot/domain/execution/live.py` | 50, 70, 71, 80, 140 | `assert_live_guards(access_tier, ...)` — **LIVE TRADING GUARD** |
+| `projects/polymarket/crusaderbot/domain/execution/router.py` | 27, 35, 57 | Router passes access_tier to live engine |
+| `projects/polymarket/crusaderbot/domain/execution/parity.py` | 57, 82, 128 | Parity test infrastructure (≥4 for live) |
+| `projects/polymarket/crusaderbot/scripts/seed_demo_data.py` | 204 | INSERT for demo users |
+| `projects/polymarket/crusaderbot/scripts/seed_operator_tier.py` | 5, 10, 114, 125, 126, 131, 134, 135, 143, 158, 166, 171, 172 | Entire purpose is seeding `access_tier`; ON CONFLICT/GREATEST logic |
+
+### Test references (must update once production paths are migrated)
+
+`tests/test_access_tiers.py`, `tests/test_users.py`, `tests/test_signal_following.py`, `tests/test_signal_scan_job.py`, `tests/test_seed_operator_tier.py`, `tests/test_preset_system.py`, `tests/test_portfolio_charts_insights.py`, `tests/test_pipeline_runtime_hardening.py`, `tests/test_phase5j_emergency.py`, `tests/test_phase5h_onboarding.py`, `tests/test_phase5g_customize_wizard.py`, `tests/test_phase5f_copy_wizard.py`, `tests/test_phase5e_copy_trade.py`, `tests/test_phase5d_grid_menu_split.py`, `tests/test_live_opt_in_gate.py`, `tests/test_live_execution_rewire.py`, `tests/test_live_checklist.py`, `tests/test_isolation_audit.py`, `tests/test_fast_track_b.py`, `tests/test_fast_track_a.py`, `tests/test_fallback.py`, `tests/test_copy_trade.py`, `tests/test_activation_handlers.py`
+
+---
+
+## 7. What Is Working
+
+- Migration 044 file content matches the issue spec exactly.
+- Migration 031 step 5 patch from WARP-49 is intact at the expected line.
+- The forge audit completed across all `.py` files under the project root.
+
+---
+
+## 8. Known Issues
+
+**P1: Python code is NOT clean for `access_tier` removal.** Live trading guard (`domain/execution/live.py:assert_live_guards`) and risk gate (`domain/risk/gate.py`) both check `access_tier` integer thresholds (≥4 for LIVE, ≥3 for paper). These are safety-critical paths. Dropping the column drops these guards.
+
+**Recommendation:** Do NOT apply 044 to Supabase until a separate lane migrates the Python production paths above to the role-based model. After Python migration, also update tests and the dataclass `SignalCtx.access_tier` field.
+
+**Operational gap noted (out of scope here):**
+Migration 031 step 2 (live feed seed) is still missing on Supabase production per the WARP-49 escalation diagnostic. That gap is independent of WARP-50 and should be closed in its own lane.
+
+---
+
+## 9. What Is Next
+
+```text
+WARP🔹CMD review required.
+Source: projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md
+Tier: MINOR
+```
+
+**Apply order recommendation:** 031 → 044 — but **HOLD 044** until the P1 Python references in section 6 are migrated.
+
+GATE + Mr. Walker handle Supabase execution per issue spec. No further FORGE action required on this lane.

--- a/projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md
@@ -19,7 +19,7 @@
 
 No architecture changes. SQL-only deliverable. Migration pipeline unchanged.
 
-**Apply order:** 031 (already mostly applied; only step 2 live feed pending) → 044.
+**Apply order:** 031 → Python role-migration lane → 044. (031 is already mostly applied; only step 2 live feed pending. The Python role-migration lane must close all P1 references in section 6 before 044 is safe.)
 
 ⚠️ 044 must NOT be applied to Supabase until the Python `access_tier` references listed in section 6 are migrated to the role-based model. Applying 044 against the current codebase will break LIVE TRADING GUARDS, user creation, the risk gate, the admin API, the operator allowlist, and multiple background jobs.
 
@@ -40,12 +40,16 @@ No other files modified.
 
 ```sql
 -- Migration 044: Drop access_tier column from users table
--- access_tier is obsolete — access control is now role-based (admin/user).
--- Safe to run: column is no longer referenced in any Python code or migration.
--- Idempotent: IF EXISTS guard prevents error on re-run.
+-- access_tier is planned for removal — access control will move to a role-based model.
+-- WARNING: DO NOT APPLY. Column is still referenced in Python code per WARP-50 audit
+--          (see reports/forge/fix-drop-access-tier-warp50.md section 6).
+--          Apply only after the role-based Python migration lane lands.
+-- Idempotent: IF EXISTS guard prevents error on re-run once safe to apply.
 
 ALTER TABLE users DROP COLUMN IF EXISTS access_tier;
 ```
+
+> Deviation from issue spec: the comments originally specified ("obsolete", "Safe to run: column is no longer referenced") were proven false by the Python audit in section 6. Comments updated to match audit truth so the file does not mislead future maintainers.
 
 ---
 
@@ -75,7 +79,7 @@ The issue's preamble for 044 says "column is no longer referenced in any Python 
 | `projects/polymarket/crusaderbot/services/user_service.py` | 21, 23, 31, 44, 59, 72, 78, 91, 97 | INSERT/SELECT/UPDATE with audit; `update_access_tier` API |
 | `projects/polymarket/crusaderbot/services/copy_trade/monitor.py` | 290, 481 | SELECT join + ctx field |
 | `projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py` | 143, 398, 490 | Scanner SELECT + ctx instantiation |
-| `projects/polymarket/crusaderbot/services/trade_engine/engine.py` | 77, 184, 288 | `SignalCtx.access_tier: int` dataclass field |
+| `projects/polymarket/crusaderbot/services/trade_engine/engine.py` | 77, 184, 288 | `TradeSignal.access_tier: int` dataclass field |
 | `projects/polymarket/crusaderbot/api/admin.py` | 39, 41, 75, 83, 164 | Admin dashboard counts + user create endpoint |
 | `projects/polymarket/crusaderbot/bot/middleware/access_tier.py` | (file-level) | `require_access_tier` decorator; the entire module is built on this |
 | `projects/polymarket/crusaderbot/domain/activation/live_checklist.py` | 187, 191 | `SELECT access_tier FROM users` (live gate check 8) |
@@ -119,6 +123,6 @@ Source: projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp5
 Tier: MINOR
 ```
 
-**Apply order recommendation:** 031 → 044 — but **HOLD 044** until the P1 Python references in section 6 are migrated.
+**Apply order recommendation:** 031 → Python role-migration lane → 044. **HOLD 044** until the Python lane closes all P1 references in section 6.
 
 GATE + Mr. Walker handle Supabase execution per issue spec. No further FORGE action required on this lane.


### PR DESCRIPTION
Closes #1217

## Summary

Adds `044_drop_access_tier.sql` per issue spec and audits all `.py` files for remaining `access_tier` references.

**Validation Tier:** MINOR
**Claim Level:** NARROW INTEGRATION

## Deliverables

| # | Item | Status |
|---|------|--------|
| 1 | `044_drop_access_tier.sql` created with exact content from issue | ✅ |
| 2 | Python `access_tier` audit | ⚠️ **P1 BLOCKERS FOUND** |
| 3 | 031 step 5 patch (WARP-49) confirmed intact | ✅ |
| 4 | Forge report with per-file P1 list | ✅ |

## ⚠️ Critical — DO NOT APPLY 044 YET

The issue preamble claims `access_tier` is "no longer referenced in any Python code". The audit contradicts this. **16 production files still reference it**, including safety-critical paths:

- `domain/execution/live.py` — `assert_live_guards()` (LIVE TRADING GUARD)
- `domain/risk/gate.py` — risk gate `access_tier < 3` block
- `users.py`, `services/user_service.py` — user INSERT/UPDATE
- `api/admin.py` — admin counts + create-user endpoint
- `bot/middleware/access_tier.py` — `require_access_tier` decorator
- `services/trade_engine/engine.py` — `SignalCtx.access_tier: int` dataclass field
- Plus: `scheduler.py`, `services/copy_trade/monitor.py`, `services/signal_scan/signal_scan_job.py`, `domain/activation/live_checklist.py`, `domain/execution/router.py`, `domain/execution/parity.py`, `services/tiers.py`, `scripts/seed_demo_data.py`, `scripts/seed_operator_tier.py`

23 test files also reference it. Full per-line list in the forge report.

## Apply Order Recommendation

`031` (live feed seed missing) → **migrate Python to role-based model** → `044`

## Files Changed

- `projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql` — new
- `projects/polymarket/crusaderbot/reports/forge/fix-drop-access-tier-warp50.md` — new

## State Files

Not modified by FORGE — GATE handles post-merge sync per issue spec.

## Test Plan

- [ ] WARP🔹CMD reviews P1 audit and decides on Python migration lane sequencing
- [ ] After Python migration lane lands, GATE applies 044 to Supabase
- [ ] Verify `users.access_tier` is gone and runtime stays green

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLKi6EabbwvwGq1P9hwxWz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prepared an idempotent schema change to remove an obsolete user field; deployment is on hold until related application updates are completed to avoid runtime issues.

* **Documentation**
  * Added operational guidance and an audit summary detailing why the migration must be delayed, plus notes about a pending live-feed seeding step required for safe rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->