### PR TITLE
fix: strategy labels + pending_settlement open tab + dashboard today_trades

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/mvp/_users.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/mvp/_users.py
@@ -71,12 +71,29 @@ async def fetch_open_position_count(user_uuid) -> int:
         pool = get_pool()
         async with pool.acquire() as conn:
             n = await conn.fetchval(
-                "SELECT COUNT(*) FROM positions WHERE user_id=$1 AND status='open'",
+                "SELECT COUNT(*) FROM positions WHERE user_id=$1 AND status IN ('open','pending_settlement')",
                 user_uuid,
             )
             return int(n or 0)
     except Exception as exc:  # noqa: BLE001
         log.debug("open position count failed: %s", exc)
+        return 0
+
+
+async def fetch_today_trade_count(user_uuid) -> int:
+    try:
+        from ....database import get_pool  # type: ignore
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            n = await conn.fetchval(
+                """SELECT COUNT(*) FROM positions
+                   WHERE user_id=$1
+                     AND opened_at >= NOW() - INTERVAL '24 hours'""",
+                user_uuid,
+            )
+            return int(n or 0)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("today_trade_count failed: %s", exc)
         return 0
 
 

--- a/projects/polymarket/crusaderbot/bot/handlers/mvp/dashboard.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/mvp/dashboard.py
@@ -39,6 +39,7 @@ async def _read_dashboard(telegram_user) -> dict:
         data["active_strategy"] = label
     data["portfolio_value"] = await _users.fetch_balance(u["id"])
     data["today_pnl"] = await _users.fetch_daily_pnl(u["id"])
+    data["today_trades"] = await _users.fetch_today_trade_count(u["id"])
     data["open_count"] = await _users.fetch_open_position_count(u["id"])
     return data
 

--- a/projects/polymarket/crusaderbot/services/notification_service.py
+++ b/projects/polymarket/crusaderbot/services/notification_service.py
@@ -39,16 +39,30 @@ _CLOSE_REASON_LABELS: dict[str, str] = {
 }
 
 _STRAT_LABELS: dict[str, str] = {
-    "whale_mirror":  "🐋 Whale Mirror",
-    "signal_sniper": "📡 Signal Sniper",
-    "hybrid":        "🐋📡 Hybrid",
-    "value_hunter":  "🎯 Value Hunter",
-    "full_auto":     "🚀 Full Auto",
-    "confluence_scalper": "🚀 Crypto Scalper",
-    "copy_trade":    "🐋 Copy Trade",
-    "signal":        "📡 Signal",
-    "value":         "🎯 Value",
-    "manual":        "Manual",
+    # Legacy preset keys
+    "whale_mirror":       "🐋 Whale Mirror",
+    "signal_sniper":      "📡 Signal Sniper",
+    "hybrid":             "🐋📡 Hybrid",
+    "value_hunter":       "🎯 Value Hunter",
+    "full_auto":          "🚀 Full Auto",
+    "copy_trade":         "🐋 Copy Trade",
+    "signal":             "📡 Signal",
+    "value":              "🎯 Value",
+    "manual":             "Manual",
+    # Strategy class names (stored as strategy_type on positions)
+    "late_entry_v3":      "Close Sweep",
+    "expiration_timing":  "Close Sweep",
+    "confluence_scalper": "Crypto Scalper",
+    "trend_breakout":     "Trend Breakout",
+    "momentum":           "Contrarian",
+    "value_investor":     "Value Hunter",
+    "signal_following":   "Signal Following",
+    "pair_arb":           "Pair Arb",
+    "ensemble":           "Smart Mix",
+    # Preset keys (fallback if preset key stored directly)
+    "close_sweep":        "Close Sweep",
+    "flip_hunter":        "Flip Hunter",
+    "safe_close":         "Safe Close",
 }
 
 

--- a/projects/polymarket/crusaderbot/services/trade_notifications/notifier.py
+++ b/projects/polymarket/crusaderbot/services/trade_notifications/notifier.py
@@ -116,17 +116,31 @@ def _fmt_pnl(pnl_usdc: float) -> str:
 
 _SEP = "━━━━━━━━━━━━━━━━━━━━"
 
