### PR TITLE
fix: remove unused AlertKind import from AlertCenter.tsx

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAlertCenter } from "../App";
-import type { AlertItem, AlertKind, AlertMetadata } from "../lib/api";
+import type { AlertItem, AlertMetadata } from "../lib/api";
 
 type Category = "TRADE" | "SIGNAL" | "RISK" | "SYSTEM";
 


### PR DESCRIPTION
## Summary
- Removes unused `AlertKind` type import from `src/components/AlertCenter.tsx` line 5
- Fixes TypeScript error TS6196 that was blocking the Docker frontend build

## Root Cause
`AlertKind` was imported via `import type { AlertItem, AlertKind, AlertMetadata }` but never referenced in the component, causing `tsc` to fail with error TS6196 (`declared but never used`).

## Fix
Removed `AlertKind` from the import — `AlertItem` and `AlertMetadata` remain as they are used.

## Validation Tier: MINOR

---
_Generated by [Claude Code](https://claude.ai/code/session_018UBZis5XcmTbLMGkCFufn5)_