### PR TITLE
config: add SECURITY_HARDENING_VALIDATED + document AUTO_REDEEM_ENABLED intent (WARP-42)

### DIFF
--- a/projects/polymarket/crusaderbot/config.py
+++ b/projects/polymarket/crusaderbot/config.py
@@ -153,6 +153,10 @@ class Settings(BaseSettings):
     # readiness validator issues PASS on all checks).  Never set without an
     # explicit WARP🔹CMD decision backed by a SENTINEL report.
     RISK_CONTROLS_VALIDATED: bool = False
+    SECURITY_HARDENING_VALIDATED: bool = False
+    # Owner: WARP•SENTINEL. Required ON before any live operation.
+    # Verifies: kill switch drill passed, audit-log append-only enforced,
+    # operator role boundary tested, no PII in logs. See blueprint §12.
     FEE_COLLECTION_ENABLED: bool = False
 
     # --- Risk caps (Track D) — hard caps enforced per-user before any order ---
@@ -161,6 +165,10 @@ class Settings(BaseSettings):
     MAX_DAILY_LOSS_USD: float = -50.00         # configurable via env MAX_DAILY_LOSS_USD
     MAX_OPEN_POSITIONS: int = 20               # hard cap on concurrent open positions
     REFERRAL_PAYOUT_ENABLED: bool = False
+    # AUTO_REDEEM_ENABLED is intentionally True in paper mode so paper users see
+    # redeems happen on resolution. Before live launch, this guard flips to False
+    # alongside ENABLE_LIVE_TRADING — auto-redeem then requires explicit operator
+    # enable per blueprint §12 default-OFF policy.
     AUTO_REDEEM_ENABLED: bool = True
 
     # --- App config ---


### PR DESCRIPTION
## Lane B — Config Gap Fixes (MINOR, code)

Closes two activation-guard gaps surfaced by **WARP-41** (finding M-5). `config.py` only.

### Changes
- **B1** Added `SECURITY_HARDENING_VALIDATED: bool = False` to the activation-guards block (next to `RISK_CONTROLS_VALIDATED`) with owner/verification docstring. Symbol-only addition — no current code path queries it yet; presence closes the blueprint §12 spec gap.
- **B2** Added inline comment on `AUTO_REDEEM_ENABLED` explaining the intentional `True` in paper mode and the flip-to-`False` policy before live launch. No value change.

### Testing
No behavioral change (symbol + comment only). `config.py` parses cleanly. The full pytest suite could **not** be executed in the cloud sandbox due to missing runtime deps (`asyncpg`, etc.) — this is a pre-existing environment limitation, not introduced by this change. No new test required per task spec for a symbol-only addition.

Refs: WARP-41 (M-5), WARP-42 (Lane B).

---
_Generated by [Claude Code](https://claude.ai/code/session_011BrQpne6jABR8njY7nLqDR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security hardening documentation with updated guidance on verification criteria for enabling live operation readiness.

* **Chores**
  * Added new security validation configuration option to the settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->