### PR TITLE
feat(ui): portfolio defaults to analytics; market search w/ category fix

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -76,15 +76,37 @@ async def web_health():
 @router.get("/markets")
 async def get_markets_list(
     category: str | None = None,
+    q: str | None = None,
     limit: int = 50,
 ):
-    """Proxy Gamma API market list — avoids browser CORS restriction."""
+    """Proxy Polymarket Gamma — Discover Markets search + category filter.
+
+    Uses the events-with-markets endpoint so each row carries a usable
+    ``category`` string (built from event tag labels). Filtering happens
+    server-side here:
+      * ``category`` — case-insensitive substring match against the tag
+        labels string Gamma returns per event.
+      * ``q`` — case-insensitive substring match against the market
+        question. Both filters compose (AND).
+    """
+    cap = min(limit, 200)
     try:
-        markets = await _polymarket.get_markets(
-            category=category,
-            limit=min(limit, 200),
-        )
-        return markets
+        # Fetch a wider page than the cap so client filters still find ~cap rows.
+        raw = await _polymarket.get_events_with_markets(limit=max(cap * 4, 200))
+        cat_needle = category.strip().lower() if category else ""
+        q_needle = q.strip().lower() if q else ""
+        out: list[dict] = []
+        for m in raw:
+            row_cat = str(m.get("category") or "").lower()
+            row_q = str(m.get("question") or "").lower()
+            if cat_needle and cat_needle not in row_cat:
+                continue
+            if q_needle and q_needle not in row_q:
+                continue
+            out.append(m)
+            if len(out) >= cap:
+                break
+        return out
     except Exception as exc:
         log.warning("get_markets_list failed: %s", exc)
         return []

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DiscoverPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DiscoverPage.tsx
@@ -153,15 +153,26 @@ export function DiscoverPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [category, setCategory] = useState<Category>("All");
+  const [search, setSearch] = useState("");
+  // Debounced query that actually hits the API — typing fires the request
+  // 250ms after the last keystroke instead of on every character.
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 250);
+    return () => clearTimeout(t);
+  }, [search]);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(
-        `${API_BASE}/markets?limit=50${category !== "All" ? `&category=${encodeURIComponent(category)}` : ""}`,
-        { headers: { Accept: "application/json" } }
-      );
+      const qs = new URLSearchParams({ limit: "50" });
+      if (category !== "All") qs.set("category", category);
+      if (debouncedSearch) qs.set("q", debouncedSearch);
+      const res = await fetch(`${API_BASE}/markets?${qs.toString()}`, {
+        headers: { Accept: "application/json" },
+      });
       if (!res.ok) throw new Error(`markets ${res.status}`);
       const data: GammaMarket[] = await res.json();
       const parsed = data.map(parseGammaMarket);
@@ -172,25 +183,25 @@ export function DiscoverPage() {
     } finally {
       setLoading(false);
     }
-  }, [category]);
+  }, [category, debouncedSearch]);
 
   useEffect(() => { void load(); }, [load]);
 
+  // Only re-fetch on scanner_tick when no search is active — typing keeps the
+  // list stable instead of clobbering the user's query results.
   useSSE(user?.token ?? null, {
-    scanner_tick: () => void load(),
+    scanner_tick: () => { if (!debouncedSearch) void load(); },
   });
 
   const handleDeploy = useCallback((m: MarketCard) => {
     navigate(`/autotrade?market_id=${encodeURIComponent(m.id)}&market_name=${encodeURIComponent(m.title)}`);
   }, [navigate]);
 
-  const filtered = category === "All"
-    ? markets
-    : markets.filter((m) => m.category.toLowerCase() === category.toLowerCase());
-
-  const trending = [...filtered].sort((a, b) => b.volume - a.volume).slice(0, 5);
-  const highestVolume = [...filtered].sort((a, b) => b.volume - a.volume).slice(0, 5);
-  const topMovers = [...filtered].sort((a, b) =>
+  // Backend already filters by category + search query, so trust that response
+  // and only do view-shape transforms here (sort orders for the 3 sections).
+  const trending = [...markets].sort((a, b) => b.volume - a.volume).slice(0, 5);
+  const highestVolume = [...markets].sort((a, b) => b.volume - a.volume).slice(0, 5);
+  const topMovers = [...markets].sort((a, b) =>
     Math.abs(b.yesPrice - 0.5) - Math.abs(a.yesPrice - 0.5)
   ).slice(0, 5);
 
@@ -214,6 +225,33 @@ export function DiscoverPage() {
             {error}
           </div>
         )}
