### PR TITLE
feat(deposit): confirmation-depth + reorg guard (WARP-42, H6)

### DIFF
--- a/projects/polymarket/crusaderbot/config.py
+++ b/projects/polymarket/crusaderbot/config.py
@@ -170,6 +170,10 @@ class Settings(BaseSettings):
     MIN_DEPOSIT_USDC: float = 50.0
     MARKET_SCAN_INTERVAL: int = 300
     DEPOSIT_WATCH_INTERVAL: int = 120
+    # Confirmation depth before a deposit credits the ledger. Polygon reorgs are
+    # rare but real; a USDC transfer seen at block N is only credited once it is
+    # this many blocks deep on the canonical chain. See migration 047.
+    DEPOSIT_CONFIRMATION_DEPTH: int = 32
     SIGNAL_SCAN_INTERVAL: int = 180
     MARKET_SIGNAL_SCAN_INTERVAL: int = 60
     # --- Signal scanner thresholds (demo path edge_finder) ---

--- a/projects/polymarket/crusaderbot/integrations/polygon.py
+++ b/projects/polymarket/crusaderbot/integrations/polygon.py
@@ -173,6 +173,11 @@ async def scan_usdc_transfers(
                 "from": decoded["args"]["from"],
                 "to": decoded["args"]["to"],
                 "amount": decoded["args"]["value"] / (10 ** settings.USDC_DECIMALS),
+                # `removed` is True when this log came from a block that was
+                # orphaned by a reorg. eth_getLogs over a finalized range
+                # returns False; reorg-aware subscriptions set it True so the
+                # deposit watcher can un-credit a reverted transfer.
+                "removed": bool(log.get("removed", False)),
             })
         except Exception as exc:
             logger.error("decode log failed (skipping entry): %s", exc)

--- a/projects/polymarket/crusaderbot/migrations/047_deposit_confirmation_state.sql
+++ b/projects/polymarket/crusaderbot/migrations/047_deposit_confirmation_state.sql
@@ -1,0 +1,30 @@
+-- 047_deposit_confirmation_state.sql
+-- Deposit confirmation-depth + reorg guard (WARP-42, audit finding H6).
+--
+-- Adds a confirmation state machine to `deposits`. A USDC transfer is now
+-- inserted as `status='pending'` on first sighting and only credits the ledger
+-- once it is DEPOSIT_CONFIRMATION_DEPTH blocks deep on the canonical chain
+-- (`status='confirmed'`). A transfer whose log later arrives with removed=true
+-- (orphaned by a reorg) is un-credited and marked `status='reverted'`.
+--
+-- Additive + idempotent: ADD COLUMN IF NOT EXISTS, safe to re-run on every
+-- startup (run_migrations re-executes every file). No data loss.
+
+ALTER TABLE deposits
+    ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+ALTER TABLE deposits
+    ADD COLUMN IF NOT EXISTS confirmed_at_block BIGINT;
+
+-- Backfill: rows that existed before this migration were already credited by
+-- the legacy immediate-credit path (they have confirmed_at set). Mark them
+-- 'confirmed' so the new confirm pass never re-credits them. This matches only
+-- legacy rows; genuine new-code pending rows have confirmed_at = NULL.
+UPDATE deposits
+   SET status = 'confirmed'
+ WHERE confirmed_at IS NOT NULL
+   AND status = 'pending';
+
+-- Confirm pass scans pending deposits each tick; index keeps it cheap.
+CREATE INDEX IF NOT EXISTS idx_deposits_status_pending
+    ON deposits(status) WHERE status = 'pending';

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -119,13 +119,21 @@ async def sync_markets() -> None:
 # ---------------- Deposit watcher ----------------
 
 async def watch_deposits() -> None:
-    """Atomic deposit insert + ledger credit. Cursor only advances on success.
+    """Confirmation-depth deposit watcher with reorg guard (H6).
 
