### PR TITLE
observability: migrate 4 modules to structlog (chunk 2 of M-3)

### DIFF
--- a/projects/polymarket/crusaderbot/domain/execution/exit_watcher.py
+++ b/projects/polymarket/crusaderbot/domain/execution/exit_watcher.py
@@ -33,11 +33,12 @@ Failure handling:
 from __future__ import annotations
 
 import asyncio
-import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Awaitable, Callable, Optional, Protocol
+
+import structlog
 
 from ... import audit
 from ...database import get_pool
@@ -54,7 +55,7 @@ from ..strategy.registry import StrategyRegistry
 from . import order as order_module
 from . import router
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 DEFAULT_POLL_INTERVAL_SECONDS: float = 30.0
 
@@ -183,9 +184,9 @@ async def registry_strategy_evaluator(
     try:
         decision = await strat.evaluate_exit(payload)
     except Exception as exc:
-        logger.warning(
-            "exit_watcher strategy hook failed strat=%s pos=%s err=%s",
-            name, position.id, exc,
+        log.warning(
+            "exit_watcher strategy hook failed",
+            strategy=name, position_id=str(position.id), err=str(exc),
         )
         return False
     return bool(getattr(decision, "should_exit", False))
@@ -250,18 +251,17 @@ async def _fetch_live_price(
                 if 0.0 < price < 1.0:
                     return price
         except Exception as exc:
-            logger.debug(
-                "exit_watcher._fetch_live_price midpoint failed "
-                "token=%s market=%s side=%s error=%s — falling back",
-                token_id, market_id, side, exc,
+            log.debug(
+                "exit_watcher._fetch_live_price midpoint failed — falling back",
+                token=token_id, market_id=market_id, side=side, err=str(exc),
             )
     # Fallback: Gamma → CLOB /price chain.
     try:
         return await get_live_market_price(market_id, side)
     except Exception as exc:
-        logger.warning(
-            "exit_watcher._fetch_live_price market=%s side=%s error=%s",
-            market_id, side, exc,
+        log.warning(
+            "exit_watcher._fetch_live_price",
+            market_id=market_id, side=side, err=str(exc),
         )
         return None
 
@@ -459,7 +459,7 @@ async def _act_on_decision(
         except ImportError:
             pass
         except Exception as exc:
-            logger.warning("exit_watcher: SSE position_updated push failed: %s", exc)
+            log.warning("exit_watcher: SSE position_updated push failed", err=str(exc))
         return
 
     reason = decision.reason or ExitReason.STRATEGY_EXIT.value
@@ -481,14 +481,12 @@ async def _act_on_decision(
                      "failure_count": new_count,
                      "error": (result.error or "")[:500]},
         )
-        logger.info(
+        log.info(
             "close_failed (user notif suppressed, operator alert active)",
-            extra={
-                "position_id": str(position.id),
-                "market_id": position.market_id,
-                "side": position.side,
-                "error": (result.error or "unknown")[:200],
-            },
+            position_id=str(position.id),
+            market_id=position.market_id,
+            side=position.side,
+            error=(result.error or "unknown")[:200],
         )
         await monitoring_alerts.alert_operator_close_failed_persistent(
             position_id=position.id,
@@ -550,7 +548,7 @@ async def _act_on_decision(
             mode=position.mode,
         )
     except Exception as _exc:
-        logger.debug("exit_watcher: position.closed emit failed: %s", _exc)
+        log.debug("exit_watcher: position.closed emit failed", err=str(_exc))
 
 
 async def _market_actually_expired(market_id: str) -> bool:
@@ -588,18 +586,18 @@ async def _close_expired_position(position: OpenPositionForExit) -> bool:
     Returns True iff the position was closed. Returns False if the position
     was already closed by another path (idempotent).
     """
-    logger.warning(
-        "Position %s: market %s not found on Gamma after retries — closing as MARKET_EXPIRED",
-        position.id, position.market_id,
+    log.warning(
+        "Position: market not found on Gamma after retries — closing as MARKET_EXPIRED",
+        position_id=str(position.id), market_id=position.market_id,
     )
     try:
         closed = await registry.close_as_expired(
             position.id, position.user_id, position.size_usdc
         )
         if not closed:
-            logger.info(
-                "close_as_expired: position %s already closed (idempotent skip)",
-                position.id,
+            log.info(
+                "close_as_expired: position already closed (idempotent skip)",
+                position_id=str(position.id),
             )
             return False
         await audit.write(
@@ -612,21 +610,19 @@ async def _close_expired_position(position: OpenPositionForExit) -> bool:
                 "mode": position.mode,
             },
         )
-        logger.info(
+        log.info(
             "market_expired position closed (user notif suppressed)",
-            extra={
-                "position_id": str(position.id),
-                "market_id": position.market_id,
-                "side": position.side,
-                "size_usdc": position.size_usdc,
-                "mode": position.mode,
-            },
+            position_id=str(position.id),
+            market_id=position.market_id,
+            side=position.side,
+            size_usdc=position.size_usdc,
+            mode=position.mode,
         )
         return True
     except Exception as exc:
-        logger.error(
-            "exit_watcher._close_expired_position position=%s error=%s",
-            position.id, exc, exc_info=True,
+        log.exception(
+            "exit_watcher._close_expired_position",
+            position_id=str(position.id), err=str(exc),
         )
         return False
 
@@ -699,10 +695,10 @@ async def run_once(
                             # Log once per fail-threshold crossing for ops visibility; keep
                             # the counter pinned at the threshold so we recheck each tick
                             # without unbounded growth.
-                            logger.warning(
-                                "exit_watcher: position %s market %s has None price for %d ticks "
-                                "but DB shows not-resolved — treating as stale, not expired",
-                                p.id, p.market_id, fail_count,
+                            log.warning(
+                                "exit_watcher: position has None price but DB shows not-resolved — treating as stale, not expired",
+                                position_id=str(p.id), market_id=p.market_id,
+                                ticks=fail_count,
                             )
                             _price_fail_counts[p.id] = _EXPIRED_TICK_THRESHOLD
                     continue
@@ -719,9 +715,9 @@ async def run_once(
                 p, decision, close_submitter=close_submitter,
             )
         except Exception as exc:
-            logger.error(
-                "exit_watcher: position %s evaluation failed: %s",
-                p.id, exc, exc_info=True,
+            log.exception(
+                "exit_watcher: position evaluation failed",
+                position_id=str(p.id), err=str(exc),
             )
             errors += 1
 
@@ -732,16 +728,16 @@ async def run_once(
             if await _close_expired_position(p):
                 expired += 1
         except Exception as exc:
-            logger.error(
-                "exit_watcher: resolved-market position %s close failed: %s",
-                p.id, exc, exc_info=True,
+            log.exception(
+                "exit_watcher: resolved-market position close failed",
+                position_id=str(p.id), err=str(exc),
             )
             errors += 1
 
     if expired > 0:
-        logger.info(
-            "exit_watcher.run_once: submitted=%d expired=%d held=%d errors=%d",
-            submitted, expired, held, errors,
+        log.info(
+            "exit_watcher.run_once",
+            submitted=submitted, expired=expired, held=held, errors=errors,
         )
     return RunResult(submitted=submitted, expired=expired, held=held, errors=errors)
 
@@ -761,10 +757,10 @@ async def run_forever(
     ``stop`` is an optional poll predicate (returns True to break) used by
     tests; in production the loop runs until the parent task is cancelled.
     """
-    logger.info("exit_watcher.run_forever interval=%.1fs", interval_seconds)
+    log.info("exit_watcher.run_forever", interval_seconds=interval_seconds)
     while True:
         if stop is not None and stop():
-            logger.info("exit_watcher.run_forever stop predicate -> exiting")
+            log.info("exit_watcher.run_forever stop predicate -> exiting")
             return
         try:
             await run_once(
@@ -776,5 +772,5 @@ async def run_forever(
             # last-resort net for an infrastructure-level error (DB pool
             # gone, etc.). The loop must NOT die — APScheduler equivalents
             # would simply restart the tick on the next interval.
-            logger.error("exit_watcher.run_once raised: %s", exc, exc_info=True)
+            log.exception("exit_watcher.run_once raised", err=str(exc))
         await sleep(interval_seconds)

--- a/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
+++ b/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
@@ -22,10 +22,11 @@ from __future__ import annotations
 
 import datetime
 import json
-import logging
 from decimal import Decimal
 from typing import Any, Awaitable, Callable, Optional
 from uuid import UUID
+
+import structlog
 
 from ... import audit as audit_module
 from ... import notifications as notifications_module
@@ -39,7 +40,7 @@ from ...integrations.clob import (
 )
 from ...wallet import ledger
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # Status values tracked on the orders row. Kept in sync with
@@ -129,7 +130,7 @@ class OrderLifecycleManager:
             try:
                 client = self._clob_factory(s)
             except (ClobConfigError, ClobAuthError) as exc:
-                logger.error("lifecycle poll: CLOB client unavailable: %s", exc)
+                log.error("lifecycle poll: CLOB client unavailable", err=str(exc))
                 outcome["errors"] = len(rows)
                 return outcome
 
@@ -146,9 +147,9 @@ class OrderLifecycleManager:
                     )
                 except Exception as exc:  # noqa: BLE001
                     outcome["errors"] += 1
-                    logger.error(
-                        "lifecycle poll: order %s resolve failed: %s",
-                        order["id"], exc, exc_info=True,
+                    log.exception(
+                        "lifecycle poll: order resolve failed",
+                        order_id=str(order["id"]), err=str(exc),
                     )
                     continue
                 outcome[resolution] = outcome.get(resolution, 0) + 1
@@ -157,7 +158,7 @@ class OrderLifecycleManager:
                 try:
                     await client.aclose()
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("lifecycle poll: client.aclose failed: %s", exc)
+                    log.warning("lifecycle poll: client.aclose failed", err=str(exc))
 
         return outcome
 
@@ -323,9 +324,9 @@ class OrderLifecycleManager:
                 )
                 if updated is None:
                     # Already terminal — another poll cycle won the race.
-                    logger.info(
-                        "lifecycle on_fill: order %s already terminal, skipping",
-                        order["id"],
+                    log.info(
+                        "lifecycle on_fill: order already terminal, skipping",
+                        order_id=str(order["id"]),
                     )
                     return
                 await self._record_fills_in_conn(
@@ -522,9 +523,9 @@ class OrderLifecycleManager:
                     0.0,
                 )
                 if updated is None:
-                    logger.info(
-                        "lifecycle %s: order %s already terminal",
-                        audit_action, order["id"],
+                    log.info(
+                        "lifecycle: order already terminal",
+                        audit_action=audit_action, order_id=str(order["id"]),
                     )
                     return
 
@@ -626,9 +627,9 @@ class OrderLifecycleManager:
                 " last_polled_at=NOW() WHERE id=$1",
                 order["id"],
             )
-            logger.info(
-                "lifecycle slippage_retry deferred: gate inactive, counter advanced order=%s",
-                order["id"],
+            log.info(
+                "lifecycle slippage_retry deferred: gate inactive, counter advanced",
+                order_id=str(order["id"]),
             )
             return
         broker_id = str(order.get("polymarket_order_id") or "")
@@ -636,9 +637,9 @@ class OrderLifecycleManager:
             try:
                 await client.cancel_order(broker_id)
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "lifecycle slippage_retry: cancel failed order=%s broker=%s: %s",
-                    order["id"], broker_id, exc,
+                log.warning(
+                    "lifecycle slippage_retry: cancel failed",
+                    order_id=str(order["id"]), broker=broker_id, err=str(exc),
                 )
 
         # Widen by one extra tick in the aggressive direction.
@@ -656,9 +657,9 @@ class OrderLifecycleManager:
                 order["market_id"],
             )
         if mkt is None:
-            logger.error(
-                "lifecycle slippage_retry: market %s not found — cannot re-submit order %s",
-                order["market_id"], order["id"],
+            log.error(
+                "lifecycle slippage_retry: market not found — cannot re-submit",
+                market_id=order["market_id"], order_id=str(order["id"]),
             )
             return
 
@@ -666,9 +667,9 @@ class OrderLifecycleManager:
             mkt["yes_token_id"] if side in {"yes", "buy"} else mkt["no_token_id"]
         )
         if not token_id:
-            logger.error(
-                "lifecycle slippage_retry: missing token_id for order %s side=%s",
-                order["id"], side,
+            log.error(
+                "lifecycle slippage_retry: missing token_id",
+                order_id=str(order["id"]), side=side,
             )
             return
 
@@ -685,9 +686,9 @@ class OrderLifecycleManager:
                 result.get("orderID") or result.get("order_id") or result.get("id") or ""
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error(
-                "lifecycle slippage_retry: re-submit failed order=%s: %s",
-                order["id"], exc,
+            log.error(
+                "lifecycle slippage_retry: re-submit failed",
+                order_id=str(order["id"]), err=str(exc),
             )
             return
 
@@ -716,10 +717,10 @@ class OrderLifecycleManager:
                 "new_broker_id": new_broker_id,
             },
         )
-        logger.info(
-            "lifecycle slippage_retry: order=%s re-submitted at %.4f (was %.4f) "
-            "broker=%s",
-            order["id"], new_limit, original_price, new_broker_id,
+        log.info(
+            "lifecycle slippage_retry: order re-submitted",
+            order_id=str(order["id"]), new_limit=new_limit,
+            was=original_price, broker=new_broker_id,
         )
 
     async def _on_slippage_cancel(
@@ -741,9 +742,9 @@ class OrderLifecycleManager:
             try:
                 await client.cancel_order(broker_id)
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "lifecycle slippage_cancel: cancel failed order=%s broker=%s: %s",
-                    order["id"], broker_id, exc,
+                log.warning(
+                    "lifecycle slippage_cancel: cancel failed",
+                    order_id=str(order["id"]), broker=broker_id, err=str(exc),
                 )
 
         await self._safe_audit(
@@ -792,7 +793,7 @@ class OrderLifecycleManager:
                 "Reconcile via Polymarket dashboard."
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error("lifecycle stale notify failed: %s", exc)
+            log.error("lifecycle stale notify failed", err=str(exc))
 
     async def _touch(self, order_id: UUID, attempts: int) -> None:
         pool = self._pool_override or get_pool()
@@ -854,11 +855,10 @@ class OrderLifecycleManager:
             # always whole-share discrepancies, well outside this band.
             EPSILON = 1e-6
             if existing_total + EPSILON >= incoming_total:
-                logger.debug(
-                    "lifecycle: skipping aggregate fills insert; "
-                    "per-trade sum %.6f already covers incoming "
-                    "aggregate %.6f for order %s",
-                    existing_total, incoming_total, order_id,
+                log.debug(
+                    "lifecycle: skipping aggregate fills insert; per-trade sum covers incoming aggregate",
+                    per_trade_sum=existing_total, incoming=incoming_total,
+                    order_id=str(order_id),
                 )
                 return
 
@@ -875,9 +875,9 @@ class OrderLifecycleManager:
                 price = float(fill.get("price", 0) or 0)
                 size = float(fill.get("size", 0) or 0)
             except (TypeError, ValueError):
-                logger.warning(
-                    "lifecycle: dropping fill with non-numeric price/size: %s",
-                    fill,
+                log.warning(
+                    "lifecycle: dropping fill with non-numeric price/size",
+                    fill=fill,
                 )
                 continue
             # ON CONFLICT DO UPDATE so synthetic ``agg-*`` rows
@@ -943,22 +943,22 @@ class OrderLifecycleManager:
         broker_id = event.get("broker_order_id")
         fill_id = event.get("fill_id")
         if not broker_id or not fill_id:
-            logger.debug(
-                "lifecycle ws_fill: dropping event missing ids: %s", event,
+            log.debug(
+                "lifecycle ws_fill: dropping event missing ids", event=event,
             )
             return
 
         order_row = await self._lookup_order_by_broker_id(broker_id)
         if order_row is None:
-            logger.info(
-                "lifecycle ws_fill: no local order matches broker_id=%s",
-                broker_id,
+            log.info(
+                "lifecycle ws_fill: no local order matches broker_id",
+                broker_id=broker_id,
             )
             return
         if order_row["status"] not in STATUS_OPEN:
-            logger.debug(
-                "lifecycle ws_fill: order %s already terminal (%s)",
-                order_row["id"], order_row["status"],
+            log.debug(
+                "lifecycle ws_fill: order already terminal",
+                order_id=str(order_row["id"]), status=order_row["status"],
             )
             return
 
@@ -966,9 +966,9 @@ class OrderLifecycleManager:
             price = float(event["price"])
             size = float(event["size"])
         except (TypeError, ValueError, KeyError) as exc:
-            logger.warning(
-                "lifecycle ws_fill: dropping non-numeric event %s: %s",
-                event, exc,
+            log.warning(
+                "lifecycle ws_fill: dropping non-numeric event",
+                event=event, err=str(exc),
             )
             return
         side = str(event.get("side") or order_row["side"]).lower()
@@ -1155,7 +1155,7 @@ class OrderLifecycleManager:
         try:
             await self._audit_write(**kwargs)
         except Exception as exc:  # noqa: BLE001
-            logger.error("lifecycle audit write failed: %s", exc)
+            log.error("lifecycle audit write failed", err=str(exc))
 
     async def _safe_notify_user(self, *, user_id: UUID, text: str) -> None:
         pool = self._pool_override or get_pool()
@@ -1168,7 +1168,7 @@ class OrderLifecycleManager:
         try:
             await self._notify_user(int(tg_id), text)
         except Exception as exc:  # noqa: BLE001
-            logger.error("lifecycle user notify failed: %s", exc)
+            log.error("lifecycle user notify failed", err=str(exc))
 
 
 # ---------------------------------------------------------------------------

--- a/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
+++ b/projects/polymarket/crusaderbot/domain/execution/lifecycle.py
@@ -944,7 +944,7 @@ class OrderLifecycleManager:
         fill_id = event.get("fill_id")
         if not broker_id or not fill_id:
             log.debug(
-                "lifecycle ws_fill: dropping event missing ids", event=event,
+                "lifecycle ws_fill: dropping event missing ids", payload=event,
             )
             return
 
@@ -968,7 +968,7 @@ class OrderLifecycleManager:
         except (TypeError, ValueError, KeyError) as exc:
             log.warning(
                 "lifecycle ws_fill: dropping non-numeric event",
-                event=event, err=str(exc),
+                payload=event, err=str(exc),
             )
             return
         side = str(event.get("side") or order_row["side"]).lower()

--- a/projects/polymarket/crusaderbot/domain/strategy/strategies/late_entry_v3.py
+++ b/projects/polymarket/crusaderbot/domain/strategy/strategies/late_entry_v3.py
@@ -25,9 +25,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from datetime import datetime, timezone
 from typing import Any
+
+import structlog
 
 from ....config import get_settings
 from ....integrations import polymarket as pm
@@ -35,7 +36,7 @@ from ..base import BaseStrategy
 from ..eligibility import is_short_crypto_market
 from ..types import ExitDecision, MarketFilters, SignalCandidate, UserContext
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 # Entry gates (mirror of the reference strategy).
 # Final ~35s before close (ref Kreo Close Sweep: 5m Time 265-299s / 15m 865-899s).
@@ -196,7 +197,7 @@ class LateEntryV3Strategy(BaseStrategy):
         try:
             markets = await pm.get_crypto_window_markets(timeframe or "5m", assets)
         except Exception as exc:
-            logger.warning("late_entry_v3 scan: get_crypto_window_markets failed err=%s", exc)
+            log.warning("late_entry_v3 scan: get_crypto_window_markets failed", err=str(exc))
             return []
 
         if not markets:
@@ -229,39 +230,37 @@ class LateEntryV3Strategy(BaseStrategy):
                     force_exit_at_rem_sec=force_exit_at_rem_sec,
                 )
             except Exception as exc:
-                logger.debug("late_entry_v3 scan: skip market err=%s", exc)
+                log.debug("late_entry_v3 scan: skip market", err=str(exc))
                 reject_counts["exception"] = reject_counts.get("exception", 0) + 1
                 continue
             if candidate is not None:
                 candidates.append(candidate)
-                logger.info(
-                    "late_entry_v3 candidate slug=%s side=%s entry_price=%.3f diff=%.3f secs=%.0f size=%.2f underdog=%s",
-                    m.get("slug", ""),
-                    candidate.side,
-                    candidate.metadata.get("entry_price", candidate.metadata.get("fav_price", 0)),
-                    candidate.metadata.get("ask_diff", 0),
-                    candidate.metadata.get("seconds_to_close", 0),
-                    candidate.suggested_size_usdc,
-                    candidate.metadata.get("underdog_mode", False),
+                log.info(
+                    "late_entry_v3 candidate",
+                    slug=m.get("slug", ""),
+                    side=candidate.side,
+                    entry_price=candidate.metadata.get("entry_price", candidate.metadata.get("fav_price", 0)),
+                    diff=candidate.metadata.get("ask_diff", 0),
+                    secs=candidate.metadata.get("seconds_to_close", 0),
+                    size=candidate.suggested_size_usdc,
+                    underdog=candidate.metadata.get("underdog_mode", False),
                 )
             elif reject_reason:
                 reject_counts[reject_reason] = reject_counts.get(reject_reason, 0) + 1
 
         candidates.sort(key=lambda c: c.confidence, reverse=True)
-        logger.info(
-            "late_entry_v3 scan_summary markets=%d eligible=%d candidates=%d "
-            "gate_rejects=%s min_ask_diff=%.3f window_sec=%.0f fav_price_min=%.2f fav_price_max=%.2f "
-            "min_entry_sec=%s underdog=%s",
-            len(markets),
-            eligible,
-            len(candidates),
-            reject_counts,
-            min_ask_diff,
-            entry_window_sec,
-            fav_price_min,
-            fav_price_max,
-            min_entry_sec,
-            underdog_mode,
+        log.info(
+            "late_entry_v3 scan_summary",
+            markets=len(markets),
+            eligible=eligible,
+            candidates=len(candidates),
+            gate_rejects=reject_counts,
+            min_ask_diff=min_ask_diff,
+            window_sec=entry_window_sec,
+            fav_price_min=fav_price_min,
+            fav_price_max=fav_price_max,
+            min_entry_sec=min_entry_sec,
+            underdog=underdog_mode,
         )
         return candidates
 
@@ -458,7 +457,7 @@ async def _evaluate_market(
         m.get("conditionId") or m.get("condition_id") or m.get("conditionID") or ""
     )
     if not condition_id:
-        logger.debug("late_entry_v3 skip: no conditionId slug=%s", m.get("slug", ""))
+        log.debug("late_entry_v3 skip: no conditionId", slug=m.get("slug", ""))
         return None, "no_condition_id"
     market_id = condition_id  # canonical DB key
 
@@ -473,34 +472,34 @@ async def _evaluate_market(
     # while the CLOB book still has liquidity and orders. Relying on closed +
     # acceptingOrders is sufficient; the active flag kills every in-window candidate.
     if m.get("closed"):
-        logger.debug("late_entry_v3 skip closed slug=%s", slug)
+        log.debug("late_entry_v3 skip closed", slug=slug)
         return None, "closed"
     if not is_candle and not m.get("active"):
-        logger.debug("late_entry_v3 skip inactive (non-candle) slug=%s", slug)
+        log.debug("late_entry_v3 skip inactive (non-candle)", slug=slug)
         return None, "inactive"
     if not m.get("acceptingOrders", m.get("accepting_orders", True)):
-        logger.debug("late_entry_v3 skip not_accepting_orders slug=%s", slug)
+        log.debug("late_entry_v3 skip not_accepting_orders", slug=slug)
         return None, "not_accepting_orders"
 
     # Timing gate — only act inside the configured window before candle close.
     seconds_left = _seconds_to_close(m, now_ts)
     if seconds_left is None or seconds_left <= 0 or seconds_left > entry_window_sec:
-        logger.debug(
-            "late_entry_v3 skip timing slug=%s secs=%s window=%.0f",
-            slug, seconds_left, entry_window_sec,
+        log.debug(
+            "late_entry_v3 skip timing",
+            slug=slug, secs=seconds_left, window=entry_window_sec,
         )
         return None, "outside_window"
     # Lower bound: safe_close skips the final <30s to avoid last-second fills.
     if min_entry_sec is not None and seconds_left < min_entry_sec:
-        logger.debug(
-            "late_entry_v3 skip inside_min slug=%s secs=%.1f min=%.0f",
-            slug, seconds_left, min_entry_sec,
+        log.debug(
+            "late_entry_v3 skip inside_min",
+            slug=slug, secs=seconds_left, min=min_entry_sec,
         )
         return None, "inside_min_entry_sec"
 
     tokens = _coerce_str_list(m.get("clobTokenIds")) or _coerce_str_list(m.get("tokenIds"))
     if len(tokens) < 2 or not tokens[0] or not tokens[1]:
-        logger.debug("late_entry_v3 skip no_tokens slug=%s", slug)
+        log.debug("late_entry_v3 skip no_tokens", slug=slug)
         return None, "no_tokens"
     yes_token, no_token = tokens[0], tokens[1]
 
@@ -510,9 +509,9 @@ async def _evaluate_market(
     yes_ask = _best_ask(yes_book)
     no_ask = _best_ask(no_book)
     if yes_ask is None or no_ask is None:
-        logger.debug(
-            "late_entry_v3 skip empty_book slug=%s yes_ask=%s no_ask=%s",
-            slug, yes_ask, no_ask,
+        log.debug(
+            "late_entry_v3 skip empty_book",
+            slug=slug, yes_ask=yes_ask, no_ask=no_ask,
         )
         return None, "empty_book"
 
@@ -530,15 +529,15 @@ async def _evaluate_market(
     fav_price = max(yes_ask, no_ask)
 
     if ask_diff < min_ask_diff:
-        logger.debug(
-            "late_entry_v3 skip low_ask_diff slug=%s diff=%.4f min=%.4f",
-            slug, ask_diff, min_ask_diff,
+        log.debug(
+            "late_entry_v3 skip low_ask_diff",
+            slug=slug, diff=ask_diff, min=min_ask_diff,
         )
         return None, "low_ask_diff"
     if spread <= 0 or spread > MAX_SPREAD:
-        logger.debug(
-            "late_entry_v3 skip spread slug=%s spread=%.4f max=%.4f",
-            slug, spread, MAX_SPREAD,
+        log.debug(
+            "late_entry_v3 skip spread",
+            slug=slug, spread=spread, max=MAX_SPREAD,
         )
         return None, "spread_out_of_range"
 
@@ -553,16 +552,16 @@ async def _evaluate_market(
         entry_price = fav_price
 
     if entry_price < fav_price_min:
-        logger.debug(
-            "late_entry_v3 skip entry_price_too_low slug=%s price=%.4f min=%.4f underdog=%s",
-            slug, entry_price, fav_price_min, underdog_mode,
+        log.debug(
+            "late_entry_v3 skip entry_price_too_low",
+            slug=slug, price=entry_price, min=fav_price_min, underdog=underdog_mode,
         )
         return None, "fav_price_too_low"
 
     if entry_price >= fav_price_max:
-        logger.debug(
-            "late_entry_v3 skip entry_price_too_high slug=%s price=%.4f max=%.4f underdog=%s",
-            slug, entry_price, fav_price_max, underdog_mode,
+        log.debug(
+            "late_entry_v3 skip entry_price_too_high",
+            slug=slug, price=entry_price, max=fav_price_max, underdog=underdog_mode,
         )
         return None, "fav_price_too_high"
 

--- a/projects/polymarket/crusaderbot/scheduler.py
+++ b/projects/polymarket/crusaderbot/scheduler.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import html
-import logging
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import TypedDict
 
+import structlog
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 import asyncio
@@ -42,7 +42,7 @@ from .services.redeem import redeem_router
 from .services import portfolio_snapshots
 from .wallet import ledger
 
-logger = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # ---------------- Market sync ----------------
@@ -51,7 +51,7 @@ async def sync_markets() -> None:
     try:
         markets = await polymarket.get_markets(limit=100)
     except Exception as exc:
-        logger.warning("sync_markets fetch failed: %s", exc)
+        log.warning("sync_markets fetch failed", err=str(exc))
         return
     if not markets:
         return
@@ -113,9 +113,8 @@ async def sync_markets() -> None:
                 )
                 upserts += 1
             except Exception as exc:
-                logger.warning("market upsert failed for %s: %s",
-                               m.get("id"), exc)
-    logger.info("sync_markets: upserted %d", upserts)
+                log.warning("market upsert failed", market_id=m.get("id"), err=str(exc))
+    log.info("sync_markets: upserted", count=upserts)
 
 
 # ---------------- Deposit watcher ----------------
@@ -174,7 +173,7 @@ async def watch_deposits() -> None:
     try:
         head = await polygon.latest_block()
     except Exception as exc:
-        logger.warning("watch_deposits head read failed (no cursor advance): %s", exc)
+        log.warning("watch_deposits head read failed (no cursor advance)", err=str(exc))
         return
 
     cursor_start = await _read_cursor("usdc_deposits")
@@ -183,7 +182,7 @@ async def watch_deposits() -> None:
             addresses, cursor_start,
         )
     except Exception as exc:
-        logger.warning("watch_deposits scan failed (no cursor advance): %s", exc)
+        log.warning("watch_deposits scan failed (no cursor advance)", err=str(exc))
         return
 
     all_ok = True
@@ -197,8 +196,8 @@ async def watch_deposits() -> None:
             else:
                 await _record_pending_deposit(user_id, t)
         except Exception as exc:
-            logger.error("deposit record failed for %s: %s — cursor will not advance",
-                         t.get("tx_hash"), exc)
+            log.error("deposit record failed — cursor will not advance",
+                      tx_hash=t.get("tx_hash"), err=str(exc))
             all_ok = False
 
     if all_ok:
@@ -210,7 +209,7 @@ async def watch_deposits() -> None:
             head, settings.DEPOSIT_CONFIRMATION_DEPTH,
         )
     except Exception as exc:
-        logger.error("deposit confirm pass failed: %s", exc)
+        log.error("deposit confirm pass failed", err=str(exc))
         notify_after = []
 
     deposit_kb = InlineKeyboardMarkup([[
@@ -447,8 +446,8 @@ async def run_signal_scan() -> SignalScanMetrics:
             try:
                 candidates = await strat.scan(user, user)
             except Exception as exc:
-                logger.warning("strategy %s scan failed for user %s: %s",
-                               strat_name, user["id"], exc)
+                log.warning("strategy scan failed",
+                            strategy=strat_name, user_id=str(user["id"]), err=str(exc))
                 continue
             for cand in candidates:
                 candidates_emitted += 1
@@ -457,7 +456,7 @@ async def run_signal_scan() -> SignalScanMetrics:
                 try:
                     outcome = await _process_candidate(user, cand)
                 except Exception as exc:
-                    logger.error("candidate processing failed: %s", exc)
+                    log.error("candidate processing failed", err=str(exc))
                     errors += 1
                     continue
                 if outcome == "executed":
@@ -526,8 +525,9 @@ async def _process_candidate(user: dict, cand) -> str:
     )
     result = await evaluate(ctx_g)
     if not result.approved:
-        logger.info("trade rejected user=%s market=%s reason=%s step=%s",
-                    user["id"], cand.market_id, result.reason, result.failed_step)
+        log.info("trade rejected",
+                 user_id=str(user["id"]), market_id=cand.market_id,
+                 reason=result.reason, step=result.failed_step)
         return "rejected"
     try:
         await router_execute(
@@ -549,8 +549,9 @@ async def _process_candidate(user: dict, cand) -> str:
             sl_pct=float(user["sl_pct"]) if user["sl_pct"] is not None else None,
         )
     except Exception as exc:
-        logger.error("router execute failed user=%s market=%s mode=%s: %s",
-                     user["id"], cand.market_id, result.chosen_mode, exc)
+        log.error("router execute failed",
+                  user_id=str(user["id"]), market_id=cand.market_id,
+                  mode=result.chosen_mode, err=str(exc))
         return "error"
     return "executed"
 
@@ -595,15 +596,15 @@ async def log_resumed_open_positions() -> dict:
                 "SELECT COUNT(*) FROM positions WHERE status='open' AND mode='live'"
             ) or 0)
     except Exception as exc:
-        logger.error(
-            "startup_recovery: open-position count query failed: %s",
-            exc, exc_info=True,
+        log.exception(
+            "startup_recovery: open-position count query failed",
+            err=str(exc),
         )
         return {"resumed_paper": None, "resumed_live": None, "error": str(exc)[:300]}
 
-    logger.info(
-        "startup_recovery: Resumed monitoring %d open positions (%d paper, %d live)",
-        paper_open + live_open, paper_open, live_open,
+    log.info(
+        "startup_recovery: Resumed monitoring open positions",
+        total=paper_open + live_open, paper=paper_open, live=live_open,
     )
     return {"resumed_paper": paper_open, "resumed_live": live_open}
 
@@ -682,12 +683,12 @@ async def ws_watchdog() -> None:
         return
     global _ws_client
     if _ws_client is None or not _ws_client.is_alive():
-        logger.warning("ws_watchdog: client not alive, reconnecting")
+        log.warning("ws_watchdog: client not alive, reconnecting")
         if _ws_client is not None:
             try:
                 await _ws_client.stop()
             except Exception as exc:  # noqa: BLE001
-                logger.warning("ws_watchdog: stale client stop failed: %s", exc)
+                log.warning("ws_watchdog: stale client stop failed", err=str(exc))
             _ws_client = None
         await ws_connect()
 
@@ -753,7 +754,7 @@ async def sweep_deposits() -> None:
                 " UPDATE deposits SET swept=TRUE WHERE swept=FALSE RETURNING 1"
                 ") SELECT COUNT(*) FROM u"
             )
-    logger.info("sweep_deposits: %s deposits marked swept", count)
+    log.info("sweep_deposits: deposits marked swept", count=int(count))
     await audit.write(
         actor_role="bot",
         action="deposit_sweep",
@@ -789,14 +790,14 @@ async def _sweep_deposits_onchain() -> None:
         try:
             pk = await get_decrypted_pk(u["user_id"])
             if pk is None:
-                logger.error("sweep_skip user=%s: no wallet key", u["user_id"])
+                log.error("sweep_skip: no wallet key", user_id=str(u["user_id"]))
                 continue
             result = await sweep_usdc_to_master(u["deposit_address"], pk)
         except PreflightError as exc:
-            logger.warning("sweep_skip user=%s: %s", u["user_id"], exc)
+            log.warning("sweep_skip", user_id=str(u["user_id"]), err=str(exc))
             continue
         except Exception as exc:
-            logger.error("sweep_failed user=%s error=%s", u["user_id"], exc)
+            log.error("sweep_failed", user_id=str(u["user_id"]), err=str(exc))
             continue
         if result.get("skipped"):
             continue
@@ -815,7 +816,7 @@ async def _sweep_deposits_onchain() -> None:
                      "amount_usdc": result.get("amount_usdc"),
                      "gas_topup_matic": result.get("gas_topup_matic")},
         )
-    logger.info("sweep_deposits_onchain: %s user wallets swept", swept_users)
+    log.info("sweep_deposits_onchain: user wallets swept", count=swept_users)
 
 
 async def check_balance_alerts() -> None:
@@ -852,9 +853,9 @@ async def check_balance_alerts() -> None:
                 threshold=threshold,
             )
         except Exception as exc:
-            logger.warning(
-                "check_balance_alerts: alert failed tg=%s balance=%.2f: %s",
-                tg_id, balance, exc,
+            log.warning(
+                "check_balance_alerts: alert failed",
+                tg_id=tg_id, balance=balance, err=str(exc),
             )
 
 
@@ -903,7 +904,7 @@ def _job_tracker_listener(event) -> None:
         try:
             asyncio.run(coro)
         except Exception as exc:  # noqa: BLE001
-            logger.error("job_runs sync write failed: %s", exc)
+            log.error("job_runs sync write failed", err=str(exc))
         return
     loop.create_task(coro)
 

--- a/projects/polymarket/crusaderbot/tests/test_warp54_closed_beta_hardening.py
+++ b/projects/polymarket/crusaderbot/tests/test_warp54_closed_beta_hardening.py
@@ -42,6 +42,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from structlog.testing import capture_logs
 from telegram.error import BadRequest
 
 from projects.polymarket.crusaderbot import notifications
@@ -268,11 +269,11 @@ def test_send_returns_false_when_plain_text_also_fails(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_log_resumed_open_positions_emits_count(caplog):
-    """log_resumed_open_positions must log
-    'startup_recovery: Resumed monitoring N open positions' with the count,
-    and return a dict with {resumed_paper, resumed_live} so APScheduler
-    listener writes the count into job_runs.metadata.
+def test_log_resumed_open_positions_emits_count():
+    """log_resumed_open_positions must log the structured
+    'startup_recovery: Resumed monitoring open positions' event with the
+    paper/live counts, and return a dict with {resumed_paper, resumed_live}
+    so APScheduler listener writes the count into job_runs.metadata.
     """
     scheduler = _try_import_scheduler()
 
@@ -284,15 +285,17 @@ def test_log_resumed_open_positions_emits_count(caplog):
     pool, _conn = _make_pool(fetchval_side_effect=_fetchval)
 
     with patch.object(scheduler, "get_pool", return_value=pool), \
-         caplog.at_level(logging.INFO, logger=scheduler.logger.name):
+         capture_logs() as logs:
         result = _run(scheduler.log_resumed_open_positions())
 
     assert result == {"resumed_paper": 3, "resumed_live": 1}
     assert any(
-        "Resumed monitoring 4 open positions" in r.getMessage()
-        and "(3 paper, 1 live)" in r.getMessage()
-        for r in caplog.records
-    ), [r.getMessage() for r in caplog.records]
+        entry.get("event") == "startup_recovery: Resumed monitoring open positions"
+        and entry.get("total") == 4
+        and entry.get("paper") == 3
+        and entry.get("live") == 1
+        for entry in logs
+    ), logs
 
 
 def test_log_resumed_open_positions_swallows_db_error():


### PR DESCRIPTION
## Summary

Chunk 2 of Axis #5 M-3 structlog migration. Replaces stdlib `logging.Logger` calls with `structlog` keyword-arg API across 4 production-critical modules.

Files migrated:
- `domain/strategy/strategies/late_entry_v3.py` (16 calls)
- `scheduler.py` (22 calls)
- `domain/execution/lifecycle.py` (21 calls)
- `domain/execution/exit_watcher.py` (17 calls)

Conversion rules applied:
- `logger.info("msg %s", val)` → `log.info("msg", key=val)`
- Multi-line `%s` formatters flattened into structured kwargs
- `logger.error(..., exc_info=True)` inside `except` → `log.exception(...)`
- `extra={...}` dicts inlined as kwargs

All 4 files compile clean (`py_compile`). Zero remaining `logger.` references.

## Test plan

- [x] `py_compile` on all 4 files
- [x] Zero remaining stdlib `logger.` calls
- [ ] CI lint + test (auto)
- [ ] CodeRabbit review (auto)

Follow-up: Chunk 3 will deliver forge report, PROJECT_STATE sync, Sentry/healthcheck audit notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAmsmixQPGNWkpA1BjbWXu)_