### PR TITLE
webtrader: center deposit/withdraw modals vertically on mobile

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DepositModal.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DepositModal.tsx
@@ -47,7 +47,7 @@ export function DepositModal({ address, paperMode, balance, onClose }: Props) {
     <>
       {/* Modal backdrop */}
       <div
-        className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+        className="fixed inset-0 z-50 flex items-center justify-center px-2"
         style={{ background: "rgba(0,0,0,0.78)" }}
         onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
         role="dialog"
@@ -55,7 +55,7 @@ export function DepositModal({ address, paperMode, balance, onClose }: Props) {
         aria-label="Deposit USDC"
       >
         <div
-          className="w-full max-w-sm bg-surface border border-border-1 clip-card p-5 pb-8 md:pb-5"
+          className="w-full max-w-sm bg-surface border border-border-1 clip-card p-5 pb-8 md:pb-5 max-h-[90vh] overflow-y-auto"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/WithdrawModal.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/WithdrawModal.tsx
@@ -68,7 +68,7 @@ export function WithdrawModal({ paperMode, balance, onClose, onWithdraw, onSucce
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end md:items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center px-2"
       style={{ background: "rgba(0,0,0,0.78)" }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
@@ -76,7 +76,7 @@ export function WithdrawModal({ paperMode, balance, onClose, onWithdraw, onSucce
       aria-label="Withdraw USDC"
     >
       <div
-        className="w-full max-w-sm bg-surface border border-border-1 clip-card p-5 pb-8 md:pb-5"
+        className="w-full max-w-sm bg-surface border border-border-1 clip-card p-5 pb-8 md:pb-5 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary

- DepositModal and WithdrawModal were using `items-end` on mobile, anchoring them to the bottom of the screen
- Changed to `items-center px-2` on all screen sizes — modal now appears vertically centered
- Added `max-h-[90vh] overflow-y-auto` to the panel so content scrolls on very small screens instead of overflowing

## Files changed

- `webtrader/frontend/src/components/DepositModal.tsx`
- `webtrader/frontend/src/components/WithdrawModal.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHWRY6reBrH2n4xXenvi4i)_