### PR TITLE
fix: redirect legacy /copytrade command + setup copy path to wizard

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/copy_trade.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/copy_trade.py
@@ -437,41 +437,20 @@ async def text_input(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Legacy /copytrade command (copy_targets table — unchanged from P3)
+# /copytrade command — redirects to the Copy Trade menu
 # ---------------------------------------------------------------------------
-
-
-_USAGE = (
-    "<b>/copytrade</b> commands:\n"
-    "<code>/copytrade add &lt;wallet_address&gt;</code>\n"
-    "<code>/copytrade remove &lt;wallet_address&gt;</code>\n"
-    "<code>/copytrade list</code>\n\n"
-    f"Max {MAX_COPY_TARGETS_PER_USER} active leaders per account."
-)
 
 
 async def copy_trade_command(
     update: Update, ctx: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    """Legacy /copytrade command dispatcher (copy_targets table)."""
+    """Redirect /copytrade to the Copy Trade menu (wizard path)."""
     if update.message is None:
         return
-    user, ok = await _resolve_user(update)
-    if not ok or user is None:
-        return
-    args = ctx.args or []
-    if not args:
-        await update.message.reply_text(_USAGE, parse_mode=ParseMode.HTML)
-        return
-    sub = args[0].lower()
-    if sub == "add":
-        await _legacy_add(update, user["id"], args[1:])
-    elif sub == "remove":
-        await _legacy_remove(update, user["id"], args[1:])
-    elif sub == "list":
-        await _legacy_list(update, user["id"])
-    else:
-        await update.message.reply_text(_USAGE, parse_mode=ParseMode.HTML)
+    await update.message.reply_text(
+        "Use the <b>🐋 Copy Trade</b> button in the main menu to manage copy wallets.",
+        parse_mode=ParseMode.HTML,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/projects/polymarket/crusaderbot/bot/handlers/setup.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/setup.py
@@ -148,10 +148,8 @@ async def setup_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None
         await q.message.reply_text("Pick categories:",
                                    reply_markup=category_picker(s["category_filters"]))
     elif sub == "copy":
-        ctx.user_data["awaiting"] = "copy_target"
         await q.message.reply_text(
-            "Send a Polygon wallet address (0x…) to copy-trade. Send <code>list</code> to see "
-            "current targets, or <code>remove 0x…</code> to remove one.",
+            "Use the <b>🐋 Copy Trade</b> button in the main menu to manage copy wallets.",
             parse_mode=ParseMode.HTML,
         )
     elif sub == "mode":
@@ -378,8 +376,6 @@ async def text_input(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> bool:
             await update.message.reply_text(
                 f"✅ Capital allocation set to {pct:.0f}%."
             )
-        elif awaiting == "copy_target":
-            await _handle_copy_target_input(update, user, text)
         else:
             # Unknown awaiting value — could belong to another consumer
             # (e.g. activation's CONFIRM flow). Do NOT pop it, otherwise


### PR DESCRIPTION
## Summary

- `/copytrade add/remove/list` slash command now replies "Use the 🐋 Copy Trade button in the main menu" instead of writing to the dead `copy_targets` table
- `setup.py` "copy" sub-case no longer sets `awaiting = "copy_target"` (which wrote to `copy_targets`) — now redirects to Copy Trade menu
- `awaiting == "copy_target"` text handler branch removed from `setup.py`
- Primary wizard path (Phase 5F ConversationHandler → `copy_trade_tasks`) untouched ✅
- Legacy helper functions kept in place to preserve test coverage; `copy_targets` table preserved (DROP in a future migration lane)

## Test plan

- [ ] CI green
- [ ] `/copytrade add 0x...` in Telegram → shows redirect message, no DB write
- [ ] Setup "copy" sub → redirect message, no awaiting state set
- [ ] Copy Trade menu wizard → still works (writes to `copy_trade_tasks`)

https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_