-_STRAT_LABELS = {
-    "whale_mirror":  "🐋 Whale Mirror",
-    "signal_sniper": "📡 Signal Sniper",
-    "hybrid":        "🐋📡 Hybrid",
-    "value_hunter":  "🎯 Value Hunter",
-    "full_auto":     "🚀 Full Auto",
-    "confluence_scalper": "🚀 Crypto Scalper",
-    "copy_trade":    "🐋 Copy Trade",
-    "signal":        "📡 Signal",
-    "value":         "🎯 Value",
-    "manual":        "Manual",
+_STRAT_LABELS: dict[str, str] = {
+    # Legacy preset keys
+    "whale_mirror":       "🐋 Whale Mirror",
+    "signal_sniper":      "📡 Signal Sniper",
+    "hybrid":             "🐋📡 Hybrid",
+    "value_hunter":       "🎯 Value Hunter",
+    "full_auto":          "🚀 Full Auto",
+    "copy_trade":         "🐋 Copy Trade",
+    "signal":             "📡 Signal",
+    "value":              "🎯 Value",
+    "manual":             "Manual",
+    # Strategy class names (stored as strategy_type on positions)
+    "late_entry_v3":      "Close Sweep",
+    "expiration_timing":  "Close Sweep",
+    "confluence_scalper": "Crypto Scalper",
+    "trend_breakout":     "Trend Breakout",
+    "momentum":           "Contrarian",
+    "value_investor":     "Value Hunter",
+    "signal_following":   "Signal Following",
+    "pair_arb":           "Pair Arb",
+    "ensemble":           "Smart Mix",
+    # Preset keys (fallback if preset key stored directly)
+    "close_sweep":        "Close Sweep",
+    "flip_hunter":        "Flip Hunter",
+    "safe_close":         "Safe Close",
 }
 
 # Human-readable reasoning labels for signal_reason values

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -383,3 +383,4 @@ Hard product rules enforced: no manual trade buttons, markets intelligence-only,
 2026-05-27 07:30 | WARP/trade-strategy-preset-names | WebTrader trade cards: map strategy_type → preset display name (late_entry_v3 → "Close Sweep", etc.) per owner request
 2026-05-26 23:04 | WARP/telegram-ux-v2 | Telegram MVP UI: HTML → MarkdownV2 (ui/tree.py + messages_mvp.py + _send.py); render_positions_empty() added; dead if-False removed
 2026-05-26 23:40 | WARP/telegram-legacy-markdownv2 | Legacy wallet + emergency screens HTML → MarkdownV2 (messages.py 10 fns + wallet.py + emergency.py); admin_withdrawal_item_text kept HTML (operator path)
+2026-05-27 05:40 | WARP/ROOT/notification-strategy-labels | Fix 3 runtime bugs: Telegram strategy labels (late_entry_v3→Close Sweep); WebTrader OPEN tab includes pending_settlement; Dashboard today_trades always-0

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-26 23:40
-Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). MVP UI migrated to MarkdownV2 (MERGED #1382). New: legacy wallet + emergency screens also migrated HTML → MarkdownV2 (messages.py 10 fns + wallet.py + emergency.py); admin_withdrawal_item_text kept HTML (operator path). PR open: WARP/telegram-legacy-markdownv2.
+Last Updated : 2026-05-27 05:40
+Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). WARP/ROOT/notification-strategy-labels PR open: 3 runtime bugs fixed — (1) Telegram strategy labels now show preset display names (late_entry_v3→Close Sweep); (2) WebTrader OPEN tab now includes pending_settlement positions; (3) Dashboard today_trades no longer hardcoded 0.
 
 - WARP-57 (issue #1260): SENTINEL re-audited — APPROVED (Round 2 Score 86/100, 0 critical). PR #1261 / WARP/warp57-telegram-ux-mvp at SHA aa4fe24c55e8. Round-1 CRITICAL-1 (copy_targets schema mismatch) RESOLVED — `bot/handlers/mvp/copy_wallet.py` SELECT/INSERT/UPDATE now use canonical columns (`target_wallet_address`, `status='active'/'inactive'`, `scale_factor`) per mig 009. Round-1 MEDIUM-1 (`wallets.public_address` → `deposit_address` in onboarding.py:38) also RESOLVED. NEW MEDIUM-4 (post-merge follow-up): MVP writes to `copy_targets` but production scanner `services/copy_trade/monitor.py:80` reads `copy_trade_tasks` via `domain/copy_trade/repository.py:list_active_tasks` — end-to-end mirror not yet active until a follow-up lane swaps the MVP table to `copy_trade_tasks`; legacy `/copytrade` 8-step wizard remains the only path that produces mirrored trades. Round-1 MEDIUM-2 (auto:start engine bootstrap) + MEDIUM-3 (legacy `/settings` sub-route regression) P2-deferred per WARP🔹CMD direction. Activation guards untouched (Risk 3 PASS), no manual trade buttons (Risk 2 PASS), paper-mode default preserved (Risk 6 PASS). Report: projects/polymarket/crusaderbot/reports/sentinel/warp57-telegram-ux-mvp.md.
 - WARP-55 (issue #1256): MERGED (abd3b43dbe10) — RUNTIME_EVIDENCE.md: 7/7 P2 finish criteria proven. 🏁 CrusaderBot closed beta DONE. Guards LOCKED. STANDARD, evidence-only.
@@ -58,21 +58,14 @@ Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). MVP UI migrate
 - Production monitoring of late_entry_v3 on Fly (paper): FAV_PRICE_MAX=0.70 ceiling live. Watch 24-48h net PnL.
 
 [NOT STARTED]
-- Apply migration 030 (job_runs metadata JSONB) to production before Fly.io deploy (trading-unblock MERGED PR #1065, live on main).
-- Apply migration 029 (portfolio_snapshots, system_alerts, NOTIFY triggers) to production before deploying WARP/CRUSADERBOT-WEBTRADER.
-- Set fly secret WEBTRADER_JWT_SECRET=<openssl rand -hex 32> before deploying WebTrader.
-- Register crusaderbot.fly.dev domain in BotFather: /setdomain @CrusaderBot crusaderbot.fly.dev (required for Telegram Login Widget).
-- migration 027 (notifications_on) must be applied before deploying crusaderbot-mvp-runtime-ux to production.
 - Wire share_trade_kb into trade close call sites when PNL > 0; surface ready, wiring deferred.
 - Referral payout activation: separate lane, requires WARP🔹CMD decision.
 - Fee collection activation: separate lane, requires WARP🔹CMD decision.
 - Wire @require_access_tier('PREMIUM') onto trading command handlers as separate lane.
 - Seed boss user ADMIN tier row in user_tiers via /admin settier post-deploy.
-- Fast Track Week 4 -- Closed beta observation; no new feature PRs planned in that week.
 
 [NEXT PRIORITY]
-- WARP🔹CMD review + merge WARP/telegram-legacy-markdownv2 (PR open) then fly deploy. STANDARD — display-only. Post-deploy verify /wallet withdraw flow + /emergency menu render cleanly.
-- WARP/telegram-ux-v2 MERGED #1382 + auto-deployed (MVP UI MarkdownV2).
+- WARP🔹CMD review + merge WARP/ROOT/notification-strategy-labels (PR open). STANDARD — Telegram labels, WebTrader open tab, dashboard today_trades. Post-deploy verify: Telegram shows "Close Sweep" not "late_entry_v3"; WebTrader OPEN tab shows pending_settlement positions; Dashboard Trades count matches reality.
 - WARP🔹CMD: apply migration 058 (DROP copy_targets, backfill into copy_trade_tasks) to Supabase before fly deploy.
 - Verify post-deploy: Telegram copy-task wizard → confirm task created successfully + copy monitor picks it up (F-HIGH-2 secondary fix #1374).
 - Verify post-deploy: WebTrader withdraw flow on both Wallet + Portfolio pages (amount → address → confirm → submit → pending status shown).

--- a/projects/polymarket/crusaderbot/tests/test_trade_notifications.py
+++ b/projects/polymarket/crusaderbot/tests/test_trade_notifications.py
@@ -132,7 +132,7 @@ async def test_notify_entry_strategy_type_shown():
             strategy_type="signal_following",
         )
     text: str = mock_send.call_args[0][1]
-    assert "signal_following" in text
+    assert "Signal Following" in text
 
 
 @pytest.mark.asyncio

--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -210,7 +210,7 @@ async def get_dashboard(user: _CurrentUser) -> DashboardSummary:
             "SELECT balance_usdc FROM wallets WHERE user_id = $1::uuid", user_id
         )
         open_count = await conn.fetchval(
-            "SELECT COUNT(*) FROM positions WHERE user_id=$1::uuid AND status='open'",
+            "SELECT COUNT(*) FROM positions WHERE user_id=$1::uuid AND status IN ('open','pending_settlement')",
             user_id,
         )
         pnl_today = await conn.fetchval(
@@ -352,7 +352,10 @@ async def get_positions(
     user_id = user["user_id"]
     where = "WHERE p.user_id = $1::uuid"
     params: list = [user_id]
-    if status:
+    if status == "open":
+        # Include pending_settlement so won-positions awaiting payout are visible
+        where += " AND p.status IN ('open', 'pending_settlement')"
+    elif status:
         where += f" AND p.status = ${len(params)+1}"
         params.append(status)
 
@@ -394,7 +397,7 @@ async def get_positions(
             tp_price=_tp_sl_price(float(r["entry_price"]), r["side"], r["tp_pct"], is_tp=True),
             sl_price=_tp_sl_price(float(r["entry_price"]), r["side"], r["sl_pct"], is_tp=False),
             awaiting_redeem=(
-                r["status"] == "open"
+                r["status"] in ("open", "pending_settlement")
                 and bool(r["market_resolved"])
                 and r["winning_side"] is not None
                 and str(r["winning_side"]) == str(r["side"])
@@ -1213,7 +1216,7 @@ async def get_runtime_status(user: _CurrentUser) -> RuntimeStatus:
             user_id,
         )
         open_count = await conn.fetchval(
-            "SELECT COUNT(*) FROM positions WHERE user_id=$1::uuid AND status='open'",
+            "SELECT COUNT(*) FROM positions WHERE user_id=$1::uuid AND status IN ('open','pending_settlement')",
             user_id,
         )
     scanner = get_scanner_state()
@@ -1248,7 +1251,7 @@ async def get_portfolio_summary(user: _CurrentUser) -> PortfolioSummary:
             ) or 0
         )
         open_rows = await conn.fetch(
-            "SELECT size_usdc, entry_price, current_price FROM positions WHERE user_id=$1::uuid AND status='open'",
+            "SELECT size_usdc, entry_price, current_price FROM positions WHERE user_id=$1::uuid AND status IN ('open','pending_settlement')",
             user_id,
         )
 
@@ -1322,7 +1325,7 @@ async def get_portfolio_chart(
             *params_period,
         )
         open_rows = await conn.fetch(
-            "SELECT size_usdc, entry_price, current_price FROM positions WHERE user_id=$1::uuid AND status='open'",
+            "SELECT size_usdc, entry_price, current_price FROM positions WHERE user_id=$1::uuid AND status IN ('open','pending_settlement')",
             user_id,
         )
 


### PR DESCRIPTION
## Summary

- **Bug 1 — Telegram strategy labels** (`notification_service.py`, `notifier.py`): `_STRAT_LABELS` was missing all new preset mappings. `late_entry_v3`, `expiration_timing`, `confluence_scalper`, `trend_breakout`, `momentum`, `value_investor`, `signal_following`, `pair_arb`, `ensemble`, `close_sweep`, `flip_hunter`, `safe_close` all added. "Auto Trade Executed" and "TRADE OPENED" cards now show "Close Sweep" instead of "late_entry_v3".

- **Bug 2 — WebTrader OPEN tab missing pending_settlement positions** (`webtrader/backend/router.py`): `GET /positions?status=open` filtered `status = 'open'` exactly, making won-positions in `pending_settlement` state invisible in both OPEN and CLOSED tabs. Fixed to `IN ('open', 'pending_settlement')` across the positions query, `awaiting_redeem` flag, and all open_count queries (dashboard, runtime_status, portfolio_summary, chart).

- **Bug 3 — Dashboard "Trades 0" always zero** (`_users.py`, `dashboard.py`): `_read_dashboard` initialised `today_trades = 0` and never fetched it. Added `fetch_today_trade_count` (positions opened in last 24h) and wired it in.

## Files changed

| File | Change |
|---|---|
| `services/notification_service.py` | Expand `_STRAT_LABELS` — 13 entries added |
| `services/trade_notifications/notifier.py` | Same — sync to frontend map |
| `webtrader/backend/router.py` | `status='open'` → `IN ('open','pending_settlement')` in 5 places; `awaiting_redeem` condition updated |
| `bot/handlers/mvp/_users.py` | `fetch_today_trade_count` added; `fetch_open_position_count` includes `pending_settlement` |
| `bot/handlers/mvp/dashboard.py` | Wire `fetch_today_trade_count` |
| `tests/test_trade_notifications.py` | Update assertion: `"signal_following"` → `"Signal Following"` |
| `state/PROJECT_STATE.md` | Updated; stale [NOT STARTED] migration entries removed |
| `state/CHANGELOG.md` | Entry appended |

## Test plan

- [ ] `test_trade_notifications.py` — 16 tests pass (was 15 before strategy label fix)
- [ ] `test_webtrader_positions.py` — 5 tests pass
- [ ] `py_compile` clean on all 5 production files
- [ ] Post-deploy verify in Telegram: "Auto Trade Executed" shows "Close Sweep" not "late_entry_v3"
- [ ] Post-deploy verify in WebTrader: OPEN tab shows pending_settlement positions (won trades awaiting payout)
- [ ] Post-deploy verify in Telegram Dashboard: Today Trades shows actual count not 0

Validation Tier: STANDARD
Claim Level: NARROW INTEGRATION

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHWRY6reBrH2n4xXenvi4i)_