### PR TITLE
fix: unblock Link Email — replace passlib with bcrypt direct

### DIFF
--- a/projects/polymarket/crusaderbot/pyproject.toml
+++ b/projects/polymarket/crusaderbot/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "tenacity>=8.2",
     "eth-account>=0.10",
     "sentry-sdk[fastapi]>=2.0",
-    "passlib[bcrypt]>=1.7",
+    "bcrypt>=4.0",
     # Phase 4D — push-based fill streaming over wss://ws-subscriptions-clob.polymarket.com.
     "websockets>=12.0,<14.0",
     # Test-only — listed here (not in a separate test extra) because the

--- a/projects/polymarket/crusaderbot/tests/test_webtrader_auth_bcrypt.py
+++ b/projects/polymarket/crusaderbot/tests/test_webtrader_auth_bcrypt.py
@@ -1,0 +1,48 @@
+"""Regression tests for the bcrypt password path in webtrader/backend/auth.py.
+
+Background: passlib's bcrypt backend runs a `detect_wrap_bug` self-test on
+first use that feeds a 73-byte secret to the underlying bcrypt library. With
+`bcrypt>=4.0` that raises `ValueError: password cannot be longer than 72
+bytes`, which propagates as a 500 on `/auth/link-email` (Sentry
+DAWN-SNOWFLAKE-1729-2B). The fix swaps passlib for bcrypt directly. These
+tests pin the new helpers + ensure the byte-length validation fires BEFORE
+hashing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from projects.polymarket.crusaderbot.webtrader.backend import auth as auth_mod
+
+
+def test_hash_password_round_trip_short():
+    h = auth_mod._hash_password("hunter22!")
+    assert h.startswith("$2b$"), "must produce a standard bcrypt hash"
+    assert auth_mod._verify_password("hunter22!", h)
+    assert not auth_mod._verify_password("wrong-pass", h)
+
+
+def test_hash_password_round_trip_72_bytes_exact():
+    """72 ASCII bytes is the bcrypt ceiling — must hash + verify without error."""
+    pw = "a" * 72
+    h = auth_mod._hash_password(pw)
+    assert auth_mod._verify_password(pw, h)
+
+
+def test_verify_password_rejects_malformed_hash_silently():
+    """A malformed stored hash must not raise; auth handler treats as mismatch."""
+    assert not auth_mod._verify_password("anything", "not-a-bcrypt-hash")
+
+
+def test_bcrypt_max_bytes_constant_pinned_at_72():
+    """Bcrypt's hard limit is 72 bytes — surface as a named constant."""
+    assert auth_mod._BCRYPT_MAX_BYTES == 72
+
+
+def test_passlib_no_longer_imported():
+    """Regression guard: passlib's self-test crashes on bcrypt>=4 — must stay out."""
+    src = open(auth_mod.__file__, encoding="utf-8").read()
+    # Comment references in the explanatory docstring are fine; an import is not.
+    assert "from passlib" not in src
+    assert "import passlib" not in src
+    assert "CryptContext" not in src

--- a/projects/polymarket/crusaderbot/webtrader/backend/auth.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/auth.py
@@ -8,10 +8,10 @@ import re
 import time
 from typing import Optional
 
+import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, Query
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from passlib.context import CryptContext
 
 from ...config import get_settings
 from ...database import get_pool
@@ -26,7 +26,27 @@ from .schemas import (
     TokenResponse,
 )
 
