### PR TITLE
fix(ui): label copy_trade strategy as 'Copy Trade' (was 'Whale Mirror')

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/PortfolioPage.tsx
@@ -742,7 +742,7 @@ const STRATEGY_LABEL: Record<string, string> = {
   trend_breakout: "Trend Breakout",
   momentum: "Contrarian",
   value_investor: "Value Hunter",
-  copy_trade: "Whale Mirror",
+  copy_trade: "Copy Trade",
   signal: "Signal Sniper",
   signal_following: "Signal Following",
   pair_arb: "Pair Arb",


### PR DESCRIPTION
## Owner request

Copy Trade positions should display as **"Copy Trade"** in the WebTrader portfolio (not "Whale Mirror"). Telegram side already says "🐋 Copy Trade" — this aligns the web label.

## Change

One line in `PortfolioPage.tsx` `STRATEGY_LABEL` map:
- `copy_trade: "Whale Mirror"` → `copy_trade: "Copy Trade"`

Affects the Profit by Strategy card AND the per-position strategy badge in the Closed list. The `whale_mirror` PRESET (separate concept — auto-trade preset that uses the whale_tracking lib strategy) is untouched and still renders as "Whale Mirror" where applicable.

## Test Plan
- [x] `tsc --noEmit` clean
- [ ] Post-deploy: copy-trade position shows "Copy Trade" in Profit by Strategy + position card meta

MINOR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUVYgw4Q8h7Ds8BhpLpYCy)_