### PR TITLE
fix(migrations): disable 044 — keep access_tier column as placeholder

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
+++ b/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql
@@ -1,8 +1,0 @@
--- Migration 044: Drop access_tier column from users table
--- access_tier is planned for removal — access control will move to a role-based model.
--- WARNING: DO NOT APPLY. Column is still referenced in Python code per WARP-50 audit
---          (see reports/forge/fix-drop-access-tier-warp50.md section 6).
---          Apply only after the role-based Python migration lane lands.
--- Idempotent: IF EXISTS guard prevents error on re-run once safe to apply.
-
-ALTER TABLE users DROP COLUMN IF EXISTS access_tier;

--- a/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql.disabled
+++ b/projects/polymarket/crusaderbot/migrations/044_drop_access_tier.sql.disabled
@@ -1,0 +1,19 @@
+-- Migration 044: Drop access_tier column from users table — DISABLED
+-- Renamed to *.sql.disabled so database.run_migrations()'s `*.sql` glob skips it.
+--
+-- Background: in production this migration ran before WARP-50b shipped, dropping
+-- the access_tier column while the live Python image still wrote access_tier=4 on
+-- INSERT, which caused an UndefinedColumnError crash loop. The column was
+-- restored as a placeholder (045b_restore_access_tier_placeholder) and the
+-- merged WARP-50b code continues to write access_tier=4 by design.
+--
+-- DO NOT rename back to .sql until a follow-up lane removes every
+-- `access_tier=4` placeholder from INSERTs in:
+--   * users.py
+--   * services/user_service.py
+--   * scripts/seed_demo_data.py
+--   * scripts/seed_operator_tier.py
+-- Once those are gone, rename to 044_drop_access_tier.sql, apply, and delete
+-- this header.
+
+ALTER TABLE users DROP COLUMN IF EXISTS access_tier;


### PR DESCRIPTION
## Summary

Renames `migrations/044_drop_access_tier.sql` to `044_drop_access_tier.sql.disabled` so `database.run_migrations()`'s `*.sql` glob skips it on Fly startup.

## Why

In production 044 already ran and dropped the column **before** the WARP-50b code (which still writes `access_tier=4` on INSERT) shipped. The result was an `UndefinedColumnError` crash loop. The column has been restored manually as a placeholder (`045b_restore_access_tier_placeholder` on Supabase). Without this rename, the next deploy would re-run 044, drop the column again, and restart the crash loop.

## Test plan

- [x] No code paths reference 044 by name
- [x] `database.run_migrations()` uses `*.sql` glob — `.sql.disabled` is excluded by extension
- [ ] Next Fly deploy: confirm 044 is NOT in the startup migration log, `/health` returns OK

## Follow-up

Once a later lane removes every `INSERT INTO users (..., access_tier, ...)` write from:
- `users.py`
- `services/user_service.py`
- `scripts/seed_demo_data.py`
- `scripts/seed_operator_tier.py`

…rename the file back to `044_drop_access_tier.sql`, apply, and remove the disabled-state header in the SQL.

## Forge metadata

- Validation Tier: **MINOR**
- Claim Level: **FOUNDATION**
- Validation Target: migration runner skips the disabled file
- Not in Scope: removing `access_tier=4` placeholder writes from Python code


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaJwo628mP5Hk786kNpmev)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled a pending database migration to defer automatic schema changes and prevent conflicts with ongoing application behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->