### PR TITLE
fix: PortfolioPage WithdrawModal props — unblock fly deploy build

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -412,6 +412,8 @@ export function PortfolioPage() {
           paperMode={isPaperMode}
           balance={summary?.available_usdc ?? 0}
           onClose={() => setShowWithdraw(false)}
+          onWithdraw={api.requestWithdrawal}
+          onSuccess={() => { setShowWithdraw(false); void loadPositions(); }}
         />
       )}
 


### PR DESCRIPTION
## Summary

`fly deploy` failed at the frontend build step:

```
src/pages/PortfolioPage.tsx(411,10): error TS2741: Property 'onWithdraw' is missing in type
'{ paperMode: boolean; balance: number; onClose: () => void; }' but required in type 'Props'.
```

`WithdrawModal`'s Props gained required `onWithdraw` (and optional `onSuccess`) in #1373. `WalletPage.tsx` was updated, but a **second** usage in `PortfolioPage.tsx:411` was missed, so `tsc` failed and the Docker build aborted.

## Fix

Wired the same props at the PortfolioPage call site:
- `onWithdraw={api.requestWithdrawal}` (`api` already in scope at line 46)
- `onSuccess={() => { setShowWithdraw(false); void loadPositions(); }}` — `loadPositions` refreshes `getPortfolioSummary` so the balance updates after a withdrawal

## Validation

- `npm ci && npm run build` (`tsc && vite build`) → exit 0, build clean
- Confirmed via grep these are the only two `<WithdrawModal>` usages in the codebase

## Test plan

- [ ] `fly deploy` reaches past the frontend build step
- [ ] Portfolio page → Withdraw → flow works same as Wallet page

Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoXAXTHrqYzaXeUhwf5rNM)_