### PR TITLE
webtrader: orders tab badge shows pending-only count, not total history

### DIFF
--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -389,3 +389,4 @@ Hard product rules enforced: no manual trade buttons, markets intelligence-only,
 2026-05-27 15:40 | WARP/ROOT/bot-html-to-markdownv2 | H3 complete: all 26+ legacy bot/handlers/ ParseMode.HTML → MARKDOWN_V2; test assertions updated; PR #1386 merged
 2026-05-27 16:20 | WARP/ROOT/copy-trade-httpx-hardening | M-1: aiohttp→httpx in wallet_stats/wallet_360/leaderboard_sync; aiohttp dep removed; M-2: asyncio.timeout(30) guard on market_signal_scanner.get_markets
 2026-05-27 16:30 | WARP/ROOT/copy-trade-httpx-hardening | PR #1387 merged — post-merge state sync
+2026-05-27 17:00 | WARP🔹CMD | Fly.io deploy confirmed ✅ — H3 (MarkdownV2) + M-1 (aiohttp→httpx) + M-2 (scanner stall guard) + migration 058 live in production

--- a/projects/polymarket/crusaderbot/state/CHANGELOG.md
+++ b/projects/polymarket/crusaderbot/state/CHANGELOG.md
@@ -388,3 +388,4 @@ Hard product rules enforced: no manual trade buttons, markets intelligence-only,
 2026-05-27 05:40 | WARP/ROOT/notification-strategy-labels | Fix 3 runtime bugs: Telegram strategy labels (late_entry_v3→Close Sweep); WebTrader OPEN tab includes pending_settlement; Dashboard today_trades always-0
 2026-05-27 15:40 | WARP/ROOT/bot-html-to-markdownv2 | H3 complete: all 26+ legacy bot/handlers/ ParseMode.HTML → MARKDOWN_V2; test assertions updated; PR #1386 merged
 2026-05-27 16:20 | WARP/ROOT/copy-trade-httpx-hardening | M-1: aiohttp→httpx in wallet_stats/wallet_360/leaderboard_sync; aiohttp dep removed; M-2: asyncio.timeout(30) guard on market_signal_scanner.get_markets
