### PR TITLE
Inline asset+timeframe selector + live crypto candle market fetch

### DIFF
--- a/projects/polymarket/crusaderbot/domain/strategy/eligibility.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/eligibility.py
@@ -34,6 +34,48 @@ CONFLUENCE_SCALPER_ASSET_PATTERN: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# UI asset ticker -> the alias words that identify it in market text. Used to
+# restrict crypto-short presets to a user-selected subset (BTC/ETH/SOL/BNB...).
+ASSET_ALIASES: dict[str, tuple[str, ...]] = {
+    "BTC": ("btc", "bitcoin"),
+    "ETH": ("eth", "ethereum"),
+    "SOL": ("sol", "solana"),
+    "BNB": ("bnb", "binance coin"),
+    "XRP": ("xrp", "ripple"),
+    "DOGE": ("doge", "dogecoin"),
+    "HYPE": ("hype", "hyperliquid"),
+}
+
+
+def _assets_pattern(assets: Iterable[str]) -> re.Pattern[str] | None:
+    """Compile a word-boundary regex matching any alias of the given tickers."""
+    aliases: list[str] = []
+    for a in assets:
+        aliases.extend(ASSET_ALIASES.get(str(a).strip().upper(), ()))
+    if not aliases:
+        return None
+    return re.compile(
+        r"\b(" + "|".join(re.escape(x) for x in aliases) + r")\b", re.IGNORECASE
+    )
+
+
+def market_matches_assets(market: Any, assets: Iterable[str] | None) -> bool:
+    """True if ``market`` text names one of the selected asset tickers.
+
+    ``assets`` empty/None means "any whitelisted crypto asset" (no restriction
+    beyond the existing whitelist). Unknown tickers contribute no aliases.
+    """
+    if not isinstance(market, dict):
+        return False
+    pattern = _assets_pattern(assets) if assets else CONFLUENCE_SCALPER_ASSET_PATTERN
+    if pattern is None:
+        pattern = CONFLUENCE_SCALPER_ASSET_PATTERN
+    haystack = " ".join(
+        str(market.get(field) or "")
+        for field in ("question", "title", "slug", "groupItemTitle")
+    )
+    return bool(pattern.search(haystack))
+
 
 def is_confluence_scalper_eligible(market: Any) -> bool:
     """Return True if a Gamma market dict qualifies for the confluence scalper.
@@ -166,7 +208,11 @@ def classify_crypto_timeframe(market: Any) -> CryptoTimeframe | None:
     return None
 
 
-def is_short_crypto_market(market: Any, timeframe: str | None) -> bool:
+def is_short_crypto_market(
+    market: Any,
+    timeframe: str | None,
+    assets: Iterable[str] | None = None,
+) -> bool:
     """True iff ``market`` is a short-duration crypto candle market AND its
     classified timeframe matches ``timeframe``.
 
@@ -185,11 +231,9 @@ def is_short_crypto_market(market: Any, timeframe: str | None) -> bool:
     """
     if not isinstance(market, dict):
         return False
-    haystack = " ".join(
-        str(market.get(field) or "")
-        for field in ("question", "title", "slug", "groupItemTitle")
-    )
-    if not CONFLUENCE_SCALPER_ASSET_PATTERN.search(haystack):
+    # Asset gate: a whitelisted crypto ticker (optionally narrowed to the
+    # user's selected subset, e.g. BTC/ETH/SOL/BNB) must appear in the text.
+    if not market_matches_assets(market, assets):
         return False
     tf = classify_crypto_timeframe(market)
     if tf is None:
@@ -207,4 +251,6 @@ __all__ = [
     "CryptoTimeframe",
     "classify_crypto_timeframe",
     "is_short_crypto_market",
+    "ASSET_ALIASES",
+    "market_matches_assets",
 ]

--- a/projects/polymarket/crusaderbot/domain/strategy/strategies/confluence_scalper.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/strategies/confluence_scalper.py
@@ -95,10 +95,13 @@ class ConfluenceScalperStrategy(BaseStrategy):
         Returns an empty list on any failure or when no market qualifies.
         Never raises — scan errors must not crash the scheduler scan loop.
         """
+        # Crypto Scalper trades short-duration crypto candle markets, which the
+        # generic /markets fetch misses — pull the dedicated newest-first candle
+        # universe (live 5m/15m markets with real in-window liquidity).
         try:
-            markets = await pm.get_markets(limit=SCAN_MARKET_LIMIT)
+            markets = await pm.get_crypto_short_markets()
         except Exception as exc:
-            logger.warning("confluence_scalper scan: get_markets failed err=%s", exc)
+            logger.warning("confluence_scalper scan: get_crypto_short_markets failed err=%s", exc)
             return []
 
         if not markets:
@@ -108,19 +111,16 @@ class ConfluenceScalperStrategy(BaseStrategy):
         blacklist = set(market_filters.blacklisted_market_ids)
         effective_min_liquidity = max(market_filters.min_liquidity, 0.0)
         timeframe = getattr(user_context, "selected_timeframe", None)
