### PR TITLE
forge: lazy-load heavy pages + vendor chunk splitting

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AlertCenter } from "./components/AlertCenter";
 import { BottomNav } from "./components/BottomNav";
@@ -7,13 +7,23 @@ import { AuthContext, useAuth, useAuthState } from "./lib/auth";
 import { SSEStatusContext, useSSE } from "./lib/sse";
 import { UiModeContext, useUiModeState } from "./lib/uiMode";
 import { makeApi, setUnauthorizedHandler, type AlertItem } from "./lib/api";
+// Critical path — keep eager
 import { AuthPage } from "./pages/AuthPage";
-import { AutoTradePage } from "./pages/AutoTradePage";
 import { DashboardPage } from "./pages/DashboardPage";
-import { DiscoverPage } from "./pages/DiscoverPage";
-import { PortfolioPage } from "./pages/PortfolioPage";
-import { SettingsPage } from "./pages/SettingsPage";
-import { WalletPage } from "./pages/WalletPage";
+// Heavy pages — lazy-loaded on first navigation
+const AutoTradePage  = lazy(() => import("./pages/AutoTradePage").then(m => ({ default: m.AutoTradePage })));
+const DiscoverPage   = lazy(() => import("./pages/DiscoverPage").then(m => ({ default: m.DiscoverPage })));
+const PortfolioPage  = lazy(() => import("./pages/PortfolioPage").then(m => ({ default: m.PortfolioPage })));
+const SettingsPage   = lazy(() => import("./pages/SettingsPage").then(m => ({ default: m.SettingsPage })));
+const WalletPage     = lazy(() => import("./pages/WalletPage").then(m => ({ default: m.WalletPage })));
+
+function PageLoader() {
+  return (
+    <div className="flex items-center justify-center min-h-[40vh]">
+      <span className="w-5 h-5 rounded-full border-2 border-ink-4 border-t-grn animate-spin" />
+    </div>
+  );
+}
 
 const LAST_SEEN_KEY = "alertCenter_lastSeen";
 
@@ -198,39 +208,41 @@ function AppShell() {
               : "max-w-mobile md:max-w-none",
           ].join(" ")}
         >
-          <Routes>
-            <Route path="/" element={<Navigate to={user ? "/dashboard" : "/auth"} replace />} />
-            <Route path="/auth" element={<AuthPage />} />
-            <Route
-              path="/dashboard"
-              element={user ? <DashboardPage /> : <Navigate to="/auth" replace />}
-            />
-            <Route
-              path="/autotrade"
-              element={user ? <AutoTradePage /> : <Navigate to="/auth" replace />}
-            />
-            <Route
-              path="/portfolio"
-              element={user ? <PortfolioPage /> : <Navigate to="/auth" replace />}
-            />
-            <Route
-              path="/wallet"
-              element={user ? <WalletPage /> : <Navigate to="/auth" replace />}
-            />
-            <Route
-              path="/copy-trade"
-              element={<Navigate to="/autotrade?tab=copy" replace />}
-            />
-            <Route
-              path="/discover"
-              element={user ? <DiscoverPage /> : <Navigate to="/auth" replace />}
-            />
-            <Route
-              path="/settings"
-              element={user ? <SettingsPage /> : <Navigate to="/auth" replace />}
-            />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
+          <Suspense fallback={<PageLoader />}>
+            <Routes>
+              <Route path="/" element={<Navigate to={user ? "/dashboard" : "/auth"} replace />} />
+              <Route path="/auth" element={<AuthPage />} />
+              <Route
+                path="/dashboard"
+                element={user ? <DashboardPage /> : <Navigate to="/auth" replace />}
+              />
+              <Route
+                path="/autotrade"
+                element={user ? <AutoTradePage /> : <Navigate to="/auth" replace />}
+              />
+              <Route
+                path="/portfolio"
+                element={user ? <PortfolioPage /> : <Navigate to="/auth" replace />}
+              />
+              <Route
+                path="/wallet"
+                element={user ? <WalletPage /> : <Navigate to="/auth" replace />}
+              />
+              <Route
+                path="/copy-trade"
+                element={<Navigate to="/autotrade?tab=copy" replace />}
+              />
+              <Route
+                path="/discover"
+                element={user ? <DiscoverPage /> : <Navigate to="/auth" replace />}
+              />
+              <Route
+                path="/settings"
+                element={user ? <SettingsPage /> : <Navigate to="/auth" replace />}
+              />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </Suspense>
           {showChrome && <BottomNav />}
         </div>
       </div>

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TopBar.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/TopBar.tsx
@@ -56,10 +56,10 @@ export function TopBar({ tradingMode = "paper", notifCount: _notifCount, onBellC
       {/* Brand — left, never shrinks */}
       <div className="flex items-center gap-2.5 flex-shrink-0">
         <img
-          src="/crusaderbot-logo.png"
+          src={`${import.meta.env.BASE_URL}crusaderbot-logo.png`}
           alt="CrusaderBot"
-          width={44}
-          height={50}
+          width={40}
+          height={27}
           className="flex-shrink-0 object-contain"
           style={{ filter: "drop-shadow(0 0 10px rgba(245,200,66,0.45))" }}
           onError={(e) => {

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AuthPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AuthPage.tsx
@@ -45,10 +45,10 @@ export function AuthPage() {
         {/* Brand */}
         <div className="mb-8">
           <img
-            src="/crusaderbot-logo.png"
+            src={`${import.meta.env.BASE_URL}crusaderbot-logo.png`}
             alt="CrusaderBot"
-            width={88}
-            height={100}
+            width={120}
+            height={80}
             style={{
               objectFit: "contain",
               filter: "drop-shadow(0 0 12px rgba(245,200,66,0.5))",

--- a/projects/polymarket/crusaderbot/webtrader/frontend/vite.config.ts
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/vite.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react":  ["react", "react-dom", "react-router-dom"],
+          "vendor-charts": ["recharts"],
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- `React.lazy` applied to AutoTradePage, DiscoverPage, PortfolioPage, SettingsPage, WalletPage — each becomes a separate JS chunk loaded only on first navigation
- DashboardPage + AuthPage remain eager (critical path, loaded immediately)
- `<Suspense>` wraps all Routes with a minimal `PageLoader` spinner (green ring, matches app theme)
- Vite `manualChunks`: `vendor-react` (react + react-dom + react-router-dom), `vendor-charts` (recharts) — both are heavy, stable deps that benefit from long-term caching

**Expected result:** Initial bundle drops from 690 kB monolith to ~150–200 kB (dashboard + auth + shared components). Heavy pages load on demand with a brief spinner.

## Test plan

- [ ] Docker build passes (`npm run build` in Dockerfile stage)
- [ ] Dashboard loads instantly on first visit (no spinner)
- [ ] Navigating to Portfolio/AutoTrade/Settings shows brief spinner then page
- [ ] No JS errors in console on page transitions
- [ ] Bundle output shows separate `vendor-react`, `vendor-charts` and per-page chunks

https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pages now load dynamically when first visited, with a loading indicator shown during navigation for smoother transitions.
* **Performance**
  * App bundling optimized and code split to reduce initial load and improve responsiveness.
* **Style**
  * Brand logo path and displayed size adjusted for more reliable loading and tighter header layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bayuewalker/walkermind-os/pull/1354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->