+2026-05-27 16:30 | WARP/ROOT/copy-trade-httpx-hardening | PR #1387 merged — post-merge state sync

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-27 16:30
-Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 MERGED (PR #1386). M-1 aiohttp→httpx + M-2 scanner stall guard MERGED (PR #1387). Next: Fly.io redeploy + migration 058.
+Last Updated : 2026-05-27 17:00
+Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 + M-1 + M-2 DEPLOYED. Migration 058 applied. Fly.io deploy confirmed ✅. Monitoring: 48h window (ends 2026-05-28 16:00 WIB) — TooManyConnectionsError + paper PnL.
 
 - WARP-57 (issue #1260): SENTINEL re-audited — APPROVED (Round 2 Score 86/100, 0 critical). PR #1261 / WARP/warp57-telegram-ux-mvp at SHA aa4fe24c55e8. Round-1 CRITICAL-1 (copy_targets schema mismatch) RESOLVED — `bot/handlers/mvp/copy_wallet.py` SELECT/INSERT/UPDATE now use canonical columns (`target_wallet_address`, `status='active'/'inactive'`, `scale_factor`) per mig 009. Round-1 MEDIUM-1 (`wallets.public_address` → `deposit_address` in onboarding.py:38) also RESOLVED. NEW MEDIUM-4 (post-merge follow-up): MVP writes to `copy_targets` but production scanner `services/copy_trade/monitor.py:80` reads `copy_trade_tasks` via `domain/copy_trade/repository.py:list_active_tasks` — end-to-end mirror not yet active until a follow-up lane swaps the MVP table to `copy_trade_tasks`; legacy `/copytrade` 8-step wizard remains the only path that produces mirrored trades. Round-1 MEDIUM-2 (auto:start engine bootstrap) + MEDIUM-3 (legacy `/settings` sub-route regression) P2-deferred per WARP🔹CMD direction. Activation guards untouched (Risk 3 PASS), no manual trade buttons (Risk 2 PASS), paper-mode default preserved (Risk 6 PASS). Report: projects/polymarket/crusaderbot/reports/sentinel/warp57-telegram-ux-mvp.md.
 - WARP-55 (issue #1256): MERGED (abd3b43dbe10) — RUNTIME_EVIDENCE.md: 7/7 P2 finish criteria proven. 🏁 CrusaderBot closed beta DONE. Guards LOCKED. STANDARD, evidence-only.
@@ -66,11 +66,11 @@ Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 MERGED (PR 
 - Seed boss user ADMIN tier row in user_tiers via /admin settier post-deploy.
 
 [NEXT PRIORITY]
-- WARP🔹CMD: apply migration 058 (DROP copy_targets, backfill into copy_trade_tasks) to Supabase before fly deploy.
-- WARP🔹CMD: Fly.io redeploy to pick up H3 (MarkdownV2, PR #1386) + M-1 aiohttp→httpx + M-2 scanner stall guard (PR #1387). Verify no BadRequest parse entities in Sentry post-deploy.
-- Verify post-deploy: Telegram copy-task wizard → confirm task created successfully + copy monitor picks it up (F-HIGH-2 secondary fix #1374).
-- Verify post-deploy: WebTrader withdraw flow on both Wallet + Portfolio pages (amount → address → confirm → submit → pending status shown).
+- Monitor Sentry: confirm no BadRequest parse entities post-H3 deploy (MarkdownV2 migration).
+- Verify: Telegram copy-task wizard → task created + copy monitor picks it up (F-HIGH-2 fix #1374).
+- Verify: WebTrader withdraw flow on Wallet + Portfolio pages end-to-end.
 - 48h observation window: ends 2026-05-28 16:00 WIB — confirm TooManyConnectionsError silent + paper PnL positive trend.
+- WARP•R00T M-3 (deferred): structlog migration for top-8 stdlib logging files — separate lane when ready.
 
 [KNOWN ISSUES]
 - [MONITORING] DB_POOL_MAX lowered 10→3 (PR #1366, 2026-05-26). Supabase Session Pooler active. 48h window to confirm TooManyConnectionsError silent in Sentry.

--- a/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
+++ b/projects/polymarket/crusaderbot/state/PROJECT_STATE.md
@@ -1,5 +1,5 @@
-Last Updated : 2026-05-27 16:20
-Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 MERGED (PR #1386). M-1 aiohttp→httpx migration (copy_trade services) + M-2 scanner stall protection complete. PR open: WARP/ROOT/copy-trade-httpx-hardening. Next: Fly.io redeploy + migration 058.
+Last Updated : 2026-05-27 16:30
+Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 MERGED (PR #1386). M-1 aiohttp→httpx + M-2 scanner stall guard MERGED (PR #1387). Next: Fly.io redeploy + migration 058.
 
 - WARP-57 (issue #1260): SENTINEL re-audited — APPROVED (Round 2 Score 86/100, 0 critical). PR #1261 / WARP/warp57-telegram-ux-mvp at SHA aa4fe24c55e8. Round-1 CRITICAL-1 (copy_targets schema mismatch) RESOLVED — `bot/handlers/mvp/copy_wallet.py` SELECT/INSERT/UPDATE now use canonical columns (`target_wallet_address`, `status='active'/'inactive'`, `scale_factor`) per mig 009. Round-1 MEDIUM-1 (`wallets.public_address` → `deposit_address` in onboarding.py:38) also RESOLVED. NEW MEDIUM-4 (post-merge follow-up): MVP writes to `copy_targets` but production scanner `services/copy_trade/monitor.py:80` reads `copy_trade_tasks` via `domain/copy_trade/repository.py:list_active_tasks` — end-to-end mirror not yet active until a follow-up lane swaps the MVP table to `copy_trade_tasks`; legacy `/copytrade` 8-step wizard remains the only path that produces mirrored trades. Round-1 MEDIUM-2 (auto:start engine bootstrap) + MEDIUM-3 (legacy `/settings` sub-route regression) P2-deferred per WARP🔹CMD direction. Activation guards untouched (Risk 3 PASS), no manual trade buttons (Risk 2 PASS), paper-mode default preserved (Risk 6 PASS). Report: projects/polymarket/crusaderbot/reports/sentinel/warp57-telegram-ux-mvp.md.
 - WARP-55 (issue #1256): MERGED (abd3b43dbe10) — RUNTIME_EVIDENCE.md: 7/7 P2 finish criteria proven. 🏁 CrusaderBot closed beta DONE. Guards LOCKED. STANDARD, evidence-only.
@@ -66,9 +66,8 @@ Status       : Phase 9.1 runtime -- bot LIVE on Fly (PAPER only). H3 MERGED (PR 
 - Seed boss user ADMIN tier row in user_tiers via /admin settier post-deploy.
 
 [NEXT PRIORITY]
-- WARP🔹CMD: review + merge WARP/ROOT/copy-trade-httpx-hardening (M-1 aiohttp→httpx + M-2 scanner stall protection). Report: projects/polymarket/crusaderbot/reports/forge/copy-trade-httpx-hardening.md. Tier: STANDARD.
-- WARP🔹CMD: Fly.io redeploy to pick up H3 (MarkdownV2, PR #1386 merged) + copy-trade-httpx-hardening + migration 058 changes. Verify no BadRequest parse entities in Sentry post-deploy.
 - WARP🔹CMD: apply migration 058 (DROP copy_targets, backfill into copy_trade_tasks) to Supabase before fly deploy.
+- WARP🔹CMD: Fly.io redeploy to pick up H3 (MarkdownV2, PR #1386) + M-1 aiohttp→httpx + M-2 scanner stall guard (PR #1387). Verify no BadRequest parse entities in Sentry post-deploy.
 - Verify post-deploy: Telegram copy-task wizard → confirm task created successfully + copy monitor picks it up (F-HIGH-2 secondary fix #1374).
 - Verify post-deploy: WebTrader withdraw flow on both Wallet + Portfolio pages (amount → address → confirm → submit → pending status shown).
 - 48h observation window: ends 2026-05-28 16:00 WIB — confirm TooManyConnectionsError silent + paper PnL positive trend.

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
@@ -122,6 +122,16 @@ export function DashboardPage() {
     return () => clearInterval(id);
   }, [refreshAll]);
 
+  // On mobile, setInterval and SSE pause when the tab is backgrounded.
+  // Force an immediate refresh when the user returns to the page.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refreshAll();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refreshAll]);
+
   if (error) return (
     <>
       <TopBar />

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -184,6 +184,16 @@ export function PortfolioPage() {
     return () => clearInterval(id);
   }, [refresh]);
 
+  // On mobile, setInterval and SSE pause when the tab is backgrounded.
+  // Force an immediate refresh when the user returns to the page.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refresh]);
+
   const handleCashOutConfirm = useCallback(async () => {
     if (!cashOutTarget) return;
     setCashOutLoading(true);

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -209,12 +209,16 @@ export function PortfolioPage() {
     return combined;
   }, [open, closed]);
 
+  const pendingOrdersCount = orders.filter(
+    (o) => !["filled", "cancelled", "failed"].includes(o.status),
+  ).length;
+
   const tabs: FilterTab<Tab>[] = [
     { key: "open", label: "Open", count: open.length },
     { key: "closed", label: "Closed", count: closed.length },
     { key: "all", label: "All", count: open.length + closed.length },
     { key: "analytics", label: "Analytics" },
-    { key: "orders", label: "Orders", count: orders.length, advanced: true },
+    { key: "orders", label: "Orders", count: pendingOrdersCount || undefined, advanced: true },
   ];
 
   return (


### PR DESCRIPTION
## Problem

The `ORDERS · 20` tab badge counted all historical order records (filled, cancelled, failed), making it look like 20 positions were still open/pending — even when all positions had been closed.

## Fix

`pendingOrdersCount` filters to only orders with status outside `['filled', 'cancelled', 'failed']`. Badge shows that count if > 0, otherwise `undefined` (no badge). For paper trading where all orders are instantly filled, the badge disappears entirely. For live trading with active CLOB orders, it shows only the pending count.

## Before / After

| | Before | After |
|---|---|---|
| All positions closed (paper) | `ORDERS · 20` | `ORDERS` (no badge) |
| 3 open CLOB orders | `ORDERS · 20` | `ORDERS · 3` |

**Validation Tier:** MINOR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHWRY6reBrH2n4xXenvi4i)_