### PR TITLE
ui: dashboard polish — risk tag colors, SSE live dot, entry price, empty state

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/051_email_auth.sql
+++ b/projects/polymarket/crusaderbot/migrations/051_email_auth.sql
@@ -7,9 +7,16 @@
 -- telegram_user_id becomes nullable so web-only registrations are possible.
 -- The UNIQUE constraint is preserved (two Telegram accounts cannot share a row).
 
--- 1. Make telegram_user_id nullable (was NOT NULL).
-ALTER TABLE users
-  ALTER COLUMN telegram_user_id DROP NOT NULL;
+-- 1. Make telegram_user_id nullable (was NOT NULL). Safe to run twice.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='users' AND column_name='telegram_user_id' AND is_nullable='NO'
+  ) THEN
+    ALTER TABLE users ALTER COLUMN telegram_user_id DROP NOT NULL;
+  END IF;
+END$$;
 
 -- 2. Add email (unique, nullable — NULL for Telegram-only accounts).
 ALTER TABLE users
@@ -23,6 +30,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS users_email_unique
   WHERE email IS NOT NULL;
 
 -- 3. Enforce: every user must have at least one identity (Telegram OR email).
-ALTER TABLE users
-  ADD CONSTRAINT users_identity_required
-  CHECK (telegram_user_id IS NOT NULL OR email IS NOT NULL);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'users_identity_required'
+      AND table_name = 'users'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_identity_required
+      CHECK (telegram_user_id IS NOT NULL OR email IS NOT NULL);
+  END IF;
+END$$;

--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -242,6 +242,7 @@ async def get_dashboard(user: _CurrentUser) -> DashboardSummary:
         kill_switch_active=ks_active,
         trading_mode=trading_mode,
         active_preset=settings_row["active_preset"] if settings_row else None,
+        risk_profile=str(settings_row["risk_profile"] or "balanced") if settings_row else "balanced",
     )
 
 

--- a/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
@@ -56,6 +56,7 @@ class DashboardSummary(BaseModel):
     kill_switch_active: bool
     trading_mode: str
     active_preset: Optional[str] = None
+    risk_profile: str = "balanced"
 
 
 # ── Market feed ───────────────────────────────────────────────────────────────

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/HeroCard.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/HeroCard.tsx
@@ -199,19 +199,22 @@ function Cross({ pos, className }: { pos: "tl" | "tr" | "bl" | "br"; className?:
   );
 }
 
+const RISK_COLOR: Record<RiskLevel, { bg: string; text: string; border: string }> = {
+  safe:       { bg: "rgba(0,229,255,0.10)",  text: "var(--cyan,#00E5FF)", border: "rgba(0,229,255,0.30)" },
+  balanced:   { bg: "rgba(245,200,66,0.10)", text: "var(--gold,#F5C842)", border: "rgba(245,200,66,0.30)" },
+  aggressive: { bg: "rgba(255,45,85,0.10)",  text: "var(--red,#FF2D55)",  border: "rgba(255,45,85,0.30)" },
+};
+
 function RiskTag({ risk }: { risk: RiskLevel }) {
+  const c = RISK_COLOR[risk];
   return (
     <span
       className="inline-flex items-baseline gap-1.5 font-mono text-[9px] font-bold tracking-[2px] py-1 px-2.5 uppercase clip-tab"
-      style={{
-        background: "rgba(245,200,66,0.10)",
-        color: "var(--gold,#F5C842)",
-        border: "1px solid rgba(245,200,66,0.3)",
-      }}
+      style={{ background: c.bg, color: c.text, border: `1px solid ${c.border}` }}
     >
-      <span className="text-ink-3 mr-0.5">[</span>
+      <span className="opacity-50 mr-0.5">[</span>
       {RISK_LABEL[risk]}
-      <span className="text-ink-3 ml-0.5">]</span>
+      <span className="opacity-50 ml-0.5">]</span>
     </span>
   );
 }

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AdvancedOnly } from "../components/AdvancedGate";
 import { DesktopPageHeader } from "../components/DesktopPageHeader";
+import { EmptyState } from "../components/EmptyState";
 import { HeroCard, type RiskLevel } from "../components/HeroCard";
 import { KillSwitchButton } from "../components/KillSwitchButton";
 import { StatCard } from "../components/StatCard";
@@ -17,20 +18,10 @@ import { useAuth } from "../lib/auth";
 import { useSSE } from "../lib/sse";
 import { PositionRow } from "./PortfolioPage";
 
