### PR TITLE
fix: migration 058 — drop copy_trade_events FK before dropping copy_targets

### DIFF
--- a/projects/polymarket/crusaderbot/migrations/058_drop_copy_targets.sql
+++ b/projects/polymarket/crusaderbot/migrations/058_drop_copy_targets.sql
@@ -30,4 +30,8 @@ WHERE COALESCE(ct.target_wallet_address, ct.wallet_address) IS NOT NULL
   )
 ON CONFLICT DO NOTHING;
 
+-- copy_trade_events has a FK to copy_targets (copy_target_id). Drop it first
+-- so the table drop does not fail with a dependency error. The column itself
+-- is retired with the legacy copy-trade path.
+ALTER TABLE copy_trade_events DROP CONSTRAINT IF EXISTS copy_trade_events_copy_target_id_fkey;
 DROP TABLE IF EXISTS copy_targets;


### PR DESCRIPTION
## Summary

Migration 058 (`058_drop_copy_targets.sql`, merged in #1372) failed when applied to the production Supabase DB:

```
ERROR: 2BP01: cannot drop table copy_targets because other objects depend on it
DETAIL: constraint copy_trade_events_copy_target_id_fkey on table copy_trade_events depends on table copy_targets
```

`copy_trade_events.copy_target_id` carries an FK to `copy_targets` that the original migration didn't account for, so `DROP TABLE copy_targets` errored.

## Fix

Added `ALTER TABLE copy_trade_events DROP CONSTRAINT IF EXISTS copy_trade_events_copy_target_id_fkey;` before the `DROP TABLE`. Idempotent (`IF EXISTS`), keeps the migration runnable on a fresh DB.

## Production status

Already applied to production (CrusaderBot project) with this exact FK-drop sequence. Verified safe:
- `copy_targets`: 0 rows
- `copy_trade_events`: 0 rows (0 non-null `copy_target_id`)
- `copy_targets` confirmed dropped post-apply

This PR only brings the repo migration file in line with what was applied, so fresh installs don't hit the same error.

## Test plan

- [ ] Fresh DB: run migrations through 058 → no dependency error

Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_