### PR TITLE
fix(access_tier): WARP-50b — replace access_tier with role-based model

### DIFF
--- a/projects/polymarket/crusaderbot/api/admin.py
+++ b/projects/polymarket/crusaderbot/api/admin.py
@@ -35,10 +35,12 @@ async def status(authorization: str | None = Header(default=None)):
     pool = get_pool()
     async with pool.acquire() as conn:
         users = await conn.fetchval("SELECT COUNT(*) FROM users")
-        funded = await conn.fetchval(
-            "SELECT COUNT(*) FROM users WHERE access_tier>=3")
+        # 'funded' historically meant access_tier>=3 — paper is now open to all
+        # users so funded == total users (kept in the payload for backwards
+        # compatibility with existing operator dashboards).
+        funded = users
         live = await conn.fetchval(
-            "SELECT COUNT(*) FROM users WHERE access_tier>=4")
+            "SELECT COUNT(*) FROM users WHERE role = 'admin'")
         open_paper = await conn.fetchval(
             "SELECT COUNT(*) FROM positions WHERE status='open' AND mode='paper'")
         open_live = await conn.fetchval(
@@ -63,7 +65,7 @@ async def live_gate_status(authorization: str | None = Header(default=None)):
 
     Returns a machine-readable and human-readable summary of whether each gate
     is open or locked, which makes operator validation and CI monitoring
-    straightforward. All five must be True before any Tier 4 user can route a
+    straightforward. All five must be True before any admin user can route a
     real order to the Polymarket CLOB.
     """
     token = authorization.removeprefix("Bearer ").strip() if authorization else None
@@ -72,7 +74,7 @@ async def live_gate_status(authorization: str | None = Header(default=None)):
     pool = get_pool()
     async with pool.acquire() as conn:
         tier4_count = int(await conn.fetchval(
-            "SELECT COUNT(*) FROM users WHERE access_tier >= 4"
+            "SELECT COUNT(*) FROM users WHERE role = 'admin'"
         ))
         live_mode_count = int(await conn.fetchval(
             "SELECT COUNT(*) FROM user_settings WHERE trading_mode = 'live'"
@@ -80,7 +82,7 @@ async def live_gate_status(authorization: str | None = Header(default=None)):
         live_mode_tier4_count = int(await conn.fetchval(
             "SELECT COUNT(*) FROM users u "
             "JOIN user_settings s ON s.user_id = u.id "
-            "WHERE u.access_tier >= 4 AND s.trading_mode = 'live'"
+            "WHERE u.role = 'admin' AND s.trading_mode = 'live'"
         ))
         open_live = int(await conn.fetchval(
             "SELECT COUNT(*) FROM positions WHERE status='open' AND mode='live'"
@@ -93,8 +95,8 @@ async def live_gate_status(authorization: str | None = Header(default=None)):
         "ENABLE_LIVE_TRADING": s.ENABLE_LIVE_TRADING,
         "EXECUTION_PATH_VALIDATED": s.EXECUTION_PATH_VALIDATED,
         "CAPITAL_MODE_CONFIRMED": s.CAPITAL_MODE_CONFIRMED,
-        "tier4_users_exist": tier4_count > 0,
-        "live_mode_tier4_users_exist": live_mode_tier4_count > 0,
+        "admin_users_exist": tier4_count > 0,
+        "live_mode_admin_users_exist": live_mode_tier4_count > 0,
     }
     operator_guards_open = (
         s.ENABLE_LIVE_TRADING
@@ -119,9 +121,9 @@ async def live_gate_status(authorization: str | None = Header(default=None)):
         "live_routing_possible": operator_guards_open and live_mode_tier4_count > 0,
         "gates": gates,
         "users": {
-            "tier4_total": tier4_count,
+            "admin_total": tier4_count,
             "live_mode_total": live_mode_count,
-            "tier4_and_live_mode": live_mode_tier4_count,
+            "admin_and_live_mode": live_mode_tier4_count,
         },
         "positions": {
             "open_live": open_live,
@@ -161,7 +163,7 @@ async def dry_run(request: dict, authorization: str | None = Header(default=None
         signal = TradeSignal(
             user_id=uuid.UUID(str(request.get("user_id", ""))),
             telegram_user_id=int(request.get("telegram_user_id", 0)),
-            access_tier=int(request.get("access_tier", 2)),
+            role=str(request.get("role", "user")),
             auto_trade_on=bool(request.get("auto_trade_on", True)),
             paused=bool(request.get("paused", False)),
             market_id=str(request.get("market_id", "")),

--- a/projects/polymarket/crusaderbot/bot/middleware/access_tier.py
+++ b/projects/polymarket/crusaderbot/bot/middleware/access_tier.py
@@ -1,15 +1,18 @@
-"""String-tier access gate decorator for Telegram command handlers.
+"""Role-based access gate decorator for Telegram command handlers.
 
 Usage:
-    from ..middleware.access_tier import require_access_tier
+    from ..middleware.access_tier import require_role
 
-    @require_access_tier('PREMIUM')
-    async def my_premium_handler(update, context):
+    @require_role('admin')
+    async def my_admin_handler(update, context):
         ...
 
 Two roles only: `user` (default — full paper access) and `admin`
 (OPERATOR_CHAT_ID or ADMIN). This decorator gates admin-only handlers;
-non-admin features are open to every user.
+non-admin features are open to every user (paper trading is unrestricted).
+
+The file name is retained as `access_tier.py` for import-path stability;
+the legacy integer access_tier scheme has been removed.
 """
 from __future__ import annotations
 
@@ -20,28 +23,46 @@ import structlog
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ...services.tiers import TIER_ADMIN, TIER_PREMIUM, get_user_tier, meets_tier
+from ...database import get_pool
 
 log = structlog.get_logger(__name__)
 
-_UPGRADE_MESSAGES: dict[str, str] = {
-    TIER_PREMIUM: "This feature is not available.",
-    TIER_ADMIN: "Admin access required.",
-}
+VALID_ROLES: frozenset[str] = frozenset({"admin", "user"})
 
 HandlerFn = Callable[..., Awaitable[Any]]
 
 
-def require_access_tier(min_tier: str) -> Callable[[HandlerFn], HandlerFn]:
-    """Decorator: gate a Telegram handler on the caller's string tier.
+async def _get_role(telegram_user_id: int) -> str:
+    """Return the user's role; defaults to 'user' when row or column is missing.
 
-    Raises ValueError at decoration time if min_tier is not a known tier,
-    so typos are caught when the module is imported, not at runtime.
+    Fail-open to 'user' (not 'admin') so a missing column never grants
+    elevated access. Admin handlers are still safe because the role check
+    requires equality with 'admin'.
     """
-    from ...services.tiers import VALID_TIERS  # local import avoids circular at module level
-    if min_tier not in VALID_TIERS:
+    try:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT role FROM users WHERE telegram_user_id=$1",
+                telegram_user_id,
+            )
+    except Exception as exc:  # noqa: BLE001 — never crash a handler on a role read
+        log.warning("role_read_failed", telegram_user_id=telegram_user_id, err=str(exc))
+        return "user"
+    if row is None or row["role"] is None:
+        return "user"
+    return str(row["role"])
+
+
+def require_role(required_role: str) -> Callable[[HandlerFn], HandlerFn]:
+    """Decorator: gate a Telegram handler on the caller's role.
+
+    Raises ValueError at decoration time if required_role is unknown so
+    typos are caught at import, not at runtime.
+    """
+    if required_role not in VALID_ROLES:
         raise ValueError(
-            f"require_access_tier: unknown tier {min_tier!r}. Valid: {sorted(VALID_TIERS)}"
+            f"require_role: unknown role {required_role!r}. Valid: {sorted(VALID_ROLES)}"
         )
 
     def decorator(handler: HandlerFn) -> HandlerFn:
@@ -55,20 +76,17 @@ def require_access_tier(min_tier: str) -> Callable[[HandlerFn], HandlerFn]:
             if update.effective_user is None or update.effective_message is None:
                 return None
             telegram_user_id = update.effective_user.id
-            user_tier = await get_user_tier(telegram_user_id)
-            if not meets_tier(user_tier, min_tier):
+            user_role = await _get_role(telegram_user_id)
+            if user_role != required_role and required_role == "admin":
                 log.info(
-                    "access_tier.denied",
+                    "role.denied",
                     telegram_user_id=telegram_user_id,
-                    user_tier=user_tier,
-                    required=min_tier,
+                    user_role=user_role,
+                    required=required_role,
                     handler=handler.__name__,
                 )
-                msg = _UPGRADE_MESSAGES.get(
-                    min_tier, "This feature is not available."
-                )
                 await update.effective_message.reply_text(
-                    msg, parse_mode="Markdown"
+                    "Admin access required.", parse_mode="Markdown"
                 )
                 return None
             return await handler(update, context, *args, **kwargs)

--- a/projects/polymarket/crusaderbot/domain/activation/live_checklist.py
+++ b/projects/polymarket/crusaderbot/domain/activation/live_checklist.py
@@ -184,18 +184,18 @@ async def _gate_two_factor(user_id: UUID) -> GateOutcome:
 
 
 async def _gate_operator_allowlist(user_id: UUID) -> GateOutcome:
-    """[8] Operator allowlist approved → users.access_tier >= 4 (Tier 4)."""
+    """[8] Operator allowlist approved → users.role = 'admin'."""
     pool = get_pool()
     async with pool.acquire() as conn:
-        tier = await conn.fetchval(
-            "SELECT access_tier FROM users WHERE id=$1", user_id,
+        role = await conn.fetchval(
+            "SELECT role FROM users WHERE id=$1", user_id,
         )
-    if tier is None:
+    if role is None:
         return GateOutcome(GATE_OPERATOR_ALLOWLIST, False, "user not found")
-    if int(tier) >= 4:
-        return GateOutcome(GATE_OPERATOR_ALLOWLIST, True, f"tier={int(tier)}")
+    if str(role) == "admin":
+        return GateOutcome(GATE_OPERATOR_ALLOWLIST, True, "role=admin")
     return GateOutcome(
-        GATE_OPERATOR_ALLOWLIST, False, f"tier={int(tier)}<4",
+        GATE_OPERATOR_ALLOWLIST, False, f"role={role}",
     )
 
 

--- a/projects/polymarket/crusaderbot/domain/execution/live.py
+++ b/projects/polymarket/crusaderbot/domain/execution/live.py
@@ -47,7 +47,7 @@ class LivePostSubmitError(RuntimeError):
     """Raised after a CLOB submission has occurred — paper-fallback is UNSAFE."""
 
 
-def assert_live_guards(access_tier: int, trading_mode: str) -> None:
+def assert_live_guards(role: str, trading_mode: str) -> None:
     """Raise unless ALL activation guards pass.
 
     USE_REAL_CLOB is included as a guard because MockClobClient records
@@ -55,6 +55,9 @@ def assert_live_guards(access_tier: int, trading_mode: str) -> None:
     real order to Polymarket — phantom live exposure. Requiring the real
     client here ensures the router also paper-falls-back when USE_REAL_CLOB
     is not set, even if all three env guards are enabled.
+
+    role must equal 'admin' — live trading is owner-only while
+    EXECUTION_PATH_VALIDATED / CAPITAL_MODE_CONFIRMED remain owner-gated.
     """
     s = get_settings()
     if not s.ENABLE_LIVE_TRADING:
@@ -67,8 +70,8 @@ def assert_live_guards(access_tier: int, trading_mode: str) -> None:
         raise LivePreSubmitError(
             "USE_REAL_CLOB must be True when ENABLE_LIVE_TRADING is set"
         )
-    if access_tier < 4:
-        raise LivePreSubmitError(f"tier {access_tier}<4")
+    if role != "admin":
+        raise LivePreSubmitError(f"role={role!r} not admin")
     if trading_mode != "live":
         raise LivePreSubmitError(f"user trading_mode={trading_mode}")
 
@@ -77,7 +80,7 @@ async def execute(
     *,
     user_id: UUID,
     telegram_user_id: int,
-    access_tier: int,
+    role: str,
     trading_mode: str,
     market_id: str,
     market_question: str | None,
@@ -137,7 +140,7 @@ async def execute(
         )
         return {"status": "dry_run", "mode": "paper", "_mock": True}
 
-    assert_live_guards(access_tier, trading_mode)
+    assert_live_guards(role, trading_mode)
 
     token_id = yes_token_id if side == "yes" else no_token_id
     if not token_id:

--- a/projects/polymarket/crusaderbot/domain/execution/parity.py
+++ b/projects/polymarket/crusaderbot/domain/execution/parity.py
@@ -54,7 +54,7 @@ async def validate_gate_parity(
     *,
     user_id: UUID,
     telegram_user_id: int,
-    access_tier: int,
+    role: str,
     market_id: str,
     side: str,
     proposed_size_usdc: Decimal,
@@ -79,7 +79,7 @@ async def validate_gate_parity(
     base_ctx = GateContext(
         user_id=user_id,
         telegram_user_id=telegram_user_id,
-        access_tier=access_tier,
+        role=role,
         auto_trade_on=True,
         paused=False,
         market_id=market_id,
@@ -125,7 +125,7 @@ async def validate_gate_parity(
     live_ctx = GateContext(
         user_id=user_id,
         telegram_user_id=telegram_user_id,
-        access_tier=max(access_tier, 4),  # min Tier 4 for live gate
+        role="admin",  # force admin for live gate parity simulation
         auto_trade_on=True,
         paused=False,
         market_id=market_id,

--- a/projects/polymarket/crusaderbot/domain/execution/router.py
+++ b/projects/polymarket/crusaderbot/domain/execution/router.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 async def execute(*, chosen_mode: str, user_id: UUID, telegram_user_id: int,
-                  access_tier: int, market_id: str, market_question: str | None,
+                  role: str, market_id: str, market_question: str | None,
                   yes_token_id: str | None, no_token_id: str | None,
                   side: str, size_usdc: Decimal, price: float,
                   idempotency_key: str, strategy_type: str,
@@ -32,7 +32,7 @@ async def execute(*, chosen_mode: str, user_id: UUID, telegram_user_id: int,
                   trading_mode: str = "paper") -> dict:
     if chosen_mode == "live":
         try:
-            live_engine.assert_live_guards(access_tier, trading_mode)
+            live_engine.assert_live_guards(role, trading_mode)
         except Exception as exc:
             # CRITICAL: live path was requested but guards are not all SET.
             # This is a guard bypass attempt — operator must investigate.
@@ -54,7 +54,7 @@ async def execute(*, chosen_mode: str, user_id: UUID, telegram_user_id: int,
         try:
             return await live_engine.execute(
                 user_id=user_id, telegram_user_id=telegram_user_id,
-                access_tier=access_tier, trading_mode=trading_mode,
+                role=role, trading_mode=trading_mode,
                 market_id=market_id, market_question=market_question,
                 yes_token_id=yes_token_id, no_token_id=no_token_id,
                 side=side, size_usdc=size_usdc, price=price,

--- a/projects/polymarket/crusaderbot/domain/risk/gate.py
+++ b/projects/polymarket/crusaderbot/domain/risk/gate.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class GateContext:
     user_id: UUID
     telegram_user_id: int
-    access_tier: int
+    role: str
     auto_trade_on: bool
     paused: bool
     market_id: str
@@ -137,7 +137,7 @@ def _passes_live_guards(ctx: GateContext, settings) -> bool:
         settings.ENABLE_LIVE_TRADING
         and settings.EXECUTION_PATH_VALIDATED
         and settings.CAPITAL_MODE_CONFIRMED
-        and ctx.access_tier >= 4
+        and ctx.role == "admin"
         and ctx.trading_mode == "live"
     )
 
@@ -235,13 +235,13 @@ async def evaluate(ctx: GateContext) -> GateResult:
         return GateResult(False, "auto_trade_off_or_paused", 2)
     await _log(ctx.user_id, ctx.market_id, 2, True, "ok")
 
-    # 3. Paper trading is open to every user (no gate). Live retains a
-    #    funded-account check as defence-in-depth; the authoritative live
-    #    safety boundary is assert_live_guards (Tier 4 + activation guards)
-    #    at order submission, which is intentionally left intact.
-    if ctx.trading_mode == "live" and ctx.access_tier < 3:
-        await _log(ctx.user_id, ctx.market_id, 3, False, f"tier_{ctx.access_tier}")
-        return GateResult(False, "insufficient_tier", 3)
+    # 3. Paper trading is open to every user (no gate). Live retains an
+    #    admin-role check as defence-in-depth; the authoritative live
+    #    safety boundary is assert_live_guards (role=='admin' + activation
+    #    guards) at order submission, which is intentionally left intact.
+    if ctx.trading_mode == "live" and ctx.role != "admin":
+        await _log(ctx.user_id, ctx.market_id, 3, False, f"role_{ctx.role}")
+        return GateResult(False, "insufficient_role", 3)
     await _log(ctx.user_id, ctx.market_id, 3, True, "ok")
 
     # 4. Strategy availability

--- a/projects/polymarket/crusaderbot/migrations/045_add_role_column.sql
+++ b/projects/polymarket/crusaderbot/migrations/045_add_role_column.sql
@@ -1,0 +1,24 @@
+-- Migration 045: Add role column to users table (WARP-50b)
+-- Two-role access model: 'admin' = full owner access, 'user' = standard paper trading.
+-- Paper trading is open to every user; live trading requires role='admin'
+-- (plus the activation guards in domain/execution/live.assert_live_guards).
+--
+-- access_tier remains in the schema for now — it is no longer read by any
+-- access-gating code path but is still written on INSERT to avoid breaking
+-- the NOT NULL constraint. Migration 044_drop_access_tier.sql removes the
+-- column once this lane has been stable in production.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + conditional admin backfill.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(20) NOT NULL DEFAULT 'user';
+
+-- Bootstrap: promote the earliest-created user to admin so a fresh DB has
+-- at least one operator capable of running /allowlist and live-trading
+-- flows. No-op once any user already has role='admin' (covers reruns and
+-- DBs already seeded via scripts/seed_operator_tier.py).
+UPDATE users
+   SET role = 'admin'
+ WHERE id = (
+     SELECT id FROM users ORDER BY created_at ASC LIMIT 1
+ )
+   AND NOT EXISTS (SELECT 1 FROM users WHERE role = 'admin');

--- a/projects/polymarket/crusaderbot/reports/forge/fix-access-tier-open-warp50b.md
+++ b/projects/polymarket/crusaderbot/reports/forge/fix-access-tier-open-warp50b.md
@@ -1,0 +1,102 @@
+# WARP-50b — Replace access_tier with role-based access model
+
+Validation Tier: STANDARD
+Claim Level: NARROW INTEGRATION
+Validation Target: All production files referencing `access_tier` for access gating — gating logic replaced with `users.role` column ('admin' | 'user'). `access_tier` column itself stays in DB; migration 044 (DROP) deferred.
+Not in Scope: DB schema DROP (044), frontend, new features, refactor of `services/tiers.py` (string `user_tiers` system — separate from `access_tier`).
+Suggested Next Step: WARP🔹CMD review → merge. Run `045_add_role_column.sql` against staging before merging. Once stable, schedule a follow-up lane to apply `044_drop_access_tier.sql`.
+
+---
+
+## 1. What was built
+
+- All access gating moved from the integer `users.access_tier` column to a two-value `users.role` column (`'admin'` | `'user'`).
+- Paper trading is open to every user (no role check anywhere in the paper path).
+- Live trading and admin tooling now check `role == 'admin'` instead of `access_tier >= 4`.
+- Legacy `access_tier` column is left intact in the schema and explicitly set to `4` on all new INSERTs so the NOT NULL constraint does not break. Removal stays staged behind `044_drop_access_tier.sql`.
+- New migration `045_add_role_column.sql` adds the column with default `'user'` and promotes the earliest-created user to `'admin'` if no admin exists yet.
+
+## 2. Current system architecture
+
+```
+INSERT path (users.py / user_service.py / scripts/seed_*)
+    └─> users (telegram_user_id, username, access_tier=4, role='user'|'admin')
+
+Access gating
+    ├─ paper trading       : open to all users (no decorator, no SQL filter)
+    ├─ admin Telegram cmds : @require_role('admin') from bot/middleware/access_tier.py
+    ├─ live risk gate      : domain/risk/gate.py — ctx.role == 'admin' (step 3 + _passes_live_guards)
+    ├─ live order submit   : domain/execution/live.assert_live_guards(role, trading_mode)
+    └─ live checklist [8]  : domain/activation/live_checklist._gate_operator_allowlist — SELECT role
+
+ctx propagation
+    scheduler.run_signal_scan   ─┐
+    signal_scan_job._build_*    ─┼─> TradeSignal.role ─> GateContext.role ─> router.execute(role=…)
+    copy_trade.monitor          ─┘                                          └─> live.assert_live_guards(role, mode)
+
+Operator seeding
+    scripts/seed_operator_tier  ─> users.role = 'admin' (idempotent upsert, prev role audited)
+```
+
+## 3. Files created / modified (full repo-root paths)
+
+Created:
+
+- `projects/polymarket/crusaderbot/migrations/045_add_role_column.sql`
+- `projects/polymarket/crusaderbot/reports/forge/fix-access-tier-open-warp50b.md`
+
+Modified — production:
+
+- `projects/polymarket/crusaderbot/users.py`
+- `projects/polymarket/crusaderbot/services/user_service.py`
+- `projects/polymarket/crusaderbot/services/tiers.py` (docstring only — module is the parallel string-tier system and untouched)
+- `projects/polymarket/crusaderbot/bot/middleware/access_tier.py`
+- `projects/polymarket/crusaderbot/domain/risk/gate.py`
+- `projects/polymarket/crusaderbot/domain/activation/live_checklist.py`
+- `projects/polymarket/crusaderbot/domain/execution/live.py`
+- `projects/polymarket/crusaderbot/domain/execution/router.py`
+- `projects/polymarket/crusaderbot/domain/execution/parity.py`
+- `projects/polymarket/crusaderbot/services/trade_engine/engine.py`
+- `projects/polymarket/crusaderbot/scheduler.py`
+- `projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py`
+- `projects/polymarket/crusaderbot/services/copy_trade/monitor.py`
+- `projects/polymarket/crusaderbot/api/admin.py`
+- `projects/polymarket/crusaderbot/scripts/seed_demo_data.py`
+- `projects/polymarket/crusaderbot/scripts/seed_operator_tier.py`
+
+Modified — tests:
+
+- `projects/polymarket/crusaderbot/tests/test_access_tiers.py`
+- `projects/polymarket/crusaderbot/tests/test_isolation_audit.py`
+- `projects/polymarket/crusaderbot/tests/test_live_checklist.py`
+- `projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py`
+- `projects/polymarket/crusaderbot/tests/test_seed_operator_tier.py`
+- `projects/polymarket/crusaderbot/tests/test_fast_track_a.py`
+- `projects/polymarket/crusaderbot/tests/test_pipeline_runtime_hardening.py`
+- `projects/polymarket/crusaderbot/tests/test_fallback.py`
+
+## 4. What is working
+
+- `python3 -m compileall` on every modified production file: clean.
+- Full pytest suite: `1512 passed, 24 warnings` (0 failed).
+- `assert_live_guards(role='admin', trading_mode='live')` accepts admin only; `role='user'` raises `LivePreSubmitError("role='user' not admin")`.
+- `require_role('admin')` decorator blocks non-admin Telegram users and replies "Admin access required."; `require_role('user')` is open.
+- `_gate_operator_allowlist` reads `SELECT role FROM users WHERE id=$1` and passes iff role='admin'.
+- Risk gate step 3 enforces `role == 'admin'` only when `trading_mode == 'live'`; paper mode is unconditional pass.
+- Scheduler + signal_scan_job + copy_trade monitor all SELECT `u.role` and propagate it to `GateContext.role` / `TradeSignal.role`.
+- `seed_operator_tier` idempotently upserts `role='admin'` (with `access_tier=4` placeholder); existing-admin path is a no-op; user→admin path emits an `operator_role_seed` audit row with `prev_role`/`new_role`.
+
+## 5. Known issues
+
+- `access_tier` column is still present and is set to a constant `4` on every INSERT. This is intentional — removal is staged behind `044_drop_access_tier.sql`, which is to be applied as a separate lane after this PR is stable in production. Until then the column is dead-write data.
+- `users.set_tier` / `users.force_set_tier` remain in `users.py` so existing admin tooling (`bot/handlers/admin.py:allowlist_command`) that writes `access_tier` still functions, but those writes no longer gate anything — admin promotion now requires `users.set_role(user_id, 'admin')` (also new in this lane).
+- `services/tiers.py` (the `user_tiers` string-tier table) is unchanged. It is a parallel system that predates the role model; the docstring was updated to call this out. Cleanup is a separate lane.
+
+## 6. What is next
+
+1. Apply `045_add_role_column.sql` on staging.
+2. WARP🔹CMD review of this PR.
+3. After merge + stable production window, open a follow-up lane to:
+   - Apply `044_drop_access_tier.sql` and remove every remaining write of `access_tier=4` in INSERT statements.
+   - Replace `users.set_tier` / `users.force_set_tier` / `bot/handlers/admin.py:allowlist_command` with the role-based equivalent.
+   - Decide the fate of `services/tiers.py` (`user_tiers` table).

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -241,7 +241,7 @@ async def run_signal_scan() -> None:
     async with pool.acquire() as conn:
         users = await conn.fetch(
             """
-            SELECT u.id, u.telegram_user_id, u.access_tier, u.auto_trade_on,
+            SELECT u.id, u.telegram_user_id, u.role, u.auto_trade_on,
                    u.paused, w.balance_usdc, s.*
               FROM users u
               JOIN wallets w ON w.user_id = u.id
@@ -283,7 +283,7 @@ async def _process_candidate(user: dict, cand) -> None:
     ctx_g = GateContext(
         user_id=user["id"],
         telegram_user_id=user["telegram_user_id"],
-        access_tier=user["access_tier"],
+        role=user.get("role") or "user",
         auto_trade_on=user["auto_trade_on"],
         paused=user["paused"],
         market_id=cand.market_id,
@@ -311,7 +311,7 @@ async def _process_candidate(user: dict, cand) -> None:
             chosen_mode=result.chosen_mode,
             user_id=user["id"],
             telegram_user_id=user["telegram_user_id"],
-            access_tier=user["access_tier"],
+            role=user.get("role") or "user",
             trading_mode=user["trading_mode"],
             market_id=cand.market_id,
             market_question=market["question"],

--- a/projects/polymarket/crusaderbot/scripts/seed_demo_data.py
+++ b/projects/polymarket/crusaderbot/scripts/seed_demo_data.py
@@ -202,8 +202,8 @@ async def _upsert_demo_users(conn: asyncpg.Connection) -> list[uuid.UUID]:
         await conn.execute(
             """
             INSERT INTO users (id, telegram_user_id, username, access_tier,
-                               auto_trade_on, paused, is_demo)
-            VALUES ($1, $2, $3, 3, FALSE, FALSE, TRUE)
+                               role, auto_trade_on, paused, is_demo)
+            VALUES ($1, $2, $3, 4, 'user', FALSE, FALSE, TRUE)
             ON CONFLICT (telegram_user_id) DO NOTHING
             """,
             det_id, tg_id, f"demo_user_{i}",

--- a/projects/polymarket/crusaderbot/scripts/seed_operator_tier.py
+++ b/projects/polymarket/crusaderbot/scripts/seed_operator_tier.py
@@ -1,17 +1,15 @@
-"""Admin/access seeder for CrusaderBot.
+"""Admin role seeder for CrusaderBot.
 
 Reads ``ADMIN_USER_IDS`` from the environment (comma-separated Telegram
-user ids) and ensures each id has a row in ``users`` with a sufficient
-``access_tier``. In the two-role model every user already has full paper
-access; this seeder guarantees designated ids are provisioned (and is the
-mechanism for bootstrapping admin/funded ids on a fresh deploy).
+user ids) and ensures each id has a row in ``users`` with ``role='admin'``.
+In the two-role model every user already has full paper access; this
+seeder grants the admin role to the designated owner/operator ids (and is
+the mechanism for bootstrapping admin ids on a fresh deploy).
 
 The script is idempotent: re-running it on a database that already has
-the operators seeded is a no-op. Existing rows have ``access_tier``
-raised to 2 only when the current value is below 2 (we never *demote*
-an existing operator — a Tier 4 operator stays Tier 4). Missing rows
-are inserted with sensible defaults (auto_trade_on=FALSE, paused=FALSE,
-no wallet — the operator must run /start once to provision a wallet).
+the operators seeded is a no-op. Missing rows are inserted with sensible
+defaults (auto_trade_on=FALSE, paused=FALSE, no wallet — the operator
+must run /start once to provision a wallet).
 
 The seeder is wired into the Fly release_command so it runs on every
 deploy. In the Fly image the package installs as top-level
@@ -31,18 +29,7 @@ Process exit code
 The CLI entry point (``main``) ALWAYS exits 0 so Fly's release_command
 never aborts the deploy. Fly fails any release whose hook returns a
 non-zero code, but every failure mode of this seeder is recoverable
-without rolling the release back:
-
-* Missing ``ADMIN_USER_IDS`` — the operator simply hasn't supplied the
-  secret yet; the bot still runs, /kill / /resume still work, and the
-  next deploy after the secret is set will pick the operators up.
-* Missing ``DATABASE_URL`` — the app itself cannot start without it
-  and will surface the failure through /health, not the seeder.
-* DB error — transient connectivity, OR (on the very first deploy)
-  the schema does not exist yet because ``run_migrations()`` runs in
-  the app lifespan AFTER the release_command. The seeder logs the
-  error and the operator can re-run it after the bot is up. A future
-  enhancement is to gate the seed on a "migrations applied" probe.
+without rolling the release back.
 
 Internal status codes (returned by ``_run`` for tests + programmatic
 callers, but always wrapped to exit 0 by ``main``):
@@ -53,9 +40,9 @@ callers, but always wrapped to exit 0 by ``main``):
 
 Audit
 -----
-Every successful insert or tier-raise emits one row to ``audit.log``
-(actor_role=``operator``, action=``operator_tier_seed``, payload contains
-the affected telegram_user_id and the previous + new tier values). The
+Every successful insert or role-promotion emits one row to ``audit.log``
+(actor_role=``operator``, action=``operator_role_seed``, payload contains
+the affected telegram_user_id and the previous + new role values). The
 audit write is best-effort: a failure to write audit MUST NOT block
 deploy completion.
 """
@@ -72,9 +59,10 @@ import asyncpg
 
 logger = logging.getLogger("crusaderbot.scripts.seed_operator_tier")
 
-OPERATOR_TIER: int = 2
+ADMIN_ROLE: str = "admin"
+ACCESS_TIER_DUMMY: int = 4  # legacy column placeholder; role is the source of truth
 AUDIT_ACTOR_ROLE: str = "operator"
-AUDIT_ACTION: str = "operator_tier_seed"
+AUDIT_ACTION: str = "operator_role_seed"
 
 
 def _parse_ids(raw: str | None) -> list[int]:
@@ -103,93 +91,47 @@ def _parse_ids(raw: str | None) -> list[int]:
 
 async def _seed_one(
     conn: asyncpg.Connection, telegram_user_id: int,
-) -> tuple[str, int | None, int]:
-    """Ensure one operator row exists at >= Tier 2.
+) -> tuple[str, str | None, str]:
+    """Ensure one operator row exists with ``role='admin'``.
 
-    Returns a tuple ``(action, prev_tier, new_tier)`` where ``action``
-    is one of ``inserted`` / ``raised`` / ``noop``. ``prev_tier`` is
-    ``None`` for inserted rows.
+    Returns ``(action, prev_role, new_role)`` where ``action`` is one of
+    ``inserted`` / ``raised`` / ``noop``. ``prev_role`` is ``None`` for
+    inserted rows.
     """
     row = await conn.fetchrow(
-        "SELECT id, access_tier FROM users WHERE telegram_user_id=$1",
+        "SELECT id, role FROM users WHERE telegram_user_id=$1",
         telegram_user_id,
     )
     if row is None:
