### PR TITLE
fix: persist scan_runs telemetry from run_close_sweep_fast when orders created

### DIFF
--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -1560,7 +1560,8 @@ async def run_close_sweep_fast() -> None:
     # Skipping zero-order ticks keeps the table clean at 15s cadence.
     if tel.paper_orders_created > 0:
         tel.users_evaluated = candle_users_evaluated
-        _cfg_live = get_settings()
+        from ...config import get_settings as _get_settings
+        _cfg_live = _get_settings()
         _is_live = _cfg_live.ENABLE_LIVE_TRADING and _cfg_live.EXECUTION_PATH_VALIDATED and _cfg_live.CAPITAL_MODE_CONFIRMED
         await _insert_scan_run(
             fast_run_id,

--- a/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
+++ b/projects/polymarket/crusaderbot/services/signal_scan/signal_scan_job.py
@@ -1495,11 +1495,14 @@ async def run_close_sweep_fast() -> None:
     except Exception:
         _preset_params = _CANDLE_PRESET_PARAMS  # type: ignore[assignment]
 
-    tel = ScanTelemetry()  # in-memory only — never persisted to scan_runs
+    tel = ScanTelemetry()
+    fast_run_id: str = str(_uuid_mod.uuid4())
+    candle_users_evaluated = 0
     for row in users:
         active_preset = row.get("active_preset")
         if active_preset not in _CANDLE_PRESETS:
             continue
+        candle_users_evaluated += 1
 
         pp = _preset_params.get(active_preset, _CANDLE_PRESET_PARAMS["close_sweep"])
 
@@ -1552,6 +1555,20 @@ async def run_close_sweep_fast() -> None:
                     market_id=cand.market_id,
                     error=str(exc),
                 )
+
+    # Persist a scan_runs row only when this tick actually created paper orders.
+    # Skipping zero-order ticks keeps the table clean at 15s cadence.
+    if tel.paper_orders_created > 0:
+        tel.users_evaluated = candle_users_evaluated
+        _cfg_live = get_settings()
+        _is_live = _cfg_live.ENABLE_LIVE_TRADING and _cfg_live.EXECUTION_PATH_VALIDATED and _cfg_live.CAPITAL_MODE_CONFIRMED
+        await _insert_scan_run(
+            fast_run_id,
+            strategies_loaded=1,
+            live_trading=_is_live,
+            mode="LIVE" if _is_live else "PAPER",
+        )
+        await _finish_scan_run(fast_run_id, tel)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- `paper_orders_created` was always `0` in `scan_runs` even though trades were actively happening
- **Root cause**: candle-preset trades (close_sweep/safe_close/flip_hunter) are created by `run_close_sweep_fast` (15s tick) which used a non-persisted `ScanTelemetry`. The main `run_once` scan saw those markets as already-open duplicates and never counted them
- **Fix**: when `run_close_sweep_fast` creates ≥1 paper order in a tick, it now writes a `scan_runs` row with full telemetry. Zero-order ticks still write nothing (keeps table clean at 15s cadence)

## Changes
- `services/signal_scan/signal_scan_job.py`: track `candle_users_evaluated`, generate `fast_run_id`, persist scan_run at end of tick only when `paper_orders_created > 0`

## Validation Tier: STANDARD
Telemetry/observability only. No trading logic modified.

## Test plan
- [ ] CI passes (1767 tests)
- [ ] After deploy: `scan_runs` shows rows with `paper_orders_created > 0` when candle trades fire

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_