### PR TITLE
fix(ui): auth tabs cleanup + unread alert visual + tactical footer

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/App.tsx
@@ -41,6 +41,12 @@ function loadDismissed(): Set<string> {
 interface AlertCenterCtx {
   alerts: AlertItem[];
   unreadCount: number;
+  // Snapshot of lastSeen captured at the moment the panel opened — alerts
+  // whose created_at exceeds this value are styled "unread" while the panel
+  // is open (yellow dot, slight highlight). Stays stable until the panel
+  // closes + re-opens, so a card the user is currently looking at doesn't
+  // visually "settle" mid-view.
+  panelOpenedAt: number;
   isOpen: boolean;
   openAlertCenter: () => void;
   closeAlertCenter: () => void;
@@ -53,6 +59,7 @@ interface AlertCenterCtx {
 export const AlertCenterContext = createContext<AlertCenterCtx>({
   alerts: [],
   unreadCount: 0,
+  panelOpenedAt: 0,
   isOpen: false,
   openAlertCenter: () => undefined,
   closeAlertCenter: () => undefined,
@@ -95,6 +102,11 @@ function AppShell() {
     const stored = localStorage.getItem(LAST_SEEN_KEY);
     return stored ? Number(stored) : 0;
   });
+  // `panelOpenedAt` freezes the lastSeen value at the moment the panel was
+  // opened. While the panel is visible, alerts created after this snapshot
+  // render with the "unread" treatment. Re-opens recapture from the
+  // post-bump lastSeen, so once the user has seen an alert it stays read.
+  const [panelOpenedAt, setPanelOpenedAt] = useState<number>(0);
 
   const fetchAlerts = useCallback(async (offset = 0, append = false) => {
     if (!user) return;
@@ -192,11 +204,15 @@ function AppShell() {
   );
 
   const openAlertCenter = useCallback(() => {
+    // Snapshot BEFORE bumping lastSeen so the AlertCenter can still tell
+    // which currently-visible alerts arrived after the previous open. If
+    // we bumped first, every alert would appear "read" immediately.
+    setPanelOpenedAt(lastSeen);
     setIsAlertOpen(true);
     const now = Date.now();
     setLastSeen(now);
     localStorage.setItem(LAST_SEEN_KEY, String(now));
-  }, []);
+  }, [lastSeen]);
 
   const closeAlertCenter = useCallback(() => setIsAlertOpen(false), []);
 
@@ -204,6 +220,7 @@ function AppShell() {
     () => ({
       alerts: visibleAlerts,
       unreadCount,
+      panelOpenedAt,
       isOpen: isAlertOpen,
       openAlertCenter,
       closeAlertCenter,
@@ -212,7 +229,7 @@ function AppShell() {
       loadMoreAlerts,
       hasMoreAlerts,
     }),
-    [visibleAlerts, unreadCount, isAlertOpen, openAlertCenter, closeAlertCenter, dismissAlert, markAllRead, loadMoreAlerts, hasMoreAlerts],
+    [visibleAlerts, unreadCount, panelOpenedAt, isAlertOpen, openAlertCenter, closeAlertCenter, dismissAlert, markAllRead, loadMoreAlerts, hasMoreAlerts],
   );
 
   return (

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
@@ -59,7 +59,7 @@ type Props = {
 };
 
 export function AlertCenter({ isOpen, alerts, onClose }: Props) {
-  const { dismissAlert, markAllRead, loadMoreAlerts, hasMoreAlerts, unreadCount } = useAlertCenter();
+  const { dismissAlert, markAllRead, loadMoreAlerts, hasMoreAlerts, unreadCount, panelOpenedAt } = useAlertCenter();
   const navigate = useNavigate();
 
   // "Preferences" link target — opens the Settings page where alert filtering
@@ -154,8 +154,24 @@ export function AlertCenter({ isOpen, alerts, onClose }: Props) {
                   const cat = deriveCategory(alert);
                   const style = CATEGORY_STYLE[cat];
                   const icon = CATEGORY_ICON[cat];
+                  // Unread when the alert was created after the user last
+                  // saw the panel. Gives the row a visual highlight + a
+                  // small dot before the title (matches the mock design).
+                  const isUnread = new Date(alert.created_at).getTime() > panelOpenedAt;
                   return (
-                    <div key={alert.id} className="px-4 py-3 flex gap-3 hover:bg-surface-3 transition-colors">
+                    <div
+                      key={alert.id}
+                      className="relative px-4 py-3 flex gap-3 hover:bg-surface-3 transition-colors"
+                      style={isUnread ? { background: "rgba(245,200,66,0.04)" } : undefined}
+                    >
+                      {/* Unread accent bar — runs the full left edge of the card */}
+                      {isUnread && (
+                        <span
+                          className="absolute left-0 top-0 bottom-0 w-[3px]"
+                          style={{ background: "var(--gold, #F5C842)" }}
+                          aria-hidden
+                        />
+                      )}
                       {/* Icon badge */}
                       <div
                         className="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-[16px] mt-0.5"
@@ -167,7 +183,18 @@ export function AlertCenter({ isOpen, alerts, onClose }: Props) {
                       {/* Content */}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start gap-1.5 mb-0.5">
-                          <span className="font-sans text-[12px] text-ink-1 font-semibold leading-snug flex-1">
+                          {isUnread && (
+                            <span
+                              className="inline-block w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0"
+                              style={{ background: "var(--gold, #F5C842)", boxShadow: "0 0 6px rgba(245,200,66,0.6)" }}
+                              aria-label="Unread"
+                            />
+                          )}
+                          <span
+                            className={`font-sans text-[12px] leading-snug flex-1 ${
+                              isUnread ? "text-ink-1 font-bold" : "text-ink-2 font-semibold"
+                            }`}
+                          >
                             {alert.title}
                           </span>
                           {/* Dismiss — always visible (was hover-only). Matches the screenshot

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AuthPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AuthPage.tsx
@@ -4,12 +4,17 @@ import { TelegramAuth } from "../components/TelegramAuth";
 import { useAuth } from "../lib/auth";
 import { apiLoginEmail, apiRegisterEmail } from "../lib/api";
 
-type AuthTab = "telegram" | "login" | "register";
+type AuthTab = "telegram" | "email";
+type EmailMode = "login" | "register";
 
 export function AuthPage() {
   const { user, login } = useAuth();
   const navigate = useNavigate();
   const [tab, setTab] = useState<AuthTab>("telegram");
+  // Within the email tab: login vs register sub-mode. The two are mutually
+  // exclusive — only the active mode's form is visible. Switch via the bottom
+  // link inside the form ("No account? Register" / "Already registered? Sign in").
+  const [emailMode, setEmailMode] = useState<EmailMode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [firstName, setFirstName] = useState("");
@@ -25,7 +30,7 @@ export function AuthPage() {
     setError(null);
     setLoading(true);
     try {
-      const res = tab === "register"
+      const res = emailMode === "register"
         ? await apiRegisterEmail(email.trim(), password, firstName.trim())
         : await apiLoginEmail(email.trim(), password);
       login(res.access_token, res.user_id, res.first_name);
@@ -78,9 +83,11 @@ export function AuthPage() {
             <span>◢ </span>Authentication Required
           </div>
 
-          {/* Tab switcher */}
+          {/* Tab switcher — only 2 top-level tabs (Telegram | Email).
+              Within Email, the bottom link inside the form switches between
+              login and register modes so the user never sees both at once. */}
           <div className="flex gap-1 mb-5 bg-surface-2 rounded p-0.5">
-            {(["telegram", "login", "register"] as AuthTab[]).map((t) => (
+            {(["telegram", "email"] as AuthTab[]).map((t) => (
               <button
                 key={t}
                 onClick={() => { setTab(t); setError(null); }}
@@ -91,7 +98,7 @@ export function AuthPage() {
                     : "text-ink-3 hover:text-ink-1",
                 ].join(" ")}
               >
-                {t === "telegram" ? "Telegram" : t === "login" ? "Email Login" : "Register"}
+                {t === "telegram" ? "Telegram" : "Email"}
               </button>
             ))}
           </div>
@@ -109,7 +116,7 @@ export function AuthPage() {
                 No Telegram?{" "}
                 <button
                   className="text-gold underline-offset-2 hover:underline"
-                  onClick={() => setTab("register")}
+                  onClick={() => { setTab("email"); setEmailMode("register"); setError(null); }}
                 >
                   Register with email
                 </button>
@@ -117,10 +124,16 @@ export function AuthPage() {
             </>
           )}
 
-          {/* Email login / register tab */}
-          {(tab === "login" || tab === "register") && (
+          {/* Email tab — single form, login OR register based on emailMode.
+              Never both visible at once. */}
+          {tab === "email" && (
             <form onSubmit={(e) => void handleEmailSubmit(e)} className="text-left space-y-3">
-              {tab === "register" && (
+              <div className="text-center mb-1">
+                <span className="font-hud text-[12px] font-bold tracking-[2px] uppercase text-ink-1">
+                  {emailMode === "register" ? "Create Account" : "Sign In"}
+                </span>
+              </div>
+              {emailMode === "register" && (
                 <div>
                   <label className="block text-[10px] font-hud tracking-widest uppercase text-ink-3 mb-1">
                     Name
@@ -156,7 +169,7 @@ export function AuthPage() {
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  placeholder={tab === "register" ? "Min 8 characters" : "Password"}
+                  placeholder={emailMode === "register" ? "Min 8 characters" : "Password"}
                   required
                   minLength={8}
                   className="w-full bg-surface-2 border border-border-2 rounded px-3 py-2 text-[13px] text-ink-1 placeholder:text-ink-4 focus:outline-none focus:border-gold"
@@ -172,19 +185,19 @@ export function AuthPage() {
                 disabled={loading}
                 className="w-full py-2.5 mt-1 bg-gold text-black font-hud text-[11px] tracking-widest uppercase rounded hover:bg-gold/90 disabled:opacity-50 transition-all"
               >
-                {loading ? "…" : tab === "register" ? "Create Account" : "Sign In"}
+                {loading ? "…" : emailMode === "register" ? "Create Account" : "Sign In"}
               </button>
 
               <p className="text-ink-3 text-[11px] text-center font-sans pt-1">
-                {tab === "login" ? (
+                {emailMode === "login" ? (
                   <>No account?{" "}
-                    <button type="button" className="text-gold hover:underline" onClick={() => setTab("register")}>
+                    <button type="button" className="text-gold hover:underline" onClick={() => { setEmailMode("register"); setError(null); }}>
                       Register
                     </button>
                   </>
                 ) : (
                   <>Already registered?{" "}
-                    <button type="button" className="text-gold hover:underline" onClick={() => setTab("login")}>
+                    <button type="button" className="text-gold hover:underline" onClick={() => { setEmailMode("login"); setError(null); }}>
                       Sign in
                     </button>
                   </>
@@ -194,8 +207,8 @@ export function AuthPage() {
           )}
         </div>
 
-        <p className="text-ink-4 text-[11px] mt-2 font-mono tracking-[0.5px]">
-          PAPER TRADING MODE — no real capital deployed
+        <p className="text-ink-4 text-[10px] mt-2 font-mono tracking-[1.5px] uppercase">
+          <span className="text-gold">◢</span> Secure channel · Tactical sim active
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Three small UX fixes from owner feedback

### 1. Login footer — cooler tagline
Old: `PAPER TRADING MODE — no real capital deployed`
New: `◢ SECURE CHANNEL · TACTICAL SIM ACTIVE` (gold accent caret, tracked uppercase, font-mono)

Still tells the user it's a sim, just in the CrusaderBot tactical voice instead of a flat disclaimer.

### 2. Login / Register mutually exclusive
Old: 3 top-level tabs visible at once (`Telegram | Email Login | Register`). Confusing on mobile — both Login and Register buttons present even when you're already in Login mode.

New: 2 top-level tabs (`Telegram | Email`). Inside the Email tab, a sub-title shows the current mode (`Sign In` or `Create Account`) and the bottom link toggles between them — only one form visible at a time, just like the standard login UX users expect.

Refactor: `tab: "telegram" | "email"` + new `emailMode: "login" | "register"` (transient state).

### 3. Unread vs read visual distinction
Old: opening the panel immediately bumped `lastSeen`, so every alert in the panel appeared "read" with no styling cue — the user couldn't tell what was new.

New: `panelOpenedAt` snapshot captures `lastSeen` BEFORE bumping. Alerts created after that snapshot get:
- Gold left-edge accent bar
- Small gold dot before the title (with glow)
- Bold title + slight background tint

Once the panel closes and re-opens, the new snapshot is the post-bump `lastSeen`, so previously-seen alerts naturally settle into the muted "read" style. Matches the mock screenshot the owner shared.

## Files Changed
- `webtrader/frontend/src/pages/AuthPage.tsx` — tab refactor + footer text
- `webtrader/frontend/src/App.tsx` — `panelOpenedAt` snapshot + context exposure
- `webtrader/frontend/src/components/AlertCenter.tsx` — unread visual treatment

`tsc --noEmit` clean. MINOR, NARROW INTEGRATION.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUVYgw4Q8h7Ds8BhpLpYCy)_