### PR TITLE
hotfix(preset-activation): stale asset list locks the preset picker

### DIFF
--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -851,7 +851,7 @@ def _sanitize_selected_assets(raw: Any) -> Optional[list[str]]:
     "explicit empty selection" keeps working. Comparison normalises
     case + strips whitespace to catch pre-uppercase-normalisation rows.
     """
-    if not raw:
+    if not raw or not isinstance(raw, (list, tuple, set)):
         return None
     out: list[str] = []
     seen: set[str] = set()

--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -705,7 +705,10 @@ async def get_autotrade(user: _CurrentUser) -> AutoTradeState:
         min_volume_24h=float(s_row["min_volume_24h"]) if s_row and s_row["min_volume_24h"] is not None else 100.0,
         slippage_tolerance_pct=float(s_row["slippage_tolerance_pct"]) if s_row and s_row["slippage_tolerance_pct"] is not None else None,
         selected_timeframe=s_row["selected_timeframe"] if s_row else None,
-        selected_assets=list(s_row["selected_assets"]) if s_row and s_row["selected_assets"] else None,
+        # noqa next line: ruff F821 false-positive — _sanitize_selected_assets
+        # is defined at module level a few hundred lines below; Python
+        # resolves the name at request time, not at module-load time.
+        selected_assets=_sanitize_selected_assets(s_row["selected_assets"]) if s_row else None,  # noqa: F821
         equity_usdc=round(equity, 2),
         effective_max_per_trade_usdc=round(suggested_trade_size(equity, cap_pct, ceiling_usdc=ceiling), 2),
         max_per_trade_mode=mpt_mode,
@@ -830,6 +833,37 @@ _CRYPTO_SHORT_ASSETS: tuple[str, ...] = ("BTC", "ETH", "SOL")
 _VALID_ASSETS: frozenset[str] = frozenset(_CRYPTO_SHORT_ASSETS)
 _DEFAULT_CRYPTO_SHORT_ASSETS: tuple[str, ...] = ("BTC", "ETH")
 
+
+def _sanitize_selected_assets(raw: Any) -> Optional[list[str]]:
+    """Normalise persisted ``selected_assets`` against the current
+    tradable set on READ.
+
+    Legacy user rows may carry assets (e.g. ``["BNB","XRP","DOGE","HYPE"]``)
+    that were valid when the preset was last activated but have since
+    been removed from the universe. Without this filter,
+    ``/autotrade/state`` + ``/admin/users/{id}`` echo the stale assets,
+    the UI re-renders them as "selected", the user clicks save, and
+    the activate_preset validator 400s — blocking timeframe/asset
+    edits for affected users.
+
+    Returns ``None`` (not ``[]``) for empty / fully-invalid input so
+    downstream code that distinguishes "no selection persisted" from
+    "explicit empty selection" keeps working. Comparison normalises
+    case + strips whitespace to catch pre-uppercase-normalisation rows.
+    """
+    if not raw:
+        return None
+    out: list[str] = []
+    seen: set[str] = set()
+    for a in raw:
+        sym = str(a).strip().upper()
+        if not sym or sym in seen:
+            continue
+        if sym in _VALID_ASSETS:
+            seen.add(sym)
+            out.append(sym)
+    return out or None
+
 # Light per-timeframe params merged into user_settings.strategy_params (JSONB).
 # close_sweep / safe_close: expiration_timing lib strategy reads these config knobs.
 # flip_hunter: same market filters; underdog direction is hardcoded in the strategy.
@@ -892,14 +926,30 @@ async def activate_preset(body: PresetActivateRequest, user: _CurrentUser):
             raise HTTPException(
                 status_code=400, detail=f"invalid timeframe: {timeframe} (expected 5m or 15m)"
             )
-        # Normalize + validate the asset selection; default to all offered assets.
+        # Normalize + silently drop assets that are no longer tradable
+        # (e.g. legacy ["BNB","XRP","DOGE","HYPE"] from before the
+        # universe was trimmed). Returning 400 here would lock the UI:
+        # the user can't switch presets because their persisted state
+        # carries an asset that's no longer in _VALID_ASSETS. Drop +
+        # heal on the way through. We log if anything was dropped so
+        # the operator can spot drift but don't fail the request.
         raw_assets = [str(a).strip().upper() for a in (body.selected_assets or [])]
-        assets = [a for a in raw_assets if a in _VALID_ASSETS]
-        bad = [a for a in raw_assets if a not in _VALID_ASSETS]
-        if bad:
-            raise HTTPException(
-                status_code=400,
-                detail=f"invalid asset(s): {', '.join(bad)} (expected any of {', '.join(_CRYPTO_SHORT_ASSETS)})",
+        assets = []
+        seen: set[str] = set()
+        for a in raw_assets:
+            if a in _VALID_ASSETS and a not in seen:
+                seen.add(a)
+                assets.append(a)
+        dropped = [a for a in raw_assets if a not in _VALID_ASSETS]
+        if dropped:
+            log.info(
+                "activate_preset_dropped_stale_assets",
+                extra={
+                    "user_id": str(user_id),
+                    "preset": body.preset_key,
+                    "dropped": dropped,
+                    "kept": assets,
+                },
             )
         if not assets:
             assets = list(_DEFAULT_CRYPTO_SHORT_ASSETS)
@@ -2647,7 +2697,10 @@ async def admin_user_detail(user_id: str, user: _AdminUser) -> AdminUserDetail:
         max_per_trade_usdc=float(s_row["max_per_trade_usdc"]) if s_row and s_row["max_per_trade_usdc"] is not None else None,
         max_per_trade_pct=float(s_row["max_per_trade_pct"]) if s_row and s_row["max_per_trade_pct"] is not None else None,
         selected_timeframe=s_row["selected_timeframe"] if s_row else None,
-        selected_assets=list(s_row["selected_assets"]) if s_row and s_row["selected_assets"] else None,
+        # Same stale-asset sanitisation as get_autotrade — operator-side
+        # admin drawer must not show ["BNB"] etc as selected, else the
+        # operator's save round-trip would 400.
+        selected_assets=_sanitize_selected_assets(s_row["selected_assets"]) if s_row else None,
         recent_trades=recent_trades,
         recent_audit=recent_audit,
     )

--- a/projects/polymarket/crusaderbot/webtrader/backend/router.py
+++ b/projects/polymarket/crusaderbot/webtrader/backend/router.py
@@ -934,12 +934,7 @@ async def activate_preset(body: PresetActivateRequest, user: _CurrentUser):
         # heal on the way through. We log if anything was dropped so
         # the operator can spot drift but don't fail the request.
         raw_assets = [str(a).strip().upper() for a in (body.selected_assets or [])]
-        assets = []
-        seen: set[str] = set()
-        for a in raw_assets:
-            if a in _VALID_ASSETS and a not in seen:
-                seen.add(a)
-                assets.append(a)
+        assets = _sanitize_selected_assets(body.selected_assets) or []
         dropped = [a for a in raw_assets if a not in _VALID_ASSETS]
         if dropped:
             log.info(

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -106,6 +106,11 @@ export function AutoTradePage() {
   const [customSl, setCustomSl]           = useState("10");
   const [customErr, setCustomErr]         = useState<string | null>(null);
   const [savingRisk, setSavingRisk]       = useState(false);
+  // Surface preset/timeframe/asset toggle errors so a 400 from the
+  // backend doesn't silently swallow the user's tap. Cleared on next
+  // successful preset change.
+  const [presetErr, setPresetErr]         = useState<string | null>(null);
+  const [presetSaving, setPresetSaving]   = useState<string | null>(null);
 
   // Market filter state
   const [filterCats, setFilterCats]           = useState<string[]>(ALL_CATEGORIES);
@@ -178,35 +183,84 @@ export function AutoTradePage() {
   }
 
   async function handleActivatePreset(key: string) {
-    if (CRYPTO_SHORT_PRESETS.includes(key)) {
-      // Crypto-short presets carry a timeframe + asset selection.
-      const tf = (state?.selected_timeframe as Timeframe) ?? "5m";
-      const assets = selectedAssets.length > 0 ? selectedAssets : [...CRYPTO_ASSETS_DEFAULT];
-      await api.activatePreset(key, tf, assets);
-    } else {
-      await api.activatePreset(key);
+    if (presetSaving) return;  // ignore double-taps while a request is in flight
+    setPresetErr(null);
+    setPresetSaving(key);
+    try {
+      if (CRYPTO_SHORT_PRESETS.includes(key)) {
+        // Crypto-short presets carry a timeframe + asset selection.
+        // Filter `selectedAssets` against the UI's current asset
+        // universe so a stale persisted entry (e.g. legacy BNB before
+        // the universe trim) doesn't get re-submitted and 400 the
+        // backend. The backend ALSO drops + heals stale entries, but
+        // a clean payload makes the round-trip predictable.
+        const cleanAssets = selectedAssets.filter(
+          (a) => (CRYPTO_ASSETS as readonly string[]).includes(a),
+        );
+        const tf = (state?.selected_timeframe as Timeframe) ?? "5m";
+        const assets = cleanAssets.length > 0 ? cleanAssets : [...CRYPTO_ASSETS_DEFAULT];
+        await api.activatePreset(key, tf, assets);
+      } else {
+        await api.activatePreset(key);
+      }
+      await load();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // Trim the leading "HTTP 400: " prefix common to api.ts errors so
+      // the visible message reads as the operator-facing reason.
+      setPresetErr(msg.replace(/^HTTP \d+:\s*/, ""));
+    } finally {
+      setPresetSaving(null);
     }
-    await load();
   }
 
   async function handleSelectTimeframe(tf: Timeframe) {
     if (!state?.active_preset) return;
-    const assets = selectedAssets.length > 0 ? selectedAssets : [...CRYPTO_ASSETS_DEFAULT];
-    await api.activatePreset(state.active_preset, tf, assets);
-    await load();
+    if (presetSaving) return;
+    setPresetErr(null);
+    setPresetSaving(state.active_preset);
+    try {
+      const cleanAssets = selectedAssets.filter(
+        (a) => (CRYPTO_ASSETS as readonly string[]).includes(a),
+      );
+      const assets = cleanAssets.length > 0 ? cleanAssets : [...CRYPTO_ASSETS_DEFAULT];
+      await api.activatePreset(state.active_preset, tf, assets);
+      await load();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setPresetErr(msg.replace(/^HTTP \d+:\s*/, ""));
+    } finally {
+      setPresetSaving(null);
+    }
   }
 
   async function handleToggleAsset(asset: string) {
     if (!state?.active_preset) return;
+    if (presetSaving) return;
     // Keep at least one asset selected.
     const next = selectedAssets.includes(asset)
       ? selectedAssets.filter(a => a !== asset)
       : [...selectedAssets, asset];
     if (next.length === 0) return;
-    setSelectedAssets(next);
-    const tf = (state.selected_timeframe as Timeframe) ?? "5m";
-    await api.activatePreset(state.active_preset, tf, next);
-    await load();
+    // Filter against current asset universe so a stale persisted
+    // entry (e.g. legacy BNB) doesn't get re-submitted.
+    const cleanNext = next.filter(
+      (a) => (CRYPTO_ASSETS as readonly string[]).includes(a),
+    );
+    if (cleanNext.length === 0) return;
+    setSelectedAssets(cleanNext);
+    setPresetErr(null);
+    setPresetSaving(state.active_preset);
+    try {
+      const tf = (state.selected_timeframe as Timeframe) ?? "5m";
+      await api.activatePreset(state.active_preset, tf, cleanNext);
+      await load();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setPresetErr(msg.replace(/^HTTP \d+:\s*/, ""));
+    } finally {
+      setPresetSaving(null);
+    }
   }
 
   async function handleActivateRisk(profile: RiskProfileParams["profile"]) {
@@ -473,6 +527,12 @@ export function AutoTradePage() {
         <p className="text-ink-3 text-xs font-mono mb-3 mx-0.5">
           Select the algorithm to drive your trades. Independent of risk sizing.
         </p>
+
+        {presetErr && (
+          <div className="mb-3 px-3 py-2 rounded-lg border border-red/40 bg-red/10 text-red text-xs font-mono">
+            {presetErr}
+          </div>
+        )}
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
           {STRATEGY_PRESETS.filter((p) => {

--- a/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
+++ b/projects/polymarket/crusaderbot/webtrader/frontend/src/pages/AutoTradePage.tsx
@@ -248,6 +248,7 @@ export function AutoTradePage() {
       (a) => (CRYPTO_ASSETS as readonly string[]).includes(a),
     );
     if (cleanNext.length === 0) return;
+    const prevAssets = selectedAssets;
     setSelectedAssets(cleanNext);
     setPresetErr(null);
     setPresetSaving(state.active_preset);
@@ -256,6 +257,7 @@ export function AutoTradePage() {
       await api.activatePreset(state.active_preset, tf, cleanNext);
       await load();
     } catch (e) {
+      setSelectedAssets(prevAssets);
       const msg = e instanceof Error ? e.message : String(e);
       setPresetErr(msg.replace(/^HTTP \d+:\s*/, ""));
     } finally {


### PR DESCRIPTION
## Summary

🐛 **Hotfix for user-reported issue: "Strategy preset gak bisa dipilih, gw pencet gak respon"**

Strategy preset picker silently unresponsive when the user's persisted `selected_assets` carried legacy `{BNB, XRP, DOGE, HYPE}` entries from before the universe was trimmed. UI re-submits them → backend validator returns 400 → `handleActivatePreset` swallowed the error → user sees nothing happen.

## Root causes

### 1. Lost commit on PR #1487
`_sanitize_selected_assets` helper never made it to main. The squash merge of #1487 was created from `be2fcfe7` while my CodeRabbit-followup `92376bea` (which contained the sanitizer) landed seconds later and was excluded from the squash. Both READ sites (`get_autotrade`, `admin_user_detail`) were silently returning raw stale lists.

### 2. activate_preset rejects instead of heals
The validator was raising 400 on any non-`_VALID_ASSETS` entry. That meant stale UI submits got hard-blocked instead of being silently cleaned up.

### 3. Frontend has no error feedback path
`handleActivatePreset` was `async` with no try/catch — rejection became an unhandled promise, no visible error, no spinner, no toast.

## What changes

**`webtrader/backend/router.py`**
- Re-added `_sanitize_selected_assets(raw) -> Optional[list[str]]` helper (case-insensitive, dedup, filters against current `_VALID_ASSETS`)
- Wired at line 711 (`get_autotrade`) and line 2702 (`admin_user_detail`)
- `activate_preset` now silently drops stale assets + logs `activate_preset_dropped_stale_assets` for observability instead of 400ing. Falls back to `_DEFAULT_CRYPTO_SHORT_ASSETS = ("BTC","ETH")` if everything was stale. The DB row heals on first successful save.
- `# noqa: F821` on the forward-reference call site (Python resolves the name at request time; ruff doesn't know that).

**`webtrader/frontend/src/pages/AutoTradePage.tsx`**
- New `presetErr` + `presetSaving` state, red error banner under "Strategy Preset" section title.
- `handleActivatePreset`, `handleSelectTimeframe`, `handleToggleAsset` all gain try/catch + saving-lock + error surfacing. Trims leading `HTTP \d+: ` from API errors so the visible message reads as the operator-facing reason.
- Frontend filters `selectedAssets` against current `CRYPTO_ASSETS` constant before submit (defence-in-depth alongside backend sanitisation).

## Test Plan

- [x] `ruff check` + `py_compile` clean on backend
- [x] 70/70 prior tests pass (`test_admin_console` + `test_bnb_monitor_only`)
- [x] Backend: stale persisted list → sanitizer strips on read → frontend never re-submits stale values → no 400
- [x] Backend fallback: activate_preset with `["BNB"]` (no valid assets) → drops + falls back to `["BTC","ETH"]` instead of 400
- [x] Frontend: API error → red banner shown under section title (not silent)

## Operator impact

After deploy: existing users with stale persisted assets will see their preset picker work again immediately. No DB migration required — stale rows heal on the next successful preset save (or sooner via the sanitiser on read).

**Validation Tier**: MAJOR (user-blocking bug + missed-merge recovery)
**Claim Level**: NARROW INTEGRATION

---

_Generated by [Claude Code](https://claude.ai/code/session_01BwLy6Z7qnkRk9GPrLwJ4Eg)_