### PR TITLE
observability: structlog M-3 migration — chunk 1 (users, kill_switch, polymarket, admin)

### DIFF
--- a/projects/polymarket/crusaderbot/bot/handlers/admin.py
+++ b/projects/polymarket/crusaderbot/bot/handlers/admin.py
@@ -3,9 +3,10 @@ the ADMIN role. OPERATOR_CHAT_ID is infrastructure (alert routing + root
 admin), not a user-facing role."""
 from __future__ import annotations
 
-import logging
 import os
 import socket
+
+import structlog
 import time
 from datetime import datetime, timezone
 from typing import Any, Iterable
@@ -38,7 +39,7 @@ from ...users import (
 from ..keyboards.admin import admin_menu, ops_dashboard_keyboard
 from ..ui.tree import md_v2_escape as _md
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 _BOOT_MONOTONIC = time.monotonic()
 
@@ -237,8 +238,7 @@ async def _admin_broadcast(message, args: list[str], ctx) -> None:
             else:
                 failed += 1
         except Exception as exc:  # noqa: BLE001
-            logger.warning("broadcast send failed user=%s err=%s",
-                           r["telegram_user_id"], exc)
+            log.warning("broadcast send failed", user=r["telegram_user_id"], err=str(exc))
             failed += 1
     await message.reply_text(
         f"✅ Broadcast sent: {sent} delivered, {failed} failed."
@@ -298,7 +298,7 @@ async def _admin_status_hud(message: Message) -> None:
     try:
         recent_jobs = await job_tracker.fetch_recent(limit=3)
     except Exception as exc:  # noqa: BLE001
-        logger.error("admin status: recent jobs fetch failed: %s", exc)
+        log.error("admin status: recent jobs fetch failed", err=str(exc))
         recent_jobs = []
 
     ks_label = "🔴 ACTIVE" if ks_active else "🟢 inactive"
@@ -622,9 +622,9 @@ async def _admin_withdrawals_callback(update: Update, q, sub: str) -> None:
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
             except Exception as exc:
-                logger.warning("Failed to notify user of approval: %s", exc)
+                log.warning("Failed to notify user of approval", err=str(exc))
         except Exception as exc:
-            logger.error("approve_withdrawal failed: %s", exc)
+            log.error("approve_withdrawal failed", err=str(exc))
             await msg.reply_text(f"❌ {_md(str(exc))}", parse_mode=ParseMode.MARKDOWN_V2)
 
     elif action.startswith("reject:"):
@@ -657,9 +657,9 @@ async def _admin_withdrawals_callback(update: Update, q, sub: str) -> None:
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
             except Exception as exc:
-                logger.warning("Failed to notify user of rejection: %s", exc)
+                log.warning("Failed to notify user of rejection", err=str(exc))
         except Exception as exc:
-            logger.error("reject_withdrawal failed: %s", exc)
+            log.error("reject_withdrawal failed", err=str(exc))
             await msg.reply_text(f"❌ {_md(str(exc))}", parse_mode=ParseMode.MARKDOWN_V2)
 
 
@@ -801,13 +801,13 @@ async def _collect_dashboard_snapshot() -> dict[str, Any]:
             snapshot["kill_switch_active"] = await ops_kill_switch.is_active(conn)
             snapshot["lock_mode"] = await ops_kill_switch.get_lock_mode(conn)
     except Exception as exc:  # noqa: BLE001
-        logger.error("ops_dashboard snapshot DB read failed: %s", exc)
+        log.error("ops_dashboard snapshot DB read failed", err=str(exc))
         snapshot["errors"].append(f"db: {exc}")
 
     try:
         snapshot["recent_jobs"] = await job_tracker.fetch_recent(limit=3)
     except Exception as exc:  # noqa: BLE001
-        logger.error("ops_dashboard recent jobs read failed: %s", exc)
+        log.error("ops_dashboard recent jobs read failed", err=str(exc))
         snapshot["errors"].append(f"jobs: {exc}")
 
     return snapshot
@@ -949,7 +949,7 @@ async def _broadcast_pause(ctx: ContextTypes.DEFAULT_TYPE | None,
             tg_ids = [int(r["telegram_user_id"]) for r in rows
                       if r["telegram_user_id"] is not None]
         except Exception as exc:  # noqa: BLE001
-            logger.error("killswitch broadcast user lookup failed: %s", exc)
+            log.error("killswitch broadcast user lookup failed", err=str(exc))
             return 0
 
     sent = 0
@@ -958,10 +958,7 @@ async def _broadcast_pause(ctx: ContextTypes.DEFAULT_TYPE | None,
             await notifications.send(tg_id, message)
             sent += 1
         except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "killswitch broadcast send failed user=%s err=%s",
-                tg_id, exc,
-            )
+            log.warning("killswitch broadcast send failed", user=tg_id, err=str(exc))
     return sent
 
 
@@ -985,7 +982,7 @@ async def _apply_killswitch_action(
             lock_recipients = [int(r["telegram_user_id"]) for r in _rows
                                if r["telegram_user_id"] is not None]
         except Exception as exc:  # noqa: BLE001
-            logger.warning("lock broadcast pre-fetch failed: %s", exc)
+            log.warning("lock broadcast pre-fetch failed", err=str(exc))
 
     # Path 1 — Telegram command (Track D). The "pause" action routes through the
     # unified executor (execute_kill_switch) which converges all 3 activation
@@ -1000,7 +997,7 @@ async def _apply_killswitch_action(
             )
             result = {"active": True, "lock_mode": False, "users_disabled": 0}
         except Exception as exc:  # noqa: BLE001
-            logger.error("killswitch execute_kill_switch failed: %s", exc)
+            log.error("killswitch execute_kill_switch failed", err=str(exc))
             if reply is not None:
                 await reply(f"❌ kill switch failed: {exc}")
             return
@@ -1009,7 +1006,7 @@ async def _apply_killswitch_action(
             await ks_reset(triggered_by=f"admin:{actor_id}")
             result = {"active": False, "lock_mode": False, "users_disabled": 0}
         except Exception as exc:  # noqa: BLE001
-            logger.error("killswitch reset failed: %s", exc)
+            log.error("killswitch reset failed", err=str(exc))
             if reply is not None:
                 await reply(f"❌ kill switch reset failed: {exc}")
             return
@@ -1023,7 +1020,7 @@ async def _apply_killswitch_action(
                 await reply(f"❌ {exc}")
             return
         except Exception as exc:  # noqa: BLE001
-            logger.error("killswitch %s failed: %s", action, exc)
+            log.error("killswitch action failed", action=action, err=str(exc))
             if reply is not None:
                 await reply(f"❌ killswitch {action} failed: {exc}")
             return
@@ -1205,7 +1202,7 @@ async def jobs_command(update: Update,
     try:
         rows = await job_tracker.fetch_recent(limit=limit, only_failed=only_failed)
     except Exception as exc:  # noqa: BLE001
-        logger.error("/jobs query failed: %s", exc)
+        log.error("/jobs query failed", err=str(exc))
         await update.message.reply_text(f"❌ /jobs query failed: {exc}")
         return
     await update.message.reply_text(
@@ -1251,7 +1248,7 @@ async def auditlog_command(update: Update,
     try:
         rows = await _fetch_audit_tail(limit)
     except Exception as exc:  # noqa: BLE001
-        logger.error("/auditlog query failed: %s", exc)
+        log.error("/auditlog query failed", err=str(exc))
         await update.message.reply_text(f"❌ /auditlog query failed: {exc}")
         return
     await update.message.reply_text(

--- a/projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py
+++ b/projects/polymarket/crusaderbot/domain/risk/kill_switch_exec.py
@@ -11,12 +11,12 @@ Admin notification is best-effort (try/except) and must not block the kill.
 """
 from __future__ import annotations
 
