### PR TITLE
fix: remove unused color param from Sparkline — fixes TS6133 build error

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/StatCard.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/StatCard.tsx
@@ -21,7 +21,7 @@ type Props = {
   sparkline?: [number, number, number];
 };
 
-function Sparkline({ values, color }: { values: [number, number, number]; color: string }) {
+function Sparkline({ values }: { values: [number, number, number] }) {
   const w = 36, h = 14;
   const min = Math.min(...values);
   const max = Math.max(...values);
@@ -117,7 +117,7 @@ export function StatCard({
       )}
       {sparkline && (
         <div className="mt-2 opacity-80">
-          <Sparkline values={sparkline} color={BAR_COLOR[color]} />
+          <Sparkline values={sparkline} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- `StatCard.tsx:24` — `Sparkline` function declared a `color` parameter that was never read (TS6133)
- Removed `color` from the function signature and the call site
- The sparkline already uses trend-based coloring (green if up, red if down) so the prop was redundant

## Test plan

- [ ] `tsc && vite build` passes with exit code 0
- [ ] Sparkline renders correctly on Dashboard Balance and Win Rate cards
- [ ] Green/red trend color logic unchanged

https://claude.ai/code/session_01U9aNhaHf3UePgspuD3vibe

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9aNhaHf3UePgspuD3vibe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sparkline charts now automatically display color-coded indicators—green for positive or stable trends, red for declining trends—providing clearer visual feedback at a glance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->