### PR TITLE
Fix: match real crypto candle markets in short-timeframe gate

### DIFF
--- a/projects/polymarket/crusaderbot/domain/strategy/eligibility.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/eligibility.py
@@ -167,14 +167,29 @@ def classify_crypto_timeframe(market: Any) -> CryptoTimeframe | None:
 
 
 def is_short_crypto_market(market: Any, timeframe: str | None) -> bool:
-    """True iff ``market`` is a whitelisted crypto market AND its classified
-    timeframe matches ``timeframe``.
+    """True iff ``market`` is a short-duration crypto candle market AND its
+    classified timeframe matches ``timeframe``.
+
+    Crypto-ness is established by a whitelisted asset ticker (BTC/ETH/SOL/...)
+    appearing as a whole word in the market text, NOT by the literal "crypto"
+    category — Polymarket's recurring up/down candle markets carry category =
+    their own series slug (e.g. "btc-updown-5m-1779249900"), so the category
+    gate used by ``is_confluence_scalper_eligible`` would reject them. The
+    timeframe gate (a detected 5m/15m interval) supplies the precision that the
+    category check otherwise provided: a non-crypto market is extremely unlikely
+    to both name a crypto asset AND resolve on a 5/15-minute candle.
 
     ``timeframe=None`` means "any 5m or 15m crypto market" (classification must
-    still resolve to a non-None bucket). Non-crypto markets and markets that
-    cannot be classified are rejected (fail-closed).
+    still resolve to a non-None bucket). Markets that cannot be classified are
+    rejected (fail-closed).
     """
-    if not is_confluence_scalper_eligible(market):
+    if not isinstance(market, dict):
+        return False
+    haystack = " ".join(
+        str(market.get(field) or "")
+        for field in ("question", "title", "slug", "groupItemTitle")
+    )
+    if not CONFLUENCE_SCALPER_ASSET_PATTERN.search(haystack):
         return False
     tf = classify_crypto_timeframe(market)
     if tf is None:

--- a/projects/polymarket/crusaderbot/reports/forge/crypto-timeframe-presets.md
+++ b/projects/polymarket/crusaderbot/reports/forge/crypto-timeframe-presets.md
@@ -90,6 +90,20 @@ Modified:
   than before, by design.
 - whale_tracking remains degraded (out of scope); only hidden from the web grid.
 
+## 5a. Follow-up fix (WARP/crypto-timeframe-detection-fix)
+
+Live test on deploy (Close Sweep @ 5m) emitted 0 candidates: real Polymarket
+candle markets carry `category` = their own series slug (e.g.
+`btc-updown-5m-1779249900`) with no literal "crypto", so the old
+`is_confluence_scalper_eligible` category gate inside `is_short_crypto_market`
+rejected every real 5m/15m market. Fixed `is_short_crypto_market` to establish
+crypto-ness via the asset-ticker whitelist (BTC/ETH/SOL/...) + a detected
+5m/15m interval instead of the literal category — the timeframe gate supplies
+the precision. The classifier regex already matched the `-5m-`/`-15m-` slug
+tokens. Added real-slug regression tests (btc-updown-5m/15m, eth-updown-5m,
+eth daily skip); updated the non-crypto scan test to assert via the timeframe
+gate. 146 tests green.
+
 ## 6. What is next
 
 - WARP•SENTINEL MAJOR validation.

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -331,3 +331,4 @@ Hard product rules enforced: no manual trade buttons, markets intelligence-only,
 2026-05-24 17:30 | claude/fervent-hawking-yNP0Z | Lane 1: category-mapping — get_events_with_markets() enriches market dicts with Gamma event tags; category filter now works for all dashboard categories
 
 2026-05-24 19:10 | WARP/crypto-timeframe-presets | crypto-short presets (Crypto Scalper + Close Sweep) gated to 5m/15m short-duration crypto + category auto-lock (mig 049); Ensemble→Smart Mix; hide whale_mirror + Coming Soon in web
+2026-05-24 19:45 | WARP/crypto-timeframe-detection-fix | fix is_short_crypto_market: identify crypto via asset-ticker + 5m/15m interval (not literal category) so real btc/eth-updown candle markets qualify; Close Sweep/Crypto Scalper now match live data

--- a/projects/polymarket/crusaderbot/tests/test_confluence_scalper.py
+++ b/projects/polymarket/crusaderbot/tests/test_confluence_scalper.py
@@ -275,11 +275,17 @@ def test_scan_skips_malformed_market_dict_without_exception():
 # ---------------------------------------------------------------------------
 
 
-def test_scan_skips_non_crypto_category():
-    # A market that satisfies every confluence signal but lives in a non-crypto
-    # category must self-skip inside scan(); other strategies on the same tick
-    # are unaffected.
-    _assert_scan_empty([_make_market(category="Politics", question="Will BTC ban pass?")])
+def test_scan_skips_non_short_duration_market():
+    # A market that names a crypto asset but is NOT a short-duration candle
+    # (no 5m/15m interval in its text) must self-skip inside scan() — the
+    # timeframe gate is fail-closed. e.g. a long-horizon political "ban" market.
+    _assert_scan_empty([
+        _make_market(
+            category="Politics",
+            question="Will BTC ban pass?",
+            slug="btc-ban-referendum-2026",
+        )
+    ])
 
 
 def test_scan_skips_off_whitelist_crypto_asset():

--- a/projects/polymarket/crusaderbot/tests/test_crypto_timeframe.py
+++ b/projects/polymarket/crusaderbot/tests/test_crypto_timeframe.py
@@ -47,6 +47,51 @@ def test_keyword_question_field():
     assert classify_crypto_timeframe(m) == "5m"
 
 
+# ── real Polymarket candle slug formats (regression for live data) ──────────
+
+def test_real_btc_updown_5m_slug():
+    # Production format — category is the series slug, NOT the literal "crypto".
+    m = {
+        "question": "Bitcoin Up or Down - May 20, 12:05AM-12:10AM ET",
+        "slug": "btc-updown-5m-1779249900",
+        "category": "btc-updown-5m-1779249900",
+    }
+    assert classify_crypto_timeframe(m) == "5m"
+    assert is_short_crypto_market(m, "5m") is True
+    assert is_short_crypto_market(m, "15m") is False
+
+
+def test_real_btc_updown_15m_slug():
+    m = {
+        "question": "Bitcoin Up or Down - May 21, 1:00AM-1:15AM ET",
+        "slug": "btc-updown-15m-1779339600",
+        "category": "btc-updown-15m-1779339600",
+    }
+    assert classify_crypto_timeframe(m) == "15m"
+    assert is_short_crypto_market(m, "15m") is True
+
+
+def test_real_eth_updown_5m_slug():
+    m = {
+        "question": "Ethereum Up or Down - May 21, 1:50PM-1:55PM ET",
+        "slug": "eth-updown-5m-1779385800",
+        "category": "eth-updown-5m-1779385800",
+    }
+    assert classify_crypto_timeframe(m) == "5m"
+    assert is_short_crypto_market(m, None) is True
+
+
+def test_real_eth_daily_updown_skipped():
+    # Daily up/down market — no 5m/15m interval -> not a short-duration candle.
+    m = {
+        "question": "Ethereum Up or Down on May 19?",
+        "slug": "ethereum-up-or-down-on-may-19-2026",
+        "category": "ethereum-up-or-down-on-may-19-2026",
+    }
+    assert classify_crypto_timeframe(m) is None
+    assert is_short_crypto_market(m, "5m") is False
+
+
 # ── duration fallback ───────────────────────────────────────────────────────
 
 def test_duration_fallback_5m():


### PR DESCRIPTION
## Summary

Follow-up to #1319. Live test (Close Sweep @ 5m on `crusaderbot.fly.dev`) showed the web UI working (timeframe toggle, Crypto auto-lock, preset persisted with `selected_timeframe=5m`, `category_filters=['Crypto']`, merged `strategy_params`), **but the scan emitted 0 candidates** — `expiration_timing:filter_or_no_match`, `markets_eligible: 0`.

**Root cause:** `is_short_crypto_market` established crypto-ness by calling `is_confluence_scalper_eligible`, which requires the literal word **"crypto"** in `category`/`slug`/`groupItemTitle`. But Polymarket's recurring up/down candle markets carry `category` = their own series slug with no "crypto":

| question | slug | category |
|---|---|---|
| Bitcoin Up or Down - May 20, 12:05AM-12:10AM ET | `btc-updown-5m-1779249900` | `btc-updown-5m-1779249900` |
| Bitcoin Up or Down - May 21, 1:00AM-1:15AM ET | `btc-updown-15m-1779339600` | `btc-updown-15m-1779339600` |

So every real 5m/15m market was rejected before the timeframe regex (which *does* match the `-5m-`/`-15m-` slug tokens) even ran.

**Fix:** in `is_short_crypto_market`, identify crypto via the **asset-ticker whitelist** (BTC/ETH/SOL/XRP/DOGE/BNB/HYPE, word-boundary) **+ a detected 5m/15m interval**, instead of the literal "crypto" category. The timeframe gate supplies the precision the category check provided — a non-crypto market is extremely unlikely to both name a crypto asset and resolve on a 5/15-minute candle. `is_confluence_scalper_eligible` is left unchanged (still used elsewhere).

## Test plan

- [x] New real-slug regressions in `test_crypto_timeframe.py`: `btc-updown-5m`, `btc-updown-15m`, `eth-updown-5m` → classify + `is_short_crypto_market`; `ethereum-up-or-down-on-may-19` daily → skipped.
- [x] Updated `test_confluence_scalper` non-crypto skip test to assert via the timeframe gate (long-horizon market, no interval → skip).
- [x] 146 tests green (test_crypto_timeframe + test_confluence_scalper + test_webtrader_confluence_scalper_exposure + test_signal_scan_job).
- [ ] Redeploy to Fly + re-test Close Sweep @ 5m → expect `markets_eligible > 0` and short-duration BTC/ETH candle positions opening.

https://claude.ai/code/session_01Loofdv6WzrZsjabaqPFf9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Loofdv6WzrZsjabaqPFf9u)_