### PR TITLE
fix: fly.toml DB_POOL_MAX 5→10, remove dead empty-secret overrides

### DIFF
--- a/projects/polymarket/crusaderbot/fly.toml
+++ b/projects/polymarket/crusaderbot/fly.toml
@@ -19,7 +19,7 @@ kill_timeout = "30s"
   PORT                          = "8080"
   HOST                          = "0.0.0.0"
   TIMEZONE                      = "Asia/Jakarta"
-  DB_POOL_MAX                   = "5"
+  DB_POOL_MAX                   = "10"
   LOG_LEVEL                     = "INFO"
   ENABLE_LIVE_TRADING           = "false"
   EXECUTION_PATH_VALIDATED      = "false"
@@ -28,8 +28,6 @@ kill_timeout = "30s"
   SECURITY_HARDENING_VALIDATED  = "false"
   FEE_COLLECTION_ENABLED        = "false"
   AUTO_REDEEM_ENABLED           = "true"
-  HEISENBERG_API_TOKEN          = ""
-  ADMIN_API_TOKEN               = ""
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary
- `DB_POOL_MAX` corrected from `"5"` → `"10"` — state raised this to 10 on 2026-05-25 but toml was never updated; since DB_POOL_MAX is NOT a Fly secret, the toml value was what production was actually running
- Removed `HEISENBERG_API_TOKEN = ""` and `ADMIN_API_TOKEN = ""` from `[env]` — both are set as proper Fly secrets and secrets override [env], so these empty lines were dead weight

## Validation Tier: MINOR
Config-only change. No code touched.

## Test plan
- [ ] CI passes
- [ ] After deploy: verify `/health` or `/admin/status` shows pool config at 10

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_