-        # Atomic upsert that closes the same release-time concurrency
-        # window we already handle for UPDATE: if a sibling process
-        # (e.g., the previous app version still serving the same DB
-        # during a Fly release) runs ``users.upsert_user()`` between
-        # our SELECT and our INSERT, the row appears at Tier 1 — a
-        # plain ``ON CONFLICT DO NOTHING`` would skip the upgrade and
-        # falsely report "inserted" while the actual tier stayed at 1.
-        # ``ON CONFLICT DO UPDATE SET access_tier=GREATEST(...)`` is
-        # monotonic and guarantees ``access_tier >= OPERATOR_TIER``
-        # post-statement. ``xmax = 0`` on RETURNING distinguishes a
-        # true insert (xmax=0) from a conflict-path upgrade (xmax!=0)
-        # so the audit row records the correct action.
         result = await conn.fetchrow(
-            "INSERT INTO users (telegram_user_id, access_tier, "
-            "auto_trade_on, paused) VALUES ($1, $2, FALSE, FALSE) "
+            "INSERT INTO users (telegram_user_id, access_tier, role, "
+            "auto_trade_on, paused) VALUES ($1, $2, $3, FALSE, FALSE) "
             "ON CONFLICT (telegram_user_id) DO UPDATE "
-            "SET access_tier=GREATEST(users.access_tier, EXCLUDED.access_tier) "
-            "RETURNING access_tier, (xmax = 0) AS was_inserted",
-            telegram_user_id, OPERATOR_TIER,
+            "SET role = EXCLUDED.role "
+            "RETURNING role, (xmax = 0) AS was_inserted",
+            telegram_user_id, ACCESS_TIER_DUMMY, ADMIN_ROLE,
         )