+
+        {/* Search bar — text-search across question titles. Debounced so each
+            keystroke doesn't hit the API. Empty input falls back to the live
+            trending/volume/movers view. */}
+        <div className="relative mb-3">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-ink-4 text-[13px] pointer-events-none" aria-hidden>
+            🔍
+          </span>
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search markets…"
+            aria-label="Search markets"
+            className="w-full pl-9 pr-9 py-2 rounded-lg border border-border-2 bg-surface-2 text-[12px] text-ink-1 placeholder:text-ink-4 font-mono focus:outline-none focus:border-gold transition-colors"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-ink-4 hover:text-ink-1"
+            >
+              ×
+            </button>
+          )}
+        </div>
 
         {/* Category filter tabs */}
         <div className="flex gap-1 mb-4 overflow-x-auto pb-1 scrollbar-none">
@@ -241,16 +279,38 @@ export function DiscoverPage() {
           </div>
         ) : markets.length === 0 ? (
           <div className="my-6 p-4 rounded-lg border border-surface-3 bg-surface-1/50 text-center">
-            <div className="text-2xl mb-2">📊</div>
-            <p className="font-hud text-sm font-bold text-ink-2 mb-1">No markets available.</p>
-            <p className="text-ink-3 text-xs font-mono mb-3">Market data unavailable. Check your connection.</p>
-            <button
-              onClick={() => void load()}
-              className="font-hud text-[9px] font-bold tracking-widest text-gold uppercase px-3 py-1.5 rounded border border-gold/40 bg-gold/10 hover:bg-gold/20"
-            >
-              Retry
-            </button>
+            <div className="text-2xl mb-2">{debouncedSearch ? "🔍" : "📊"}</div>
+            <p className="font-hud text-sm font-bold text-ink-2 mb-1">
+              {debouncedSearch ? "No matches" : "No markets available."}
+            </p>
+            <p className="text-ink-3 text-xs font-mono mb-3">
+              {debouncedSearch
+                ? `Nothing matches "${debouncedSearch}". Try different keywords or clear the search.`
+                : "Market data unavailable. Check your connection."}
+            </p>
+            {debouncedSearch ? (
+              <button
+                onClick={() => setSearch("")}
+                className="font-hud text-[9px] font-bold tracking-widest text-gold uppercase px-3 py-1.5 rounded border border-gold/40 bg-gold/10 hover:bg-gold/20"
+              >
+                Clear search
+              </button>
+            ) : (
+              <button
+                onClick={() => void load()}
+                className="font-hud text-[9px] font-bold tracking-widest text-gold uppercase px-3 py-1.5 rounded border border-gold/40 bg-gold/10 hover:bg-gold/20"
+              >
+                Retry
+              </button>
+            )}
           </div>
+        ) : debouncedSearch ? (
+          // Active search → single flat result list ordered by volume.
+          <Section
+            title={`Search Results (${markets.length})`}
+            markets={[...markets].sort((a, b) => b.volume - a.volume)}
+            onDeploy={handleDeploy}
+          />
         ) : (
           <>
             <Section title="Trending Markets" markets={trending} onDeploy={handleDeploy} />

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -27,7 +27,7 @@ import {
 import { useAuth } from "../lib/auth";
 import { useSSE } from "../lib/sse";
 
-type Tab = "all" | "open" | "closed" | "orders" | "analytics";
+type Tab = "analytics" | "closed" | "all" | "orders";
 // 7D=1W, 30D=1M in backend; "All" maps to "ALL"
 type Period = "1D" | "7D" | "30D" | "All";
 
@@ -59,7 +59,10 @@ export function PortfolioPage() {
   const [summary, setSummary] = useState<PortfolioSummary | null>(null);
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
   const [chartPeriod, setChartPeriod] = useState<Period>("7D");
-  const [tab, setTab] = useState<Tab>("open");
+  // Default landing on the Portfolio tab is Analytics — open positions are
+  // already surfaced on the Home dashboard, so the deep view here leads with
+  // settled-trade insights instead.
+  const [tab, setTab] = useState<Tab>("analytics");
   const [error, setError] = useState<string | null>(null);
 
   // Cash Out modal state
@@ -226,10 +229,9 @@ export function PortfolioPage() {
   const totalClosed = summary?.total_closed ?? closed.length;
 
   const tabs: FilterTab<Tab>[] = [
-    { key: "open", label: "Open", count: open.length },
+    { key: "analytics", label: "Analytics" },
     { key: "closed", label: "Closed", count: totalClosed },
     { key: "all", label: "All", count: open.length + totalClosed },
-    { key: "analytics", label: "Analytics" },
     { key: "orders", label: "Orders", count: pendingOrdersCount || undefined, advanced: true },
   ];
 
@@ -310,32 +312,6 @@ export function PortfolioPage() {
         {error && <div className="text-red text-sm mb-3">{error}</div>}
 
         <FilterTabs tabs={tabs} active={tab} onChange={setTab} />
-
-        {tab === "open" && (
-          <CollapsibleSection id="portfolio_open_positions" label={`Open Positions (${open.length})`}>
-            {open.length === 0 ? (
-              <EmptyState
-                icon="📭"
-                title="No Open Positions"
-                text="When auto-trade opens a position, it will appear here in real-time."
-              />
-            ) : (
-              <div className="md:grid md:grid-cols-2 md:gap-3">
-                {open.map((p) => (
-                  <PositionRow
-                    key={p.id}
-                    p={p}
-                    onCashOut={() => { setCashOutTarget(p); setCashOutError(null); }}
-                    onForceRedeem={async () => {
-                      try { await api.forceRedeem(p.id); } catch { /* surfaced via refresh */ }
-                      refresh();
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </CollapsibleSection>
-        )}
 
         {tab === "closed" && (
           <CollapsibleSection id="portfolio_closed_positions" label={`Closed Trades (${totalClosed})`}>
@@ -1112,6 +1088,22 @@ function AnalyticsPanel({ api }: { api: ReturnType<typeof makeApi> }) {
     ? `${data.win_loss_ratio.toFixed(2)}`
     : settledTrades === 0 ? "Not enough data" : "—";
 
+  // Avg-hold formatting: crypto candle markets resolve in < 5 minutes, so
+  // showing "0.0h" hides the actual value. Render < 1h in minutes (or
+  // seconds when sub-minute), >= 1h in fractional hours.
+  const avgHoldValue = (() => {
+    if (data.avg_hold_hours == null) return "—";
+    const hrs = data.avg_hold_hours;
+    if (hrs >= 1) return `${hrs.toFixed(1)}h`;
+    const mins = hrs * 60;
+    if (mins >= 1) return `${mins.toFixed(1)}m`;
+    const secs = mins * 60;
+    return `${secs.toFixed(0)}s`;
+  })();
+
+  // Win rate as % — clearer than the bare ratio for a quick read.
+  const winRatePct = settledTrades > 0 ? (data.wins / settledTrades) * 100 : null;
+
   return (
     <div className="space-y-3 mt-2">
       <div className="text-[9px] font-mono text-ink-4 tracking-[1.5px] uppercase mb-1">
@@ -1125,20 +1117,21 @@ function AnalyticsPanel({ api }: { api: ReturnType<typeof makeApi> }) {
           color={drawdownColor}
         />
         <AnalyticCard
-          label="Win / Loss Ratio"
-          value={ratioValue}
-          sub={settledTrades > 0 ? `${data.wins}W · ${data.losses}L` : undefined}
-          color="var(--ink-1)"
+          label="Win Rate"
+          value={winRatePct != null ? `${winRatePct.toFixed(1)}%` : ratioValue}
+          sub={settledTrades > 0 ? `${data.wins}W · ${data.losses}L · ratio ${data.win_loss_ratio?.toFixed(2) ?? "—"}` : undefined}
+          color={winRatePct != null && winRatePct >= 50 ? "var(--grn,#00FF9C)" : "var(--ink-1)"}
         />
         <AnalyticCard
-          label="Avg Hold Duration"
-          value={data.avg_hold_hours != null ? `${data.avg_hold_hours.toFixed(1)}h` : "—"}
+          label="Avg Hold"
+          value={avgHoldValue}
+          sub={settledTrades > 0 ? `over ${settledTrades} trades` : undefined}
           color="var(--ink-1)"
         />
         <AnalyticCard
           label="Best Trade"
           value={data.best_trade != null ? `${data.best_trade.pnl_usdc >= 0 ? "+" : ""}$${data.best_trade.pnl_usdc.toFixed(2)}` : "—"}
-          sub={data.best_trade?.market_question?.slice(0, 30) ?? undefined}
+          sub={data.best_trade?.market_question ?? undefined}
           color="var(--grn,#00FF9C)"
         />
       </div>
@@ -1147,8 +1140,8 @@ function AnalyticsPanel({ api }: { api: ReturnType<typeof makeApi> }) {
       {data.worst_trade && (
         <div className="p-3 rounded-lg border border-surface-3 bg-surface-1">
           <div className="text-[9px] font-mono text-ink-4 uppercase tracking-widest mb-1">Worst Trade</div>
-          <div className="flex items-center justify-between">
-            <span className="text-[10px] font-mono text-ink-2 truncate max-w-[200px]">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-[10px] font-mono text-ink-2 truncate flex-1 min-w-0">
               {data.worst_trade.market_question ?? "—"}
             </span>
             <span className="font-bold font-mono text-[11px] text-red flex-shrink-0">
@@ -1158,19 +1151,24 @@ function AnalyticsPanel({ api }: { api: ReturnType<typeof makeApi> }) {
         </div>
       )}
 
-      {/* Profit per strategy */}
+      {/* Profit per strategy — share the same STRATEGY_LABEL map used for
+          PositionRow so the labels match across the app instead of showing
+          raw "late_entry_v3" snake_case identifiers. */}
       {data.profit_per_strategy.length > 0 && (
         <div className="p-3 rounded-lg border border-surface-3 bg-surface-1">
           <div className="text-[9px] font-mono text-ink-4 uppercase tracking-widest mb-2">Profit by Strategy</div>
           <div className="space-y-1.5">
-            {data.profit_per_strategy.map((s) => (
-              <div key={s.strategy} className="flex items-center justify-between">
-                <span className="text-[10px] font-mono text-ink-2 capitalize">{s.strategy}</span>
-                <span className={`font-bold font-mono text-[10px] ${s.pnl_usdc >= 0 ? "text-grn" : "text-red"}`}>
-                  {s.pnl_usdc >= 0 ? "+" : ""}${s.pnl_usdc.toFixed(2)}
-                </span>
-              </div>
-            ))}
+            {data.profit_per_strategy.map((s) => {
+              const label = fmtStrategy(s.strategy) ?? s.strategy;
+              return (
+                <div key={s.strategy} className="flex items-center justify-between">
+                  <span className="text-[10px] font-mono text-ink-2">{label}</span>
+                  <span className={`font-bold font-mono text-[10px] ${s.pnl_usdc >= 0 ? "text-grn" : "text-red"}`}>
+                    {s.pnl_usdc >= 0 ? "+" : ""}${s.pnl_usdc.toFixed(2)}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Two owner-requested polish lanes

### 1. Portfolio page — Analytics as the lead view
"Portfolio analistic taruh di tempat open, open hilangkan aja krn udh ada di home. Sempurnakan analystic."

- **Drop the `Open` tab** — open positions are already on the Home dashboard, redundant here
- **`Analytics` is now the default tab** (first in the strip, opens by default)
- New tab order: `ANALYTICS | CLOSED · N | ALL · N | ORDERS`
- The `All` tab continues to show both open + closed for users who want the combined view

**Analytics polish:**
- `Avg Hold Duration` → `Avg Hold` with smart unit: `1.5h` for ≥1h, `12.3m` for sub-hour, `45s` for sub-minute. Old display showed `0.0h` on 5-min candle markets (rounds-down bug).
- Replaced bare `Win / Loss Ratio: 1.03` with `Win Rate: 50.7%` (clearer at a glance) — ratio still shown in the sub-line alongside `WL` counts
- `Best Trade` / `Worst Trade` market name now full-width with single-line truncate instead of slice(0,30) — readable on mobile
- `Profit by Strategy` now uses the same `STRATEGY_LABEL` map as `PositionRow` so labels are consistent (no more raw `late_entry_v3` snake_case)

### 2. Discover Markets — search box + category filter fix
"Market search blm jelas fungsinya..km sempurnakan sekalian bro."

**Root cause of the empty "Politics" tab:** the `/markets` backend was calling Gamma's `/markets` endpoint which carries no category/tag data. Selecting Politics returned items but `parseGammaMarket` defaulted them all to "World Events", then a client-side `.filter()` dropped everything. Result: empty page on every non-All category.

**Fix:**
- Backend `/markets`: switched to `get_events_with_markets()` (returns markets with proper category from event tags) + added server-side `category` and `q` (search text) filters. Removed double-filtering on the client.
- Frontend: new search input (🔍) above the category tabs, debounced 250ms. Typing fires a server-side `q` query against market questions. Empty input → existing Trending/Volume/Movers view. Active search → single flat result list ordered by volume.
- New "No matches" empty state with a Clear Search button when a query yields nothing.
- `scanner_tick` SSE pulses no longer clobber an active search.

## Files Changed
- `webtrader/backend/router.py` — `/markets` rewrite with `q`+`category` server-side filters
- `webtrader/frontend/src/pages/PortfolioPage.tsx` — tab restructure + analytics polish
- `webtrader/frontend/src/pages/DiscoverPage.tsx` — search input + trust backend filter

## Test Plan
- [x] `pytest projects/polymarket/crusaderbot/tests/` — 1909 passed
- [x] `py_compile` clean
- [x] `tsc --noEmit` clean
- [ ] Post-deploy: tap Politics tab → markets actually render (was empty)
- [ ] Post-deploy: type "Bitcoin" in search → relevant markets surface
- [ ] Post-deploy: open Portfolio tab → lands on Analytics by default
- [ ] Post-deploy: Avg Hold shows e.g. `4.2m` instead of `0.0h` for candle markets

STANDARD, NARROW INTEGRATION.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUVYgw4Q8h7Ds8BhpLpYCy)_