-_pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# Direct bcrypt instead of passlib: passlib's bcrypt backend self-test
+# (detect_wrap_bug) feeds a 73-byte password to the backend and crashes on
+# bcrypt>=4.0 which now strictly enforces the 72-byte limit. The hash format
+# is identical ($2b$...), so existing passlib-produced hashes remain valid.
+_BCRYPT_MAX_BYTES = 72
+
+
+def _hash_password(plain: str) -> str:
+    """Hash with bcrypt. Caller must enforce byte-length limit."""
+    return bcrypt.hashpw(plain.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def _verify_password(plain: str, hashed: str) -> bool:
+    """Constant-time compare against a stored bcrypt hash."""
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except ValueError:
+        # bcrypt raises on malformed hash or oversize password — treat as mismatch.
+        return False
+
+
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 _MAX_AUTH_AGE = 86400  # 24 hours
@@ -126,8 +146,8 @@ async def register_email(data: EmailRegisterRequest) -> TokenResponse:
         raise HTTPException(status_code=422, detail="invalid email address")
     if len(data.password) < 8:
         raise HTTPException(status_code=422, detail="password must be at least 8 characters")
-    if len(data.password.encode("utf-8")) > 72:
-        raise HTTPException(status_code=422, detail="password must be 72 characters or fewer")
+    if len(data.password.encode("utf-8")) > _BCRYPT_MAX_BYTES:
+        raise HTTPException(status_code=422, detail="password must be 72 bytes or fewer")
     if not data.first_name.strip():
         raise HTTPException(status_code=422, detail="first_name is required")
 
@@ -139,7 +159,7 @@ async def register_email(data: EmailRegisterRequest) -> TokenResponse:
         if existing:
             raise HTTPException(status_code=409, detail="email already registered")
 
-        pw_hash = _pwd_ctx.hash(data.password)
+        pw_hash = _hash_password(data.password)
         row = await conn.fetchrow(
             """INSERT INTO users (email, password_hash, username, role)
                VALUES ($1, $2, $3, 'user')
@@ -176,7 +196,7 @@ async def register_email(data: EmailRegisterRequest) -> TokenResponse:
 
 async def login_email(data: EmailLoginRequest) -> TokenResponse:
     """Authenticate with email + password."""
-    if len(data.password.encode("utf-8")) > 72:
+    if len(data.password.encode("utf-8")) > _BCRYPT_MAX_BYTES:
         raise HTTPException(status_code=401, detail="invalid email or password")
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -186,7 +206,7 @@ async def login_email(data: EmailLoginRequest) -> TokenResponse:
         )
     if not row or not row["password_hash"]:
         raise HTTPException(status_code=401, detail="invalid email or password")
-    if not _pwd_ctx.verify(data.password, row["password_hash"]):
+    if not _verify_password(data.password, row["password_hash"]):
         raise HTTPException(status_code=401, detail="invalid email or password")
 
     first_name = str(row["username"] or data.email.split("@")[0])
@@ -202,8 +222,8 @@ async def link_email(user_id: str, data: LinkEmailRequest) -> dict:
         raise HTTPException(status_code=422, detail="invalid email address")
     if len(data.password) < 8:
         raise HTTPException(status_code=422, detail="password must be at least 8 characters")
-    if len(data.password.encode("utf-8")) > 72:
-        raise HTTPException(status_code=422, detail="password must be 72 characters or fewer")
+    if len(data.password.encode("utf-8")) > _BCRYPT_MAX_BYTES:
+        raise HTTPException(status_code=422, detail="password must be 72 bytes or fewer")
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -220,7 +240,7 @@ async def link_email(user_id: str, data: LinkEmailRequest) -> dict:
         if existing and existing["email"]:
             raise HTTPException(status_code=409, detail="account already has an email linked")
 
-        pw_hash = _pwd_ctx.hash(data.password)
+        pw_hash = _hash_password(data.password)
         await conn.execute(
             "UPDATE users SET email = $1, password_hash = $2 WHERE id = $3::uuid",
             data.email.lower(), pw_hash, user_id,


### PR DESCRIPTION
## Root Cause

Sentry `DAWN-SNOWFLAKE-1729-2B` (POST `/api/web/auth/link-email` → 500). Stack trace:

```
ValueError: password cannot be longer than 72 bytes, truncate manually if necessary
  File "passlib/handlers/bcrypt.py", line 380, in detect_wrap_bug
    if verify(secret, bug_hash):
```

**Not a user-password issue.** Passlib's bcrypt backend runs a one-time `detect_wrap_bug` self-test on first hash call that feeds a **73-byte** secret to the underlying `bcrypt` library. `bcrypt>=4.0` (which we ship transitively via `passlib[bcrypt]`) now strictly enforces the 72-byte limit and raises instead of silently truncating, so passlib's self-test crashes the first hash attempt — leaving the request as a 500.

Known incompatibility: https://foss.heptapod.net/python-libs/passlib/-/issues/190 — no fix released by passlib.

## Fix

Swap `passlib` for `bcrypt` directly. Hash format is identical (`$2b$…`) so existing stored hashes remain verifiable.

- `auth.py` — replace `_pwd_ctx.hash()` / `.verify()` with `_hash_password()` / `_verify_password()` thin wrappers around `bcrypt.hashpw` / `checkpw`. Added named `_BCRYPT_MAX_BYTES = 72` constant; replaced the literal `72` in three byte-length validators. `_verify_password` catches `ValueError` and returns False so a malformed stored hash returns 401, not 500.
- `pyproject.toml` — `passlib[bcrypt]>=1.7` → `bcrypt>=4.0`.
- `tests/test_webtrader_auth_bcrypt.py` — new hermetic regression suite (5 tests): round-trip, exact 72-byte boundary, malformed hash silent rejection, constant pinned at 72, source-level guard against re-introducing passlib.

## Test Plan

- [x] `pytest tests/test_webtrader_auth_bcrypt.py` — 5/5 pass
- [x] Full suite — 1899 passed, 5 skipped, 0 failures (vs. 1894 before; +5 are the new bcrypt tests)
- [x] `py_compile` clean
- [ ] Post-deploy: link a fresh email via the Settings page on `/config` → should succeed with `{ok: true}` instead of `Internal Server Error`

## Files Changed

- `projects/polymarket/crusaderbot/webtrader/backend/auth.py`
- `projects/polymarket/crusaderbot/pyproject.toml`
- `projects/polymarket/crusaderbot/tests/test_webtrader_auth_bcrypt.py` (new)

MAJOR (auth code path), NARROW INTEGRATION. Fixes `DAWN-SNOWFLAKE-1729-2B`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUVYgw4Q8h7Ds8BhpLpYCy)_