-        # The DO UPDATE branch is unconditional, so RETURNING always
-        # yields one row — but stay defensive in case a fixture or
-        # future schema change ever returns None.
         if result is None:
-            return ("noop", None, OPERATOR_TIER)
-        new_actual = int(result["access_tier"])
+            return ("noop", None, ADMIN_ROLE)
+        new_actual = str(result["role"])
         was_inserted = bool(result["was_inserted"])
-        # user_settings row is created lazily on first /dashboard read
-        # via users.get_settings_for(); we keep this script narrow.
         if was_inserted:
             return ("inserted", None, new_actual)
-        if new_actual > OPERATOR_TIER:
-            # Concurrent process inserted the row at a higher tier
-            # than our target — script did not lift it.
-            return ("noop", None, new_actual)
-        # Concurrent INSERT landed at a tier below ours; our DO UPDATE
-        # path lifted it up to OPERATOR_TIER. We didn't see the row in
-        # our SELECT, so prev_tier stays None for the audit.
+        # Concurrent INSERT landed earlier and our DO UPDATE set role=admin;
+        # treat as a promotion (prev unknown so audit prev_role is None).
         return ("raised", None, new_actual)
 
-    prev = int(row["access_tier"])
-    if prev >= OPERATOR_TIER:
+    prev = str(row["role"]) if row["role"] is not None else "user"
+    if prev == ADMIN_ROLE:
         return ("noop", prev, prev)
 