-    A failed credit ROLLS BACK the deposit insert so the same tx_hash will be
-    re-processed on the next scan. The block-cursor itself is only advanced
-    after the chain scan succeeds AND every transfer in that range has been
-    persisted (or non-credited because the address belongs to no user).
+    A USDC transfer is recorded as ``pending`` on first sighting — no ledger
+    credit yet. It only credits the ledger once it is
+    ``DEPOSIT_CONFIRMATION_DEPTH`` blocks deep on the canonical chain
+    (``confirmed``). A log that re-arrives with ``removed=true`` (orphaned by a
+    reorg) un-credits a confirmed deposit and marks it ``reverted``.
+
+    The block cursor only advances after every transfer in the scanned range is
+    durably recorded; a failed write re-processes on the next tick. Confirmation
+    runs as a separate pass over all pending rows, so a deposit seen near head
+    is still confirmed on a later tick even after the forward cursor moves past
+    its block.
     """
+    settings = get_settings()
     pool = get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -136,6 +144,12 @@ async def watch_deposits() -> None:
     addr_by_lower = {r["deposit_address"].lower(): r["user_id"] for r in rows}
     addresses = [r["deposit_address"] for r in rows]
 
+    try:
+        head = await polygon.latest_block()
+    except Exception as exc:
+        logger.warning("watch_deposits head read failed (no cursor advance): %s", exc)
+        return
+
     cursor_start = await _read_cursor("usdc_deposits")
     try:
         transfers, scanned_to = await polygon.scan_from_cursor(
@@ -145,58 +159,32 @@ async def watch_deposits() -> None:
         logger.warning("watch_deposits scan failed (no cursor advance): %s", exc)
         return
 
-    notify_after: list[tuple[int, Decimal, str]] = []
     all_ok = True
     for t in transfers:
-        to_addr = t["to"].lower()
-        user_id = addr_by_lower.get(to_addr)
+        user_id = addr_by_lower.get(t["to"].lower())
         if not user_id:
             continue  # address not ours — safe to skip and advance cursor
-        amount = Decimal(str(t["amount"]))
-        # log_index disambiguates multiple USDC Transfer logs in the same tx
-        # routed to distinct tracked addresses. Without it, ON CONFLICT would
-        # silently drop every Transfer past the first and under-credit users.
-        log_index = int(t.get("log_index", 0))
         try:
-            async with pool.acquire() as conn:
-                async with conn.transaction():
-                    row = await conn.fetchrow(
-                        """
-                        INSERT INTO deposits (user_id, tx_hash, log_index,
-                                              amount_usdc, block_number,
-                                              confirmed_at)
-                        VALUES ($1,$2,$3,$4,$5,NOW())
-                        ON CONFLICT (tx_hash, log_index) DO NOTHING
-                        RETURNING id
-                        """,
-                        user_id, t["tx_hash"], log_index, amount,
-                        t["block_number"],
-                    )
-                    if row is None:
-                        continue  # already credited
-                    await ledger.credit_in_conn(
-                        conn, user_id, amount, ledger.T_DEPOSIT,
-                        ref_id=row["id"], note=t["tx_hash"],
-                    )
-                    u = await conn.fetchrow(
-                        "SELECT telegram_user_id FROM users WHERE id=$1",
-                        user_id,
-                    )
-            await audit.write(actor_role="bot", action="deposit_confirmed",
-                              user_id=user_id,
-                              payload={"tx_hash": t["tx_hash"],
-                                       "amount": str(amount)})
-            if u:
-                notify_after.append(
-                    (u["telegram_user_id"], amount, t["tx_hash"])
-                )
+            if t.get("removed"):
+                await _revert_deposit(t)
+            else:
+                await _record_pending_deposit(user_id, t)
         except Exception as exc:
-            logger.error("deposit credit failed for %s: %s — cursor will not advance",
-                         t["tx_hash"], exc)
+            logger.error("deposit record failed for %s: %s — cursor will not advance",
+                         t.get("tx_hash"), exc)
             all_ok = False
 
     if all_ok:
         await _write_cursor("usdc_deposits", scanned_to)
+
+    # Confirm pass: promote pending deposits that are now deep enough.
+    try:
+        notify_after = await _confirm_ready_deposits(
+            head, settings.DEPOSIT_CONFIRMATION_DEPTH,
+        )
+    except Exception as exc:
+        logger.error("deposit confirm pass failed: %s", exc)
+        notify_after = []
 
     deposit_kb = InlineKeyboardMarkup([[
         InlineKeyboardButton("💰 Wallet", callback_data="menu:wallet"),
@@ -209,6 +197,134 @@ async def watch_deposits() -> None:
             f"<code>{html.escape(tx)}</code>",
             reply_markup=deposit_kb,
         )
+
+
+async def _record_pending_deposit(user_id, t: dict) -> None:
+    """Insert a newly-seen transfer as ``pending`` — no ledger credit yet.
+
+    Idempotent on ``(tx_hash, log_index)``: a duplicate sighting is a no-op; a
+    transfer previously ``reverted`` is reset to ``pending`` so it can confirm
+    again if the tx is re-mined on the canonical chain.
+    """
+    log_index = int(t.get("log_index", 0))
+    amount = Decimal(str(t["amount"]))
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                """
+                INSERT INTO deposits (user_id, tx_hash, log_index, amount_usdc,
+                                      block_number, status)
+                VALUES ($1,$2,$3,$4,$5,'pending')
+                ON CONFLICT (tx_hash, log_index) DO UPDATE
+                    SET status='pending', confirmed_at_block=NULL
+                    WHERE deposits.status='reverted'
+                RETURNING id
+                """,
+                user_id, t["tx_hash"], log_index, amount, t["block_number"],
+            )
+    if row is not None:
+        await audit.write(
+            actor_role="bot", action="deposit_credit_pending", user_id=user_id,
+            payload={"tx_hash": t["tx_hash"], "log_index": log_index,
+                     "amount": str(amount), "block": t["block_number"]},
+        )
+
+
+async def _revert_deposit(t: dict) -> None:
+    """Honor a ``removed=true`` log: debit a confirmed deposit back out, else
+    just mark a pending one ``reverted``. Idempotent — an already-reverted or
+    never-seen transfer is a no-op.
+    """
+    log_index = int(t.get("log_index", 0))
+    pool = get_pool()
+    reverted: tuple | None = None
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            dep = await conn.fetchrow(
+                """
+                SELECT id, user_id, amount_usdc, status
+                  FROM deposits
+                 WHERE tx_hash=$1 AND log_index=$2
+                 FOR UPDATE
+                """,
+                t["tx_hash"], log_index,
+            )
+            if dep is None or dep["status"] == "reverted":
+                return
+            await conn.execute(
+                "UPDATE deposits SET status='reverted' WHERE id=$1", dep["id"],
+            )
+            amount = Decimal(str(dep["amount_usdc"]))
+            if dep["status"] == "confirmed":
+                # roll the credited funds back out of the user's balance
+                await ledger.debit_in_conn(
+                    conn, dep["user_id"], amount, ledger.T_DEPOSIT,
+                    ref_id=dep["id"], note=f"reorg-revert {t['tx_hash']}",
+                )
+            reverted = (dep["user_id"], dep["status"], amount)
+    user_id, prior, amount = reverted
+    await audit.write(
+        actor_role="bot", action="deposit_credit_reverted", user_id=user_id,
+        payload={"tx_hash": t["tx_hash"], "log_index": log_index,
+                 "amount": str(amount), "prior_status": prior,
+                 "uncredited": prior == "confirmed"},
+    )
+
+
+async def _confirm_ready_deposits(
+    head: int, depth: int,
+) -> list[tuple[int, Decimal, str]]:
+    """Promote pending deposits that are now >= ``depth`` blocks deep to
+    ``confirmed`` and credit the ledger once. The confirming UPDATE is guarded
+    by ``status='pending'`` so a credit can never fire twice for the same row.
+
+    Returns ``(telegram_user_id, amount, tx_hash)`` tuples to notify.
+    """
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        ready = await conn.fetch(
+            """
+            SELECT id, user_id, tx_hash, amount_usdc, block_number
+              FROM deposits
+             WHERE status='pending'
+               AND block_number IS NOT NULL
+               AND ($1 - block_number) >= $2
+            """,
+            head, depth,
+        )
+    notify: list[tuple[int, Decimal, str]] = []
+    for d in ready:
+        amount = Decimal(str(d["amount_usdc"]))
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    UPDATE deposits
+                       SET status='confirmed', confirmed_at_block=$2,
+                           confirmed_at=NOW()
+                     WHERE id=$1 AND status='pending'
+                    RETURNING id
+                    """,
+                    d["id"], head,
+                )
+                if row is None:
+                    continue  # confirmed by a concurrent tick — credit once only
+                await ledger.credit_in_conn(
+                    conn, d["user_id"], amount, ledger.T_DEPOSIT,
+                    ref_id=d["id"], note=d["tx_hash"],
+                )
+                u = await conn.fetchrow(
+                    "SELECT telegram_user_id FROM users WHERE id=$1", d["user_id"],
+                )
+        await audit.write(
+            actor_role="bot", action="deposit_credit_confirmed", user_id=d["user_id"],
+            payload={"tx_hash": d["tx_hash"], "amount": str(amount),
+                     "block": d["block_number"], "confirmed_at_block": head},
+        )
+        if u:
+            notify.append((u["telegram_user_id"], amount, d["tx_hash"]))
+    return notify
 
 
 async def _read_cursor(name: str) -> int:

--- a/projects/polymarket/crusaderbot/tests/test_deposit_reorg.py
+++ b/projects/polymarket/crusaderbot/tests/test_deposit_reorg.py
@@ -1,0 +1,243 @@
+"""Deposit confirmation-depth + reorg guard (WARP-42, audit finding H6).
+
+A USDC transfer is recorded ``pending`` on first sighting and only credits the
+ledger once it is ``DEPOSIT_CONFIRMATION_DEPTH`` blocks deep (``confirmed``). A
+log re-arriving with ``removed=true`` un-credits a confirmed deposit and marks
+it ``reverted``. These tests drive the three state-machine helpers directly
+against an in-memory ``deposits`` store, with ledger + audit mocked so we can
+assert exactly when (and how often) funds move.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from projects.polymarket.crusaderbot import scheduler
+
+
+# ---------------- fake asyncpg pool/conn backed by an in-memory store --------
+
+class _Store:
+    def __init__(self) -> None:
+        self.deposits: list[dict] = []
+        self.tg_by_user: dict = {}
+
+    def find(self, tx_hash: str, log_index: int) -> dict | None:
+        for d in self.deposits:
+            if d["tx_hash"] == tx_hash and d["log_index"] == log_index:
+                return d
+        return None
+
+
+class _Txn:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return None
+
+
+class _Conn:
+    def __init__(self, store: _Store) -> None:
+        self.store = store
+
+    def transaction(self):
+        return _Txn()
+
+    async def fetch(self, sql: str, *args):
+        if "status='pending'" in sql and ">= $2" in sql:
+            head, depth = args
+            return [
+                d for d in self.store.deposits
+                if d["status"] == "pending"
+                and d["block_number"] is not None
+                and (head - d["block_number"]) >= depth
+            ]
+        raise AssertionError(f"unexpected fetch: {sql}")
+
+    async def fetchrow(self, sql: str, *args):
+        if "INSERT INTO deposits" in sql:
+            user_id, tx_hash, log_index, amount, block_number = args
+            row = self.store.find(tx_hash, log_index)
+            if row is None:
+                row = {
+                    "id": uuid.uuid4(), "user_id": user_id, "tx_hash": tx_hash,
+                    "log_index": log_index, "amount_usdc": amount,
+                    "block_number": block_number, "status": "pending",
+                    "confirmed_at_block": None,
+                }
+                self.store.deposits.append(row)
+                return {"id": row["id"]}
+            if row["status"] == "reverted":  # re-mined after reorg revert
+                row["status"] = "pending"
+                row["confirmed_at_block"] = None
+                return {"id": row["id"]}
+            return None  # already pending/confirmed — no-op
+        if "status='confirmed'" in sql and "RETURNING id" in sql:
+            dep_id, head = args
+            for d in self.store.deposits:
+                if d["id"] == dep_id and d["status"] == "pending":
+                    d["status"] = "confirmed"
+                    d["confirmed_at_block"] = head
+                    return {"id": d["id"]}
+            return None
+        if "FOR UPDATE" in sql:
+            tx_hash, log_index = args
+            d = self.store.find(tx_hash, log_index)
+            if d is None:
+                return None
+            return {"id": d["id"], "user_id": d["user_id"],
+                    "amount_usdc": d["amount_usdc"], "status": d["status"]}
+        if "telegram_user_id" in sql:
+            (user_id,) = args
+            return {"telegram_user_id": self.store.tg_by_user.get(user_id, 999)}
+        raise AssertionError(f"unexpected fetchrow: {sql}")
+
+    async def execute(self, sql: str, *args):
+        if "status='reverted'" in sql:
+            (dep_id,) = args
+            for d in self.store.deposits:
+                if d["id"] == dep_id:
+                    d["status"] = "reverted"
+            return
+        raise AssertionError(f"unexpected execute: {sql}")
+
+
+class _Acq:
+    def __init__(self, conn: _Conn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_a):
+        return None
+
+
+class _Pool:
+    def __init__(self, store: _Store) -> None:
+        self._conn = _Conn(store)
+
+    def acquire(self):
+        return _Acq(self._conn)
+
+
+def _harness(store: _Store):
+    """Patch get_pool + ledger + audit. Returns (credit_mock, debit_mock,
+    audit_mock) context manager."""
+    credit = AsyncMock()
+    debit = AsyncMock()
+    audit_write = AsyncMock()
+    ctx = patch.multiple(
+        scheduler,
+        get_pool=lambda: _Pool(store),
+    )
+    return credit, debit, audit_write, ctx
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _transfer(block: int, removed: bool = False) -> dict:
+    return {
+        "tx_hash": "0xabc", "log_index": 0, "amount": 100.0,
+        "block_number": block, "to": "0xWALLET", "removed": removed,
+    }
+
+
+# ---------------- Test 1: not credited until N+32 reached --------------------
+
+def test_pending_not_credited_until_confirmation_depth():
+    store = _Store()
+    user_id = uuid.uuid4()
+    credit, debit, audit_write, ctx = _harness(store)
+    with ctx, patch.object(scheduler.ledger, "credit_in_conn", credit), \
+         patch.object(scheduler.ledger, "debit_in_conn", debit), \
+         patch.object(scheduler.audit, "write", audit_write):
+        _run(scheduler._record_pending_deposit(user_id, _transfer(block=100)))
+        assert store.deposits[0]["status"] == "pending"
+        credit.assert_not_awaited()
+
+        # 10 blocks deep — still pending, no credit
+        _run(scheduler._confirm_ready_deposits(head=110, depth=32))
+        assert store.deposits[0]["status"] == "pending"
+        credit.assert_not_awaited()
+
+        # 32 blocks deep — confirmed + credited exactly once
+        notify = _run(scheduler._confirm_ready_deposits(head=132, depth=32))
+        assert store.deposits[0]["status"] == "confirmed"
+        credit.assert_awaited_once()
+        assert notify and notify[0][1] == Decimal("100.0")
+
+
+# ---------------- Test 2: confirmed then removed=true → debited back ----------
+
+def test_confirmed_then_reorg_removed_uncredits():
+    store = _Store()
+    user_id = uuid.uuid4()
+    store.deposits.append({
+        "id": uuid.uuid4(), "user_id": user_id, "tx_hash": "0xabc",
+        "log_index": 0, "amount_usdc": Decimal("100.0"), "block_number": 100,
+        "status": "confirmed", "confirmed_at_block": 132,
+    })
+    credit, debit, audit_write, ctx = _harness(store)
+    with ctx, patch.object(scheduler.ledger, "credit_in_conn", credit), \
+         patch.object(scheduler.ledger, "debit_in_conn", debit), \
+         patch.object(scheduler.audit, "write", audit_write):
+        _run(scheduler._revert_deposit(_transfer(block=100, removed=True)))
+
+    assert store.deposits[0]["status"] == "reverted"
+    debit.assert_awaited_once()
+    assert debit.await_args.args[2] == Decimal("100.0")  # amount un-credited
+    audit_write.assert_awaited_once()
+    kw = audit_write.await_args.kwargs
+    assert kw["action"] == "deposit_credit_reverted"
+    assert kw["payload"]["uncredited"] is True
+
+
+# ---------------- Test 3: pending then removed → reverted, no ledger move -----
+
+def test_pending_then_removed_reverts_without_ledger_movement():
+    store = _Store()
+    user_id = uuid.uuid4()
+    store.deposits.append({
+        "id": uuid.uuid4(), "user_id": user_id, "tx_hash": "0xabc",
+        "log_index": 0, "amount_usdc": Decimal("100.0"), "block_number": 100,
+        "status": "pending", "confirmed_at_block": None,
+    })
+    credit, debit, audit_write, ctx = _harness(store)
+    with ctx, patch.object(scheduler.ledger, "credit_in_conn", credit), \
+         patch.object(scheduler.ledger, "debit_in_conn", debit), \
+         patch.object(scheduler.audit, "write", audit_write):
+        _run(scheduler._revert_deposit(_transfer(block=100, removed=True)))
+
+    assert store.deposits[0]["status"] == "reverted"
+    debit.assert_not_awaited()
+    credit.assert_not_awaited()
+    kw = audit_write.await_args.kwargs
+    assert kw["action"] == "deposit_credit_reverted"
+    assert kw["payload"]["uncredited"] is False
+
+
+# ---------------- Test 4: idempotent — credit happens at most once ------------
+
+def test_reappearance_credits_at_most_once():
+    store = _Store()
+    user_id = uuid.uuid4()
+    credit, debit, audit_write, ctx = _harness(store)
+    with ctx, patch.object(scheduler.ledger, "credit_in_conn", credit), \
+         patch.object(scheduler.ledger, "debit_in_conn", debit), \
+         patch.object(scheduler.audit, "write", audit_write):
+        # same (tx_hash, log_index) seen twice in overlapping scans
+        _run(scheduler._record_pending_deposit(user_id, _transfer(block=100)))
+        _run(scheduler._record_pending_deposit(user_id, _transfer(block=100)))
+        assert len(store.deposits) == 1  # deduped on (tx_hash, log_index)
+
+        # confirm pass run twice — credit must fire only once
+        _run(scheduler._confirm_ready_deposits(head=140, depth=32))
+        _run(scheduler._confirm_ready_deposits(head=140, depth=32))
+        credit.assert_awaited_once()
+        assert store.deposits[0]["status"] == "confirmed"


### PR DESCRIPTION
## Lane C — Deposit Confirmation-Depth + Reorg Guard (STANDARD, money-path)

Remediates audit finding **H6** (WARP-41): `watch_deposits` credited deposits on first scan with no confirmation depth and no reorg handling — an orphaned USDC transfer could leave a user credited from a tx that no longer exists on the canonical chain. Prophylactic: today behind `ENABLE_LIVE_TRADING=False`, hardened before any live capital flow.

### State machine
`pending` → `confirmed` (credit) and `confirmed`/`pending` → `reverted` (un-credit if previously credited):
- **First sighting** → INSERT `status='pending'`, **no ledger credit**, audit `deposit_credit_pending`.
- **Confirm pass** (runs each tick over all pending rows) → when `head - block_number >= DEPOSIT_CONFIRMATION_DEPTH` (32), atomic UPDATE→`confirmed` + ledger credit + audit `deposit_credit_confirmed`. The UPDATE is guarded by `status='pending'`, so a credit can never fire twice. Decoupling confirmation from the forward cursor scan means a deposit seen near head still confirms on a later tick.
- **`removed=true` log** (reorged-out block) → if `confirmed`, atomic ledger **debit** (un-credit) + mark `reverted` + audit `deposit_credit_reverted`; if `pending`, just mark `reverted` (no ledger movement).
- **Re-mine after revert** → a `reverted` row reset to `pending` on re-sighting, so it can re-confirm.

### Changes
- `config.py`: `DEPOSIT_CONFIRMATION_DEPTH: int = 32`.
- `migrations/047_deposit_confirmation_state.sql`: additive + idempotent — `ADD COLUMN IF NOT EXISTS status` (default `pending`) + `confirmed_at_block`; backfills pre-existing (already-credited) rows to `confirmed` so they are never re-credited; partial index on pending.
- `scheduler.py`: rewrote `watch_deposits` + new `_record_pending_deposit` / `_revert_deposit` / `_confirm_ready_deposits` helpers.
- `integrations/polygon.py`: surface the `removed` flag from each Transfer log.
- `tests/test_deposit_reorg.py`: 4 new tests.

### Tests — 4/4 green
1. deposit at block N not credited until N+32 ✅
2. confirmed → `removed=true` → debited back + audit ✅
3. pending → `removed=true` → reverted, no ledger movement ✅
4. idempotent re-credit on re-appearance — credit at most once ✅

`test_sweep_deposits.py` (existing) still green. (Project deps had to be pip-installed into the ephemeral sandbox to run pytest; the broader suite still needs DB-backed fixtures, but the deposit suite runs standalone.)

Refs: WARP-41 (H6), WARP-42 (Lane C).

---
_Generated by [Claude Code](https://claude.ai/code/session_011BrQpne6jABR8njY7nLqDR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USDC deposits now require confirmation depth verification before being credited to user accounts.
  * Deposit system detects and reverts transfers affected by blockchain reorgs.
  * Deposit status tracking implemented with pending, confirmed, and reverted states.

* **Tests**
  * Added test suite covering deposit confirmation depth and reorg reversal scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->