-const PRESET_RISK: Record<string, RiskLevel> = {
-  signal_sniper: "safe",
-  whale_mirror:  "balanced",
-  hybrid:        "balanced",
-  full_auto:     "balanced",
-  value_hunter:  "aggressive",
-};
-
 const PRESET_CODE: Record<string, string> = {
-  signal_sniper: "SIG",
-  whale_mirror:  "CPY",
-  hybrid:        "SIG·CPY",
-  full_auto:     "SIG·CPY·VAL",
-  value_hunter:  "VAL",
+  close_sweep:  "CANDLE",
+  safe_close:   "CANDLE·SAFE",
+  flip_hunter:  "CANDLE·FLIP",
 };
 
 export function DashboardPage() {
@@ -91,7 +82,7 @@ export function DashboardPage() {
 
   useEffect(() => { void loadMarketFeed(); }, [loadMarketFeed]);
 
-  useSSE(user?.token ?? null, {
+  const { connected: sseConnected } = useSSE(user?.token ?? null, {
     positions:        refreshAll,
     portfolio:        refreshAll,
     system:           () => void load(),
@@ -128,8 +119,9 @@ export function DashboardPage() {
   );
 
   const presetKey = data.active_preset ?? "";
-  const risk: RiskLevel | null = data.active_preset
-    ? (PRESET_RISK[presetKey] ?? "balanced")
+  // Use the actual risk_profile from the backend — not a hardcoded preset map.
+  const risk: RiskLevel | null = data.auto_trade_on
+    ? (data.risk_profile as RiskLevel ?? "balanced")
     : null;
   const presetCode = data.active_preset ? PRESET_CODE[presetKey] : undefined;
 
@@ -286,15 +278,29 @@ export function DashboardPage() {
                 <span className="w-3 h-px bg-gold" aria-hidden />
                 Open Positions ({liveOpen.length})
               </div>
-              <span className="font-mono text-[9px] text-ink-4">
-                live · sse push
+              <span className="font-mono text-[9px] text-ink-4 flex items-center gap-1.5">
+                <span
+                  className={sseConnected ? "animate-status-pulse" : ""}
+                  style={{
+                    display: "inline-block",
+                    width: "6px",
+                    height: "6px",
+                    borderRadius: "50%",
+                    background: sseConnected ? "var(--grn,#00FF9C)" : "var(--ink-3,#455370)",
+                    boxShadow: sseConnected ? "0 0 6px var(--grn,#00FF9C)" : "none",
+                  }}
+                  aria-label={sseConnected ? "live" : "reconnecting"}
+                />
+                {sseConnected ? "live" : "reconnecting…"}
               </span>
             </div>
 
             {liveOpen.length === 0 ? (
-              <div className="text-[12px] text-ink-3 px-1 py-3 font-mono">
-                No open positions.
-              </div>
+              <EmptyState
+                icon="◈"
+                title="No Open Positions"
+                text="Scanner watching markets"
+              />
             ) : (
               <PositionCarousel>
                 {liveOpen.map((p) => (

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -777,6 +777,14 @@ export function PositionRow({ p, onCashOut, onForceRedeem }: {
     <span key="cost" className="text-ink-3">
       ${p.size_usdc.toFixed(2)}
     </span>,
+    // Entry price — essential context for any open position
+    ...(isOpen && !awaitingRedeem && p.entry_price > 0
+      ? [
+          <span key="entry" className="text-ink-2">
+            {p.side.toUpperCase()} @ {(p.entry_price * 100).toFixed(1)}¢
+          </span>,
+        ]
+      : []),
     ...(awaitingRedeem
       ? [
           <span key="won" className="font-bold text-grn">
@@ -806,11 +814,7 @@ export function PositionRow({ p, onCashOut, onForceRedeem }: {
       side={side}
       borderTone={tone}
       meta={metaItems}
-      metaAdvanced={[
-        <span key="entry">
-          {p.side.toUpperCase()} @ {(p.entry_price * 100).toFixed(1)}¢
-        </span>,
-      ]}
+      metaAdvanced={[]}
       footer={
         awaitingRedeem && onForceRedeem ? (
           <button


### PR DESCRIPTION
## Description

Four targeted UI improvements to the WebTrader dashboard:

**Risk tag color differentiation** (`HeroCard.tsx`)
- `safe` → cyan, `balanced` → gold (unchanged), `aggressive` → red
- Bracket delimiters now inherit the accent color at reduced opacity

**SSE live dot** (`DashboardPage.tsx`)
- Open Positions header shows a pulsing green dot when SSE is connected
- Dims to grey with "reconnecting…" label when the stream drops
- Uses the existing `connected` return value from `useSSE` — no new state

**Entry price in essential view** (`PortfolioPage.tsx`)
- `YES @ 4.2¢` / `NO @ 61.0¢` now appears in the primary meta row for open positions
- Closed positions unaffected — entry price is only relevant while a position is live
- Removed from `metaAdvanced` (no longer needed there)

**Empty state** (`DashboardPage.tsx`)
- Replaced bare "No open positions." text with the `EmptyState` component
- Icon `◈`, title "No Open Positions", sub-line "Scanner watching markets"

Also included in this branch:
- `schemas.py` / `router.py`: `risk_profile` field added to `DashboardSummary` + `/dashboard` response (fixes Home showing BALANCED instead of AGGRESSIVE)
- `migration 051`: `ALTER COLUMN` and `ADD CONSTRAINT` wrapped in idempotent `DO $$` blocks to prevent crash on re-run

## Related Issue(s)

N/A — UI polish + bug fixes from active session

## How to test

1. Deploy to Fly: `flyctl deploy`
2. Open WebTrader → Home
   - Risk tag on HeroCard should reflect actual profile color (cyan/gold/red)
   - Open Positions header shows green pulsing dot when connected, grey when not
   - With no open positions: `◈ No Open Positions / Scanner watching markets` empty state
3. Open a position (paper mode) → card should show `YES @ X.X¢` in the meta row without needing Advanced Mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email/password authentication option alongside existing authentication methods.
  * Introduced risk profile display to dashboard with "balanced" as default.
  * Added live connection status indicator showing real-time connectivity.

* **Bug Fixes**
  * Fixed entry price label visibility for open positions.

* **Style**
  * Enhanced risk profile visual styling with color-coded indicators.
  * Improved empty state UI for positions list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->