### PR TITLE
fix: retry Telegram bot.initialize() on transient network error at boot

### DIFF
--- a/projects/polymarket/crusaderbot/main.py
+++ b/projects/polymarket/crusaderbot/main.py
@@ -1,6 +1,7 @@
 """Entry point: FastAPI + Telegram (polling OR webhook) + APScheduler in one process."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import secrets
@@ -113,7 +114,24 @@ async def lifespan(_: FastAPI):
     register_handlers(bot_app)
     notifications.set_bot(bot_app.bot)
 
-    await bot_app.initialize()
+    # Retry Telegram initialize() on transient network errors during boot.
+    # Fly.io network proxy may not be fully ready the moment lifespan starts.
+    for _attempt in range(5):
+        try:
+            await bot_app.initialize()
+            break
+        except Exception as _exc:  # noqa: BLE001
+            import telegram.error as _tg_err
+            if not isinstance(_exc, (_tg_err.NetworkError, _tg_err.TimedOut)):
+                raise
+            if _attempt == 4:
+                raise
+            _wait = 2 ** _attempt
+            log.warning(
+                "Telegram initialize failed (attempt %d/5): %s — retrying in %ds",
+                _attempt + 1, _exc, _wait,
+            )
+            await asyncio.sleep(_wait)
     await bot_app.start()
     register_notification_handlers()
     webtrader_sse.register_event_bus_handlers()


### PR DESCRIPTION
## Summary
Fixes DAWN-SNOWFLAKE-1729-27 — `telegram.error.NetworkError: httpx.ConnectError` during startup.

**Root cause**: Fly.io's network proxy isn't always fully ready the moment the FastAPI lifespan starts. The bare `await bot_app.initialize()` call (which calls `get_me()` over the network) crashed the entire app if Telegram was momentarily unreachable.

**Fix**: Wrap `bot_app.initialize()` in a 5-attempt retry loop with exponential backoff (1s, 2s, 4s, 8s). Only `NetworkError` and `TimedOut` are retried — all other exceptions propagate immediately. On 5th failure the original exception is re-raised.

## Files
- `projects/polymarket/crusaderbot/main.py` — added `asyncio` import + retry loop around `bot_app.initialize()`

## Validation Tier: STANDARD
Boot path only, no trading logic touched.

## Test plan
- [ ] CI passes
- [ ] No new Sentry errors on next deploy/restart

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_