-import logging
+import structlog
 
 from ...database import get_pool
 from ...domain.ops import kill_switch as ops_kill_switch
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 async def _set_system_flag(key: str, value: str) -> None:
@@ -63,28 +63,26 @@ async def execute_kill_switch(reason: str, triggered_by: str) -> None:
     Convergence guarantee: every path calls this function.
     Audit log entry is written unconditionally.
     """
-    logger.critical(
-        "KILL SWITCH ACTIVATED: reason=%s triggered_by=%s", reason, triggered_by
-    )
+    log.critical("KILL SWITCH ACTIVATED", reason=reason, triggered_by=triggered_by)
 
     # 1. Activate via existing ops module (system_settings + kill_switch_history)
     try:
         await ops_kill_switch.set_active(action="pause", reason=reason)
     except Exception as exc:
-        logger.error("kill_switch_exec: set_active failed: %s", exc)
+        log.error("kill_switch_exec: set_active failed", err=str(exc))
 
     # 2. Cancel all pending orders
     try:
         n = await _cancel_pending_orders()
-        logger.info("kill_switch_exec: cancelled %d pending orders", n)
+        log.info("kill_switch_exec: cancelled pending orders", count=n)
     except Exception as exc:
-        logger.error("kill_switch_exec: pending order cancel failed: %s", exc)
+        log.error("kill_switch_exec: pending order cancel failed", err=str(exc))
 
     # 3. Set system_settings record (kill_switch_active key)
     try:
         await _set_system_flag("kill_switch_active", "true")
     except Exception as exc:
-        logger.error("kill_switch_exec: system_settings write failed: %s", exc)
+        log.error("kill_switch_exec: system_settings write failed", err=str(exc))
 
     # 4. Audit log (mandatory — no silent activations)
     try:
@@ -94,7 +92,7 @@ async def execute_kill_switch(reason: str, triggered_by: str) -> None:
             reason=reason,
         )
     except Exception as exc:
-        logger.error("kill_switch_exec: audit_log write failed: %s", exc)
+        log.error("kill_switch_exec: audit_log write failed", err=str(exc))
 
     # 5. Notify admin via Telegram (best-effort — failure must not block the kill)
     try:
@@ -103,22 +101,22 @@ async def execute_kill_switch(reason: str, triggered_by: str) -> None:
             f"🚨 KILL SWITCH ACTIVATED\nReason: {reason}\nBy: {triggered_by}"
         )
     except Exception as exc:
-        logger.error("kill_switch_exec: admin notify failed (non-blocking): %s", exc)
+        log.error("kill_switch_exec: admin notify failed (non-blocking)", err=str(exc))
 
 
 async def reset_kill_switch(triggered_by: str) -> None:
     """Reset the kill switch via Telegram admin command."""
-    logger.info("KILL SWITCH RESET: triggered_by=%s", triggered_by)
+    log.info("KILL SWITCH RESET", triggered_by=triggered_by)
 
     try:
         await ops_kill_switch.set_active(action="resume")
     except Exception as exc:
-        logger.error("kill_switch_exec: reset set_active failed: %s", exc)
+        log.error("kill_switch_exec: reset set_active failed", err=str(exc))
 
     try:
         await _set_system_flag("kill_switch_active", "false")
     except Exception as exc:
-        logger.error("kill_switch_exec: reset system_settings write failed: %s", exc)
+        log.error("kill_switch_exec: reset system_settings write failed", err=str(exc))
 
     try:
         await _write_audit_log(
@@ -126,4 +124,4 @@ async def reset_kill_switch(triggered_by: str) -> None:
             triggered_by=triggered_by,
         )
     except Exception as exc:
-        logger.error("kill_switch_exec: reset audit_log write failed: %s", exc)
+        log.error("kill_switch_exec: reset audit_log write failed", err=str(exc))

--- a/projects/polymarket/crusaderbot/integrations/polymarket.py
+++ b/projects/polymarket/crusaderbot/integrations/polymarket.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from typing import Any, Optional
 
 import httpx
+import structlog
 from tenacity import (
     AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_exponential,
 )
@@ -15,7 +15,7 @@ from ..cache import get_cache, set_cache
 from ..config import get_settings
 from .clob.rate_limiter import RateLimiter
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 GAMMA = "https://gamma-api.polymarket.com"
 CLOB = "https://clob.polymarket.com"
@@ -108,7 +108,7 @@ async def get_markets(category: Optional[str] = None,
         await set_cache(key, data, ttl=300)
         return data or []
     except Exception as exc:
-        logger.warning("get_markets failed: %s", exc)
+        log.warning("get_markets failed", err=str(exc))
         return []
 
 
@@ -150,7 +150,7 @@ async def get_events_with_markets(limit: int = 200) -> list[dict]:
         await set_cache(key, result, ttl=300)
         return result
     except Exception as exc:
-        logger.warning("get_events_with_markets failed: %s", exc)
+        log.warning("get_events_with_markets failed", err=str(exc))
         return []
 
 
@@ -179,7 +179,7 @@ async def get_crypto_short_markets(limit: int = 500) -> list[dict]:
         await set_cache(key, data, ttl=60)
         return data
     except Exception as exc:
-        logger.warning("get_crypto_short_markets failed: %s", exc)
+        log.warning("get_crypto_short_markets failed", err=str(exc))
         return []
 
 
@@ -227,7 +227,7 @@ async def get_crypto_window_markets(
             try:
                 events = await _get_json(f"{GAMMA}/events", params={"slug": slug})
             except Exception as exc:
-                logger.debug("get_crypto_window_markets %s failed: %s", slug, exc)
+                log.debug("get_crypto_window_markets failed", slug=slug, err=str(exc))
                 continue
             if isinstance(events, dict):
                 events = events.get("data", [])
@@ -263,7 +263,7 @@ async def get_market(market_id: str) -> Optional[dict]:
     try:
         data = await _get_json(f"{GAMMA}/markets", params={"condition_ids": market_id})
     except Exception as exc:
-        logger.warning("get_market %s failed: %s", market_id, exc)
+        log.warning("get_market failed", market_id=market_id, err=str(exc))
         return None
     markets: list = data if isinstance(data, list) else data.get("data", [])
     result = next(
@@ -295,7 +295,7 @@ async def get_event_market_by_slug(slug: str) -> Optional[dict]:
     try:
         events = await _get_json(f"{GAMMA}/events", params={"slug": slug})
     except Exception as exc:
-        logger.warning("get_event_market_by_slug %s failed: %s", slug, exc)
+        log.warning("get_event_market_by_slug failed", slug=slug, err=str(exc))
         return None
     if isinstance(events, dict):
         events = events.get("data", [])
@@ -323,7 +323,7 @@ async def get_market_by_slug(slug: str) -> Optional[dict]:
             await set_cache(key, result, ttl=120)
         return result
     except Exception as exc:
-        logger.warning("get_market_by_slug %s failed: %s", slug, exc)
+        log.warning("get_market_by_slug failed", slug=slug, err=str(exc))
         return None
 
 
@@ -356,15 +356,11 @@ async def get_live_market_price(market_id: str, side: str) -> Optional[float]:
                 timeout=5.0,
             )
         except Exception as exc:
-            logger.warning(
-                "get_live_market_price fetch failed market=%s: %s", market_id, exc
-            )
+            log.warning("get_live_market_price fetch failed", market_id=market_id, err=str(exc))
             return None
         markets: list = data if isinstance(data, list) else data.get("data", [])
         if not markets or not isinstance(markets[0], dict):
-            logger.warning(
-                "get_live_market_price no market found condition_id=%s", market_id
-            )
+            log.warning("get_live_market_price no market found", condition_id=market_id)
             return None
         market_data = markets[0]
         # Validate conditionId when present — reject if it doesn't match the
@@ -375,10 +371,7 @@ async def get_live_market_price(market_id: str, side: str) -> Optional[float]:
             market_data.get("conditionId") or market_data.get("condition_id") or ""
         )
         if returned_cid and returned_cid != str(market_id):
-            logger.warning(
-                "get_live_market_price conditionId mismatch requested=%s returned=%s",
-                market_id, returned_cid,
-            )
+            log.warning("get_live_market_price conditionId mismatch", requested=market_id, returned=returned_cid)
             return None
         await set_cache(cache_key, market_data, ttl=30)
 
@@ -411,16 +404,12 @@ async def get_live_market_price(market_id: str, side: str) -> Optional[float]:
                     # to the Gamma outcomePrices last-trade fallback.
                     if 0.0 < clob_price < 1.0:
                         return clob_price
-                    logger.warning(
-                        "get_live_market_price CLOB empty-book sentinel "
-                        "price=%.4f market=%s side=%s — falling back to Gamma",
-                        clob_price, market_id, side,
+                    log.warning(
+                        "get_live_market_price CLOB empty-book sentinel — falling back to Gamma",
+                        price=clob_price, market_id=market_id, side=side,
                     )
         except Exception as exc:
-            logger.warning(
-                "get_live_market_price CLOB price failed market=%s side=%s: %s",
-                market_id, side, exc,
-            )
+            log.warning("get_live_market_price CLOB price failed", market_id=market_id, side=side, err=str(exc))
 
     # Fallback: Gamma outcomePrices[0]=YES [1]=NO.
     # Gamma returns outcomePrices as a JSON-encoded string e.g. '["0.565","0.435"]'.
@@ -442,17 +431,11 @@ async def get_live_market_price(market_id: str, side: str) -> Optional[float]:
         # Returning None here makes callers fall back to entry_price
         # (unrealised P&L == 0 / "N/A") instead of a 1.0-inflated figure.
         if not (0.0 < price < 1.0):
-            logger.warning(
-                "get_live_market_price out-of-range price=%.4f market=%s side=%s",
-                price, market_id, side,
-            )
+            log.warning("get_live_market_price out-of-range price", price=price, market_id=market_id, side=side)
             return None
         return price
     except (IndexError, TypeError, ValueError) as exc:
-        logger.warning(
-            "get_live_market_price parse error market=%s side=%s: %s",
-            market_id, side, exc,
-        )
+        log.warning("get_live_market_price parse error", market_id=market_id, side=side, err=str(exc))
         return None
 
 
@@ -467,7 +450,7 @@ async def get_book(token_id: str) -> dict:
         await set_cache(key, data, ttl=30)
         return data
     except Exception as exc:
-        logger.warning("get_book %s failed: %s", token_id, exc)
+        log.warning("get_book failed", token_id=token_id, err=str(exc))
         return {"bids": [], "asks": []}
 
 
@@ -487,7 +470,7 @@ async def get_user_activity(wallet_address: str, limit: int = 20) -> list[dict]:
         await set_cache(key, data or [], ttl=60)
         return data or []
     except Exception as exc:
-        logger.warning("get_user_activity %s failed: %s", wallet_address, exc)
+        log.warning("get_user_activity failed", wallet=wallet_address, err=str(exc))
         return []
 
 

--- a/projects/polymarket/crusaderbot/monitoring/logging.py
+++ b/projects/polymarket/crusaderbot/monitoring/logging.py
@@ -75,6 +75,7 @@ def configure_json_logging(level: str = "INFO") -> None:
         processors=[
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.add_log_level,
+            structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(

--- a/projects/polymarket/crusaderbot/users.py
+++ b/projects/polymarket/crusaderbot/users.py
@@ -1,13 +1,14 @@
 """User CRUD helpers used across handlers + scheduler."""
 from __future__ import annotations
 
-import logging
 from typing import Optional
 from uuid import UUID
 
+import structlog
+
 from .database import get_pool
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 _DEMO_FEED_ID = "00000000-0000-0000-0001-000000000001"
 
@@ -97,9 +98,7 @@ async def upsert_user(telegram_user_id: int, username: str | None) -> dict:
     try:
         await _enroll_signal_following(row["id"])
     except Exception:
-        logger.exception(
-            "signal enrollment failed for user user_id=%s", row["id"]
-        )
+        log.exception("signal enrollment failed for user", user_id=str(row["id"]))
     return dict(row)
 
 
@@ -121,11 +120,11 @@ async def _bootstrap_new_user(user_id: UUID) -> None:
     try:
         await create_wallet_for_user(user_id)
     except Exception:
-        logger.exception("wallet creation failed for new user user_id=%s", user_id)
+        log.exception("wallet creation failed for new user", user_id=str(user_id))
     try:
         await seed_paper_capital(user_id)
     except Exception:
-        logger.exception("paper seed failed for new user user_id=%s", user_id)
+        log.exception("paper seed failed for new user", user_id=str(user_id))
     try:
         pool = get_pool()
         async with pool.acquire() as conn:
@@ -142,11 +141,11 @@ async def _bootstrap_new_user(user_id: UUID) -> None:
                 user_id,
             )
     except Exception:
-        logger.exception("default settings failed for new user user_id=%s", user_id)
+        log.exception("default settings failed for new user", user_id=str(user_id))
     try:
         await _enroll_signal_following(user_id)
     except Exception:
-        logger.exception("signal enrollment failed for user user_id=%s", user_id)
+        log.exception("signal enrollment failed for user", user_id=str(user_id))
 
 
 async def seed_paper_capital(user_id: UUID) -> bool:
@@ -296,7 +295,7 @@ async def user_notifications_enabled(user_id: UUID) -> bool:
                 user_id,
             )
     except Exception as exc:  # noqa: BLE001 — fail-open, never block the send
-        logger.warning("notifications_on read failed user=%s err=%s", user_id, exc)
+        log.warning("notifications_on read failed", user_id=str(user_id), err=str(exc))
         return True
     if row is None or row["notifications_on"] is None:
         return True
@@ -315,9 +314,7 @@ async def notifications_enabled_by_telegram_id(telegram_user_id: int) -> bool:
                 telegram_user_id,
             )
     except Exception as exc:  # noqa: BLE001 — fail-open
-        logger.warning(
-            "notifications_on read failed tg_id=%s err=%s", telegram_user_id, exc
-        )
+        log.warning("notifications_on read failed", tg_id=telegram_user_id, err=str(exc))
         return True
     if row is None or row["notifications_on"] is None:
         return True
@@ -367,9 +364,9 @@ async def backfill_missing_wallets(pool) -> int:
                 await seed_paper_capital(uid)
                 count += 1
             except Exception as exc:  # noqa: BLE001
-                logger.warning("wallet backfill: failed for user %s: %s", uid, exc)
-        logger.info("wallet backfill: %d wallets created", count)
+                log.warning("wallet backfill: failed for user", user_id=str(uid), err=str(exc))
+        log.info("wallet backfill: wallets created", count=count)
         return count
     except Exception as exc:  # noqa: BLE001
-        logger.warning("wallet backfill: startup check failed: %s", exc)
+        log.warning("wallet backfill: startup check failed", err=str(exc))
         return 0


### PR DESCRIPTION
## What

Axis #5 (WARP•R00T / observability-ops) — structured logging migration M-3, Chunk 1.

Migrates 4 modules from stdlib `logging` to `structlog` keyword-arg API. Fixes the prerequisite processor chain in `monitoring/logging.py`.

## Files changed

| File | Change |
|---|---|
| `monitoring/logging.py` | Add `structlog.processors.format_exc_info` to processor chain (required for correct exc_info serialisation) |
| `users.py` | 10 calls → structlog; `import logging` removed |
| `domain/risk/kill_switch_exec.py` | 11 calls → structlog (incl. `critical`); `import logging` removed |
| `integrations/polymarket.py` | 15 calls → structlog; `import logging` removed |
| `bot/handlers/admin.py` | 16 calls → structlog; `import logging` removed |

## Migration rules applied

- `logger.info("msg %s", val)` → `log.info("msg", key=val)`
- `logger.exception("msg %s", val)` → `log.exception("msg", key=val)`
- `logger.critical(...)` → `log.critical(...)`
- All positional `%s` args converted to explicit keyword fields
- Zero silent exceptions — all `exc_info` paths preserved via `log.exception()`

## Validation

- `py_compile` clean on all 5 files
- Zero `logger.` calls remain in migrated files
- Chunk 2 (scheduler, lifecycle, exit_watcher, late_entry_v3) pending

## Validation Tier

STANDARD — observability refactor, no trading logic touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAmsmixQPGNWkpA1BjbWXu)_