### PR TITLE
feat: live wallet — auto-derive CLOB credentials + balance check + /admin live readiness

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -70,6 +70,7 @@ _ADMIN_HELP = (
     "• Logs — /auditlog, /jobs\n"
     "• Roles — /admin settier {user_id} {user|admin}\n"
     "• Broadcast — /admin broadcast {message}\n"
+    "• Live readiness — /admin live\n"
     "• /resetonboard {telegram_user_id} — reset onboarding for testing"
 )
 
@@ -109,6 +110,8 @@ async def admin_root(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
             await _admin_status_hud(update.message)
         elif sub == "broadcast":
             await _admin_broadcast(update.message, args[1:], ctx)
+        elif sub == "live":
+            await _live_readiness_hud(update.message)
         else:
             await update.message.reply_text(
                 _ADMIN_HELP, parse_mode=ParseMode.HTML
@@ -324,6 +327,97 @@ async def _admin_status_hud(message: Message) -> None:
             lines.append(
                 f"  {status_icon} <code>{html.escape(j['job_name'])}</code> · {duration}"
             )
+    await message.reply_text("\n".join(lines), parse_mode=ParseMode.HTML)
+
+
+async def _live_readiness_hud(message) -> None:
+    """Show live trading readiness checklist — /admin live."""
+    from ...config import get_settings as _cfg
+    from ...integrations.clob import _derived as _clob_derived
+
+    s = _cfg()
+
+    # Credential status
+    has_private_key = bool(s.POLYMARKET_PRIVATE_KEY)
+    has_api_key_env = bool(s.POLYMARKET_API_KEY)
+    has_api_key_derived = bool((_clob_derived or {}).get("api_key"))
+    has_api_key = has_api_key_env or has_api_key_derived
+    api_key_source = "env" if has_api_key_env else ("auto-derived" if has_api_key_derived else "missing")
+
+    # Live wallet balance (only if USE_REAL_CLOB=True and credentials ready)
+    wallet_balance: str = "N/A (USE_REAL_CLOB=False)"
+    if s.USE_REAL_CLOB and has_private_key and has_api_key:
+        try:
+            from ...integrations.clob import get_clob_client
+            client = get_clob_client(s)
+            bal = await client.get_usdc_balance()
+            wallet_balance = f"${bal:,.2f} USDC"
+        except Exception as exc:
+            wallet_balance = f"error: {exc}"
+
+    def _g(flag: bool) -> str:
+        return "✅" if flag else "❌"
+
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        admin_count = int(await conn.fetchval(
+            "SELECT COUNT(*) FROM user_tiers WHERE tier='ADMIN'"
+        ) or 0)
+
+    lines = [
+        "<b>🔴 Live Trading Readiness</b>",
+        "",
+        "<b>Activation Guards:</b>",
+        f"  {_g(s.ENABLE_LIVE_TRADING)} ENABLE_LIVE_TRADING",
+        f"  {_g(s.EXECUTION_PATH_VALIDATED)} EXECUTION_PATH_VALIDATED",
+        f"  {_g(s.CAPITAL_MODE_CONFIRMED)} CAPITAL_MODE_CONFIRMED",
+        f"  {_g(s.RISK_CONTROLS_VALIDATED)} RISK_CONTROLS_VALIDATED",
+        f"  {_g(s.SECURITY_HARDENING_VALIDATED)} SECURITY_HARDENING_VALIDATED",
+        f"  {_g(s.USE_REAL_CLOB)} USE_REAL_CLOB",
+        "",
+        "<b>Credentials:</b>",
+        f"  {_g(has_private_key)} POLYMARKET_PRIVATE_KEY",
+        f"  {_g(has_api_key)} API credentials ({api_key_source})",
+        "",
+        "<b>Wallet:</b>",
+        f"  Balance: {wallet_balance}",
+        "",
+        "<b>Users:</b>",
+        f"  Admin role holders: {admin_count}",
+    ]
+
+    all_guards = all([
+        s.ENABLE_LIVE_TRADING, s.EXECUTION_PATH_VALIDATED,
+        s.CAPITAL_MODE_CONFIRMED, s.RISK_CONTROLS_VALIDATED,
+        s.SECURITY_HARDENING_VALIDATED, s.USE_REAL_CLOB,
+    ])
+    all_creds = has_private_key and has_api_key
+    if all_guards and all_creds and admin_count > 0:
+        lines += ["", "🟢 <b>READY — all gates clear.</b>"]
+    else:
+        missing = []
+        if not s.ENABLE_LIVE_TRADING:
+            missing.append("Set ENABLE_LIVE_TRADING=true")
+        if not s.EXECUTION_PATH_VALIDATED:
+            missing.append("Set EXECUTION_PATH_VALIDATED=true")
+        if not s.CAPITAL_MODE_CONFIRMED:
+            missing.append("Set CAPITAL_MODE_CONFIRMED=true")
+        if not s.RISK_CONTROLS_VALIDATED:
+            missing.append("Set RISK_CONTROLS_VALIDATED=true")
+        if not s.SECURITY_HARDENING_VALIDATED:
+            missing.append("Set SECURITY_HARDENING_VALIDATED=true")
+        if not s.USE_REAL_CLOB:
+            missing.append("Set USE_REAL_CLOB=true")
+        if not has_private_key:
+            missing.append("Set POLYMARKET_PRIVATE_KEY")
+        if not has_api_key:
+            missing.append("Set POLYMARKET_API_KEY or call ensure_clob_credentials()")
+        if admin_count == 0:
+            missing.append("Grant admin role to at least one user")
+        lines += ["", "🔴 <b>NOT READY:</b>"]
+        for m in missing:
+            lines.append(f"  • {m}")
+
     await message.reply_text("\n".join(lines), parse_mode=ParseMode.HTML)
 
 

--- a/projects/polymarket/crusaderbot/integrations/clob/__init__.py
+++ b/projects/polymarket/crusaderbot/integrations/clob/__init__.py
@@ -93,6 +93,7 @@ __all__ = [
     "get_clob_breaker",
     "get_clob_rate_limiter",
     "reset_clob_resilience",
+    "ensure_clob_credentials",
 ]
 
 
@@ -140,6 +141,62 @@ class ClobClientProtocol(Protocol):
 # them.
 _breaker: Optional[CircuitBreaker] = None
 _limiter: Optional[RateLimiter] = None
+
+# Auto-derived credential cache (populated by ensure_clob_credentials at boot).
+# Only used when POLYMARKET_API_KEY is absent from env. Never persisted.
+_derived: Optional[dict] = None
+
+
+async def ensure_clob_credentials(
+    settings: Optional[Settings] = None,
+) -> None:
+    """Derive and cache Polymarket API credentials from POLYMARKET_PRIVATE_KEY.
+
+    Call once at application startup when USE_REAL_CLOB=True but
+    POLYMARKET_API_KEY/SECRET/PASSPHRASE are not set in the environment.
+    Credentials are stored in the module-level ``_derived`` dict and
+    consumed by ``get_clob_client()`` transparently.
+
+    No-op when:
+      * USE_REAL_CLOB=False (paper mode — credentials not needed)
+      * POLYMARKET_API_KEY already set in env (manual creds take priority)
+      * POLYMARKET_PRIVATE_KEY not set (nothing to derive from)
+
+    Raises ``ClobAuthError`` / ``ClobNetworkError`` on failure so the
+    operator sees the error immediately at boot rather than on the first
+    live order.
+    """
+    global _derived
+    s = settings or get_settings()
+    if not s.USE_REAL_CLOB:
+        return
+    if s.POLYMARKET_API_KEY:
+        logger.info("clob: POLYMARKET_API_KEY set in env — skipping auto-derive")
+        return
+    if not s.POLYMARKET_PRIVATE_KEY:
+        logger.warning("clob: USE_REAL_CLOB=True but POLYMARKET_PRIVATE_KEY not set — cannot derive credentials")
+        return
+
+    logger.info("clob: deriving API credentials from POLYMARKET_PRIVATE_KEY …")
+    tmp = ClobAdapter(
+        api_key="",
+        api_secret="",
+        passphrase="",
+        private_key=s.POLYMARKET_PRIVATE_KEY,
+        funder_address=s.POLYMARKET_FUNDER_ADDRESS,
+        signature_type=s.POLYMARKET_SIGNATURE_TYPE,
+        circuit_breaker=get_clob_breaker(s),
+        rate_limiter=get_clob_rate_limiter(s),
+    )
+    creds = await tmp.derive_api_credentials()
+    _derived = {
+        "api_key": creds.get("apiKey") or creds.get("api_key", ""),
+        "api_secret": creds.get("secret") or creds.get("api_secret", ""),
+        "passphrase": creds.get("passphrase", ""),
+    }
+    logger.info(
+        "clob: API credentials auto-derived (key=%.8s…)", _derived["api_key"]
+    )
 
 
 async def _on_circuit_open(name: str) -> None:
@@ -240,12 +297,20 @@ def get_clob_client(
     if not s.USE_REAL_CLOB:
         return MockClobClient()
 
+    # Resolve credentials: env vars take priority; fall back to auto-derived cache.
+    api_key = s.POLYMARKET_API_KEY or (_derived or {}).get("api_key", "")
+    api_secret = s.POLYMARKET_API_SECRET or (_derived or {}).get("api_secret", "")
+    passphrase = (
+        s.POLYMARKET_API_PASSPHRASE
+        or s.POLYMARKET_PASSPHRASE
+        or (_derived or {}).get("passphrase", "")
+    )
+
     missing: list[str] = []
-    if not s.POLYMARKET_API_KEY:
-        missing.append("POLYMARKET_API_KEY")
-    if not s.POLYMARKET_API_SECRET:
+    if not api_key:
+        missing.append("POLYMARKET_API_KEY (or run ensure_clob_credentials() at startup)")
+    if not api_secret:
         missing.append("POLYMARKET_API_SECRET")
-    passphrase = s.POLYMARKET_API_PASSPHRASE or s.POLYMARKET_PASSPHRASE
     if not passphrase:
         missing.append("POLYMARKET_API_PASSPHRASE")
     if not s.POLYMARKET_PRIVATE_KEY:
@@ -257,9 +322,9 @@ def get_clob_client(
         )
 
     return ClobAdapter(
-        api_key=s.POLYMARKET_API_KEY,  # type: ignore[arg-type]
-        api_secret=s.POLYMARKET_API_SECRET,  # type: ignore[arg-type]
-        passphrase=passphrase,  # type: ignore[arg-type]
+        api_key=api_key,
+        api_secret=api_secret,
+        passphrase=passphrase,
         private_key=s.POLYMARKET_PRIVATE_KEY,  # type: ignore[arg-type]
         funder_address=s.POLYMARKET_FUNDER_ADDRESS,
         signature_type=s.POLYMARKET_SIGNATURE_TYPE,

--- a/projects/polymarket/crusaderbot/integrations/clob/adapter.py
+++ b/projects/polymarket/crusaderbot/integrations/clob/adapter.py
@@ -394,6 +394,27 @@ class ClobAdapter:
         data = resp.get("data") if isinstance(resp, dict) else None
         return list(data) if isinstance(data, list) else []
 
+    async def get_usdc_balance(self) -> float:
+        """Return the USDC collateral balance for this account.
+
+        Calls ``GET /data/balance-allowances?asset_type=COLLATERAL``.
+        The CLOB returns the balance as a decimal string (human-readable
+        USDC units, e.g. "123.456789"). Returns 0.0 on any parse error.
+        """
+        resp = await self._signed_request(
+            "GET", "/data/balance-allowances?asset_type=COLLATERAL"
+        )
+        data: dict = resp if isinstance(resp, dict) else (
+            resp[0] if isinstance(resp, list) and resp else {}
+        )
+        raw = data.get("balance", "0") or "0"
+        try:
+            val = float(raw)
+            # Guard: if value looks like raw micro-units (> $1M) divide by 1e6
+            return val / 1_000_000 if val > 1_000_000 else val
+        except (TypeError, ValueError):
+            return 0.0
+
     async def request(
         self,
         method: str,

--- a/projects/polymarket/crusaderbot/main.py
+++ b/projects/polymarket/crusaderbot/main.py
@@ -100,6 +100,18 @@ async def lifespan(_: FastAPI):
             "bootstrap_default_strategies() returned an empty registry. "
             "Check domain/strategy/strategies/ imports and lib/ vendoring."
         )
+    # Auto-derive Polymarket API credentials from private key when USE_REAL_CLOB=True
+    # but POLYMARKET_API_KEY is not set in the environment. No-op in paper mode.
+    if settings.USE_REAL_CLOB:
+        try:
+            from .integrations.clob import ensure_clob_credentials
+            await ensure_clob_credentials(settings)
+        except Exception as _cred_exc:
+            log.error(
+                "startup: CLOB credential derivation failed — live orders will "
+                "fail until credentials are provided: %s", _cred_exc,
+            )
+
     await webtrader_sse.start_listener(settings.DATABASE_URL, pool)
 
     use_webhook = bool(settings.TELEGRAM_WEBHOOK_URL)


### PR DESCRIPTION
## Summary

### 1. Auto-derive CLOB API credentials (`integrations/clob/__init__.py`)
- New `ensure_clob_credentials(settings)` async function — derives `POLYMARKET_API_KEY/SECRET/PASSPHRASE` from `POLYMARKET_PRIVATE_KEY` via `/auth/derive-api-key`. **Eliminates need to manually set 3 separate secrets.**
- Module-level `_derived` cache — survives per-call adapter construction
- `get_clob_client()` now falls back to cached derived creds when env vars not set
- Called at startup in `main.py` when `USE_REAL_CLOB=True`

### 2. Wallet USDC balance query (`integrations/clob/adapter.py`)
- New `ClobAdapter.get_usdc_balance() -> float` — calls `GET /data/balance-allowances?asset_type=COLLATERAL`
- Guards against raw micro-unit format (> $1M auto-divides by 1e6)

### 3. `/admin live` readiness command (`bot/handlers/admin.py`)
- Shows all 6 gate flags (ENABLE_LIVE_TRADING, EXECUTION_PATH_VALIDATED, CAPITAL_MODE_CONFIRMED, RISK_CONTROLS_VALIDATED, SECURITY_HARDENING_VALIDATED, USE_REAL_CLOB)
- Shows credential status (env / auto-derived / missing)
- Shows live wallet USDC balance (when USE_REAL_CLOB=True)
- Shows admin user count
- Prints "🟢 READY" or "🔴 NOT READY: …" with exact steps needed

### 4. Startup hook (`main.py`)
- `ensure_clob_credentials()` called at boot when `USE_REAL_CLOB=True`
- Failures are logged as ERROR (not fatal — paper mode continues)

## Activation guards status
All 6 guards remain `false` / `False` by default. This PR adds **infrastructure** for live trading. Actual activation requires WARP•SENTINEL MAJOR validation + explicit WARP🔹CMD decision.

## Test plan
- [ ] CI green (1767 tests pass locally)
- [ ] `/admin live` in Telegram shows correct guard status
- [ ] After deploy: `ensure_clob_credentials()` logs appear in Fly.io logs when `USE_REAL_CLOB=True`
- [ ] SENTINEL MAJOR validation required before enabling any live guards

https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_