### PR TITLE
dashboard-bot-off-reflect: scanner widget mirrors auto_trade_on (UX fix)

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DesktopSidebar.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSSEStatus } from "../lib/sse";
 import { useAuth } from "../lib/auth";
@@ -18,6 +18,26 @@ export function DesktopSidebar() {
   const { user } = useAuth();
   const api = useMemo(() => makeApi(user?.token ?? null), [user?.token]);
   const [confirming, setConfirming] = useState(false);
+  // Pull the user's auto_trade_on state so the System Status block can
+  // reflect whether the user's bot is actually running, not just the
+  // global scheduler. Polled every 30s so a toggle from Auto tab
+  // propagates here without a full reload.
+  const [autoOn, setAutoOn] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (!user?.token) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const s = await api.getDashboard();
+        if (!cancelled) setAutoOn(s.auto_trade_on);
+      } catch {
+        if (!cancelled) setAutoOn(null);
+      }
+    };
+    void tick();
+    const id = setInterval(() => void tick(), 30_000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [api, user?.token]);
   const [stopping, setStopping] = useState(false);
 
   async function handleEmergencyStop() {
@@ -191,7 +211,15 @@ export function DesktopSidebar() {
             System Status
           </div>
           {[
-            { label: "SCANNER", value: "RUNNING", tone: "grn" },
+            // SCANNER reflects the user's auto_trade_on, not the global
+            // scheduler. When the user's bot is off, the scanner is
+            // semantically IDLE for them. autoOn === null while we're
+            // still fetching the first tick — fall back to RUNNING then.
+            {
+              label: "SCANNER",
+              value: autoOn === false ? "IDLE" : "RUNNING",
+              tone: autoOn === false ? "dim" : "grn",
+            },
             { label: "MODE",    value: "PAPER",   tone: "blue" },
             { label: "GUARDS",  value: "LOCKED",  tone: "warn" },
           ].map(({ label, value, tone }) => (
@@ -206,6 +234,7 @@ export function DesktopSidebar() {
                   color:
                     tone === "grn"  ? "var(--grn,#00FF9C)"  :
                     tone === "blue" ? "var(--blue,#4D9FFF)"  :
+                    tone === "dim"  ? "var(--ink-3,#455370)" :
                                      "var(--gold,#F5C842)",
                 }}
               >

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/DashboardPage.tsx
@@ -211,7 +211,11 @@ export function DashboardPage() {
               label="Equity"
               value={equityWhole}
               cents={equityCents}
-              statusLabel={data.active_preset ? "STRATEGY ACTIVE" : "STRATEGY IDLE"}
+              statusLabel={
+                data.auto_trade_on
+                  ? (data.active_preset ? "STRATEGY ACTIVE" : "STRATEGY IDLE")
+                  : "BOT OFF"
+              }
               statusCode={presetCode ? <AdvancedOnly>{presetCode}</AdvancedOnly> : undefined}
               risk={risk}
               metaItems={
@@ -297,7 +301,10 @@ export function DashboardPage() {
           {/* RIGHT COLUMN: Scanner terminal + Recent Activity */}
           <div className="md:min-w-0 md:overflow-hidden">
             <AdvancedOnly>
-              <Terminal lines={buildScannerLines(data, lastTick, lastSignals)} />
+              <Terminal
+                status={data.auto_trade_on ? "running" : "idle"}
+                lines={buildScannerLines(data, lastTick, lastSignals)}
+              />
             </AdvancedOnly>
 
             {/* Scanner status strip — visible to all users */}
@@ -520,6 +527,37 @@ function RecentActivityCarousel({ items }: { items: PositionItem[] }) {
 
 
 function buildScannerLines(data: DashboardSummary, lastTick: number | null, lastSignals: number): TerminalLine[] {
+  // When the user's bot is OFF, the dashboard scanner widget must reflect
+  // that — the process-level scanner is still scanning markets globally,
+  // but no candidate is being routed to this user. Show an explicit OFF
+  // banner instead of the misleading "✓ ok / awaiting signal" sequence
+  // so the user isn't confused about whether their bot is trading.
+  if (!data.auto_trade_on) {
+    return [
+      {
+        parts: [
+          { type: "cmd",  text: "market_signal_scanner" },
+          { type: "dim",  text: " ◦ idle" },
+        ],
+      },
+      {
+        parts: [
+          { type: "out",  text: "bot " },
+          { type: "warn", text: "OFF" },
+          { type: "dim",  text: "  mode " },
+          { type: "dim",  text: data.trading_mode?.toUpperCase() ?? "PAPER" },
+        ],
+      },
+      {
+        parts: [
+          { type: "out", text: "status " },
+          { type: "dim", text: "auto-trade disabled — enable from Auto tab" },
+        ],
+        cursor: true,
+      },
+    ];
+  }
+
   const tickLabel = lastTick
     ? new Date(lastTick).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })
     : "—";


### PR DESCRIPTION
## Summary

When `users.auto_trade_on=FALSE` the dashboard still showed:
- `STRATEGY ACTIVE` on the HeroCard equity banner
- `scanner@crusaderbot ✓ ok` / `awaiting signal` on the Terminal widget
- `SCANNER RUNNING` on the desktop sidebar System Status block

All three pulled from **process-level scheduler state** (the global market_signal_scanner runs as a singleton regardless of any user's `auto_trade_on`) instead of the user's own flag. Confusing UX — a user who just turned the bot off saw a "live and trading" UI.

## Fixes

1. **`DashboardPage.HeroCard.statusLabel`** → `"BOT OFF"` when `!data.auto_trade_on`; otherwise the original `STRATEGY ACTIVE` / `STRATEGY IDLE` pair gated by `active_preset`.
2. **`DashboardPage.Terminal`** → `status="idle"` (grey dot) when bot off, and the body swaps to a 3-line OFF banner (`market_signal_scanner ◦ idle` / `bot OFF  mode PAPER` / `status auto-trade disabled — enable from Auto tab`) instead of the misleading `✓ ok` / `awaiting signal` sequence.
3. **`DesktopSidebar` System Status SCANNER row** → reads `IDLE (dim)` when `auto_trade_on=false`, `RUNNING (green)` when true. Sidebar polls `/api/web/dashboard` every 30 s so a toggle from the Auto tab propagates without a full reload. New `dim` tone added to the color map.

## Test plan

- [x] `npm run build` clean (tsc + vite)
- [ ] CI Lint + Test (auto)
- [ ] After deploy: toggle Auto OFF, refresh dashboard → HeroCard shows `BOT OFF`, scanner widget shows the OFF banner, sidebar SCANNER row reads `IDLE`. Toggle back ON → all 3 indicators flip back within 30 s.

Frontend-only (TS+Vite). No backend changes, no schema, no tests added (no existing AlertCenter test framework — wired against existing `DashboardSummary` fields).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAmsmixQPGNWkpA1BjbWXu)_