+        assets = getattr(user_context, "selected_assets", ()) or None
         tuning = _TIMEFRAME_TUNING.get(timeframe or "", {})
         candidates: list[SignalCandidate] = []
 
         for m in markets:
-            # Issue #1269 eligibility gate — crypto-only category + asset
-            # whitelist (BTC/ETH/SOL/XRP/DOGE/BNB/HYPE) — composed with the
-            # short-duration timeframe gate (5m/15m). Applied inside the
-            # strategy's own market loop so it operates on confluence_scalper's
-            # full universe rather than a capped lib-strategy snapshot in the
-            # scan loop. timeframe=None keeps any 5m/15m crypto market eligible;
-            # non-crypto or unclassifiable markets self-skip (fail-closed)
-            # without affecting other strategies on the same scan tick.
-            if not is_short_crypto_market(m, timeframe):
+            # Gate to crypto candle markets matching the user's timeframe (5m/15m)
+            # and selected assets (BTC/ETH/SOL/BNB...). timeframe=None keeps any
+            # 5m/15m crypto market; non-crypto / unclassifiable / off-asset
+            # markets self-skip (fail-closed) without affecting other strategies.
+            if not is_short_crypto_market(m, timeframe, assets):
                 continue
             try:
                 candidate = _evaluate_market(

--- a/projects/polymarket/crusaderbot/domain/strategy/types.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/types.py
@@ -108,6 +108,9 @@ class UserContext:
     # Crypto short-duration timeframe ('5m' | '15m') for confluence_scalper /
     # close_sweep presets. None when the active preset is not a crypto-short one.
     selected_timeframe: str | None = None
+    # Crypto assets to trade for crypto-short presets (e.g. ['BTC','ETH']).
+    # None/empty means all whitelisted assets.
+    selected_assets: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.risk_profile not in VALID_RISK_PROFILES:

--- a/projects/polymarket/crusaderbot/integrations/polymarket.py
+++ b/projects/polymarket/crusaderbot/integrations/polymarket.py
@@ -139,6 +139,41 @@ async def get_events_with_markets(limit: int = 200) -> list[dict]:
         return []
 
 
+async def get_crypto_short_markets(limit: int = 500) -> list[dict]:
+    """Fetch the freshest active markets, ordered newest-created first.
+
+    Polymarket's recurring crypto up/down candle markets (``btc-updown-5m-...``)
+    are created continuously and only carry live Gamma ``liquidity`` once they
+    enter their short trading window. A default ``/markets`` page (sorted by
+    volume/id) almost never surfaces them, so crypto-short presets see an empty
+    universe. Sorting by ``startDate`` descending brings the currently-live
+    candle markets — the ones with real in-window liquidity — to the top.
+
+    Cached 60s (shorter than the 5-min generic cache) because the live window
+    for a 5-minute candle is itself only minutes long.
+    """
+    key = f"crypto_short:{limit}"
+    if hit := await get_cache(key):
+        return hit
+    params: dict[str, Any] = {
+        "active": "true",
+        "closed": "false",
+        "limit": limit,
+        "order": "startDate",
+        "ascending": "false",
+    }
+    try:
+        data = await _get_json(f"{GAMMA}/markets", params=params)
+        if isinstance(data, dict):
+            data = data.get("data", [])
+        data = data or []
+        await set_cache(key, data, ttl=60)
+        return data
+    except Exception as exc:
+        logger.warning("get_crypto_short_markets failed: %s", exc)
+        return []
+
+
 async def get_market(market_id: str) -> Optional[dict]:
     """Fetch a single market from Gamma API by conditionId. Cached 2 min.
 

--- a/projects/polymarket/crusaderbot/migrations/050_strategy_assets.sql
+++ b/projects/polymarket/crusaderbot/migrations/050_strategy_assets.sql
@@ -1,0 +1,15 @@
+-- 050_strategy_assets.sql
+-- Per-user crypto asset selection for short-duration crypto presets.
+--
+-- The crypto-short presets (confluence_scalper "Crypto Scalper" and close_sweep
+-- "Close Sweep") let the user pick which crypto assets to trade (BTC/ETH/SOL/
+-- BNB...). NULL / empty array means "all whitelisted assets".
+--
+-- Additive + idempotent: ADD COLUMN IF NOT EXISTS, safe to re-run on every
+-- startup. No data loss.
+
+ALTER TABLE user_settings
+    ADD COLUMN IF NOT EXISTS selected_assets TEXT[];
+
+COMMENT ON COLUMN user_settings.selected_assets IS
+  'Crypto asset tickers for short-duration presets (e.g. {BTC,ETH,SOL,BNB}); NULL/empty = all whitelisted assets';

--- a/projects/polymarket/crusaderbot/reports/forge/crypto-short-asset-selector.md
+++ b/projects/polymarket/crusaderbot/reports/forge/crypto-short-asset-selector.md
@@ -1,0 +1,70 @@
+# WARP•FORGE Report — crypto-short-asset-selector
+
+Branch: WARP/crypto-short-asset-selector
+Validation Tier: MAJOR (scan pipeline + market fetch + strategy gating)
+Claim Level: NARROW INTEGRATION (code + unit/typecheck/build + live Gamma probe;
+full trade proof needs Fly deploy + migration 050 applied + a live candle window)
+Validation Target: inline asset+timeframe selector for crypto-short presets,
+asset filtering, and a fetch-coverage fix so the scanner actually sees the live
+5m/15m crypto candle markets.
+Not in Scope: assets beyond BTC/ETH/SOL/BNB in the UI; CLOB-orderbook depth as a
+liquidity source (Gamma `liquidity` is populated once a candle enters its window,
+verified live — so it is sufficient).
+Suggested Next Step: apply migration 050, Fly redeploy, re-test Close Sweep/Crypto
+Scalper @ 5m → expect `markets_eligible > 0` and BTC/ETH/SOL candle positions.
+
+## 1. What was built
+
+1. **Inline strategy config** — selecting Close Sweep or Crypto Scalper expands
+   the strategy card in place with **asset chips (BTC/ETH/SOL/BNB, multi-select)**
+   + **5m/15m** timeframe toggle + "Crypto only" badge. Removed the stranded
+   bottom timeframe section.
+2. **Asset selection** — new `user_settings.selected_assets` (migration 050).
+   Filters which crypto assets the bot trades; default = all four.
+3. **Fetch-coverage fix (the functional unlock)** — `pm.get_crypto_short_markets()`
+   fetches newest-created markets first (`order=startDate&ascending=false`),
+   surfacing the currently-live candle markets with real in-window liquidity.
+   Both crypto-short strategies now scan this universe. Verified live: 38 eligible
+   5m markets, 21 with ≥ $2000 liquidity (BTC/ETH/SOL).
+
+## 2. Current system architecture
+
+```
+selected_assets + selected_timeframe (user_settings, mig 049/050)
+  -> signal_scan_job SELECT -> UserContext.{selected_timeframe,selected_assets}
+  -> confluence_scalper.scan: pm.get_crypto_short_markets() gated by
+     is_short_crypto_market(m, tf, assets)
+  -> close_sweep: signal_scan_job pre-filters crypto_short_markets the same way
+eligibility.is_short_crypto_market = asset-ticker match (optionally narrowed to
+selected assets) + classified 5m/15m interval (fail-closed).
+```
+
+## 3. Files created / modified
+
+Created:
+- migrations/050_strategy_assets.sql
+Modified:
+- domain/strategy/eligibility.py (ASSET_ALIASES, market_matches_assets, assets arg)
+- domain/strategy/types.py (UserContext.selected_assets)
+- domain/strategy/strategies/confluence_scalper.py (get_crypto_short_markets + assets gate)
+- integrations/polymarket.py (get_crypto_short_markets)
+- services/signal_scan/signal_scan_job.py (SELECT, ctx, candle universe, close_sweep prefilter)
+- webtrader/backend/schemas.py + router.py (selected_assets validate/persist/return)
+- webtrader/frontend/src/lib/api.ts + pages/AutoTradePage.tsx (inline UI)
+- tests/test_crypto_timeframe.py (asset tests), tests/test_confluence_scalper.py (mock target)
+
+## 4. What is working
+
+- 150 backend tests green; tsc + vite build clean; py_compile clean.
+- Live Gamma probe confirms the fetch+gate surfaces tradeable candle markets.
+
+## 5. Known issues
+
+- Gamma caps `/markets` at 100 results/page; newest-first ordering still yields
+  ample live candles (38 eligible). If coverage proves thin, paginate.
+- Candle markets show liquidity=0 until they enter their short window — expected;
+  the scanner re-fetches every 60s (cache ttl) so it catches them in-window.
+
+## 6. What is next
+
+- Apply migration 050 + redeploy; confirm positions open on live candles.

--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -216,6 +216,7 @@ async def _load_enrolled_users() -> list[dict[str, Any]]:
                 COALESCE(urp.profile_name, s.risk_profile, 'balanced') AS resolved_profile,
                 s.active_preset,
                 s.selected_timeframe,
+                s.selected_assets,
                 COALESCE(s.min_liquidity, 0)         AS min_liquidity_threshold,
                 COALESCE(s.strategy_params, '{}'::jsonb)      AS strategy_params,
                 COALESCE(s.category_filters, ARRAY[]::text[]) AS category_filters
@@ -497,6 +498,7 @@ def _build_user_context(row: dict[str, Any]) -> UserContext:
     allocation = max(0.0, min(1.0, allocation))
     sub_account_id = str(row.get("sub_account_id") or row["user_id"])
     _tf = row.get("selected_timeframe")
+    _assets = tuple(str(a) for a in (row.get("selected_assets") or []))
     return UserContext(
         user_id=str(row["user_id"]),
         sub_account_id=sub_account_id,
@@ -504,6 +506,7 @@ def _build_user_context(row: dict[str, Any]) -> UserContext:
         capital_allocation_pct=allocation,
         available_balance_usdc=float(row.get("balance_usdc") or 0.0),
         selected_timeframe=str(_tf) if _tf else None,
+        selected_assets=_assets,
     )
 
 
@@ -1004,6 +1007,16 @@ async def run_once() -> None:
     markets = await _fetch_markets_for_lib_strategies()
     strategies_to_run = list(ENABLED_STRATEGIES) + list(DEFERRED_STRATEGIES)
 
+    # Crypto short-duration candle universe (btc/eth/sol/bnb up-down 5m/15m).
+    # These are created continuously and missed by the generic fetch above, so
+    # crypto-short presets (close_sweep / confluence_scalper) need a dedicated,
+    # newest-first fetch to see the currently-live candles with real liquidity.
+    try:
+        crypto_short_markets = await _polymarket.get_crypto_short_markets()
+    except Exception as exc:
+        logger.warning("crypto_short_markets_fetch_failed", error=str(exc))
+        crypto_short_markets = []
+
     tel.users_evaluated = len(users)
     tel.markets_seen = len(markets)
 
@@ -1026,6 +1039,7 @@ async def run_once() -> None:
         strategy_params: dict = _coerce_jsonb(row.get("strategy_params"), {})
         _tf = row.get("selected_timeframe")
         selected_timeframe: str | None = str(_tf) if _tf else None
+        selected_assets: list[str] = [str(a) for a in (row.get("selected_assets") or [])]
         user_log = logger.bind(user_id=str(row["user_id"]), preset=active_preset)
 
         # Filter market list to user's chosen categories (empty = all markets).
@@ -1050,16 +1064,16 @@ async def run_once() -> None:
                 lib_params = {}
             config = {"strategy_params": lib_params}
 
-            # Close Sweep is a short-duration crypto-only preset: when it is the
-            # active preset, gate expiration_timing to crypto markets whose
-            # candle interval matches the user's selected timeframe (5m/15m).
-            # Other presets (full_auto / default) keep expiration_timing's
-            # general behaviour over the full market universe.
+            # Close Sweep is a short-duration crypto preset: when active, scan
+            # the dedicated newest-first crypto candle universe (so the live
+            # 5m/15m markets with real in-window liquidity are actually seen),
+            # gated to the user's timeframe + selected assets. Other presets
+            # (full_auto / default) keep expiration_timing's general behaviour.
             scan_markets = user_markets
             if active_preset == "close_sweep" and lib_name == "expiration_timing":
                 scan_markets = [
-                    m for m in user_markets
-                    if is_short_crypto_market(m, selected_timeframe)
+                    m for m in crypto_short_markets
+                    if is_short_crypto_market(m, selected_timeframe, selected_assets)
                 ]
 
             try:

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -332,3 +332,4 @@ Hard product rules enforced: no manual trade buttons, markets intelligence-only,
 
 2026-05-24 19:10 | WARP/crypto-timeframe-presets | crypto-short presets (Crypto Scalper + Close Sweep) gated to 5m/15m short-duration crypto + category auto-lock (mig 049); Ensemble→Smart Mix; hide whale_mirror + Coming Soon in web
 2026-05-24 19:45 | WARP/crypto-timeframe-detection-fix | fix is_short_crypto_market: identify crypto via asset-ticker + 5m/15m interval (not literal category) so real btc/eth-updown candle markets qualify; Close Sweep/Crypto Scalper now match live data
+2026-05-24 20:30 | WARP/crypto-short-asset-selector | inline asset(BTC/ETH/SOL/BNB)+timeframe selector for crypto-short presets; selected_assets (mig 050); get_crypto_short_markets fetch-coverage so scanner sees live 5m/15m candle markets

--- a/projects/polymarket/crusaderbot/tests/test_confluence_scalper.py
+++ b/projects/polymarket/crusaderbot/tests/test_confluence_scalper.py
@@ -49,7 +49,7 @@ from projects.polymarket.crusaderbot.domain.strategy.types import (
 
 _PM_PATCH = (
     "projects.polymarket.crusaderbot.domain.strategy.strategies"
-    ".confluence_scalper.pm.get_markets"
+    ".confluence_scalper.pm.get_crypto_short_markets"
 )
 
 

--- a/projects/polymarket/crusaderbot/tests/test_crypto_timeframe.py
+++ b/projects/polymarket/crusaderbot/tests/test_crypto_timeframe.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from projects.polymarket.crusaderbot.domain.strategy.eligibility import (
     classify_crypto_timeframe,
     is_short_crypto_market,
+    market_matches_assets,
 )
 
 
@@ -158,3 +159,34 @@ def test_crypto_without_timeframe_rejected():
     m = _market(question="Will BTC hit $200k?", slug="btc-200k")
     assert is_short_crypto_market(m, "5m") is False
     assert is_short_crypto_market(m, None) is False
+
+
+# ── asset selection ─────────────────────────────────────────────────────────
+
+def _btc5m():
+    return {"question": "Bitcoin Up or Down", "slug": "btc-updown-5m-1779249900", "category": "crypto"}
+
+
+def _eth5m():
+    return {"question": "Ethereum Up or Down", "slug": "eth-updown-5m-1779249900", "category": "crypto"}
+
+
+def test_asset_filter_matches_selected():
+    assert is_short_crypto_market(_btc5m(), "5m", ["BTC"]) is True
+    assert is_short_crypto_market(_btc5m(), "5m", ["ETH"]) is False
+
+
+def test_asset_filter_multi_select():
+    assert is_short_crypto_market(_eth5m(), "5m", ["BTC", "ETH"]) is True
+    assert is_short_crypto_market(_eth5m(), "5m", ["BTC", "SOL"]) is False
+
+
+def test_asset_filter_empty_means_any():
+    assert is_short_crypto_market(_btc5m(), "5m", []) is True
+    assert is_short_crypto_market(_btc5m(), "5m", None) is True
+
+
+def test_market_matches_assets_helper():
+    assert market_matches_assets(_btc5m(), ["BTC"]) is True
+    assert market_matches_assets(_btc5m(), ["ETH", "SOL"]) is False
+    assert market_matches_assets(_eth5m(), None) is True  # any whitelisted

--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -387,7 +387,7 @@ async def get_autotrade(user: _CurrentUser) -> AutoTradeState:
         s_row = await conn.fetchrow(
             """SELECT risk_profile, capital_alloc_pct, tp_pct, sl_pct, active_preset,
                       category_filters, min_liquidity, max_resolution_days, min_volume_24h,
-                      slippage_tolerance_pct, selected_timeframe
+                      slippage_tolerance_pct, selected_timeframe, selected_assets
                FROM user_settings WHERE user_id=$1::uuid""",
             user_id,
         )
@@ -406,6 +406,7 @@ async def get_autotrade(user: _CurrentUser) -> AutoTradeState:
         min_volume_24h=float(s_row["min_volume_24h"]) if s_row and s_row["min_volume_24h"] is not None else 100.0,
         slippage_tolerance_pct=float(s_row["slippage_tolerance_pct"]) if s_row and s_row["slippage_tolerance_pct"] is not None else None,
         selected_timeframe=s_row["selected_timeframe"] if s_row else None,
+        selected_assets=list(s_row["selected_assets"]) if s_row and s_row["selected_assets"] else None,
     )
 
 
@@ -446,6 +447,9 @@ _PRESET_PARAMS: dict[str, dict[str, str | float]] = {
 # the market category filter to Crypto only and requires a timeframe (5m/15m).
 _CRYPTO_SHORT_PRESETS: frozenset[str] = frozenset({"confluence_scalper", "close_sweep"})
 _VALID_TIMEFRAMES: frozenset[str] = frozenset({"5m", "15m"})
+# Assets offered for crypto-short presets; activation defaults to all of them.
+_CRYPTO_SHORT_ASSETS: tuple[str, ...] = ("BTC", "ETH", "SOL", "BNB")
+_VALID_ASSETS: frozenset[str] = frozenset(_CRYPTO_SHORT_ASSETS)
 
 # Light per-timeframe params merged into user_settings.strategy_params (JSONB)
 # for the close_sweep preset (expiration_timing lib strategy reads config). The
@@ -479,12 +483,24 @@ async def activate_preset(body: PresetActivateRequest, user: _CurrentUser):
     # Resolve timeframe: crypto-short presets require one (default 5m); all other
     # presets clear it so the web UI hides the timeframe toggle and category lock.
     timeframe: str | None = None
+    assets: list[str] | None = None
     if is_crypto_short:
         timeframe = body.selected_timeframe or "5m"
         if timeframe not in _VALID_TIMEFRAMES:
             raise HTTPException(
                 status_code=400, detail=f"invalid timeframe: {timeframe} (expected 5m or 15m)"
             )
+        # Normalize + validate the asset selection; default to all offered assets.
+        raw_assets = [str(a).strip().upper() for a in (body.selected_assets or [])]
+        assets = [a for a in raw_assets if a in _VALID_ASSETS]
+        bad = [a for a in raw_assets if a not in _VALID_ASSETS]
+        if bad:
+            raise HTTPException(
+                status_code=400,
+                detail=f"invalid asset(s): {', '.join(bad)} (expected any of {', '.join(_CRYPTO_SHORT_ASSETS)})",
+            )
+        if not assets:
+            assets = list(_CRYPTO_SHORT_ASSETS)
 
     # Auto-lock market category to Crypto only for crypto-short presets;
     # None leaves the existing category_filters untouched for other presets.
@@ -509,8 +525,9 @@ async def activate_preset(body: PresetActivateRequest, user: _CurrentUser):
                                               WHEN $8::jsonb IS NULL THEN strategy_params
                                               ELSE COALESCE(strategy_params, '{}'::jsonb) || $8::jsonb
                                             END,
+                      selected_assets     = $9,
                       updated_at          = NOW()
-               WHERE user_id = $9::uuid""",
+               WHERE user_id = $10::uuid""",
             body.preset_key,
             params.get("risk_profile"),
             params.get("capital_alloc_pct"),
@@ -519,9 +536,14 @@ async def activate_preset(body: PresetActivateRequest, user: _CurrentUser):
             timeframe,
             category_filters,
             tf_params_json,
+            assets,
             user_id,
         )
-    return {"active_preset": body.preset_key, "selected_timeframe": timeframe}
+    return {
+        "active_preset": body.preset_key,
+        "selected_timeframe": timeframe,
+        "selected_assets": assets,
+    }
 
 
 @router.post("/autotrade/customize")

--- a/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
@@ -96,6 +96,7 @@ class AutoTradeState(BaseModel):
     min_volume_24h: float = 100.0
     slippage_tolerance_pct: Optional[float] = None
     selected_timeframe: Optional[str] = None  # '5m' | '15m' for crypto-short presets
+    selected_assets: Optional[list[str]] = None  # e.g. ['BTC','ETH'] for crypto-short presets
 
 
 class AutoTradeToggleRequest(BaseModel):
@@ -105,6 +106,7 @@ class AutoTradeToggleRequest(BaseModel):
 class PresetActivateRequest(BaseModel):
     preset_key: str
     selected_timeframe: Optional[str] = None  # '5m' | '15m' (crypto-short presets only)
+    selected_assets: Optional[list[str]] = None  # crypto-short presets only
 
 
 class CustomizeRequest(BaseModel):

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/lib/api.ts
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/lib/api.ts
@@ -40,8 +40,9 @@ export function makeApi(token: string | null) {
       get<ChartPoint[]>(`/portfolio/chart?period=${encodeURIComponent(period)}`),
     getAutotrade: () => get<AutoTradeState>("/autotrade"),
     toggleAutotrade: (enabled: boolean) => post<{ auto_trade_on: boolean }>("/autotrade/toggle", { enabled }),
-    activatePreset: (preset_key: string, selected_timeframe?: "5m" | "15m") =>
-      post<{ active_preset: string; selected_timeframe: string | null }>("/autotrade/preset", { preset_key, selected_timeframe }),
+    activatePreset: (preset_key: string, selected_timeframe?: "5m" | "15m", selected_assets?: string[]) =>
+      post<{ active_preset: string; selected_timeframe: string | null; selected_assets: string[] | null }>(
+        "/autotrade/preset", { preset_key, selected_timeframe, selected_assets }),
     setRiskProfile: (params: RiskProfileParams) => patch<{ risk_profile: string }>("/autotrade/risk-profile", params),
     customizeStrategy: (params: CustomizeParams) => post<{ updated: boolean }>("/autotrade/customize", params),
     getWallet: () => get<WalletInfo>("/wallet"),
@@ -143,6 +144,7 @@ export interface AutoTradeState {
   min_volume_24h: number;
   slippage_tolerance_pct: number | null;
   selected_timeframe: string | null;
+  selected_assets: string[] | null;
 }
 
 export interface CustomizeParams {

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { CollapsibleSection } from "../components/CollapsibleSection";
 import { DesktopPageHeader } from "../components/DesktopPageHeader";
@@ -92,6 +92,7 @@ const STRATEGY_PRESETS = [
 const CRYPTO_SHORT_PRESETS: readonly string[] = ["confluence_scalper", "close_sweep"];
 const TIMEFRAMES = ["5m", "15m"] as const;
 type Timeframe = (typeof TIMEFRAMES)[number];
+const CRYPTO_ASSETS = ["BTC", "ETH", "SOL", "BNB"] as const;
 
 // ── Section B: Risk Profiles ──────────────────────────────────────────────────
 
@@ -135,6 +136,8 @@ export function AutoTradePage() {
   const [filterSlippage, setFilterSlippage]   = useState<string>("3");
   const [savingFilters, setSavingFilters]     = useState(false);
   const [filterSaved, setFilterSaved]         = useState(false);
+  // Crypto-short preset config (assets shown inline inside the active card)
+  const [selectedAssets, setSelectedAssets]   = useState<string[]>([...CRYPTO_ASSETS]);
 
   const load = useCallback(async () => {
     const [autotradeResult, dashResult] = await Promise.allSettled([
@@ -155,6 +158,8 @@ export function AutoTradePage() {
     if (s.max_resolution_days != null) setFilterResolution(String(s.max_resolution_days));
     if (s.min_volume_24h != null) setFilterVolume(String(s.min_volume_24h));
     if (s.slippage_tolerance_pct != null) setFilterSlippage(String(Math.round(s.slippage_tolerance_pct * 100)));
+    if (s.selected_assets && s.selected_assets.length > 0) setSelectedAssets(s.selected_assets);
+    else setSelectedAssets([...CRYPTO_ASSETS]);
   }, [api]);
 
   useEffect(() => { void load(); }, [load]);
@@ -179,9 +184,10 @@ export function AutoTradePage() {
 
   async function handleActivatePreset(key: string) {
     if (CRYPTO_SHORT_PRESETS.includes(key)) {
-      // Crypto-short presets require a timeframe; reuse the current one or default 5m.
+      // Crypto-short presets carry a timeframe + asset selection.
       const tf = (state?.selected_timeframe as Timeframe) ?? "5m";
-      await api.activatePreset(key, tf);
+      const assets = selectedAssets.length > 0 ? selectedAssets : [...CRYPTO_ASSETS];
+      await api.activatePreset(key, tf, assets);
     } else {
       await api.activatePreset(key);
     }
@@ -190,7 +196,21 @@ export function AutoTradePage() {
 
   async function handleSelectTimeframe(tf: Timeframe) {
     if (!state?.active_preset) return;
-    await api.activatePreset(state.active_preset, tf);
+    const assets = selectedAssets.length > 0 ? selectedAssets : [...CRYPTO_ASSETS];
+    await api.activatePreset(state.active_preset, tf, assets);
+    await load();
+  }
+
+  async function handleToggleAsset(asset: string) {
+    if (!state?.active_preset) return;
+    // Keep at least one asset selected.
+    const next = selectedAssets.includes(asset)
+      ? selectedAssets.filter(a => a !== asset)
+      : [...selectedAssets, asset];
+    if (next.length === 0) return;
+    setSelectedAssets(next);
+    const tf = (state.selected_timeframe as Timeframe) ?? "5m";
+    await api.activatePreset(state.active_preset, tf, next);
     await load();
   }
 
@@ -348,81 +368,102 @@ export function AutoTradePage() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
           {STRATEGY_PRESETS.map((p) => {
             const isActive = state.active_preset === p.key;
+            const showConfig = isActive && CRYPTO_SHORT_PRESETS.includes(p.key);
             return (
-              <button
-                key={p.key}
-                onClick={() => void handleActivatePreset(p.key)}
-                className={[
-                  "w-full text-left p-3 rounded-lg border transition-all",
-                  isActive
-                    ? "border-gold bg-surface-2 shadow-[0_0_8px_rgba(191,155,48,0.25)]"
-                    : "border-surface-3 bg-surface-1 hover:border-ink-3",
-                ].join(" ")}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="text-lg">{p.emoji}</span>
-                    <div className="min-w-0">
-                      <div className="font-hud text-sm font-bold text-ink-1 flex items-center gap-2">
-                        {p.name}
-                        {isActive && (
-                          <span className="text-[9px] font-bold tracking-widest text-gold uppercase px-1.5 py-0.5 rounded border border-gold/40 bg-gold/10">
-                            ACTIVE
-                          </span>
-                        )}
+              <Fragment key={p.key}>
+                <button
+                  onClick={() => void handleActivatePreset(p.key)}
+                  className={[
+                    "w-full text-left p-3 rounded-lg border transition-all",
+                    showConfig ? "rounded-b-none" : "",
+                    isActive
+                      ? "border-gold bg-surface-2 shadow-[0_0_8px_rgba(191,155,48,0.25)]"
+                      : "border-surface-3 bg-surface-1 hover:border-ink-3",
+                  ].join(" ")}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-lg">{p.emoji}</span>
+                      <div className="min-w-0">
+                        <div className="font-hud text-sm font-bold text-ink-1 flex items-center gap-2">
+                          {p.name}
+                          {isActive && (
+                            <span className="text-[9px] font-bold tracking-widest text-gold uppercase px-1.5 py-0.5 rounded border border-gold/40 bg-gold/10">
+                              ACTIVE
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-ink-3 truncate mt-0.5">{p.signal}</div>
                       </div>
-                      <div className="text-xs text-ink-3 truncate mt-0.5">{p.signal}</div>
+                    </div>
+                    <div className="text-right shrink-0 text-xs text-ink-3">
+                      <div className={`font-bold ${riskColor[p.risk]} uppercase`}>{p.risk}</div>
+                      <div className="text-ink-4">{p.freq} freq</div>
                     </div>
                   </div>
-                  <div className="text-right shrink-0 text-xs text-ink-3">
-                    <div className={`font-bold ${riskColor[p.risk]} uppercase`}>{p.risk}</div>
-                    <div className="text-ink-4">{p.freq} freq</div>
+                  <div className="mt-1.5 text-[10px] text-ink-4 font-mono">
+                    Engine: {p.engine}
                   </div>
-                </div>
-                <div className="mt-1.5 text-[10px] text-ink-4 font-mono">
-                  Engine: {p.engine}
-                </div>
-              </button>
+                </button>
+
+                {/* Inline config for crypto-short presets: assets + timeframe */}
+                {showConfig && (
+                  <div className="md:col-span-3 p-3 rounded-lg rounded-t-none border border-t-0 border-gold/40 bg-surface-2">
+                    <div className="flex items-center justify-between gap-2 mb-2">
+                      <p className="text-[9px] text-ink-4 uppercase tracking-[1.5px] font-mono">Assets</p>
+                      <span className="text-[9px] font-bold tracking-widest text-gold uppercase px-1.5 py-0.5 rounded border border-gold/40 bg-gold/10">
+                        Crypto only
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-4 gap-2 mb-3">
+                      {CRYPTO_ASSETS.map((asset) => {
+                        const on = selectedAssets.includes(asset);
+                        return (
+                          <button
+                            key={asset}
+                            onClick={() => void handleToggleAsset(asset)}
+                            className={[
+                              "py-2 rounded-lg border text-xs font-hud font-bold transition-all",
+                              on
+                                ? "border-gold bg-gold/10 text-gold"
+                                : "border-surface-3 bg-surface-1 text-ink-3 hover:border-ink-3",
+                            ].join(" ")}
+                          >
+                            {asset}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <p className="text-[9px] text-ink-4 uppercase tracking-[1.5px] font-mono mb-2">Timeframe</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      {TIMEFRAMES.map((tf) => {
+                        const tfActive = activeTimeframe === tf;
+                        return (
+                          <button
+                            key={tf}
+                            onClick={() => void handleSelectTimeframe(tf)}
+                            className={[
+                              "py-2 rounded-lg border text-sm font-hud font-bold transition-all",
+                              tfActive
+                                ? "border-gold bg-gold/10 text-gold shadow-[0_0_8px_rgba(191,155,48,0.25)]"
+                                : "border-surface-3 bg-surface-1 text-ink-2 hover:border-ink-3",
+                            ].join(" ")}
+                          >
+                            {tf}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <p className="text-[10px] text-ink-4 font-mono mt-2">
+                      Trades only {selectedAssets.join("/")} short-duration markets ({activeTimeframe}). Category locked to Crypto.
+                    </p>
+                  </div>
+                )}
+              </Fragment>
             );
           })}
 
         </div>
-
-        {/* ── Timeframe (crypto-short presets only) ── */}
-        {isCryptoShortActive && (
-          <div className="mt-3 p-3 rounded-lg border border-gold/40 bg-surface-2">
-            <div className="flex items-center justify-between gap-2 mb-2">
-              <p className="text-[9px] text-ink-4 uppercase tracking-[1.5px] font-mono">
-                Timeframe
-              </p>
-              <span className="text-[9px] font-bold tracking-widest text-gold uppercase px-1.5 py-0.5 rounded border border-gold/40 bg-gold/10">
-                Crypto only
-              </span>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {TIMEFRAMES.map((tf) => {
-                const tfActive = activeTimeframe === tf;
-                return (
-                  <button
-                    key={tf}
-                    onClick={() => void handleSelectTimeframe(tf)}
-                    className={[
-                      "py-2 rounded-lg border text-sm font-hud font-bold transition-all",
-                      tfActive
-                        ? "border-gold bg-gold/10 text-gold shadow-[0_0_8px_rgba(191,155,48,0.25)]"
-                        : "border-surface-3 bg-surface-1 text-ink-2 hover:border-ink-3",
-                    ].join(" ")}
-                  >
-                    {tf}
-                  </button>
-                );
-              })}
-            </div>
-            <p className="text-[10px] text-ink-4 font-mono mt-2">
-              Bot trades only short-duration crypto markets ({activeTimeframe}). Market category is locked to Crypto.
-            </p>
-          </div>
-        )}
 
         {/* ── SECTION B: Risk Profile ── */}
         <SectionTitle>Risk Profile</SectionTitle>


### PR DESCRIPTION
## Summary

Follow-up to #1319/#1320, driven by live testing. Two things:

### 1. Inline strategy config (the UI you asked for)
Selecting **Close Sweep** or **Crypto Scalper** now expands the strategy card **in place** with:
- **Asset chips** — BTC / ETH / SOL / BNB (multi-select, tap to toggle, at least one required)
- **5m / 15m** timeframe toggle
- "Crypto only" badge

The stranded bottom timeframe section is removed. New `selected_assets` setting (migration `050`) filters which crypto assets the bot trades (default = all four), persisted on preset activation and validated server-side.

### 2. Fetch-coverage fix (the reason 0 trades fired)
Live testing showed the BTC/ETH/SOL 5m/15m up/down candle markets **do exist with real liquidity** ($2.5k–$19k once they enter their window) — but the scanner never saw them: its generic `/markets` fetch (volume/id-ordered, 100 rows) doesn't surface these continuously-created micro-markets, and Gamma reports `liquidity: 0` until a candle is live.

Fix: `pm.get_crypto_short_markets()` fetches **newest-created markets first** (`order=startDate&ascending=false`), which surfaces the currently-live candles with their in-window liquidity. Both crypto-short strategies now scan this universe, gated by `is_short_crypto_market(market, timeframe, assets)`.

**Verified live against Gamma:** the fetch + gate yields **38 eligible 5m markets, 21 with ≥ $2,000 liquidity** (BTC/ETH/SOL).

## Test plan

- [x] 150 backend tests green (asset-filter + real-slug regressions added; scalper mock retargeted to `get_crypto_short_markets`)
- [x] `tsc --noEmit` + `vite build` clean
- [x] `py_compile` clean; live Gamma probe confirms eligible markets with liquidity
- [ ] Apply migration `050` + Fly redeploy
- [ ] Re-test Close Sweep / Crypto Scalper @ 5m → expect `markets_eligible > 0` and BTC/ETH/SOL candle positions opening; toggle assets/timeframe in the card and confirm persistence

## Notes

- Gamma caps `/markets` at 100 rows/page; newest-first still yields ample live candles. Paginate later if coverage proves thin.
- CLOB-orderbook depth was investigated as a liquidity source but isn't needed — Gamma `liquidity` is populated once a candle is in its window (confirmed live).
- Validation Tier: MAJOR (scan pipeline + fetch + gating). Guards untouched (paper-only). Report: `projects/polymarket/crusaderbot/reports/forge/crypto-short-asset-selector.md`.

https://claude.ai/code/session_01Loofdv6WzrZsjabaqPFf9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Loofdv6WzrZsjabaqPFf9u)_