### PR TITLE
fix: use opened_at (not created_at) for positions in get_activity

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -234,12 +234,12 @@ async def get_activity(user: _CurrentUser, limit: int = 10):
             """
             SELECT p.id, p.status, p.side, p.size_usdc,
                    p.entry_price, p.pnl_usdc, p.exit_reason,
-                   p.strategy_type, p.created_at, p.closed_at,
+                   p.strategy_type, p.opened_at, p.closed_at,
                    COALESCE(m.question, p.market_question) AS market_question
               FROM positions p
               LEFT JOIN markets m ON m.id = p.market_id
              WHERE p.user_id = $1::uuid
-             ORDER BY COALESCE(p.closed_at, p.created_at) DESC
+             ORDER BY COALESCE(p.closed_at, p.opened_at) DESC
              LIMIT $2
             """,
             user_id,
@@ -257,7 +257,7 @@ async def get_activity(user: _CurrentUser, limit: int = 10):
             "exit_reason": r["exit_reason"],
             "strategy_type": r["strategy_type"],
             "market_question": r["market_question"] or "",
-            "ts": (r["closed_at"] or r["created_at"]).isoformat(),
+            "ts": (r["closed_at"] or r["opened_at"]).isoformat(),
         }
         for r in rows
     ]

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/components/AlertCenter.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAlertCenter } from "../App";
-import type { AlertItem, AlertKind, AlertMetadata } from "../lib/api";
+import type { AlertItem, AlertMetadata } from "../lib/api";
 
 type Category = "TRADE" | "SIGNAL" | "RISK" | "SYSTEM";
 


### PR DESCRIPTION
## Root Cause

Sentry DAWN-SNOWFLAKE-1729-2F: `UndefinedColumnError: column p.created_at does not exist`

The `positions` table schema defines `opened_at` (not `created_at`). The `get_activity` endpoint was querying `p.created_at` in both the SELECT and ORDER BY, causing a 500 on every `/activity` request.

## Changes

`webtrader/backend/router.py` — `get_activity` function (line ~237):

- `p.created_at` → `p.opened_at` in SELECT
- `COALESCE(p.closed_at, p.created_at)` → `COALESCE(p.closed_at, p.opened_at)` in ORDER BY
- `r["created_at"]` → `r["opened_at"]` in response dict

## Validation Tier: MINOR

Refs: https://vurtnex.sentry.io/issues/7515742041/

---
_Generated by [Claude Code](https://claude.ai/code/session_018UBZis5XcmTbLMGkCFufn5)_