### PR TITLE
fix: WebTrader — Copy Trade blank tab, alert pagination, risk layout

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
@@ -23,6 +23,9 @@ interface AlertCenterCtx {
   isOpen: boolean;
   openAlertCenter: () => void;
   closeAlertCenter: () => void;
+  dismissAlert: (id: string) => void;
+  loadMoreAlerts: () => Promise<void>;
+  hasMoreAlerts: boolean;
 }
 
 export const AlertCenterContext = createContext<AlertCenterCtx>({
@@ -31,6 +34,9 @@ export const AlertCenterContext = createContext<AlertCenterCtx>({
   isOpen: false,
   openAlertCenter: () => undefined,
   closeAlertCenter: () => undefined,
+  dismissAlert: () => undefined,
+  loadMoreAlerts: async () => undefined,
+  hasMoreAlerts: false,
 });
 
 export function useAlertCenter(): AlertCenterCtx {
@@ -57,23 +63,28 @@ function AppShell() {
 
   // ── Alert Center global state ────────────────────────────────────────────
   const [alerts, setAlerts] = useState<AlertItem[]>([]);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [alertOffset, setAlertOffset] = useState(0);
+  const [hasMoreAlerts, setHasMoreAlerts] = useState(false);
+  const ALERT_PAGE = 10;
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [lastSeen, setLastSeen] = useState<number>(() => {
     const stored = localStorage.getItem(LAST_SEEN_KEY);
     return stored ? Number(stored) : 0;
   });
 
-  const fetchAlerts = useCallback(async () => {
+  const fetchAlerts = useCallback(async (offset = 0, append = false) => {
     if (!user) return;
     try {
       const [sysResult, posResult] = await Promise.allSettled([
-        api.getAlerts(),
-        api.getPositions("closed", 10, 0),
+        offset === 0 ? api.getAlerts() : Promise.resolve([] as AlertItem[]),
+        api.getPositions("closed", ALERT_PAGE + 1, offset),
       ]);
       const sysAlerts: AlertItem[] = sysResult.status === "fulfilled" ? sysResult.value : [];
-      const closed = posResult.status === "fulfilled" ? posResult.value : [];
+      const closedRaw = posResult.status === "fulfilled" ? posResult.value : [];
+      const hasMore = closedRaw.length > ALERT_PAGE;
+      const closed = closedRaw.slice(0, ALERT_PAGE);
 
-      // Synthesize trade alerts from recent closed positions when system_alerts is empty
       const tradeAlerts: AlertItem[] = closed
         .filter((p) => p.closed_at)
         .map((p) => {
@@ -83,7 +94,7 @@ function AppShell() {
             id: `pos-${p.id}`,
             severity: "trade",
             title: won
-              ? `✓ Trade Closed  +$${pnl.toFixed(2)}`
+              ? `Trade Closed  +$${pnl.toFixed(2)}`
               : `Trade Closed  −$${Math.abs(pnl).toFixed(2)}`,
             body: p.market_question ?? null,
             created_at: p.closed_at!,
@@ -91,20 +102,31 @@ function AppShell() {
         });
 
       const seen = new Set(sysAlerts.map((a) => a.id));
-      const merged = [...sysAlerts, ...tradeAlerts.filter((a) => !seen.has(a.id))];
-      setAlerts(merged);
+      const newItems = [...(offset === 0 ? sysAlerts : []), ...tradeAlerts.filter((a) => !seen.has(a.id))];
+      setAlerts(prev => append ? [...prev, ...newItems] : newItems);
+      setHasMoreAlerts(hasMore);
     } catch {
       // non-critical — panel shows empty state
     }
   }, [api, user]);
+
+  const loadMoreAlerts = useCallback(async () => {
+    const next = alertOffset + ALERT_PAGE;
+    setAlertOffset(next);
+    await fetchAlerts(next, true);
+  }, [alertOffset, fetchAlerts]);
+
+  const dismissAlert = useCallback((id: string) => {
+    setDismissed(prev => new Set([...prev, id]));
+  }, []);
 
   const [lastScanMs, setLastScanMs] = useState<number | null>(null);
 
   // SSE connection — fetchAlerts defined above so it's safe to reference here.
   // Re-fetch on both system and alert events to keep the Alert Center in sync.
   const { connected: sseConnected } = useSSE(user?.token ?? null, {
-    system: fetchAlerts,
-    alert: fetchAlerts,
+    system: () => { setAlertOffset(0); void fetchAlerts(0, false); },
+    alert:  () => { setAlertOffset(0); void fetchAlerts(0, false); },
     scanner_tick: (raw) => {
       const payload = raw as { ts?: number };
       if (payload.ts) setLastScanMs(payload.ts * 1000);
@@ -112,12 +134,17 @@ function AppShell() {
   });
 
   useEffect(() => {
-    void fetchAlerts();
+    void fetchAlerts(0, false);
   }, [fetchAlerts]);
 
+  const visibleAlerts = useMemo(
+    () => alerts.filter((a) => !dismissed.has(a.id)),
+    [alerts, dismissed],
+  );
+
   const unreadCount = useMemo(
-    () => alerts.filter((a) => new Date(a.created_at).getTime() > lastSeen).length,
-    [alerts, lastSeen],
+    () => visibleAlerts.filter((a) => new Date(a.created_at).getTime() > lastSeen).length,
+    [visibleAlerts, lastSeen],
   );
 
   const openAlertCenter = useCallback(() => {
@@ -130,8 +157,17 @@ function AppShell() {
   const closeAlertCenter = useCallback(() => setIsAlertOpen(false), []);
 
   const alertCtx: AlertCenterCtx = useMemo(
-    () => ({ alerts, unreadCount, isOpen: isAlertOpen, openAlertCenter, closeAlertCenter }),
-    [alerts, unreadCount, isAlertOpen, openAlertCenter, closeAlertCenter],
+    () => ({
+      alerts: visibleAlerts,
+      unreadCount,
+      isOpen: isAlertOpen,
+      openAlertCenter,
+      closeAlertCenter,
+      dismissAlert,
+      loadMoreAlerts,
+      hasMoreAlerts,
+    }),
+    [visibleAlerts, unreadCount, isAlertOpen, openAlertCenter, closeAlertCenter, dismissAlert, loadMoreAlerts, hasMoreAlerts],
   );
 
   return (

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
@@ -1,3 +1,4 @@
+import { useAlertCenter } from "../App";
 import type { AlertItem } from "../lib/api";
 
 type Category = "TRADE" | "RISK" | "COPY" | "SYSTEM";
@@ -7,6 +8,13 @@ const CATEGORY_STYLE: Record<Category, { color: string; bg: string; border: stri
   RISK:   { color: "var(--red)",   bg: "var(--red-10)",   border: "var(--red-30)"   },
   COPY:   { color: "var(--cyan)",  bg: "var(--cyan-10)",  border: "var(--cyan-30)"  },
   SYSTEM: { color: "var(--ink-2)", bg: "var(--ink-2-08)", border: "var(--ink-2-20)" },
+};
+
+const CATEGORY_ICON: Record<Category, string> = {
+  TRADE:  "⚡",
+  RISK:   "⚠️",
+  COPY:   "📡",
+  SYSTEM: "🖥",
 };
 
 function deriveCategory(alert: AlertItem): Category {
@@ -43,6 +51,8 @@ type Props = {
 };
 
 export function AlertCenter({ isOpen, alerts, onClose }: Props) {
+  const { dismissAlert, loadMoreAlerts, hasMoreAlerts, unreadCount } = useAlertCenter();
+
   return (
     <>
       {/* Backdrop */}
@@ -61,7 +71,7 @@ export function AlertCenter({ isOpen, alerts, onClose }: Props) {
         aria-label="Alert Center"
         className="fixed top-0 right-0 h-full z-[201] flex flex-col"
         style={{
-          width: "min(360px, 92vw)",
+          width: "min(380px, 96vw)",
           background: "var(--surface-2)",
           borderLeft: "1px solid var(--border-2)",
           transform: isOpen ? "translateX(0)" : "translateX(100%)",
@@ -70,17 +80,25 @@ export function AlertCenter({ isOpen, alerts, onClose }: Props) {
         }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3.5 border-b border-border-2">
-          <span
-            className="font-hud text-[13px] font-bold tracking-[3px] uppercase text-gold"
-          >
-            ALERT CENTER
-          </span>
+        <div className="flex items-center justify-between px-4 py-3.5 border-b border-border-2 flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <span className="font-hud text-[13px] font-bold tracking-[3px] uppercase text-gold">
+              Notifications
+            </span>
+            {unreadCount > 0 && (
+              <span
+                className="font-mono text-[9px] font-bold px-2 py-0.5 rounded-full"
+                style={{ background: "rgba(245,200,66,0.15)", color: "var(--gold,#F5C842)", border: "1px solid rgba(245,200,66,0.3)" }}
+              >
+                {unreadCount} NEW
+              </span>
+            )}
+          </div>
           <button
             type="button"
             onClick={onClose}
             className="w-7 h-7 flex items-center justify-center rounded text-ink-3 hover:text-ink-1 transition-colors bg-border-1"
-            aria-label="Close Alert Center"
+            aria-label="Close"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
               fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -93,46 +111,85 @@ export function AlertCenter({ isOpen, alerts, onClose }: Props) {
         {/* Alert list */}
         <div className="flex-1 overflow-y-auto">
           {alerts.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full gap-2 py-12">
-              <span className="text-2xl" aria-hidden>🔔</span>
-              <span className="font-mono text-[12px] text-ink-3">No alerts yet.</span>
+            <div className="flex flex-col items-center justify-center h-full gap-3 py-12">
+              <span className="text-3xl opacity-40" aria-hidden>🔔</span>
+              <span className="font-mono text-[11px] text-ink-4">No notifications yet.</span>
+              <span className="font-mono text-[10px] text-ink-4 text-center px-8 leading-relaxed">
+                Trade closures and system events will appear here.
+              </span>
             </div>
           ) : (
-            <div className="divide-y divide-border-1">
-              {alerts.map((alert) => {
-                const cat = deriveCategory(alert);
-                const style = CATEGORY_STYLE[cat];
-                return (
-                  <div
-                    key={alert.id}
-                    className="px-4 py-3"
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      {/* Category badge */}
-                      <span
-                        className="font-hud text-[8px] font-bold tracking-[1.5px] px-1.5 py-0.5 rounded-sm uppercase"
-                        style={{ color: style.color, background: style.bg, border: `1px solid ${style.border}` }}
+            <div>
+              <div className="divide-y divide-border-1">
+                {alerts.map((alert) => {
+                  const cat = deriveCategory(alert);
+                  const style = CATEGORY_STYLE[cat];
+                  const icon = CATEGORY_ICON[cat];
+                  return (
+                    <div key={alert.id} className="px-4 py-3 flex gap-3 group hover:bg-surface-3 transition-colors">
+                      {/* Icon badge */}
+                      <div
+                        className="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-[16px] mt-0.5"
+                        style={{ background: style.bg, border: `1px solid ${style.border}` }}
                       >
-                        {cat}
-                      </span>
-                      {/* Relative timestamp */}
-                      <span className="font-mono text-[9px] text-ink-3 ml-auto">
-                        {relativeTime(alert.created_at)}
-                      </span>
-                    </div>
-                    <div className="font-sans text-[12px] text-ink-1 font-semibold leading-snug">
-                      {alert.title}
-                    </div>
-                    {alert.body && (
-                      <div className="font-mono text-[10px] text-ink-3 mt-0.5 leading-snug">
-                        {alert.body}
+                        {icon}
                       </div>
-                    )}
-                  </div>
-                );
-              })}
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start gap-1.5 mb-0.5">
+                          <span className="font-sans text-[12px] text-ink-1 font-semibold leading-snug flex-1">
+                            {alert.title}
+                          </span>
+                          {/* Dismiss */}
+                          <button
+                            type="button"
+                            onClick={() => dismissAlert(alert.id)}
+                            className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-ink-4 hover:text-ink-2 opacity-0 group-hover:opacity-100 transition-all mt-0.5"
+                            aria-label="Dismiss"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24"
+                              fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                            </svg>
+                          </button>
+                        </div>
+                        {alert.body && (
+                          <div className="font-mono text-[10px] text-ink-3 leading-snug mb-1 truncate">
+                            {alert.body}
+                          </div>
+                        )}
+                        <span className="font-mono text-[9px] text-ink-4">
+                          {relativeTime(alert.created_at)}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Load more */}
+              {hasMoreAlerts && (
+                <button
+                  type="button"
+                  onClick={() => void loadMoreAlerts()}
+                  className="w-full py-3 font-mono text-[10px] text-ink-3 hover:text-gold transition-colors border-t border-border-1"
+                >
+                  Load more
+                </button>
+              )}
             </div>
           )}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="px-4 py-2.5 border-t border-border-2 flex items-center justify-between flex-shrink-0"
+          style={{ background: "var(--surface)" }}
+        >
+          <span className="font-mono text-[9px] text-ink-4">
+            {alerts.length} shown · tap × to dismiss
+          </span>
         </div>
       </div>
     </>

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -80,9 +80,6 @@ export function AutoTradePage() {
   const navigate = useNavigate();
   const tab = searchParams.get("tab") ?? "auto";
   const marketName = searchParams.get("market_name") ?? null;
-
-  // Copy Trade is embedded here — no separate route needed
-  if (tab === "copy") return <CopyTradePage />;
   const [state, setState] = useState<AutoTradeState | null>(null);
   const [tradingMode, setTradingMode] = useState<string>("paper");
   const [loading, setLoading] = useState(false);
@@ -246,6 +243,9 @@ export function AutoTradePage() {
       setSavingRisk(false);
     }
   }
+
+  // All hooks declared above — safe to early-return here
+  if (tab === "copy") return <CopyTradePage />;
 
   if (!state) return (
     <>
@@ -464,81 +464,101 @@ export function AutoTradePage() {
           Controls capital %, take profit, and stop loss. Applies to all trade types.
         </p>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-          {RISK_PROFILES.map((rp) => {
+        {/* 3 preset cards — equal width row */}
+        <div className="grid grid-cols-3 gap-2 mb-2">
+          {RISK_PROFILES.filter(rp => rp.key !== "custom").map((rp) => {
             const isActive = state.risk_profile === rp.key;
             return (
               <button
                 key={rp.key}
                 onClick={() => void handleActivateRisk(rp.key)}
                 className={[
-                  "text-left p-3 rounded-lg border transition-all",
+                  "text-left p-2.5 rounded-lg border transition-all",
                   isActive
-                    ? "border-gold bg-surface-2 shadow-[0_0_8px_rgba(191,155,48,0.2)]"
-                    : "border-surface-3 bg-surface-1 hover:border-ink-3",
-                  rp.key === "custom" ? "col-span-2 md:col-span-1" : "",
+                    ? "border-gold bg-surface-2 shadow-[0_0_10px_rgba(245,200,66,0.15)]"
+                    : "border-border-1 bg-surface-1 hover:border-border-3",
                 ].join(" ")}
               >
-                <div className="flex items-center gap-1.5 mb-1">
-                  <span>{rp.emoji}</span>
-                  <span className="font-hud text-xs font-bold text-ink-1">{rp.name}</span>
-                  {isActive && (
-                    <span className="ml-auto text-[9px] font-bold tracking-widest text-gold uppercase px-1 py-0.5 rounded border border-gold/40 bg-gold/10">
+                <div className="flex items-center gap-1 mb-1.5">
+                  <span className="text-[13px]">{rp.emoji}</span>
+                  <span className="font-hud text-[9px] font-bold text-ink-1 leading-none">{rp.name}</span>
+                </div>
+                {isActive && (
+                  <div className="mb-1.5">
+                    <span className="text-[8px] font-bold tracking-widest text-gold uppercase px-1 py-0.5 rounded border border-gold/40 bg-gold/10">
                       ACTIVE
                     </span>
-                  )}
-                </div>
-                {rp.key !== "custom" ? (
-                  <div className="grid grid-cols-3 gap-1 text-center mt-1">
-                    {[
-                      { label: "Cap", val: `${rp.capital}%` },
-                      { label: "TP",  val: `+${rp.tp}%` },
-                      { label: "SL",  val: `-${rp.sl}%` },
-                    ].map(({ label, val }) => (
-                      <div key={label} className="bg-surface-2 rounded px-1 py-0.5">
-                        <div className="text-[9px] text-ink-4 uppercase">{label}</div>
-                        <div className="text-xs font-mono font-bold text-ink-1">{val}</div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="mt-2 space-y-1.5" onClick={e => e.stopPropagation()}>
-                    <div className="grid grid-cols-3 gap-2">
-                      {[
-                        { label: "Capital %", val: customCapital, set: setCustomCapital, max: 80 },
-                        { label: "TP %",      val: customTp,      set: setCustomTp,      max: 99 },
-                        { label: "SL %",      val: customSl,      set: setCustomSl,      max: 99 },
-                      ].map(({ label, val, set }) => (
-                        <div key={label}>
-                          <label className="text-[9px] text-ink-4 uppercase block mb-0.5">{label}</label>
-                          <input
-                            type="number"
-                            min={1}
-                            max={99}
-                            value={val}
-                            onChange={e => set(e.target.value)}
-                            className="w-full bg-surface-3 border border-surface-3 rounded px-1.5 py-1 text-xs font-mono text-ink-1 placeholder:text-ink-3 focus:border-gold focus:outline-none"
-                            style={{ color: "white" }}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                    {customErr && (
-                      <p className="text-xs text-red-400">{customErr}</p>
-                    )}
-                    <button
-                      onClick={() => void handleSaveCustomRisk()}
-                      disabled={savingRisk}
-                      className="w-full mt-1 py-1.5 rounded bg-gold/20 border border-gold/40 text-gold text-xs font-bold hover:bg-gold/30 disabled:opacity-50"
-                    >
-                      {savingRisk ? "Saving…" : "Save Custom Profile"}
-                    </button>
                   </div>
                 )}
+                <div className="space-y-1">
+                  {[
+                    { label: "CAP", val: `${rp.capital}%` },
+                    { label: "TP",  val: `+${rp.tp}%` },
+                    { label: "SL",  val: `-${rp.sl}%` },
+                  ].map(({ label, val }) => (
+                    <div key={label} className="flex justify-between items-center">
+                      <span className="text-[8px] text-ink-4 font-mono uppercase">{label}</span>
+                      <span className="text-[10px] font-mono font-bold text-ink-1">{val}</span>
+                    </div>
+                  ))}
+                </div>
               </button>
             );
           })}
         </div>
+
+        {/* Custom Risk — full-width, separate block */}
+        {(() => {
+          const rp = RISK_PROFILES.find(r => r.key === "custom")!;
+          const isActive = state.risk_profile === "custom";
+          return (
+            <div
+              className={[
+                "p-3 rounded-lg border transition-all",
+                isActive
+                  ? "border-gold/60 bg-surface-2"
+                  : "border-border-1 bg-surface-1",
+              ].join(" ")}
+            >
+              <div className="flex items-center gap-2 mb-2.5">
+                <span className="text-[14px]">{rp.emoji}</span>
+                <span className="font-hud text-[10px] font-bold text-ink-1">{rp.name}</span>
+                {isActive && (
+                  <span className="ml-auto text-[8px] font-bold tracking-widest text-gold uppercase px-1.5 py-0.5 rounded border border-gold/40 bg-gold/10">
+                    ACTIVE
+                  </span>
+                )}
+              </div>
+              <div className="grid grid-cols-3 gap-2 mb-2" onClick={e => e.stopPropagation()}>
+                {[
+                  { label: "Capital %", val: customCapital, set: setCustomCapital },
+                  { label: "TP %",      val: customTp,      set: setCustomTp      },
+                  { label: "SL %",      val: customSl,      set: setCustomSl      },
+                ].map(({ label, val, set }) => (
+                  <div key={label}>
+                    <label className="text-[9px] text-ink-4 uppercase block mb-0.5 font-mono">{label}</label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={99}
+                      value={val}
+                      onChange={e => set(e.target.value)}
+                      className="w-full bg-surface border border-border-2 rounded px-2 py-1.5 text-xs font-mono text-ink-1 focus:border-gold focus:outline-none"
+                    />
+                  </div>
+                ))}
+              </div>
+              {customErr && <p className="text-xs text-red mb-2">{customErr}</p>}
+              <button
+                onClick={() => void handleSaveCustomRisk()}
+                disabled={savingRisk}
+                className="w-full py-2 rounded border border-gold/40 bg-gold/10 text-gold text-[10px] font-bold tracking-[1.5px] uppercase hover:bg-gold/20 disabled:opacity-50 transition-colors"
+              >
+                {savingRisk ? "Saving…" : "Save Custom Profile"}
+              </button>
+            </div>
+          );
+        })()}
 
         {/* ── SECTION C: Market Filter ── */}
         <CollapsibleSection id="autotrade_market_filter" label="Market Filter" defaultOpen={true}>

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/CopyTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/CopyTradePage.tsx
@@ -27,7 +27,7 @@ export function PageTabs({ active, onSwitch }: { active: "auto" | "copy"; onSwit
   return (
     <div
       className="flex border-b border-border-1 px-3.5"
-      style={{ background: "rgba(2,5,11,0.6)" }}
+      style={{ background: "rgba(6,11,22,0.85)" }}
     >
       {(["auto", "copy"] as const).map((t) => {
         const isActive = active === t;
@@ -36,10 +36,10 @@ export function PageTabs({ active, onSwitch }: { active: "auto" | "copy"; onSwit
             key={t}
             onClick={() => onSwitch(t)}
             className={[
-              "py-2.5 px-3 font-hud text-[9.5px] font-bold tracking-[2px] uppercase transition-all border-b-2 -mb-px",
+              "py-3 px-4 font-hud text-[10px] font-bold tracking-[2px] uppercase transition-all border-b-2 -mb-px",
               isActive
                 ? "text-gold border-gold"
-                : "text-ink-3 border-transparent hover:text-ink-2",
+                : "text-ink-1 border-transparent hover:text-gold/70 opacity-50 hover:opacity-80",
             ].join(" ")}
           >
             {t === "auto" ? "Auto Trade" : "Copy Trade"}


### PR DESCRIPTION
## Summary

- **Copy Trade tab blank** — moved `if (tab === "copy") return <CopyTradePage />;` to after all hook calls in `AutoTradePage.tsx` (React Rules of Hooks violation)
- **Tab buttons invisible** — changed `PageTabs` inactive state from `text-ink-3` to `text-ink-1 opacity-50` in `CopyTradePage.tsx` for readable contrast
- **Alert Center** — full rewrite: per-alert dismiss ×, icon category badges (⚡/⚠️/📡/🖥), "N NEW" pill, "Load more" pagination, footer count
- **App.tsx alert state** — added `dismissed` set, `alertOffset`/`hasMoreAlerts` pagination, `dismissAlert` + `loadMoreAlerts` callbacks wired into `AlertCenterContext`
- **Risk profile layout** — 3 preset cards in `grid-cols-3` + separate full-width Custom Risk block (was uneven 2+1 grid)

## Test plan

- [ ] Navigate to `/autotrade` — Auto Trade content loads
- [ ] Click Copy Trade tab — renders copy trade UI (not blank)
- [ ] Both tab labels are clearly visible (not near-invisible)
- [ ] Open Alert Center — newest alerts shown first, icon badges render
- [ ] Dismiss individual alert — disappears from list
- [ ] "Load more" button appears when more than 10 alerts exist
- [ ] Risk Profile section shows 3 preset columns + custom inputs below

https://claude.ai/code/session_01U9aNhaHf3UePgspuD3vibe

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9aNhaHf3UePgspuD3vibe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Individual alert dismissal functionality
  * Paginated alert history with "Load more" button
  * Copy Trade tab in AutoTrade page
  * Unread notification count indicator

* **Style**
  * Updated Alert Center header design with category icons and badges
  * Refined Risk Profile layout and tab styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->