### PR TITLE
CI: retry pip installs to survive transient PyPI/network failures

### DIFF
--- a/.github/workflows/crusaderbot-ci.yml
+++ b/.github/workflows/crusaderbot-ci.yml
@@ -46,9 +46,20 @@ jobs:
           cache: 'pip'
 
       - name: Install lint and test tooling
+        # Retry the install so a transient PyPI/network hiccup on a cold
+        # runner (no wheel cache) does not red-flag the whole job.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ruff pytest cffi
+          n=0
+          until python -m pip install --retries 5 --timeout 60 ruff pytest cffi; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "tooling install failed after $n attempts" >&2
+              exit 1
+            fi
+            echo "tooling install attempt $n failed; retrying in $((n * 5))s" >&2
+            sleep $((n * 5))
+          done
 
       - name: Install runtime dependencies (from pyproject.toml)
         # Tests in tests/test_health.py import the monitoring package, which
@@ -56,12 +67,24 @@ jobs:
         # the dependency list directly from pyproject.toml so the CI install
         # stays in sync with the project without a duplicated requirements
         # file. Python 3.11 provides tomllib in the standard library.
+        # The install is retried so a transient download failure (the wheel
+        # set is ~50 MB incl. web3/cryptography/uvloop) does not fail CI.
         run: |
           python - <<'PY'
-          import subprocess, sys, tomllib
+          import subprocess, sys, time, tomllib
           with open("pyproject.toml", "rb") as f:
               deps = tomllib.load(f)["project"]["dependencies"]
-          subprocess.check_call([sys.executable, "-m", "pip", "install", "--ignore-installed", *deps])
+          cmd = [
+              sys.executable, "-m", "pip", "install", "--ignore-installed",
+              "--retries", "5", "--timeout", "60", *deps,
+          ]
+          for attempt in range(1, 4):
+              if subprocess.run(cmd).returncode == 0:
+                  break
+              print(f"runtime dep install attempt {attempt} failed", file=sys.stderr, flush=True)
+              if attempt == 3:
+                  sys.exit(1)
+              time.sleep(attempt * 5)
           PY
 
       - name: Lint (ruff)


### PR DESCRIPTION
## Summary

Fixes the intermittent "Lint + Test" CI failures (e.g. on #1395) that are **not** code defects.

**Diagnosis:** On #1395 (a markdown-only PR) the job failed in ~69s — too fast to have run the suite. In a clean venv with the exact CI dependency set and latest tooling (ruff 0.15.14, pytest 9.0.3, pytest-asyncio 1.4.0): dependency install exits 0, `ruff check .` is clean, and `pytest` reports **1792 passed, 1 skipped, 0 failures**. The build is deterministically green. The 69s failure points to a transient dependency-download failure on a cold runner (no wheel cache; the wheel set is ~50 MB incl. web3/cryptography/uvloop).

**Fix:** wrap both `pip install` steps in `.github/workflows/crusaderbot-ci.yml` with bounded retries (3 attempts, backoff) plus `--retries 5 --timeout 60`, so a transient PyPI/network hiccup no longer red-flags the whole job. No dependency versions changed; no test/lint logic changed.

## Changes

- `.github/workflows/crusaderbot-ci.yml` — retry the tooling install and the runtime-deps install.

## Test plan

- [ ] This PR edits the CI workflow, so the new run exercises the retried install path end-to-end.
- [ ] Confirm "Lint + Test" goes green.

Validation Tier: MINOR (CI infra only) · Note: also unblocks #1395 (docs-only audit PR).

https://claude.ai/code/session_01Ud7DacTrrAfn8Y3Qs1wEfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud7DacTrrAfn8Y3Qs1wEfs)_