### PR TITLE
fix(startup): remove duplicate event= kwarg causing Fly startup crash

### DIFF
--- a/projects/polymarket/crusaderbot/main.py
+++ b/projects/polymarket/crusaderbot/main.py
@@ -84,7 +84,6 @@ async def lifespan(_: FastAPI):
     _total_strategies = len(_all_strategy_names)
     log.info(
         "strategies_loaded",
-        event="strategies_loaded",
         count=_total_strategies,
         domain_count=len(catalog),
         lib_count=len(_lib_names),


### PR DESCRIPTION
## Summary

- `main.py` lifespan called `log.info("strategies_loaded", event="strategies_loaded", ...)` — structlog treats the first positional arg as `event`, so the `event=` kwarg was a duplicate, raising `TypeError` on every startup and crashing the Fly machine (Exit 3).
- Removed the redundant `event="strategies_loaded"` keyword arg. The positional string already sets the event.

## Root Cause

Same pattern fixed in `signal_scan_job.py` on the previous PR (#1307), but the instance in `main.py` was missed. It only manifests at runtime (lifespan startup), not in CI, because the lifespan code path is not exercised by the unit test suite.

## Test Plan

- [ ] Fly machine starts without Exit 3 after deploy
- [ ] `strategies_loaded` log line appears in Fly logs at startup
- [ ] All existing tests continue to pass (no code logic change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXUBiXLavUJqgqZfNb2c8d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging structure for strategy registry initialization during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->