-    # Use GREATEST so a concurrent promotion that lands between our
-    # SELECT and our UPDATE is preserved — the previous app version
-    # may still be serving the same database during a Fly release and
-    # an operator could be promoted to Tier 3/4 in that window. A
-    # plain ``SET access_tier=$2`` would silently demote them back to
-    # Tier 2; ``GREATEST`` is monotonic and matches the convention in
-    # ``users.set_tier()``. ``RETURNING`` gives us the actual post-
-    # update tier so the audit row reflects reality.
     new_actual = await conn.fetchval(
-        "UPDATE users SET access_tier=GREATEST(access_tier, $2) "
-        "WHERE id=$1 RETURNING access_tier",
-        row["id"], OPERATOR_TIER,
+        "UPDATE users SET role=$2 WHERE id=$1 RETURNING role",
+        row["id"], ADMIN_ROLE,
     )
     if new_actual is None:
-        # The row was deleted between our SELECT and UPDATE; nothing
-        # for us to claim credit for. Audit row stays at prev so a
-        # reviewer can correlate the disappearance with whatever
-        # concurrent process removed it.
         return ("noop", prev, prev)
-    new_actual = int(new_actual)
-    if new_actual > OPERATOR_TIER:
-        # A concurrent process already lifted the user above our
-        # target. ``GREATEST`` kept the higher value so our UPDATE was
-        # a no-op write — the script did NOT raise this tier and the
-        # audit log must not attribute the change to us.
-        return ("noop", prev, new_actual)
-    # ``new_actual == OPERATOR_TIER`` — we (or a sibling release also
-    # seeding the same tier) brought the row to the target. Either
-    # way the audit row showing ``prev_tier`` lets a reader verify
-    # the promotion came from below.
-    return ("raised", prev, new_actual)
+    return ("raised", prev, str(new_actual))
 
 
 async def _write_audit(
@@ -197,26 +139,21 @@ async def _write_audit(
     *,
     telegram_user_id: int,
     action: str,
-    prev_tier: int | None,
-    new_tier: int,
+    prev_role: str | None,
+    new_role: str,
 ) -> None:
     """Best-effort audit write — never blocks the seeder.
 
     The INSERT runs inside a NESTED ``conn.transaction()`` so an audit
     failure (missing ``audit`` schema on first deploy, permissions
     drift, etc.) rolls back ONLY the savepoint and leaves the outer
-    seed transaction healthy. asyncpg implements nested transactions
-    as savepoints — without this, a failed INSERT would put the
-    surrounding transaction into an aborted state and PostgreSQL would
-    reject every subsequent statement with ``current transaction is
-    aborted``, undoing the operator-tier seed for every later id in
-    the batch.
+    seed transaction healthy.
     """
     payload = {
         "telegram_user_id": telegram_user_id,
         "action": action,
-        "prev_tier": prev_tier,
-        "new_tier": new_tier,
+        "prev_role": prev_role,
+        "new_role": new_role,
         "source": "scripts.seed_operator_tier",
     }
     try:
@@ -251,8 +188,8 @@ async def seed(
                         conn,
                         telegram_user_id=tg_id,
                         action=action,
-                        prev_tier=prev,
-                        new_tier=new,
+                        prev_role=prev,
+                        new_role=new,
                     )
                 logger.info(
                     "seed_operator_tier tg=%s action=%s prev=%s new=%s",

--- a/projects/polymarket/crusaderbot/services/copy_trade/monitor.py
+++ b/projects/polymarket/crusaderbot/services/copy_trade/monitor.py
@@ -287,7 +287,7 @@ async def _process_one(
     signal = TradeSignal(
         user_id=task.user_id,
         telegram_user_id=user_ctx["telegram_user_id"],
-        access_tier=user_ctx["access_tier"],
+        role=user_ctx.get("role") or "user",
         auto_trade_on=user_ctx["auto_trade_on"],
         paused=user_ctx["paused"],
         market_id=market_id,
@@ -478,7 +478,7 @@ async def _load_user_context(user_id: UUID) -> dict[str, Any] | None:
         row = await conn.fetchrow(
             """
             SELECT u.telegram_user_id,
-                   u.access_tier,
+                   u.role,
                    u.auto_trade_on,
                    u.paused,
                    COALESCE(s.risk_profile, 'balanced') AS risk_profile,

--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -140,7 +140,7 @@ async def _load_enrolled_users() -> list[dict[str, Any]]:
             SELECT
                 u.id                     AS user_id,
                 u.telegram_user_id,
-                u.access_tier,
+                u.role,
                 u.auto_trade_on,
                 u.paused,
                 COALESCE(w.balance_usdc, 0)   AS balance_usdc,
@@ -395,7 +395,7 @@ def _build_trade_signal(
     return TradeSignal(
         user_id=UUID(str(row["user_id"])),
         telegram_user_id=int(row["telegram_user_id"]),
-        access_tier=int(row["access_tier"]),
+        role=str(row.get("role") or "user"),
         auto_trade_on=bool(row["auto_trade_on"]),
         paused=bool(row["paused"]),
         market_id=cand.market_id,
@@ -487,7 +487,7 @@ async def _process_candidate(
                     chosen_mode=str(stale["chosen_mode"]),
                     user_id=user_id,
                     telegram_user_id=int(row["telegram_user_id"]),
-                    access_tier=int(row["access_tier"]),
+                    role=str(row.get("role") or "user"),
                     market_id=stale["market_id"],
                     market_question=str(stale_market.get("question") or ""),
                     yes_token_id=stale_market.get("yes_token_id"),

--- a/projects/polymarket/crusaderbot/services/tiers.py
+++ b/projects/polymarket/crusaderbot/services/tiers.py
@@ -1,7 +1,11 @@
 """Access tier CRUD for the user_tiers table.
 
 String tiers: FREE < PREMIUM < ADMIN.
-Parallel to the legacy integer access_tier column — does not replace it.
+
+Note: this module pre-dates the role-based model (users.role = 'admin' |
+'user'). The user_tiers table remains the source of truth for the legacy
+string-tier scheme; runtime access gating now uses users.role via the
+role_guard decorator (bot/middleware/access_tier.py).
 """
 from __future__ import annotations
 

--- a/projects/polymarket/crusaderbot/services/trade_engine/engine.py
+++ b/projects/polymarket/crusaderbot/services/trade_engine/engine.py
@@ -74,7 +74,7 @@ class TradeSignal:
 
     user_id: UUID
     telegram_user_id: int
-    access_tier: int
+    role: str
     auto_trade_on: bool
     paused: bool
     market_id: str
@@ -181,7 +181,7 @@ class TradeEngine:
             chosen_mode=gate_result.chosen_mode,
             user_id=signal.user_id,
             telegram_user_id=signal.telegram_user_id,
-            access_tier=signal.access_tier,
+            role=signal.role,
             trading_mode=signal.trading_mode,
             market_id=signal.market_id,
             market_question=signal.market_question,
@@ -285,7 +285,7 @@ class TradeEngine:
         return GateContext(
             user_id=signal.user_id,
             telegram_user_id=signal.telegram_user_id,
-            access_tier=signal.access_tier,
+            role=signal.role,
             auto_trade_on=signal.auto_trade_on,
             paused=signal.paused,
             market_id=signal.market_id,

--- a/projects/polymarket/crusaderbot/services/user_service.py
+++ b/projects/polymarket/crusaderbot/services/user_service.py
@@ -1,4 +1,4 @@
-"""User identity service — Telegram-keyed upsert + audit-logged tier transitions."""
+"""User identity service — Telegram-keyed upsert + audit-logged role transitions."""
 from __future__ import annotations
 
 import json
@@ -11,6 +11,9 @@ import structlog
 log = structlog.get_logger(__name__)
 
 
+VALID_ROLES: frozenset[str] = frozenset({"admin", "user"})
+
+
 async def get_or_create_user(
     pool: asyncpg.Pool,
     telegram_user_id: int,
@@ -18,17 +21,21 @@ async def get_or_create_user(
 ) -> dict:
     """Upsert a user keyed on telegram_user_id. Returns full user row as dict.
 
-    On INSERT: defaults are access_tier=1, auto_trade_on=FALSE.
+    On INSERT: defaults are access_tier=4, role='user', auto_trade_on=FALSE.
+    access_tier is set to 4 explicitly so the legacy column never blocks
+    inserts while it still exists; the role column is the access source of
+    truth (see migration 045_add_role_column.sql).
     On CONFLICT: refreshes username if a non-NULL value is provided; preserves
-    every other column including access_tier, auto_trade_on, referrer_id.
+    every other column including access_tier, role, auto_trade_on, referrer_id.
     """
     async with pool.acquire() as conn:
         async with conn.transaction():
             row = await conn.fetchrow(
-                "INSERT INTO users (telegram_user_id, username) VALUES ($1, $2) "
+                "INSERT INTO users (telegram_user_id, username, access_tier, role) "
+                "VALUES ($1, $2, 4, 'user') "
                 "ON CONFLICT (telegram_user_id) DO UPDATE "
                 "SET username = COALESCE(EXCLUDED.username, users.username) "
-                "RETURNING id, telegram_user_id, username, access_tier, "
+                "RETURNING id, telegram_user_id, username, access_tier, role, "
                 "auto_trade_on, referrer_id, created_at",
                 telegram_user_id, username,
             )
@@ -41,72 +48,75 @@ async def get_user_by_telegram_id(
 ) -> Optional[dict]:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT id, telegram_user_id, username, access_tier, auto_trade_on, "
+            "SELECT id, telegram_user_id, username, access_tier, role, auto_trade_on, "
             "referrer_id, created_at FROM users WHERE telegram_user_id=$1",
             telegram_user_id,
         )
     return dict(row) if row else None
 
 
-async def bump_tier(
+async def update_role(
     pool: asyncpg.Pool,
     user_id: UUID,
-    new_tier: int,
+    new_role: str,
     actor_role: str = "system",
     *,
     conn: Optional[asyncpg.Connection] = None,
 ) -> None:
-    """Atomically update access_tier and write an audit.log entry.
+    """Atomically update users.role and write an audit.log entry.
 
-    Uses SELECT ... FOR UPDATE to lock the row; both UPDATE and audit INSERT
-    happen in the same transaction. Raises ValueError if user not found.
+    new_role must be 'admin' or 'user'. Raises ValueError on unknown role
+    or when user is not found.
 
     When `conn` is supplied the operation runs on the caller's connection
-    and inherits its open transaction — the deposit watcher uses this to
-    keep deposit insert + ledger credit + tier bump in one atomic unit so
-    a partial failure cannot leave the user credited but un-promoted (or
-    vice versa).
+    and inherits its open transaction so the caller can keep role change +
+    related writes in one atomic unit.
     """
+    if new_role not in VALID_ROLES:
+        raise ValueError(
+            f"update_role: invalid role {new_role!r}. Valid: {sorted(VALID_ROLES)}"
+        )
+
     if conn is not None:
-        old_tier = await conn.fetchval(
-            "SELECT access_tier FROM users WHERE id=$1 FOR UPDATE",
+        old_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id=$1 FOR UPDATE",
             user_id,
         )
-        if old_tier is None:
+        if old_role is None:
             raise ValueError(f"user not found: {user_id}")
         await conn.execute(
-            "UPDATE users SET access_tier=$1 WHERE id=$2",
-            new_tier, user_id,
+            "UPDATE users SET role=$1 WHERE id=$2",
+            new_role, user_id,
         )
         await conn.execute(
             "INSERT INTO audit.log (user_id, actor_role, action, payload) "
             "VALUES ($1, $2, $3, $4::jsonb)",
-            user_id, actor_role, "user.tier_changed",
-            json.dumps({"old_tier": old_tier, "new_tier": new_tier}),
+            user_id, actor_role, "user.role_changed",
+            json.dumps({"old_role": old_role, "new_role": new_role}),
         )
     else:
         async with pool.acquire() as acquired:
             async with acquired.transaction():
-                old_tier = await acquired.fetchval(
-                    "SELECT access_tier FROM users WHERE id=$1 FOR UPDATE",
+                old_role = await acquired.fetchval(
+                    "SELECT role FROM users WHERE id=$1 FOR UPDATE",
                     user_id,
                 )
-                if old_tier is None:
+                if old_role is None:
                     raise ValueError(f"user not found: {user_id}")
                 await acquired.execute(
-                    "UPDATE users SET access_tier=$1 WHERE id=$2",
-                    new_tier, user_id,
+                    "UPDATE users SET role=$1 WHERE id=$2",
+                    new_role, user_id,
                 )
                 await acquired.execute(
                     "INSERT INTO audit.log (user_id, actor_role, action, payload) "
                     "VALUES ($1, $2, $3, $4::jsonb)",
-                    user_id, actor_role, "user.tier_changed",
-                    json.dumps({"old_tier": old_tier, "new_tier": new_tier}),
+                    user_id, actor_role, "user.role_changed",
+                    json.dumps({"old_role": old_role, "new_role": new_role}),
                 )
     log.info(
-        "user.tier_bumped",
+        "user.role_changed",
         user_id=str(user_id),
-        old_tier=old_tier,
-        new_tier=new_tier,
+        old_role=old_role,
+        new_role=new_role,
         actor_role=actor_role,
     )

--- a/projects/polymarket/crusaderbot/tests/test_access_tiers.py
+++ b/projects/polymarket/crusaderbot/tests/test_access_tiers.py
@@ -170,72 +170,71 @@ def test_list_all_user_tiers_returns_dicts():
 from projects.polymarket.crusaderbot.bot.middleware import access_tier as at_mw
 
 
-def test_require_access_tier_allows_when_meets():
+def test_require_role_admin_allows_admin():
     called = []
 
     async def _handler(update, ctx):
         called.append(True)
 
-    wrapped = at_mw.require_access_tier("PREMIUM")(_handler)
+    wrapped = at_mw.require_role("admin")(_handler)
     upd = _update(user_id=10)
 
     with patch(
-        "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-        new=AsyncMock(return_value="PREMIUM"),
+        "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+        new=AsyncMock(return_value="admin"),
     ):
         _run(wrapped(upd, _ctx()))
 
     assert called == [True]
 
 
-def test_require_access_tier_blocks_when_below():
+def test_require_role_admin_blocks_non_admin():
     called = []
 
     async def _handler(update, ctx):
         called.append(True)
 
-    wrapped = at_mw.require_access_tier("PREMIUM")(_handler)
+    wrapped = at_mw.require_role("admin")(_handler)
     upd = _update(user_id=11)
 
     with patch(
-        "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-        new=AsyncMock(return_value="FREE"),
+        "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+        new=AsyncMock(return_value="user"),
     ):
         _run(wrapped(upd, _ctx()))
 
     assert called == []
     upd.effective_message.reply_text.assert_awaited_once()
-    call_kwargs = upd.effective_message.reply_text.await_args[0][0]
-    # Tier wording is hidden from users (Chunk N cleanup); message says "not available"
-    assert "not available" in call_kwargs
+    body = upd.effective_message.reply_text.await_args[0][0]
+    assert "Admin" in body
 
 
-def test_require_access_tier_admin_blocks_premium():
-    """ADMIN tier passes when PREMIUM is required (rank >= rank)."""
+def test_require_role_user_does_not_gate():
+    """require_role('user') is open — paper trading is unrestricted."""
     called = []
 
     async def _handler(update, ctx):
         called.append(True)
 
-    wrapped = at_mw.require_access_tier("PREMIUM")(_handler)
+    wrapped = at_mw.require_role("user")(_handler)
     upd = _update(user_id=12)
 
     with patch(
-        "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-        new=AsyncMock(return_value="ADMIN"),
+        "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+        new=AsyncMock(return_value="user"),
     ):
         _run(wrapped(upd, _ctx()))
 
     assert called == [True]
 
 
-def test_require_access_tier_no_user_is_noop():
+def test_require_role_no_user_is_noop():
     called = []
 
     async def _handler(update, ctx):
         called.append(True)
 
-    wrapped = at_mw.require_access_tier("PREMIUM")(_handler)
+    wrapped = at_mw.require_role("admin")(_handler)
     upd = _update()
     upd.effective_user = None
 
@@ -243,24 +242,24 @@ def test_require_access_tier_no_user_is_noop():
     assert called == []
 
 
-def test_require_access_tier_raises_at_decoration_time_on_bad_tier():
-    with pytest.raises(ValueError, match="unknown tier"):
-        at_mw.require_access_tier("PREMUM")  # typo — caught at decoration, not runtime
+def test_require_role_raises_at_decoration_time_on_bad_role():
+    with pytest.raises(ValueError, match="unknown role"):
+        at_mw.require_role("operator")  # not a valid role
 
 
-def test_require_access_tier_returns_handler_return_value():
+def test_require_role_returns_handler_return_value():
     """Wrapper must propagate the handler's return value for ConversationHandler."""
     SENTINEL = object()
 
     async def _handler(update, ctx):
         return SENTINEL
 
-    wrapped = at_mw.require_access_tier("FREE")(_handler)
+    wrapped = at_mw.require_role("admin")(_handler)
     upd = _update(user_id=10)
 
     with patch(
-        "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-        new=AsyncMock(return_value="FREE"),
+        "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+        new=AsyncMock(return_value="admin"),
     ):
         result = _run(wrapped(upd, _ctx()))
 

--- a/projects/polymarket/crusaderbot/tests/test_fallback.py
+++ b/projects/polymarket/crusaderbot/tests/test_fallback.py
@@ -280,7 +280,7 @@ def test_gate_step13_silent_downgrade_triggers_live_guard_unset_fallback():
     ctx = gate.GateContext(
         user_id=user_id,
         telegram_user_id=42,
-        access_tier=4,
+        role="admin",
         auto_trade_on=True,
         paused=False,
         market_id="m1",

--- a/projects/polymarket/crusaderbot/tests/test_fast_track_a.py
+++ b/projects/polymarket/crusaderbot/tests/test_fast_track_a.py
@@ -67,7 +67,7 @@ def _signal(
     *,
     auto_trade_on: bool = True,
     paused: bool = False,
-    access_tier: int = 3,
+    role: str = "user",
     market_status: str = "active",
     market_liquidity: float = 50_000.0,
     side: str = "yes",
@@ -82,7 +82,7 @@ def _signal(
     return TradeSignal(
         user_id=_USER_UUID,
         telegram_user_id=12345,
-        access_tier=access_tier,
+        role=role,
         auto_trade_on=auto_trade_on,
         paused=paused,
         market_id=_MARKET,
@@ -238,8 +238,8 @@ class TestTradeEngineGateRejected:
         assert result.failed_gate_step == 13
 
     def test_insufficient_tier(self):
-        sig = _signal(access_tier=2)
-        gate_rej = _rejected_gate("insufficient_tier", 3)
+        sig = _signal(role="user")
+        gate_rej = _rejected_gate("insufficient_role", 3)
         with pytest.MonkeyPatch().context() as mp:
             mp.setattr(
                 "projects.polymarket.crusaderbot.services.trade_engine.engine._risk_evaluate",
@@ -424,7 +424,7 @@ class TestGateContextMapping:
             price=0.60,
             market_liquidity=25_000.0,
             market_status="active",
-            access_tier=4,
+            role="admin",
             auto_trade_on=True,
             paused=False,
             risk_profile="aggressive",
@@ -432,7 +432,7 @@ class TestGateContextMapping:
         ctx = TradeEngine._build_gate_context(sig)
         assert ctx.user_id == _USER_UUID
         assert ctx.telegram_user_id == 12345
-        assert ctx.access_tier == 4
+        assert ctx.role == "admin"
         assert ctx.auto_trade_on is True
         assert ctx.paused is False
         assert ctx.market_id == _MARKET
@@ -625,7 +625,7 @@ class TestTradeSignalContract:
 
     def test_signal_ts_none_allowed(self):
         sig = TradeSignal(
-            user_id=_USER_UUID, telegram_user_id=12345, access_tier=3,
+            user_id=_USER_UUID, telegram_user_id=12345, role="user",
             auto_trade_on=True, paused=False, market_id=_MARKET,
             market_question=None, yes_token_id=None, no_token_id=None,
             side="yes", proposed_size_usdc=Decimal("50"), price=0.50,
@@ -724,7 +724,7 @@ def _make_scan_row(user_id: UUID | None = None) -> dict:
     return {
         "user_id": user_id or _USER_UUID,
         "telegram_user_id": 12345,
-        "access_tier": 3,
+        "role": "user",
         "auto_trade_on": True,
         "paused": False,
         "balance_usdc": Decimal("500.00"),

--- a/projects/polymarket/crusaderbot/tests/test_isolation_audit.py
+++ b/projects/polymarket/crusaderbot/tests/test_isolation_audit.py
@@ -855,16 +855,16 @@ class TestAdminBoundary:
             asyncio.run(admin_root(upd, ctx))
         upd.message.reply_text.assert_called_once()
 
-    # 4-H: require_access_tier decorator — FREE blocked from PREMIUM handler
-    def test_require_access_tier_blocks_free_from_premium(self):
+    # 4-H: require_role decorator — non-admin blocked from admin handler
+    def test_require_role_blocks_user_from_admin(self):
         from projects.polymarket.crusaderbot.bot.middleware.access_tier import (
-            require_access_tier,
+            require_role,
         )
 
         called = []
 
-        @require_access_tier("PREMIUM")
-        async def _premium_handler(update, context):
+        @require_role("admin")
+        async def _admin_handler(update, context):
             called.append("executed")
 
         msg = MagicMock()
@@ -875,24 +875,24 @@ class TestAdminBoundary:
         ctx = MagicMock()
 
         with patch(
-            "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-            new=AsyncMock(return_value="FREE"),
+            "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+            new=AsyncMock(return_value="user"),
         ):
-            asyncio.run(_premium_handler(upd, ctx))
+            asyncio.run(_admin_handler(upd, ctx))
 
-        assert not called, "PREMIUM handler should not execute for FREE user"
+        assert not called, "admin handler should not execute for non-admin user"
         msg.reply_text.assert_called_once()
 
-    # 4-I: require_access_tier — PREMIUM can access PREMIUM handler
-    def test_require_access_tier_allows_premium(self):
+    # 4-I: require_role — admin can access admin handler
+    def test_require_role_allows_admin(self):
         from projects.polymarket.crusaderbot.bot.middleware.access_tier import (
-            require_access_tier,
+            require_role,
         )
 
         called = []
 
-        @require_access_tier("PREMIUM")
-        async def _premium_handler(update, context):
+        @require_role("admin")
+        async def _admin_handler(update, context):
             called.append("executed")
 
         msg = MagicMock()
@@ -903,23 +903,23 @@ class TestAdminBoundary:
         ctx = MagicMock()
 
         with patch(
-            "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-            new=AsyncMock(return_value="PREMIUM"),
+            "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+            new=AsyncMock(return_value="admin"),
         ):
-            asyncio.run(_premium_handler(upd, ctx))
+            asyncio.run(_admin_handler(upd, ctx))
 
-        assert "executed" in called, "PREMIUM handler should execute for PREMIUM user"
+        assert "executed" in called, "admin handler should execute for admin user"
 
-    # 4-J: require_access_tier — ADMIN tier blocked from ADMIN handler if not ADMIN
-    def test_require_access_tier_blocks_premium_from_admin(self):
+    # 4-J: require_role('user') is open — paper trading is unrestricted
+    def test_require_role_user_does_not_gate(self):
         from projects.polymarket.crusaderbot.bot.middleware.access_tier import (
-            require_access_tier,
+            require_role,
         )
 
         called = []
 
-        @require_access_tier("ADMIN")
-        async def _admin_handler(update, context):
+        @require_role("user")
+        async def _open_handler(update, context):
             called.append("executed")
 
         msg = MagicMock()
@@ -930,9 +930,9 @@ class TestAdminBoundary:
         ctx = MagicMock()
 
         with patch(
-            "projects.polymarket.crusaderbot.bot.middleware.access_tier.get_user_tier",
-            new=AsyncMock(return_value="PREMIUM"),
+            "projects.polymarket.crusaderbot.bot.middleware.access_tier._get_role",
+            new=AsyncMock(return_value="user"),
         ):
-            asyncio.run(_admin_handler(upd, ctx))
+            asyncio.run(_open_handler(upd, ctx))
 
-        assert not called, "ADMIN handler should not execute for PREMIUM user"
+        assert "executed" in called, "user-role handler is open to all users"

--- a/projects/polymarket/crusaderbot/tests/test_live_checklist.py
+++ b/projects/polymarket/crusaderbot/tests/test_live_checklist.py
@@ -35,7 +35,7 @@ class FakeConn:
                  strategy_types: list[str] | None = None,
                  risk_profile: str | None = "balanced",
                  two_factor: bool = True,
-                 access_tier: int = 4,
+                 role: str = "admin",
                  user_exists: bool = True) -> None:
         self.has_wallet = has_wallet
         self.deposit_count = deposit_count
@@ -44,7 +44,7 @@ class FakeConn:
         )
         self.risk_profile = risk_profile
         self.two_factor = two_factor
-        self.access_tier = access_tier
+        self.role = role
         self.user_exists = user_exists
         self.audit_inserts: list[tuple] = []
 
@@ -65,8 +65,8 @@ class FakeConn:
     async def fetchval(self, query: str, *args: Any):
         if "COUNT(*) FROM deposits" in query:
             return self.deposit_count
-        if "access_tier FROM users" in query:
-            return self.access_tier if self.user_exists else None
+        if "role FROM users" in query:
+            return self.role if self.user_exists else None
         return 0
 
     async def execute(self, query: str, *args: Any):
@@ -173,8 +173,8 @@ def test_two_factor_gate_fails_when_flag_unset():
     assert lc.GATE_TWO_FACTOR_SETUP in r.failed_gates
 
 
-def test_operator_allowlist_gate_fails_below_tier_4():
-    conn = FakeConn(access_tier=3)
+def test_operator_allowlist_gate_fails_when_role_not_admin():
+    conn = FakeConn(role="user")
     r = _run(conn, _settings())
     assert lc.GATE_OPERATOR_ALLOWLIST in r.failed_gates
 
@@ -189,8 +189,8 @@ def test_operator_allowlist_gate_fails_when_user_missing():
 
 
 def test_partial_pass_three_env_three_user():
-    # Three env gates pass, three user gates fail (subaccount, 2fa, tier).
-    conn = FakeConn(has_wallet=False, two_factor=False, access_tier=2)
+    # Three env gates pass, three user gates fail (subaccount, 2fa, role).
+    conn = FakeConn(has_wallet=False, two_factor=False, role="user")
     r = _run(conn, _settings())
     assert r.passed is False
     assert lc.GATE_ACTIVE_SUBACCOUNT in r.failed_gates

--- a/projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py
+++ b/projects/polymarket/crusaderbot/tests/test_live_execution_rewire.py
@@ -150,7 +150,7 @@ def _settings(
 _EXEC_KWARGS: dict[str, Any] = dict(
     user_id=USER_ID,
     telegram_user_id=12345,
-    access_tier=4,
+    role="admin",
     trading_mode="live",
     market_id="mkt-abc",
     market_question="Will X happen?",
@@ -195,7 +195,7 @@ class TestAssertLiveGuards:
         s = _settings()
         with patch("projects.polymarket.crusaderbot.domain.execution.live.get_settings",
                    return_value=s):
-            assert_live_guards(access_tier=4, trading_mode="live")
+            assert_live_guards(role="admin", trading_mode="live")
 
     def test_enable_live_trading_false_raises(self) -> None:
         s = _settings(enable_live=False)
@@ -204,7 +204,7 @@ class TestAssertLiveGuards:
                   return_value=s),
             pytest.raises(LivePreSubmitError, match="ENABLE_LIVE_TRADING"),
         ):
-            assert_live_guards(access_tier=4, trading_mode="live")
+            assert_live_guards(role="admin", trading_mode="live")
 
     def test_execution_path_not_validated_raises(self) -> None:
         s = _settings(exec_validated=False)
@@ -213,7 +213,7 @@ class TestAssertLiveGuards:
                   return_value=s),
             pytest.raises(LivePreSubmitError, match="EXECUTION_PATH_VALIDATED"),
         ):
-            assert_live_guards(access_tier=4, trading_mode="live")
+            assert_live_guards(role="admin", trading_mode="live")
 
     def test_capital_mode_not_confirmed_raises(self) -> None:
         s = _settings(capital_confirmed=False)
@@ -222,7 +222,7 @@ class TestAssertLiveGuards:
                   return_value=s),
             pytest.raises(LivePreSubmitError, match="CAPITAL_MODE_CONFIRMED"),
         ):
-            assert_live_guards(access_tier=4, trading_mode="live")
+            assert_live_guards(role="admin", trading_mode="live")
 
     def test_use_real_clob_false_raises(self) -> None:
         """USE_REAL_CLOB=False with all other guards set → LivePreSubmitError.
@@ -238,16 +238,16 @@ class TestAssertLiveGuards:
                   return_value=s),
             pytest.raises(LivePreSubmitError, match="USE_REAL_CLOB must be True"),
         ):
-            assert_live_guards(access_tier=4, trading_mode="live")
+            assert_live_guards(role="admin", trading_mode="live")
 
     def test_low_tier_raises(self) -> None:
         s = _settings()
         with (
             patch("projects.polymarket.crusaderbot.domain.execution.live.get_settings",
                   return_value=s),
-            pytest.raises(LivePreSubmitError, match="tier 3"),
+            pytest.raises(LivePreSubmitError, match="not admin"),
         ):
-            assert_live_guards(access_tier=3, trading_mode="live")
+            assert_live_guards(role="user", trading_mode="live")
 
     def test_paper_trading_mode_raises(self) -> None:
         s = _settings()
@@ -256,7 +256,7 @@ class TestAssertLiveGuards:
                   return_value=s),
             pytest.raises(LivePreSubmitError, match="trading_mode=paper"),
         ):
-            assert_live_guards(access_tier=4, trading_mode="paper")
+            assert_live_guards(role="admin", trading_mode="paper")
 
 
 # ---------------------------------------------------------------------------

--- a/projects/polymarket/crusaderbot/tests/test_pipeline_runtime_hardening.py
+++ b/projects/polymarket/crusaderbot/tests/test_pipeline_runtime_hardening.py
@@ -76,7 +76,7 @@ def _signal(**overrides: Any) -> TradeSignal:
     defaults: dict[str, Any] = dict(
         user_id=_USER,
         telegram_user_id=99_999,
-        access_tier=3,
+        role="user",
         auto_trade_on=True,
         paused=False,
         market_id=_MARKET,
@@ -361,7 +361,7 @@ async def test_strategy_scan_done_event_emitted():
     _mock_user = {
         "user_id": str(_USER),
         "telegram_user_id": 12345,
-        "access_tier": 3,
+        "role": "user",
         "auto_trade_on": True,
         "paused": False,
         "balance_usdc": Decimal("1000.00"),

--- a/projects/polymarket/crusaderbot/tests/test_seed_operator_tier.py
+++ b/projects/polymarket/crusaderbot/tests/test_seed_operator_tier.py
@@ -1,4 +1,4 @@
-"""Tests for the Tier 2 operator seeder.
+"""Tests for the admin role seeder.
 
 The seeder is wired into the Fly release_command, so its failure modes
 matter as much as its happy path: a missing or malformed
@@ -43,176 +43,96 @@ def test_parse_ids_skips_unparseable_tokens(caplog):
 
 
 def test_parse_ids_handles_negative_ids():
-    """Telegram supplies positive ids; negative ids appear in the demo
-    seeder. The parser must still accept them — validation belongs at
-    the caller, not here.
-    """
     assert seed._parse_ids("-1, -2, 3") == [-1, -2, 3]
 
 
 # ---------------------------------------------------------------------------
-# _seed_one
+# _seed_one — role-based seeder
 # ---------------------------------------------------------------------------
 
 
 def test_seed_one_inserts_when_user_missing():
     conn = MagicMock()
-    # First fetchrow is the SELECT — returns None (no existing row).
-    # Second fetchrow is the upsert RETURNING. ``xmax = 0`` means our
-    # INSERT actually created the row (no concurrent insert happened).
+    # SELECT returns None (no existing row); upsert RETURNING reports a fresh insert.
     conn.fetchrow = AsyncMock(side_effect=[
         None,
-        {"access_tier": seed.OPERATOR_TIER, "was_inserted": True},
+        {"role": seed.ADMIN_ROLE, "was_inserted": True},
     ])
 
     action, prev, new = _run(seed._seed_one(conn, 123))
 
     assert action == "inserted"
     assert prev is None
-    assert new == seed.OPERATOR_TIER
-    # The upsert SQL is the second fetchrow call.
+    assert new == seed.ADMIN_ROLE
     upsert_sql = conn.fetchrow.await_args_list[1].args[0]
     assert "INSERT INTO users" in upsert_sql
-    assert "ON CONFLICT (telegram_user_id) DO UPDATE" in upsert_sql, (
-        "missing-user path must be an atomic upsert (DO UPDATE), not "
-        "DO NOTHING — see test_seed_one_atomic_upsert_handles_concurrent_insert"
-    )
-    assert "GREATEST(users.access_tier, EXCLUDED.access_tier)" in upsert_sql
+    assert "ON CONFLICT (telegram_user_id) DO UPDATE" in upsert_sql
+    assert "SET role = EXCLUDED.role" in upsert_sql
     assert "(xmax = 0) AS was_inserted" in upsert_sql
 
 
-def test_seed_one_atomic_upsert_handles_concurrent_insert_below_target():
-    """Race: ``users.upsert_user()`` from the previous app version
-    inserts the same telegram_user_id at default Tier 1 between our
-    SELECT (returned None) and our INSERT. The atomic upsert's
-    ``DO UPDATE SET access_tier=GREATEST(...)`` lifts the row to
-    Tier 2; ``xmax != 0`` flags that the conflict path fired so the
-    audit label is "raised", not "inserted".
-    """
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(side_effect=[
-        None,  # SELECT: no row yet (we read before the concurrent INSERT)
-        # Upsert RETURNING: was_inserted=False (conflict fired) +
-        # access_tier=2 (GREATEST(1, 2) = 2 — concurrent row at Tier 1
-        # was lifted to our target).
-        {"access_tier": 2, "was_inserted": False},
-    ])
-
-    action, prev, new = _run(seed._seed_one(conn, 123))
-
-    assert action == "raised", (
-        "concurrent INSERT below target must be lifted and labelled "
-        "'raised' — not silently mislabelled 'inserted'"
-    )
-    assert prev is None
-    assert new == 2
-
-
-def test_seed_one_atomic_upsert_handles_concurrent_insert_above_target():
-    """Race: a concurrent process inserted the row at Tier 4
-    between our SELECT and our upsert. ``GREATEST(4, 2) = 4`` so
-    our DO UPDATE was a no-op — the script did not change anything
-    and must label it "noop".
+def test_seed_one_atomic_upsert_handles_concurrent_insert():
+    """Race: a concurrent process inserted the row between our SELECT and
+    INSERT. The atomic upsert's ``DO UPDATE SET role = EXCLUDED.role``
+    promotes the row to admin; ``xmax != 0`` flags the conflict path so
+    the audit label is "raised", not "inserted".
     """
     conn = MagicMock()
     conn.fetchrow = AsyncMock(side_effect=[
         None,
-        {"access_tier": 4, "was_inserted": False},
+        {"role": seed.ADMIN_ROLE, "was_inserted": False},
     ])
 
     action, prev, new = _run(seed._seed_one(conn, 123))
 
-    assert action == "noop"
+    assert action == "raised"
     assert prev is None
-    assert new == 4
+    assert new == seed.ADMIN_ROLE
 
 
-def test_seed_one_raises_tier_when_below_threshold():
+def test_seed_one_promotes_user_to_admin():
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(return_value={"id": "uuid-1", "access_tier": 1})
-    conn.execute = AsyncMock()
-    conn.fetchval = AsyncMock(return_value=seed.OPERATOR_TIER)
+    conn.fetchrow = AsyncMock(return_value={"id": "uuid-1", "role": "user"})
+    conn.fetchval = AsyncMock(return_value=seed.ADMIN_ROLE)
 
     action, prev, new = _run(seed._seed_one(conn, 123))
 
     assert action == "raised"
-    assert prev == 1
-    assert new == seed.OPERATOR_TIER
+    assert prev == "user"
+    assert new == seed.ADMIN_ROLE
     sql = conn.fetchval.await_args.args[0]
-    assert "UPDATE users SET access_tier=GREATEST" in sql, (
-        "UPDATE must be GREATEST(access_tier, target) — see "
-        "test_seed_one_does_not_demote_concurrent_promotion for the "
-        "race-condition rationale"
-    )
-    assert "RETURNING access_tier" in sql
-
-
-def test_seed_one_does_not_demote_concurrent_promotion():
-    """Race: the previous app version is still serving the DB during a
-    Fly release. Our SELECT sees ``access_tier=1`` but a concurrent
-    process promotes the operator to Tier 4 before our UPDATE lands.
-    The GREATEST clause must keep the higher tier and our action
-    label must report "noop" (the script did not lower the value).
-    """
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(
-        return_value={"id": "uuid-1", "access_tier": 1},
-    )
-    # GREATEST(4, 2) = 4 — the concurrent promotion wins.
-    conn.fetchval = AsyncMock(return_value=4)
-
-    action, prev, new = _run(seed._seed_one(conn, 123))
-
-    assert action == "noop", (
-        "concurrent promote must produce a noop label so the audit "
-        "log does not falsely attribute the change to this script"
-    )
-    assert prev == 1
-    assert new == 4
+    assert "UPDATE users SET role=$2" in sql
+    assert "RETURNING role" in sql
 
 
 def test_seed_one_handles_returning_none_after_concurrent_delete():
-    """If the row is DELETEd between our SELECT and UPDATE, RETURNING
-    yields no row and ``fetchval`` returns ``None``. The seeder must
-    fall back to the pre-update tier so the audit row stays consistent.
+    """If the row is DELETEd between SELECT and UPDATE, RETURNING yields
+    no row. The seeder must fall back to the pre-update role for audit
+    consistency.
     """
     conn = MagicMock()
     conn.fetchrow = AsyncMock(
-        return_value={"id": "uuid-1", "access_tier": 1},
+        return_value={"id": "uuid-1", "role": "user"},
     )
     conn.fetchval = AsyncMock(return_value=None)
 
     action, prev, new = _run(seed._seed_one(conn, 123))
 
     assert action == "noop"
-    assert prev == 1
-    assert new == 1
+    assert prev == "user"
+    assert new == "user"
 
 
-def test_seed_one_noop_when_already_at_or_above_tier():
+def test_seed_one_noop_when_already_admin():
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(return_value={"id": "uuid-1", "access_tier": 2})
+    conn.fetchrow = AsyncMock(return_value={"id": "uuid-1", "role": "admin"})
     conn.execute = AsyncMock()
 
     action, prev, new = _run(seed._seed_one(conn, 123))
 
     assert action == "noop"
-    assert prev == 2
-    assert new == 2
-    conn.execute.assert_not_awaited()
-
-
-def test_seed_one_noop_does_not_demote_higher_tier():
-    """A Tier 4 (live-eligible) operator must not be demoted to Tier 2."""
-    conn = MagicMock()
-    conn.fetchrow = AsyncMock(return_value={"id": "uuid-1", "access_tier": 4})
-    conn.execute = AsyncMock()
-
-    action, prev, new = _run(seed._seed_one(conn, 123))
-
-    assert action == "noop"
-    assert prev == 4
-    assert new == 4
+    assert prev == "admin"
+    assert new == "admin"
     conn.execute.assert_not_awaited()
 
 
@@ -222,12 +142,6 @@ def test_seed_one_noop_does_not_demote_higher_tier():
 
 
 class _NoopTx:
-    """Async context manager mock that simulates asyncpg's nested
-    transaction (a SAVEPOINT). ``__aexit__`` returns False so any
-    exception raised inside the context propagates outward — exactly
-    what real asyncpg does with ``Transaction.__aexit__``.
-    """
-
     async def __aenter__(self):
         return self
 
@@ -249,8 +163,8 @@ def test_write_audit_inserts_into_audit_log():
         conn,
         telegram_user_id=42,
         action="inserted",
-        prev_tier=None,
-        new_tier=2,
+        prev_role=None,
+        new_role="admin",
     ))
 
     conn.execute.assert_awaited_once()
@@ -259,11 +173,9 @@ def test_write_audit_inserts_into_audit_log():
 
 
 def test_write_audit_uses_nested_transaction_for_savepoint_isolation():
-    """The INSERT must run inside ``async with conn.transaction()`` so a
-    failed audit row does NOT poison the outer seed transaction.
-    PostgreSQL aborts the surrounding transaction after any failed
-    statement, so without a savepoint the seeder would fail on every
-    subsequent id in the batch with ``current transaction is aborted``.
+    """Audit INSERT runs inside ``async with conn.transaction()`` so a
+    failed audit row rolls back to a savepoint instead of poisoning the
+    outer seed transaction.
     """
     conn = _conn_with_tx()
 
@@ -271,17 +183,13 @@ def test_write_audit_uses_nested_transaction_for_savepoint_isolation():
         conn,
         telegram_user_id=42,
         action="inserted",
-        prev_tier=None,
-        new_tier=2,
+        prev_role=None,
+        new_role="admin",
     ))
-    assert conn.transaction.call_count == 1, (
-        "audit write must enter a nested conn.transaction() so an audit "
-        "INSERT failure rolls back to a savepoint"
-    )
+    assert conn.transaction.call_count == 1
 
 
 def test_write_audit_swallows_exceptions(caplog):
-    """Audit failure must never propagate out of the seeder."""
     conn = _conn_with_tx(execute_side_effect=RuntimeError("audit table missing"))
 
     with caplog.at_level("WARNING"):
@@ -289,8 +197,8 @@ def test_write_audit_swallows_exceptions(caplog):
             conn,
             telegram_user_id=42,
             action="inserted",
-            prev_tier=None,
-            new_tier=2,
+            prev_role=None,
+            new_role="admin",
         ))
     assert any("audit write failed" in rec.getMessage() for rec in caplog.records)
 
@@ -304,62 +212,45 @@ def test_write_audit_swallows_exceptions(caplog):
 def fake_conn_factory():
     """Patch ``asyncpg.connect`` to return a controllable mock connection."""
 
-    def _factory(initial_rows: dict[int, int | None]):
-        """``initial_rows`` maps telegram_id -> existing access_tier (or None)."""
+    def _factory(initial_rows: dict[int, str | None]):
+        """``initial_rows`` maps telegram_id -> existing role (or None for missing)."""
         conn = MagicMock()
         conn.close = AsyncMock()
 
-        # Track per-id state across calls (insert/raise should mutate state).
         state = dict(initial_rows)
 
         async def _fetchrow(sql, *args):
-            # SELECT lookup before deciding insert vs update.
-            if sql.startswith("SELECT id, access_tier FROM users"):
+            if sql.startswith("SELECT id, role FROM users"):
                 tg_id = args[0]
-                tier = state.get(tg_id)
-                if tier is None:
+                role = state.get(tg_id)
+                if role is None:
                     return None
-                return {"id": f"uuid-{tg_id}", "access_tier": tier}
-            # Atomic upsert RETURNING. ``xmax = 0`` is True only when
-            # this is a fresh insert; in our fake we determine that by
-            # whether the id was absent from state at call time.
+                return {"id": f"uuid-{tg_id}", "role": role}
             if "INSERT INTO users" in sql and "DO UPDATE" in sql:
                 tg_id = args[0]
-                target = args[1]
+                new_role = args[2]
                 pre = state.get(tg_id)
-                if pre is None:
-                    state[tg_id] = target
-                    return {"access_tier": target, "was_inserted": True}
-                new = max(pre, target)
-                state[tg_id] = new
-                return {"access_tier": new, "was_inserted": False}
+                state[tg_id] = new_role
+                return {"role": new_role, "was_inserted": pre is None}
             return None
 
         async def _execute(sql, *args):
             return None
 
         async def _fetchval(sql, *args):
-            # The raise path issues an ``UPDATE ... GREATEST RETURNING``
-            # so the seeder picks up the actual post-update tier even
-            # under a concurrent promotion. Replicate the GREATEST
-            # semantics here so tests exercise the same branching the
-            # production query would.
-            if "UPDATE users SET access_tier=GREATEST" in sql:
+            if "UPDATE users SET role=$2" in sql:
                 uuid_str = args[0]
-                target = args[1]
+                new_role = args[1]
                 if isinstance(uuid_str, str) and uuid_str.startswith("uuid-"):
                     tg = int(uuid_str.removeprefix("uuid-"))
-                    current = state.get(tg, 0)
-                    new = max(current, target)
-                    state[tg] = new
-                    return new
+                    state[tg] = new_role
+                    return new_role
             return None
 
         conn.fetchrow = AsyncMock(side_effect=_fetchrow)
         conn.execute = AsyncMock(side_effect=_execute)
         conn.fetchval = AsyncMock(side_effect=_fetchval)
 
-        # ``conn.transaction()`` must be an async context manager.
         class _Tx:
             async def __aenter__(self):
                 return self
@@ -375,28 +266,26 @@ def fake_conn_factory():
 
 def test_seed_counts_actions_correctly(fake_conn_factory):
     conn = fake_conn_factory({
-        100: None,  # missing -> inserted
-        200: 1,     # below tier -> raised
-        300: 2,     # at tier   -> noop
-        400: 4,     # above     -> noop
+        100: None,     # missing  -> inserted
+        200: "user",   # user     -> raised
+        300: "admin",  # admin    -> noop
     })
 
     async def _connect(dsn):
         return conn
 
     with patch("asyncpg.connect", new=_connect):
-        counts = _run(seed.seed("postgresql://x", [100, 200, 300, 400]))
+        counts = _run(seed.seed("postgresql://x", [100, 200, 300]))
 
-    assert counts == {"inserted": 1, "raised": 1, "noop": 2}
+    assert counts == {"inserted": 1, "raised": 1, "noop": 1}
     conn.close.assert_awaited()
 
 
 def test_seed_runs_each_id_in_single_outer_transaction(fake_conn_factory):
-    """A partial DB outage mid-loop must roll the whole batch back so the
-    operator sees a clean retry rather than half-applied state. The
-    audit writes use nested savepoints on top so an audit failure does
-    NOT poison the outer transaction; total ``conn.transaction()``
-    calls = 1 outer + N audit savepoints (one per non-noop id).
+    """Partial DB outage mid-loop rolls the whole batch back. Audit
+    writes use nested savepoints on top so an audit failure does NOT
+    poison the outer transaction; total ``conn.transaction()`` calls =
+    1 outer + N audit savepoints (one per non-noop id).
     """
     conn = fake_conn_factory({100: None, 200: None})
 
@@ -406,23 +295,13 @@ def test_seed_runs_each_id_in_single_outer_transaction(fake_conn_factory):
     with patch("asyncpg.connect", new=_connect):
         _run(seed.seed("postgresql://x", [100, 200]))
 
-    # 1 outer batch transaction + 2 audit savepoints (both ids inserted).
     assert conn.transaction.call_count == 3
 
 
 def test_seed_outer_transaction_survives_audit_failure(fake_conn_factory):
-    """When an audit INSERT raises, the outer seed transaction MUST
-    survive (savepoint rolls back, outer continues) and the next id in
-    the batch must still be processed. This is the regression Codex
-    flagged: without nested transactions PostgreSQL aborts the whole
-    txn after the first failed audit row.
-    """
+    """An audit INSERT failure must NOT abort the outer seed transaction."""
     conn = fake_conn_factory({100: None, 200: None})
 
-    # Stash the seeder's normal execute side effect, then wrap it so
-    # the audit INSERT for id=100 raises while every other statement
-    # behaves normally. The outer txn must keep going; id=200 must
-    # still be inserted at Tier 2.
     state = {"audit_calls": 0}
     real_execute = conn.execute.side_effect
 
@@ -442,10 +321,8 @@ def test_seed_outer_transaction_survives_audit_failure(fake_conn_factory):
     with patch("asyncpg.connect", new=_connect):
         counts = _run(seed.seed("postgresql://x", [100, 200]))
 
-    # Both ids were inserted at Tier 2 — the audit failure on id=100
-    # did NOT prevent id=200 from being processed.
     assert counts == {"inserted": 2, "raised": 0, "noop": 0}
-    assert state["audit_calls"] == 2  # both audit writes were attempted
+    assert state["audit_calls"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -496,8 +373,6 @@ def test_run_returns_4_on_db_error(monkeypatch):
 
 
 def test_main_returns_zero_when_inner_run_returns_zero(monkeypatch):
-    """Happy path: inner _run returned 0, main returns 0."""
-
     async def _ok():
         return 0
 
@@ -507,33 +382,21 @@ def test_main_returns_zero_when_inner_run_returns_zero(monkeypatch):
 
 @pytest.mark.parametrize("inner_rc", [2, 3, 4])
 def test_main_swallows_nonzero_inner_run_for_fly_deploy(monkeypatch, caplog, inner_rc):
-    """Fly's release_command aborts the deploy on any non-zero exit. The
-    seeder's internal failure modes (missing env, missing DSN, DB blip on
-    first deploy before migrations) are ALL recoverable without rolling
-    back the release, so main() must wrap them to exit 0 and only log
-    the inner status code for diagnostics.
-    """
-
     async def _failing():
         return inner_rc
 
     monkeypatch.setattr(seed, "_run", _failing)
     with caplog.at_level("WARNING"):
         rc = seed.main()
-    assert rc == 0, (
-        f"main() returned {rc} for inner_rc={inner_rc}; Fly release_command "
-        "would have aborted the deploy"
-    )
-    assert any(
-        "exiting 0" in rec.getMessage() for rec in caplog.records
-    ), "main() should log the swallowed inner status code at WARNING"
+    assert rc == 0
+    assert any("exiting 0" in rec.getMessage() for rec in caplog.records)
 
 
 def test_run_returns_0_on_success(monkeypatch, fake_conn_factory):
     monkeypatch.setenv("ADMIN_USER_IDS", "123,456")
     monkeypatch.setenv("DATABASE_URL", "postgresql://x")
 
-    conn = fake_conn_factory({123: None, 456: 1})
+    conn = fake_conn_factory({123: None, 456: "user"})
 
     async def _connect(dsn):
         return conn

--- a/projects/polymarket/crusaderbot/users.py
+++ b/projects/polymarket/crusaderbot/users.py
@@ -68,8 +68,8 @@ async def upsert_user(telegram_user_id: int, username: str | None) -> dict:
             )
             if row is None:
                 row = await conn.fetchrow(
-                    "INSERT INTO users (telegram_user_id, username, access_tier) "
-                    "VALUES ($1, $2, 3) RETURNING *",
+                    "INSERT INTO users (telegram_user_id, username, access_tier, role) "
+                    "VALUES ($1, $2, 4, 'user') RETURNING *",
                     telegram_user_id, username,
                 )
                 await conn.execute(
@@ -79,10 +79,6 @@ async def upsert_user(telegram_user_id: int, username: str | None) -> dict:
                 )
                 _is_new_user = True
             else:
-                if row["access_tier"] < 3:
-                    await conn.execute(
-                        "UPDATE users SET access_tier=3 WHERE id=$1", row["id"],
-                    )
                 if username and username != row["username"]:
                     await conn.execute(
                         "UPDATE users SET username=$1 WHERE id=$2",
@@ -183,6 +179,12 @@ async def get_user_by_username(username: str) -> Optional[dict]:
 
 
 async def set_tier(user_id: UUID, tier: int) -> None:
+    """Legacy integer-tier setter. Retained while access_tier column exists.
+
+    access_tier no longer gates anything (role column is the source of truth).
+    Kept so existing admin tooling that writes the column still works until
+    migration 044 drops the column.
+    """
     pool = get_pool()
     async with pool.acquire() as conn:
         await conn.execute(
@@ -192,10 +194,22 @@ async def set_tier(user_id: UUID, tier: int) -> None:
 
 
 async def force_set_tier(user_id: UUID, tier: int) -> None:
+    """Legacy integer-tier overwrite. See set_tier docstring."""
     pool = get_pool()
     async with pool.acquire() as conn:
         await conn.execute(
             "UPDATE users SET access_tier=$2 WHERE id=$1", user_id, tier,
+        )
+
+
+async def set_role(user_id: UUID, role: str) -> None:
+    """Set users.role — 'admin' or 'user'. The role column is the access source of truth."""
+    if role not in {"admin", "user"}:
+        raise ValueError(f"set_role: invalid role {role!r} (expected 'admin' or 'user')")
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE users SET role=$2 WHERE id=$1", user_id, role,
         )
 
 


### PR DESCRIPTION
## Summary

- Replaces integer `users.access_tier` gating with a two-value `users.role` column (`'admin'` | `'user'`) across all 16 production files in scope.
- Paper trading is now open to every user; live trading and admin tooling check `role == 'admin'`.
- Adds migration `045_add_role_column.sql`; legacy `access_tier` column kept in schema (set to `4` on INSERTs) — drop stays staged behind `044_drop_access_tier.sql`.

## Closes

Closes #1219

## Forge metadata

- Validation Tier: **STANDARD**
- Claim Level: **NARROW INTEGRATION**
- Validation Target: every production reference to `access_tier` for access gating.
- Not in Scope: DB DROP (044), frontend, refactor of `services/tiers.py` (parallel `user_tiers` string-tier system).
- Suggested Next Step: WARP🔹CMD review → apply 045 on staging → merge.

## Test plan

- [x] `python3 -m compileall` clean on all modified production files
- [x] `pytest projects/polymarket/crusaderbot/tests/` — **1512 passed, 0 failed**
- [ ] Apply `migrations/045_add_role_column.sql` on staging and verify `users.role` defaults + earliest-user admin promotion
- [ ] Manual smoke: `/allowlist`, paper trade flow, live checklist (admin user), live checklist (non-admin user)

## Report

`projects/polymarket/crusaderbot/reports/forge/fix-access-tier-open-warp50b.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaJwo628mP5Hk786kNpmev)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a simplified role-based access control system with two roles—"admin" and "user"—replacing the previous multi-tier authorization model.

* **Refactor**
  * Updated authorization checks throughout the system to use role-based evaluation instead of tier comparisons.
  * Live trading access is now restricted to users with the "admin" role.
  * Admin-only features now require explicit "admin" role assignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->