### PR TITLE
webtrader: fix CLOSED badge stuck at 20 — use DB total_closed count

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -1254,6 +1254,12 @@ async def get_portfolio_summary(user: _CurrentUser) -> PortfolioSummary:
             "SELECT size_usdc, entry_price, current_price FROM positions WHERE user_id=$1::uuid AND status IN ('open','pending_settlement')",
             user_id,
         )
+        total_closed = int(
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM positions WHERE user_id=$1::uuid AND status IN ('closed', 'expired', 'market_expired')",
+                user_id,
+            ) or 0
+        )
 
     balance = float(balance_row["balance_usdc"]) if balance_row else 0.0
     unrealized_pnl = _unrealized_pnl(open_rows)
@@ -1266,6 +1272,7 @@ async def get_portfolio_summary(user: _CurrentUser) -> PortfolioSummary:
         unrealized_pnl=unrealized_pnl,
         equity_usdc=equity,
         balance_usdc=balance,
+        total_closed=total_closed,
     )
 
 

--- a/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/schemas.py
@@ -273,6 +273,7 @@ class PortfolioSummary(BaseModel):
     unrealized_pnl: float
     equity_usdc: float
     balance_usdc: float
+    total_closed: int = 0
 
 
 class ChartPoint(BaseModel):

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/lib/api.ts
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/lib/api.ts
@@ -187,6 +187,7 @@ export interface PortfolioSummary {
   unrealized_pnl: number;
   equity_usdc: number;
   balance_usdc: number;
+  total_closed: number;
 }
 
 export interface ChartPoint {

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -223,10 +223,12 @@ export function PortfolioPage() {
     (o) => !["filled", "cancelled", "failed"].includes(o.status),
   ).length;
 
+  const totalClosed = summary?.total_closed ?? closed.length;
+
   const tabs: FilterTab<Tab>[] = [
     { key: "open", label: "Open", count: open.length },
-    { key: "closed", label: "Closed", count: closed.length },
-    { key: "all", label: "All", count: open.length + closed.length },
+    { key: "closed", label: "Closed", count: totalClosed },
+    { key: "all", label: "All", count: open.length + totalClosed },
     { key: "analytics", label: "Analytics" },
     { key: "orders", label: "Orders", count: pendingOrdersCount || undefined, advanced: true },
   ];
@@ -336,7 +338,7 @@ export function PortfolioPage() {
         )}
 
         {tab === "closed" && (
-          <CollapsibleSection id="portfolio_closed_positions" label={`Closed Trades (${closed.length})`}>
+          <CollapsibleSection id="portfolio_closed_positions" label={`Closed Trades (${totalClosed})`}>
             {closed.length === 0 ? (
               <EmptyState
                 icon="📦"


### PR DESCRIPTION
## Summary

- **Root cause**: `CLOSED_PAGE_SIZE = 20` means `closed.length` (from the paginated fetch) never exceeds 20, so the CLOSED·20 and ALL·20 badges were stuck even when the DB had more trades
- **Backend**: `PortfolioSummary` schema gains `total_closed: int` (DB COUNT query in `/portfolio/summary` endpoint)
- **Frontend**: `PortfolioPage` computes `totalClosed = summary?.total_closed ?? closed.length` and uses it for the Closed tab badge, All tab badge, and CollapsibleSection heading

## Files changed

- `webtrader/backend/schemas.py` — `PortfolioSummary.total_closed: int = 0`
- `webtrader/backend/router.py` — COUNT query for closed/expired positions
- `webtrader/frontend/src/lib/api.ts` — `PortfolioSummary.total_closed: number`
- `webtrader/frontend/src/pages/PortfolioPage.tsx` — `totalClosed` computed, used in tabs + section heading

## Test plan

- [ ] Open Portfolio page → CLOSED badge shows actual DB count (not capped at 20)
- [ ] ALL badge = open count + DB closed count
- [ ] CollapsibleSection heading shows correct total
- [ ] Works with 0 closed trades (fallback to `closed.length = 0`)
- [ ] `summary` null guard works on first load (before API response)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHWRY6reBrH2n4xXenvi4i)_